### PR TITLE
Fix: Clear billing token on all auth flows to prevent session mixing

### DIFF
--- a/frontend/src/components/AppleAuthProvider.tsx
+++ b/frontend/src/components/AppleAuthProvider.tsx
@@ -5,6 +5,7 @@ import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { Button } from "./ui/button";
 import { Apple } from "./icons/Apple";
+import { getBillingService } from "@/billing/billingService";
 
 // Define the props interface
 interface AppleAuthProviderProps {
@@ -220,6 +221,13 @@ export function AppleAuthProvider({
             // Call the OpenSecret SDK to handle the authentication
             await os.handleAppleCallback(code, state, inviteCode || "");
 
+            // Clear any existing billing token to prevent session mixing
+            try {
+              getBillingService().clearToken();
+            } catch (billingError) {
+              console.warn("Failed to clear billing token:", billingError);
+            }
+
             // Check if this is a Tauri app auth flow (desktop or mobile)
             const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";
 
@@ -324,6 +332,13 @@ export function AppleAuthProvider({
 
           // Call the OpenSecret SDK to handle the authentication
           await os.handleAppleCallback(code, state, inviteCode || "");
+
+          // Clear any existing billing token to prevent session mixing
+          try {
+            getBillingService().clearToken();
+          } catch (billingError) {
+            console.warn("Failed to clear billing token:", billingError);
+          }
 
           // Check if this is a Tauri app auth flow (desktop or mobile)
           const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";

--- a/frontend/src/routes/auth.$provider.callback.tsx
+++ b/frontend/src/routes/auth.$provider.callback.tsx
@@ -5,6 +5,7 @@ import { AlertDestructive } from "@/components/AlertDestructive";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { getBillingService } from "@/billing/billingService";
 
 export const Route = createFileRoute("/auth/$provider/callback")({
   component: OAuthCallback
@@ -125,6 +126,13 @@ function OAuthCallback() {
             await handleAppleCallback(code || "", state || "", "");
           } else {
             throw new Error(`Unsupported provider: ${provider}`);
+          }
+
+          // Clear any existing billing token to prevent session mixing
+          try {
+            getBillingService().clearToken();
+          } catch (billingError) {
+            console.warn("Failed to clear billing token:", billingError);
           }
 
           // Handle the successful authentication (redirect)

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -16,6 +16,7 @@ import type { AppleCredential } from "@/types/apple-sign-in";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { AppleAuthProvider } from "@/components/AppleAuthProvider";
+import { getBillingService } from "@/billing/billingService";
 
 type LoginSearchParams = {
   next?: string;
@@ -94,6 +95,12 @@ function LoginPage() {
 
     try {
       await os.signIn(email, password);
+      // Clear any existing billing token to prevent session mixing
+      try {
+        getBillingService().clearToken();
+      } catch (billingError) {
+        console.warn("Failed to clear billing token:", billingError);
+      }
       setTimeout(() => {
         if (selected_plan) {
           navigate({
@@ -236,6 +243,12 @@ function LoginPage() {
           // Send to backend via SDK
           try {
             await os.handleAppleNativeSignIn(appleUser, "");
+            // Clear any existing billing token to prevent session mixing
+            try {
+              getBillingService().clearToken();
+            } catch (billingError) {
+              console.warn("Failed to clear billing token:", billingError);
+            }
             // Redirect after successful login
             if (selected_plan) {
               navigate({

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -16,6 +16,7 @@ import type { AppleCredential } from "@/types/apple-sign-in";
 import { sha256 } from "@noble/hashes/sha256";
 import { bytesToHex } from "@noble/hashes/utils";
 import { AppleAuthProvider } from "@/components/AppleAuthProvider";
+import { getBillingService } from "@/billing/billingService";
 
 type SignupSearchParams = {
   next?: string;
@@ -94,6 +95,12 @@ function SignupPage() {
 
     try {
       await os.signUp(email, password, "", "ANON");
+      // Clear any existing billing token to prevent session mixing
+      try {
+        getBillingService().clearToken();
+      } catch (billingError) {
+        console.warn("Failed to clear billing token:", billingError);
+      }
       setTimeout(() => {
         if (selected_plan) {
           navigate({
@@ -236,6 +243,12 @@ function SignupPage() {
           // Send to backend via SDK
           try {
             await os.handleAppleNativeSignIn(appleUser, "");
+            // Clear any existing billing token to prevent session mixing
+            try {
+              getBillingService().clearToken();
+            } catch (billingError) {
+              console.warn("Failed to clear billing token:", billingError);
+            }
             // Redirect after successful signup
             if (selected_plan) {
               navigate({


### PR DESCRIPTION
This PR fixes issue #127 where billing JWT tokens were persisting across user sessions, causing payment sessions to be created for the previous user's UUID.

## Changes
- Added billing token clearing to all authentication flows
- Email login/signup now clear billing tokens after successful auth
- OAuth callbacks (GitHub, Google, Apple) clear billing tokens
- Native Apple Sign-In on iOS clears billing tokens
- Apple web authentication clears billing tokens

## Testing
- Code passes all linting checks
- Properly formatted with Prettier
- Follows existing error handling patterns

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved session security by automatically clearing any existing billing tokens after successful login, signup, or authentication via Apple, Google, or GitHub.
	- Added safeguards to prevent session mixing of billing tokens during authentication flows.
	- Enhanced error handling to log warnings if clearing billing tokens fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->