### PR TITLE
feat: implement inline system message display with truncation and expand

### DIFF
--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -105,30 +105,28 @@ function SystemPromptMessage({ text }: { text: string }) {
             <span className="text-sm font-medium text-muted-foreground">System Prompt</span>
           </div>
           <div className="text-sm text-foreground">{isExpanded ? text : truncatedText}</div>
-          <div className="flex items-center gap-2">
-            {text.length > 100 && (
-              <Button
-                variant="ghost"
-                size="sm"
-                className="self-start -mx-2 text-xs h-auto p-1 text-primary hover:text-primary/80"
-                onClick={() => setIsExpanded(!isExpanded)}
-              >
-                <ChevronRight
-                  className={`h-3 w-3 mr-1 transition-transform ${isExpanded ? "rotate-90" : ""}`}
-                />
-                {isExpanded ? "Show less" : "Show more"}
-              </Button>
-            )}
+          {text.length > 100 && (
             <Button
               variant="ghost"
               size="sm"
-              className="self-start -mx-2 group-hover:opacity-100 opacity-0 transition-opacity h-auto p-1"
-              onClick={handleCopy}
-              aria-label={isCopied ? "Copied" : "Copy to clipboard"}
+              className="self-start -mx-2 text-xs h-auto p-1 text-primary hover:text-primary/80"
+              onClick={() => setIsExpanded(!isExpanded)}
             >
-              {isCopied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+              <ChevronRight
+                className={`h-3 w-3 mr-1 transition-transform ${isExpanded ? "rotate-90" : ""}`}
+              />
+              {isExpanded ? "Show less" : "Show more"}
             </Button>
-          </div>
+          )}
+          <Button
+            variant="ghost"
+            size="sm"
+            className="self-start -mx-2 -mb-2 group-hover:opacity-100 opacity-0 transition-opacity"
+            onClick={handleCopy}
+            aria-label={isCopied ? "Copied" : "Copy to clipboard"}
+          >
+            {isCopied ? <Check className="h-4 w-4" /> : <Copy className="h-4 w-4" />}
+          </Button>
         </div>
       </div>
     </div>

--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import { createFileRoute } from "@tanstack/react-router";
-import { AsteriskIcon, Check, Copy, UserIcon, ChevronDown, Bot, ChevronRight, SquarePenIcon } from "lucide-react";
+import { AsteriskIcon, Check, Copy, UserIcon, ChevronDown, Bot, SquarePenIcon } from "lucide-react";
 import ChatBox from "@/components/ChatBox";
 import { useOpenAI } from "@/ai/useOpenAi";
 import { useLocalState } from "@/state/useLocalState";
@@ -92,8 +92,6 @@ function SystemPromptMessage({ text }: { text: string }) {
     }
   }, [text]);
 
-  const truncatedText = text.length > 100 ? text.slice(0, 100) + "..." : text;
-
   return (
     <div className="group flex flex-col p-4 rounded-lg bg-muted/50">
       <div className="rounded-lg flex flex-col md:flex-row gap-4">
@@ -104,20 +102,39 @@ function SystemPromptMessage({ text }: { text: string }) {
           <div className="flex items-center gap-2">
             <span className="text-sm font-medium text-muted-foreground">System Prompt</span>
           </div>
-          <div className="text-sm text-foreground">{isExpanded ? text : truncatedText}</div>
-          {text.length > 100 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="self-start -mx-2 text-xs h-auto p-1 text-primary hover:text-primary/80"
-              onClick={() => setIsExpanded(!isExpanded)}
-            >
-              <ChevronRight
-                className={`h-3 w-3 mr-1 transition-transform ${isExpanded ? "rotate-90" : ""}`}
-              />
-              {isExpanded ? "Show less" : "Show more"}
-            </Button>
-          )}
+          <div className="text-sm text-foreground">
+            {isExpanded ? (
+              <>
+                {text}
+                {text.length > 100 && (
+                  <>
+                    {" "}
+                    <button
+                      className="text-primary hover:text-primary/80 underline cursor-pointer"
+                      onClick={() => setIsExpanded(false)}
+                    >
+                      show less
+                    </button>
+                  </>
+                )}
+              </>
+            ) : (
+              <>
+                {text.length > 100 ? text.slice(0, 100) : text}
+                {text.length > 100 && (
+                  <>
+                    {"... "}
+                    <button
+                      className="text-primary hover:text-primary/80 underline cursor-pointer"
+                      onClick={() => setIsExpanded(true)}
+                    >
+                      see more
+                    </button>
+                  </>
+                )}
+              </>
+            )}
+          </div>
           <Button
             variant="ghost"
             size="sm"


### PR DESCRIPTION
Implement a new approach to display system prompts inline with chat messages, showing truncated text with expand functionality and copy button.

## Changes
- Add SystemPromptMessage component with Bot icon and "System Prompt" label
- Show truncated text (100 chars) with "..." and expand/collapse functionality
- Include copy button with same pattern as assistant messages (hover reveal)
- Remove system message filter to allow inline rendering
- System messages now appear naturally at top of chat
- Styled with muted background to distinguish from regular messages

Resolves #98

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - System messages now have a dedicated design with a "System Prompt" label, bot icon, expandable text, and a copy-to-clipboard button.
- **Improvements**
  - All message types, including system messages, are displayed in chat for a complete conversation history.
  - Added copy-to-clipboard functionality with success feedback for system messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->