### PR TITLE
fix: enable Apple OAuth desktop redirect to app

### DIFF
--- a/frontend/src/components/AppleAuthProvider.tsx
+++ b/frontend/src/components/AppleAuthProvider.tsx
@@ -220,7 +220,31 @@ export function AppleAuthProvider({
             // Call the OpenSecret SDK to handle the authentication
             await os.handleAppleCallback(code, state, inviteCode || "");
 
-            // Handle successful login redirection
+            // Check if this is a Tauri app auth flow (desktop or mobile)
+            const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";
+
+            if (isTauriAuth) {
+              // Clear the flag
+              localStorage.removeItem("redirect-to-native");
+
+              // Handle Tauri redirect - redirect back to desktop app
+              const accessToken = localStorage.getItem("access_token") || "";
+              const refreshToken = localStorage.getItem("refresh_token");
+
+              let deepLinkUrl = `cloud.opensecret.maple://auth?access_token=${encodeURIComponent(accessToken)}`;
+
+              if (refreshToken) {
+                deepLinkUrl += `&refresh_token=${encodeURIComponent(refreshToken)}`;
+              }
+
+              setTimeout(() => {
+                window.location.href = deepLinkUrl;
+              }, 1000);
+
+              return;
+            }
+
+            // Handle web flow - regular navigation
             if (onSuccess) {
               onSuccess();
             }
@@ -301,7 +325,31 @@ export function AppleAuthProvider({
           // Call the OpenSecret SDK to handle the authentication
           await os.handleAppleCallback(code, state, inviteCode || "");
 
-          // Handle successful login redirection
+          // Check if this is a Tauri app auth flow (desktop or mobile)
+          const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";
+
+          if (isTauriAuth) {
+            // Clear the flag
+            localStorage.removeItem("redirect-to-native");
+
+            // Handle Tauri redirect - redirect back to desktop app
+            const accessToken = localStorage.getItem("access_token") || "";
+            const refreshToken = localStorage.getItem("refresh_token");
+
+            let deepLinkUrl = `cloud.opensecret.maple://auth?access_token=${encodeURIComponent(accessToken)}`;
+
+            if (refreshToken) {
+              deepLinkUrl += `&refresh_token=${encodeURIComponent(refreshToken)}`;
+            }
+
+            setTimeout(() => {
+              window.location.href = deepLinkUrl;
+            }, 1000);
+
+            return;
+          }
+
+          // Handle web flow - regular navigation
           if (onSuccess) {
             onSuccess();
           }


### PR DESCRIPTION
Fixes #94

Apple OAuth now properly redirects back to desktop app after authentication. Previously, AppleAuthProvider would navigate within the browser instead of checking the redirect-to-native flag and redirecting to the desktop app.

This fix adds the same Tauri redirect logic used by GitHub/Google OAuth:
- Check localStorage for "redirect-to-native" flag
- If set, clear flag and redirect to deep link with access/refresh tokens
- Otherwise, use regular web navigation

**Changes Made:**
- Updated `AppleAuthProvider.tsx` to check for Tauri desktop auth flow
- Added same deep link redirect logic as GitHub/Google OAuth
- Maintains backward compatibility with web and iOS flows

**Testing:**
- ✅ Code formatting (Prettier)
- ✅ Linting (ESLint) - only existing warnings
- ✅ Build successful

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved Apple authentication flow to support seamless redirection back to the native app when running in a Tauri environment.
  - Automatically handles deep linking with authentication tokens after successful sign-in on desktop or mobile native apps.

- **Bug Fixes**
  - Ensured consistent redirection behavior after Apple authentication across both web and native environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->