### PR TITLE
feat: rename "chats" to "messages" in free tier usage limits

### DIFF
--- a/frontend/src/components/BillingDebugger.tsx
+++ b/frontend/src/components/BillingDebugger.tsx
@@ -65,7 +65,7 @@ export function BillingDebugger({ currentStatus, onOverride }: BillingDebuggerPr
         </div>
 
         <div>
-          <label className="block text-sm">Chats Remaining</label>
+          <label className="block text-sm">Messages Remaining</label>
           <Input
             type="number"
             value={debugStatus.chats_remaining ?? ""}
@@ -158,7 +158,7 @@ export function BillingDebugger({ currentStatus, onOverride }: BillingDebuggerPr
             }}
             className="border-yellow-500/30 hover:bg-yellow-500/20"
           >
-            Test Pro + No Chats
+            Test Pro + No Messages
           </Button>
         </div>
       </div>

--- a/frontend/src/components/BillingStatus.tsx
+++ b/frontend/src/components/BillingStatus.tsx
@@ -34,15 +34,15 @@ export function BillingStatus() {
   const getChatsText = () => {
     if (isFree) {
       if (billingStatus.chats_remaining === null || billingStatus.chats_remaining <= 0) {
-        return "You've run out of chats, upgrade to keep chatting!";
+        return "You've run out of messages, upgrade to keep chatting!";
       }
-      return `Free Plan — ${billingStatus.chats_remaining} Chat${billingStatus.chats_remaining === 1 ? "" : "s"} Left This Week`;
+      return `Free Plan — ${billingStatus.chats_remaining} Message${billingStatus.chats_remaining === 1 ? "" : "s"} Left This Week`;
     }
     if (!billingStatus.can_chat) {
       if (isPro) {
         return "Contact us to increase your limits";
       }
-      return "You've run out of chats, upgrade to keep chatting!";
+      return "You've run out of messages, upgrade to keep chatting!";
     }
     return `${billingStatus.product_name} Plan`;
   };

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -312,7 +312,7 @@ export default function Component({
     if (billingStatus === null || freshBillingStatus === undefined)
       return "Type your message here...";
     if (freshBillingStatus.can_chat === false) {
-      return "You've used up all your chats. Upgrade to continue.";
+      return "You've used up all your messages. Upgrade to continue.";
     }
     return "Type your message here...";
   })();

--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -651,7 +651,7 @@ export function Marketing() {
           {/* Free Account Callout */}
           <div className="text-center mb-8">
             <p className="text-lg text-[hsl(var(--marketing-text-muted))]">
-              Free account comes with 10 free chats per week
+              Free account comes with 10 free messages per week
             </p>
           </div>
 
@@ -661,7 +661,7 @@ export function Marketing() {
               price="$5.99"
               description="Get started with secure AI chat"
               features={[
-                "Enough chats for casual use",
+                "Enough messages for casual use",
                 "AI Naming of Chats",
                 "",
                 "Included from Free",
@@ -679,7 +679,7 @@ export function Marketing() {
               price="$20"
               description="For power users who need more"
               features={[
-                "5x more chats than Starter",
+                "5x more messages than Starter",
                 "Priority support",
                 "Upcoming Pro-only features",
                 "Features from Starter"
@@ -694,7 +694,7 @@ export function Marketing() {
               price="$30"
               description="For teams and businesses"
               features={[
-                "8x more chats than Starter per user",
+                "8x more messages than Starter per user",
                 "Unified billing",
                 "Pool chat credits among team",
                 "Features from Pro"

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -61,9 +61,10 @@ function PricingFAQ() {
             <p>The plans are sized to grow with your needs.</p>
             <ul className="list-disc list-inside space-y-1 ml-4">
               <li>
-                Free: 10 chats per week, resets Sunday 00:00 UTC. Max length on individual chats.
+                Free: 10 messages per week, resets Sunday 00:00 UTC. Max length on individual
+                messages.
               </li>
-              <li>Starter: Enough chats per month for a casual user</li>
+              <li>Starter: Enough messages per month for a casual user</li>
               <li>Pro: Great for heavier workloads with a high monthly cap</li>
               <li>Enterprise: Message us at team@opensecret.cloud</li>
             </ul>


### PR DESCRIPTION
Update UI text throughout the application to use "messages" instead of "chats" when referring to free tier usage limits. This addresses user confusion about what counts as a "chat" by clarifying that each individual message sent to the AI counts toward the limit.

**Changes:**
- Update pricing page FAQ and plan descriptions
- Update billing status component messages
- Update ChatBox placeholder text
- Update marketing copy for plan features
- Update debug interface labels

Fixes #90

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated all user-facing text to use "messages" instead of "chats" across billing, chat, marketing, and pricing sections for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->