### PR TITLE
fix: add general content overflow protection with horizontal scrolling

### DIFF
--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -374,7 +374,7 @@ export function Markdown(
 
   return (
     <div
-      className="markdown-body"
+      className="markdown-body overflow-x-auto max-w-full"
       style={{
         fontSize: `${props.fontSize ?? 16}px`,
         fontFamily: props.fontFamily || "inherit"

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -374,7 +374,7 @@ export function Markdown(
 
   return (
     <div
-      className="markdown-body overflow-x-auto max-w-full"
+      className="markdown-body overflow-x-auto max-w-full min-w-0"
       style={{
         fontSize: `${props.fontSize ?? 16}px`,
         fontFamily: props.fontFamily || "inherit"

--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -25,7 +25,7 @@ function UserMessage({ text, chatId }: { text: string; chatId: string }) {
         <div>
           <UserIcon />
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 min-w-0">
           <Markdown content={text} loading={false} chatId={chatId} />
         </div>
       </div>
@@ -60,7 +60,7 @@ function SystemMessage({
         <div>
           <AsteriskIcon />
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 min-w-0">
           <Markdown content={text} loading={loading} chatId={chatId} />
           <Button
             variant="ghost"


### PR DESCRIPTION
Replaces table-specific solution with universal overflow handling. Added overflow-x-auto and max-w-full classes to markdown container to prevent any content (tables, code blocks, long text) from expanding beyond chat interface boundaries.

## Changes:
- Added `overflow-x-auto max-w-full` to markdown container in `src/components/markdown.tsx:377`
- Provides horizontal scrolling for any content that exceeds width constraints
- Universal solution that handles tables, code blocks, and any other wide content

Fixes #114

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Enhanced the Markdown component and message containers to prevent content overflow and improve layout by enabling horizontal scrolling and better width constraints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->