### PR TITLE
teeny fix for nav spacing

### DIFF
--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -40,7 +40,7 @@ export function TopNav() {
       <nav className="w-full my-4 rounded-lg">
         <div className="flex h-16 items-center px-4 sm:px-6 relative overflow-visible rounded-lg border bg-black/75 border-white/10">
           <div className="relative z-10 flex w-full items-center justify-between">
-            <div className="mr-4 flex-shrink-0">
+            <div className="flex-shrink-0">
               <Link to="/" className="flex items-center space-x-2">
                 <img src="/maple-logo.svg" alt="Maple" className="w-24" />
               </Link>


### PR DESCRIPTION
Top nav felt slightly off to me and I noticed the logo has unused right margin. Text tends to have uneven visual weight too so it's hard to make pixel centering it perfect but this improves it afaict.

Before:
<img width="749" alt="Screenshot 2025-01-28 at 11 55 35 AM" src="https://github.com/user-attachments/assets/3aadb9b9-bcb0-4636-9510-56ed48721195" />

After:
<img width="753" alt="Screenshot 2025-01-28 at 11 55 18 AM" src="https://github.com/user-attachments/assets/52754684-e749-44ef-8c9a-e64aa8e6d348" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Adjusted styling in the top navigation bar by removing a right margin class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->