### PR TITLE
Increment build version to 1.0.9

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "1.0.8",
+  "version": "1.0.9",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "1.0.8"
+version = "1.0.9"
 description = "Maple AI"
 authors = ["tony@opensecret.cloud"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.5</string>
+	<string>1.0.9</string>
 	<key>CFBundleVersion</key>
-	<string>1.0.5</string>
+	<string>1.0.9</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -51,8 +51,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 1.0.2
-        CFBundleVersion: 1.0.2
+        CFBundleShortVersionString: 1.0.9
+        CFBundleVersion: 1.0.9
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Updated version numbers across all configuration files:
- frontend/package.json: 1.0.8 → 1.0.9
- frontend/src-tauri/tauri.conf.json: 1.0.8 → 1.0.9
- frontend/src-tauri/Cargo.toml: 1.0.8 → 1.0.9
- frontend/src-tauri/gen/apple/maple_iOS/Info.plist: 1.0.5 → 1.0.9
- frontend/src-tauri/gen/apple/project.yml: 1.0.2 → 1.0.9

Fixes #83

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated application version number to 1.0.9 across relevant files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->