### PR TITLE
feat: add mobile new chat button to chat title bar

### DIFF
--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -610,7 +610,7 @@ END OF INSTRUCTIONS`;
                 <SquarePenIcon className="h-4 w-4" />
               </Button>
             )}
-            <h2 className="text-lg font-semibold self-center truncate max-w-[20rem] mx-[6rem] py-2">
+            <h2 className="text-base font-semibold self-center truncate max-w-[20rem] mx-[6rem] py-2">
               {localChat.title}
             </h2>
           </div>


### PR DESCRIPTION
Fixes #100

Adds a mobile-only new chat button to the chat title bar as requested in the issue. The button:

- Only appears on mobile devices using useIsMobile() hook
- Is positioned in the top right corner of the chat title bar
- Uses SquarePenIcon for consistency with the sidebar design
- Navigates to home page and focuses message input when tapped
- Includes proper accessibility attributes

This eliminates the need for mobile users to open the sidebar to start a new chat.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a dedicated button for mobile users to easily start a new chat from the chat interface.
  - Improved mobile detection to enhance chat interface responsiveness on mobile devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->