### PR TITLE
Add standard macOS app menu items for Hide/Show/Quit

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -95,6 +95,12 @@ pub fn run() {
                             .about(None)
                             // Add our update checker to the app menu
                             .text(check_updates_id, "Check for Updates")
+                            .separator()
+                            .hide()
+                            .hide_others()
+                            .show_all()
+                            .separator()
+                            .quit()
                             .build()?;
 
                         // Create edit submenu with standard clipboard operations


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the macOS application menu by adding new options, including hide, hide others, show all, and quit functionalities along with visual separators, providing users with improved control over the application window and its visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->