### PR TITLE
feat: add Document and Image Upload features to pricing and FAQ

### DIFF
--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -14,6 +14,21 @@ import { Switch } from "@/components/ui/switch";
 import { type } from "@tauri-apps/plugin-os";
 import { PRICING_PLANS } from "@/config/pricingConfig";
 
+// File type constants for upload features
+const SUPPORTED_IMAGE_FORMATS = [".jpg", ".png", ".webp"];
+const SUPPORTED_DOCUMENT_FORMATS = [
+  ".pdf",
+  ".doc",
+  ".docx",
+  ".txt",
+  ".rtf",
+  ".xlsx",
+  ".xls",
+  ".pptx",
+  ".ppt",
+  ".md"
+];
+
 type PricingSearchParams = {
   selected_plan?: string;
   success?: boolean;
@@ -114,6 +129,36 @@ function PricingFAQ() {
             No. When you chat with AI in Maple, nobody knows what is being said back and forth. Thus
             data is not able to be used for training new AI models by any company.
           </p>
+        </details>
+
+        <details className="group">
+          <summary className="cursor-pointer text-lg font-medium hover:text-foreground/80">
+            Which file types are supported for document and image upload?
+          </summary>
+          <div className="mt-4 text-[hsl(var(--marketing-text-muted))] space-y-4">
+            <p>We support a range of file types with potential to add more in the future.</p>
+            <div>
+              <strong>Images:</strong>
+              <ul className="list-disc list-inside ml-4 mt-2 space-y-1">
+                {SUPPORTED_IMAGE_FORMATS.map((format) => (
+                  <li key={format}>
+                    <code className="bg-foreground/10 px-1 py-0.5 rounded text-sm">{format}</code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div>
+              <strong>Documents:</strong>
+              <ul className="list-disc list-inside ml-4 mt-2 space-y-1">
+                {SUPPORTED_DOCUMENT_FORMATS.map((format) => (
+                  <li key={format}>
+                    <code className="bg-foreground/10 px-1 py-0.5 rounded text-sm">{format}</code>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <p>There is a 1 file limit per chat prompt with a 5MB file size limit per file.</p>
+          </div>
         </details>
 
         <details className="group">


### PR DESCRIPTION
Fixes #132

Adds the new Document and Image Upload features to the pricing matrix and FAQ section as requested.

## Changes
- Added Image Upload and Document Upload features to pricing plans
- Available for Pro and Team plans only (Free/Starter show as not included)
- Added new FAQ section about supported file types:
  - Images: .jpg, .png, .webp
  - Documents: .pdf, .doc, .docx, .txt, .rtf, .xlsx, .xls, .pptx, .ppt, .md
  - 1 file limit per chat prompt, 5MB file size limit

## Test Plan
- [x] Code formatted with Prettier
- [x] ESLint passed with no new warnings
- [x] Production build completed successfully
- [ ] Visual verification of pricing matrix on homepage
- [ ] Visual verification of pricing matrix on /pricing page
- [ ] Visual verification of new FAQ section

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated pricing plans to include "Image Upload" and "Document Upload" features, showing availability across all plan tiers.
  * Added a new FAQ entry outlining supported file types and upload limits for image and document uploads.

* **Documentation**
  * Enhanced the FAQ section with detailed information on file type support and upload restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->