### PR TITLE
fix: add responsive table wrapper to prevent overflow

### DIFF
--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -237,10 +237,23 @@ function CustomCode(props: JSX.IntrinsicElements["code"]) {
 
 function ResponsiveTable(props: JSX.IntrinsicElements["table"]) {
   return (
-    <div className="overflow-x-auto max-w-full">
+    <div
+      className="overflow-x-auto"
+      style={{
+        width: "100%",
+        maxWidth: "100%",
+        boxSizing: "border-box"
+      }}
+    >
       <table
         {...props}
-        style={{ ...props.style, tableLayout: "auto", width: "max-content", minWidth: "100%" }}
+        style={{
+          ...props.style,
+          display: "table",
+          width: "max-content",
+          minWidth: "100%",
+          maxWidth: "none"
+        }}
       >
         {props.children}
       </table>

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -237,7 +237,7 @@ function CustomCode(props: JSX.IntrinsicElements["code"]) {
 
 function ResponsiveTable(props: JSX.IntrinsicElements["table"]) {
   return (
-    <div className="overflow-x-auto max-w-full">
+    <div className="overflow-x-auto w-full min-w-0">
       <table {...props}>{props.children}</table>
     </div>
   );

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -235,6 +235,14 @@ function CustomCode(props: JSX.IntrinsicElements["code"]) {
   return <code>{props.children}</code>;
 }
 
+function ResponsiveTable(props: JSX.IntrinsicElements["table"]) {
+  return (
+    <div className="overflow-x-auto max-w-full">
+      <table {...props}>{props.children}</table>
+    </div>
+  );
+}
+
 function escapeDollarNumber(text: string) {
   let escapedText = "";
 
@@ -305,6 +313,7 @@ function MarkDownContentToMemo(props: { content: string }) {
       components={{
         pre: (props: JSX.IntrinsicElements["pre"]) => <PreCode {...props} />,
         code: (props: JSX.IntrinsicElements["code"]) => <CustomCode {...props} />,
+        table: (props: JSX.IntrinsicElements["table"]) => <ResponsiveTable {...props} />,
         p: (pProps) => <p {...pProps} dir="auto" />,
         a: (aProps) => {
           const href = aProps.href || "";

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -237,8 +237,13 @@ function CustomCode(props: JSX.IntrinsicElements["code"]) {
 
 function ResponsiveTable(props: JSX.IntrinsicElements["table"]) {
   return (
-    <div className="overflow-x-auto w-full min-w-0">
-      <table {...props}>{props.children}</table>
+    <div className="overflow-x-auto max-w-full">
+      <table
+        {...props}
+        style={{ ...props.style, tableLayout: "auto", width: "max-content", minWidth: "100%" }}
+      >
+        {props.children}
+      </table>
     </div>
   );
 }

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -240,19 +240,17 @@ function ResponsiveTable(props: JSX.IntrinsicElements["table"]) {
     <div
       className="overflow-x-auto"
       style={{
-        width: "100%",
         maxWidth: "100%",
-        boxSizing: "border-box"
+        width: "100%"
       }}
     >
       <table
         {...props}
         style={{
           ...props.style,
-          display: "table",
           width: "max-content",
           minWidth: "100%",
-          maxWidth: "none"
+          maxWidth: "100%"
         }}
       >
         {props.children}


### PR DESCRIPTION
Fixes wide markdown table overflow issue where tables expanded beyond chat interface boundaries.

Changes:
- Added ResponsiveTable component that wraps tables in scrollable container
- Uses Tailwind CSS overflow-x-auto and max-w-full classes
- Applied to all markdown tables via ReactMarkdown components prop

Fixes #114

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved markdown table display with a new responsive table component, allowing horizontal scrolling and better viewing on smaller screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->