### PR TITLE
Bump to 1.1.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2230,7 +2230,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maple"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "log",
  "once_cell",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "1.1.2"
+version = "1.1.3"
 description = "Maple AI"
 authors = ["tony@opensecret.cloud"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.2</string>
+	<string>1.1.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -51,8 +51,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 1.1.2
-        CFBundleVersion: 1.1.2
+        CFBundleShortVersionString: 1.1.3
+        CFBundleVersion: 1.1.3
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Closes #111

This PR bumps the version from 1.1.2 to 1.1.3 across all project files:

- package.json
- tauri.conf.json
- Cargo.toml
- iOS project.yml (CFBundleShortVersionString and CFBundleVersion)
- Info.plist (CFBundleShortVersionString and CFBundleVersion)
- Cargo.lock (updated via cargo check)

All linting and build processes completed successfully.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated application version number to 1.1.3 across all relevant configuration files. No other changes were made.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->