### PR TITLE
Enable Zaprite (Bitcoin) payments on iOS app

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "1.0.7",
+  "version": "1.0.8",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "1.0.7"
+version = "1.0.8"
 description = "Maple AI"
 authors = ["tony@opensecret.cloud"]
 license = "MIT"

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -665,22 +665,20 @@ function PricingPage() {
           </div>
         )}
 
-        {!isIOS && (
-          <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-center">
-            <div className="inline-flex items-center gap-4 px-6 py-2.5 rounded-full bg-[hsl(var(--marketing-card))]/50 backdrop-blur-sm border border-[hsl(var(--marketing-card-border))]">
-              <div className="flex items-center gap-2 text-[hsl(var(--bitcoin))] text-base font-light">
-                <Bitcoin className="w-4.5 h-4.5" />
-                <span>Pay with Bitcoin</span>
-              </div>
-              <Switch
-                id="bitcoin-toggle"
-                checked={useBitcoin}
-                onCheckedChange={setUseBitcoin}
-                className="data-[state=checked]:bg-[hsl(var(--bitcoin))] data-[state=unchecked]:border-foreground/30 scale-100"
-              />
+        <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-center">
+          <div className="inline-flex items-center gap-4 px-6 py-2.5 rounded-full bg-[hsl(var(--marketing-card))]/50 backdrop-blur-sm border border-[hsl(var(--marketing-card-border))]">
+            <div className="flex items-center gap-2 text-[hsl(var(--bitcoin))] text-base font-light">
+              <Bitcoin className="w-4.5 h-4.5" />
+              <span>Pay with Bitcoin</span>
             </div>
+            <Switch
+              id="bitcoin-toggle"
+              checked={useBitcoin}
+              onCheckedChange={setUseBitcoin}
+              className="data-[state=checked]:bg-[hsl(var(--bitcoin))] data-[state=unchecked]:border-foreground/30 scale-100"
+            />
           </div>
-        )}
+        </div>
 
         <div className="pt-8 w-full max-w-7xl mx-auto grid grid-cols-1 md:grid-cols-4 gap-4 md:gap-4 lg:gap-6 px-4 sm:px-6 lg:px-8">
           {products &&


### PR DESCRIPTION
Remove iOS platform restriction for Bitcoin payment toggle in pricing page.
The underlying Zaprite checkout functionality and Universal Links were
already implemented for iOS, but the UI toggle was hidden.

Fixes #79

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Bitcoin payment toggle is now visible and accessible on all platforms, including iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->