### PR TITLE
fix: enable Apple OAuth for desktop users

### DIFF
--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -40,22 +40,25 @@ function LoginPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isIOS, setIsIOS] = useState(false);
+  const [isTauriEnv, setIsTauriEnv] = useState(false);
 
-  // Check if running on iOS
+  // Check if running on iOS and in Tauri environment
   useEffect(() => {
     const checkPlatform = async () => {
       try {
         // First check if we're in a Tauri environment
-        let isTauriEnv = false;
+        let tauriEnv = false;
         try {
-          isTauriEnv = await isTauri();
+          tauriEnv = await isTauri();
         } catch {
           // Not in Tauri environment
-          isTauriEnv = false;
+          tauriEnv = false;
         }
 
+        setIsTauriEnv(tauriEnv);
+
         // Only check platform type if we're in a Tauri environment
-        if (isTauriEnv) {
+        if (tauriEnv) {
           const platform = await type();
           setIsIOS(platform === "ios");
         } else {
@@ -65,6 +68,7 @@ function LoginPage() {
       } catch (error) {
         console.error("Error checking platform:", error);
         setIsIOS(false);
+        setIsTauriEnv(false);
       }
     };
 
@@ -305,7 +309,7 @@ function LoginPage() {
           <Google className="mr-2 h-4 w-4" />
           Log in with Google
         </Button>
-        {isIOS ? (
+        {isTauriEnv ? (
           <Button onClick={handleAppleLogin} className="w-full">
             <Apple className="mr-2 h-4 w-4" />
             Log in with Apple

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -48,12 +48,7 @@ function LoginPage() {
       try {
         // First check if we're in a Tauri environment
         let tauriEnv = false;
-        try {
-          tauriEnv = await isTauri();
-        } catch {
-          // Not in Tauri environment
-          tauriEnv = false;
-        }
+        tauriEnv = await isTauri();
 
         setIsTauriEnv(tauriEnv);
 

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -48,12 +48,7 @@ function SignupPage() {
       try {
         // First check if we're in a Tauri environment
         let tauriEnv = false;
-        try {
-          tauriEnv = await isTauri();
-        } catch {
-          // Not in Tauri environment
-          tauriEnv = false;
-        }
+        tauriEnv = await isTauri();
 
         setIsTauriEnv(tauriEnv);
 

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -40,22 +40,25 @@ function SignupPage() {
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [isIOS, setIsIOS] = useState(false);
+  const [isTauriEnv, setIsTauriEnv] = useState(false);
 
-  // Check if running on iOS
+  // Check if running on iOS and in Tauri environment
   useEffect(() => {
     const checkPlatform = async () => {
       try {
         // First check if we're in a Tauri environment
-        let isTauriEnv = false;
+        let tauriEnv = false;
         try {
-          isTauriEnv = await isTauri();
+          tauriEnv = await isTauri();
         } catch {
           // Not in Tauri environment
-          isTauriEnv = false;
+          tauriEnv = false;
         }
 
+        setIsTauriEnv(tauriEnv);
+
         // Only check platform type if we're in a Tauri environment
-        if (isTauriEnv) {
+        if (tauriEnv) {
           const platform = await type();
           setIsIOS(platform === "ios");
         } else {
@@ -65,6 +68,7 @@ function SignupPage() {
       } catch (error) {
         console.error("Error checking platform:", error);
         setIsIOS(false);
+        setIsTauriEnv(false);
       }
     };
 
@@ -305,7 +309,7 @@ function SignupPage() {
           <Google className="mr-2 h-4 w-4" />
           Sign up with Google
         </Button>
-        {isIOS ? (
+        {isTauriEnv ? (
           <Button onClick={handleAppleSignup} className="w-full">
             <Apple className="mr-2 h-4 w-4" />
             Sign up with Apple


### PR DESCRIPTION
Fixes #94

Desktop users can now access Apple OAuth by opening the browser first, following the same pattern as GitHub and Google OAuth on desktop.

**Changes:**
- Added `isTauriEnv` state to both login and signup pages
- Changed conditional rendering from `isIOS` to `isTauriEnv`
- Desktop users now see Apple OAuth button that opens browser
- iOS users continue to use native SIWA flow
- Web users continue to use AppleAuthProvider popup flow

This ensures all Tauri environments (iOS + desktop) show the Apple button while web environments use the AppleAuthProvider component.

**Testing Notes:**
- ✅ ESLint: No new errors, only existing warnings
- ✅ Prettier: All files properly formatted
- ✅ Build: Successful with only existing warnings

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved detection of the Tauri environment in login and signup screens.
  - Apple login and sign-up buttons are now displayed only when running in a Tauri environment, providing a more accurate and consistent user experience across platforms.
  - Enhanced Apple OAuth authentication on desktop with a new popup-based sign-in flow, replacing the redirect method for a smoother user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->