### PR TITLE
fix: enable Apple OAuth for desktop users

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -40,22 +40,25 @@ function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isIOS, setIsIOS] = useState(false);
+  const [isTauriEnv, setIsTauriEnv] = useState(false);
 
-  // Check if running on iOS
+  // Check if running on iOS and in Tauri environment
   useEffect(() => {
     const checkPlatform = async () => {
       try {
         // First check if we're in a Tauri environment
-        let isTauriEnv = false;
+        let tauriEnv = false;
         try {
-          isTauriEnv = await isTauri();
+          tauriEnv = await isTauri();
         } catch {
           // Not in Tauri environment
-          isTauriEnv = false;
+          tauriEnv = false;
         }
 
+        setIsTauriEnv(tauriEnv);
+
         // Only check platform type if we're in a Tauri environment
-        if (isTauriEnv) {
+        if (tauriEnv) {
           const platform = await type();
           setIsIOS(platform === "ios");
         } else {
@@ -65,6 +68,7 @@ function LoginPage() {
       } catch (error) {
         console.error("Error checking platform:", error);
         setIsIOS(false);
+        setIsTauriEnv(false);
       }
     };
 
@@ -305,7 +309,7 @@ function LoginPage() {
           <Google className="mr-2 h-4 w-4" />
           Log in with Google
         </Button>
-        {isIOS ? (
+        {isTauriEnv ? (
           <Button onClick={handleAppleLogin} className="w-full">
             <Apple className="mr-2 h-4 w-4" />
             Log in with Apple

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -40,22 +40,25 @@ function SignupPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isIOS, setIsIOS] = useState(false);
+  const [isTauriEnv, setIsTauriEnv] = useState(false);
 
-  // Check if running on iOS
+  // Check if running on iOS and in Tauri environment
   useEffect(() => {
     const checkPlatform = async () => {
       try {
         // First check if we're in a Tauri environment
-        let isTauriEnv = false;
+        let tauriEnv = false;
         try {
-          isTauriEnv = await isTauri();
+          tauriEnv = await isTauri();
         } catch {
           // Not in Tauri environment
-          isTauriEnv = false;
+          tauriEnv = false;
         }
 
+        setIsTauriEnv(tauriEnv);
+
         // Only check platform type if we're in a Tauri environment
-        if (isTauriEnv) {
+        if (tauriEnv) {
           const platform = await type();
           setIsIOS(platform === "ios");
         } else {
@@ -65,6 +68,7 @@ function SignupPage() {
       } catch (error) {
         console.error("Error checking platform:", error);
         setIsIOS(false);
+        setIsTauriEnv(false);
       }
     };
 
@@ -305,7 +309,7 @@ function SignupPage() {
           <Google className="mr-2 h-4 w-4" />
           Sign up with Google
         </Button>
-        {isIOS ? (
+        {isTauriEnv ? (
           <Button onClick={handleAppleSignup} className="w-full">
             <Apple className="mr-2 h-4 w-4" />
             Sign up with Apple


### PR DESCRIPTION
Fixes #94

The Apple OAuth button was not appearing for desktop users because the conditional rendering only showed it for iOS devices. Desktop users would see the AppleAuthProvider component, but it returns null in Tauri environments.

Changed the conditional from `isIOS` to `isTauriEnv` so that both iOS and desktop Tauri apps show the Apple button, which properly redirects to the web OAuth flow.

This ensures desktop users can access Apple OAuth via browser redirect, matching the behavior of GitHub and Google OAuth on desktop.

Generated with [Claude Code](https://claude.ai/code)