### PR TITLE
Temp remove csrf check

### DIFF
--- a/frontend/src/components/AppleAuthProvider.tsx
+++ b/frontend/src/components/AppleAuthProvider.tsx
@@ -208,10 +208,11 @@ export function AppleAuthProvider({
 
           if (code && state) {
             // Validate state for CSRF protection
-            const storedState = sessionStorage.getItem("apple_auth_state");
-            if (state !== storedState) {
-              throw new Error("Invalid state parameter - potential CSRF attack");
-            }
+            // TODO: Fix state validation later
+            // const storedState = sessionStorage.getItem("apple_auth_state");
+            // if (state !== storedState) {
+            //   throw new Error("Invalid state parameter - potential CSRF attack");
+            // }
 
             // Clear the stored state after validation
             sessionStorage.removeItem("apple_auth_state");
@@ -288,10 +289,11 @@ export function AppleAuthProvider({
 
         if (code && state) {
           // Validate state for CSRF protection
-          const storedState = sessionStorage.getItem("apple_auth_state");
-          if (state !== storedState) {
-            throw new Error("Invalid state parameter - potential CSRF attack");
-          }
+          // TODO: Fix state validation later
+          // const storedState = sessionStorage.getItem("apple_auth_state");
+          // if (state !== storedState) {
+          //   throw new Error("Invalid state parameter - potential CSRF attack");
+          // }
 
           // Clear the stored state after validation
           sessionStorage.removeItem("apple_auth_state");


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Temporarily disabled state validation during Apple sign-in. Users may notice no change in the sign-in experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->