### PR TITLE
feat: enable Gemma 3 27B model with starter plan access

### DIFF
--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -42,6 +42,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       { text: "Rename Chats", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
+      { text: "Gemma 3 27B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       { text: "DeepSeek R1 70B", included: false, icon: <X className="w-4 h-4 text-red-500" /> }
     ],
     ctaText: "Start Free"
@@ -66,6 +67,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
+      { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       { text: "DeepSeek R1 70B", included: false, icon: <X className="w-4 h-4 text-red-500" /> }
     ],
     ctaText: "Start Chatting"
@@ -90,6 +92,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
+      { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       {
         text: "DeepSeek R1 70B",
         included: true,
@@ -129,6 +132,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
+      { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       {
         text: "DeepSeek R1 70B",
         included: true,


### PR DESCRIPTION
Enable the Gemma 3 27B model with starter/pro/team plan access, following the established model implementation pattern.

## Changes
- Remove disabled status and "Coming Soon" badges from Gemma models
- Add new `requiresStarter` flag for starter/pro/team plan access control
- Implement starter-level access logic in `hasAccessToModel` function
- Add green gradient styling for "Starter" badge
- Update pricing configuration to include Gemma 3 27B for paid plans
- Maintain existing Pro-only access for DeepSeek R1 70B

Resolves #109

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a "Starter" badge and access tier for certain models, allowing users on the Starter plan to access these models.
  - Updated model selection dropdown to display "Starter" badges and adjust access controls based on the new tier.

- **Enhancements**
  - Added "Gemma 3 27B" feature visibility to all pricing plans, clearly indicating which plans include access.

- **Style**
  - Added a new green gradient style for the "Starter" badge in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->