### PR TITLE
feat: implement accurate token-based counting with progressive warnings

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -23,6 +23,7 @@
         "@tauri-apps/plugin-os": "^2.2.1",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.1",
+        "gpt-tokenizer": "^3.0.1",
         "lucide-react": "^0.436.0",
         "openai": "^4.56.1",
         "react": "^18.3.1",
@@ -708,6 +709,8 @@
     "goober": ["goober@2.1.16", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g=="],
 
     "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
+    "gpt-tokenizer": ["gpt-tokenizer@3.0.1", "", {}, "sha512-5jdaspBq/w4sWw322SvQj1Fku+CN4OAfYZeeEg8U7CWtxBz+zkxZ3h0YOHD43ee+nZYZ5Ud70HRN0ANcdIj4qg=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@tauri-apps/plugin-os": "^2.2.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
+    "gpt-tokenizer": "^3.0.1",
     "lucide-react": "^0.436.0",
     "openai": "^4.56.1",
     "react": "^18.3.1",

--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -7,18 +7,18 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useRef, useState, useMemo } from "react";
 import { useLocalState } from "@/state/useLocalState";
 import { cn, useIsMobile } from "@/utils/utils";
 import { useQuery } from "@tanstack/react-query";
 import { getBillingService } from "@/billing/billingService";
-import { BillingStatus } from "@/billing/billingApi";
 import { Route as ChatRoute } from "@/routes/_auth.chat.$chatId";
 import { ChatMessage } from "@/state/LocalStateContext";
 import { useNavigate, useRouter } from "@tanstack/react-router";
-import { ModelSelector, MODEL_CONFIG } from "@/components/ModelSelector";
+import { ModelSelector, MODEL_CONFIG, getModelTokenLimit } from "@/components/ModelSelector";
 import { useOpenSecret } from "@opensecret/react";
 import type { DocumentResponse } from "@opensecret/react";
+import { encode } from "gpt-tokenizer";
 
 interface ParsedDocument {
   document: {
@@ -35,30 +35,15 @@ interface ParsedDocument {
   timings: Record<string, unknown>;
 }
 
-// Rough token estimation function
+// Accurate token counting using gpt-tokenizer
 function estimateTokenCount(text: string): number {
-  // A very rough estimation: ~4 characters per token on average
-  return Math.ceil(text.length / 4);
+  // Use gpt-tokenizer for accurate token counting
+  return encode(text).length;
 }
 
-function TokenWarning({
-  messages,
-  currentInput,
-  chatId,
-  className,
-  billingStatus,
-  onCompress,
-  isCompressing = false
-}: {
-  messages: ChatMessage[];
-  currentInput: string;
-  chatId?: string;
-  className?: string;
-  billingStatus?: BillingStatus;
-  onCompress?: () => void;
-  isCompressing?: boolean;
-}) {
-  const totalTokens =
+// Calculate total tokens for messages and current input
+function calculateTotalTokens(messages: ChatMessage[], currentInput: string): number {
+  return (
     messages.reduce((acc, msg) => {
       if (typeof msg.content === "string") {
         return acc + estimateTokenCount(msg.content);
@@ -75,22 +60,48 @@ function TokenWarning({
           }, 0)
         );
       }
-    }, 0) + (currentInput ? estimateTokenCount(currentInput) : 0);
+    }, 0) + (currentInput ? estimateTokenCount(currentInput) : 0)
+  );
+}
 
+// Custom hook for debouncing values
+function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+function TokenWarning({
+  chatId,
+  className,
+  onCompress,
+  isCompressing = false,
+  tokenPercentage
+}: {
+  chatId?: string;
+  className?: string;
+  onCompress?: () => void;
+  isCompressing?: boolean;
+  tokenPercentage: number;
+}) {
   const navigate = useNavigate();
 
-  // Check if user is on starter plan
-  const isStarter = billingStatus?.product_name?.toLowerCase().includes("starter") || false;
+  // Only show warning if above 50%
+  if (tokenPercentage < 50) return null;
 
-  // Token thresholds for different plan types
-  const STARTER_WARNING_THRESHOLD = 4000;
-  const PRO_WARNING_THRESHOLD = 10000;
-
-  // Different thresholds for starter vs pro users
-  const warningThreshold = isStarter ? STARTER_WARNING_THRESHOLD : PRO_WARNING_THRESHOLD;
-
-  // Only show warning if above the threshold
-  if (totalTokens < warningThreshold) return null;
+  // Determine the severity and behavior based on percentage
+  const isAt95Percent = tokenPercentage >= 95;
+  const isAt99Percent = tokenPercentage >= 99;
 
   const handleNewChat = async (e: React.MouseEvent) => {
     e.preventDefault();
@@ -103,7 +114,17 @@ function TokenWarning({
     }
   };
 
-  // Determine button text based on compression state
+  // Get appropriate message and styling based on threshold
+  const getMessage = () => {
+    if (isAt99Percent) {
+      return "This chat is too long to continue.";
+    } else if (isAt95Percent) {
+      return "Chat is at capacity. Compress to continue.";
+    } else {
+      return "This chat is getting long. Compress it to save tokens.";
+    }
+  };
+
   const getButtonText = () => {
     if (isCompressing) {
       return { desktop: "Compressing...", mobile: "Compressing..." };
@@ -116,26 +137,46 @@ function TokenWarning({
 
   const buttonText = getButtonText();
 
+  // Determine background color based on severity
+  const bgClass = isAt99Percent
+    ? "bg-destructive/20 border border-destructive/30"
+    : isAt95Percent
+      ? "bg-warning/20 border border-warning/30"
+      : "bg-muted/50";
+
   return (
     <div
       className={cn(
         "flex items-center justify-between px-3 py-1.5 mb-1",
-        "bg-muted/50 backdrop-blur-sm rounded-t-lg",
-        "text-xs text-muted-foreground/90",
+        "backdrop-blur-sm rounded-t-lg",
+        "text-xs",
+        bgClass,
+        isAt99Percent
+          ? "text-destructive"
+          : isAt95Percent
+            ? "text-warning-foreground"
+            : "text-muted-foreground/90",
         className
       )}
     >
       <div className="flex items-center gap-2 min-w-0">
-        <span className="text-[11px] font-semibold text-foreground/70 shrink-0">Tip:</span>
-        <span className="min-w-0">This chat is getting long. Compress it to save tokens.</span>
+        <span className="text-[11px] font-semibold shrink-0">
+          {isAt99Percent ? "Error:" : isAt95Percent ? "Warning:" : "Tip:"}
+        </span>
+        <span className="min-w-0">{getMessage()}</span>
       </div>
-      {chatId && (
+      {chatId && !isAt99Percent && (
         <button
           onClick={!isCompressing ? onCompress || handleNewChat : undefined}
           disabled={isCompressing}
           className={cn(
-            "font-medium text-primary transition-colors whitespace-nowrap shrink-0 ml-4",
-            isCompressing ? "opacity-70 cursor-default" : "hover:text-primary/80 hover:underline"
+            "font-medium transition-colors whitespace-nowrap shrink-0 ml-4",
+            isCompressing ? "opacity-70 cursor-default" : "hover:underline",
+            isAt99Percent
+              ? "text-destructive"
+              : isAt95Percent
+                ? "text-warning-foreground hover:text-warning-foreground/80"
+                : "text-primary hover:text-primary/80"
           )}
         >
           <span className="hidden md:inline">{buttonText.desktop}</span>
@@ -556,6 +597,18 @@ export default function Component({
     }
   }, [systemPromptValue]);
 
+  // Debounce input for token calculations to avoid lag while typing
+  const debouncedInputValue = useDebounce(inputValue, 300);
+
+  // Calculate token usage percentage
+  const totalTokens = useMemo(
+    () => calculateTotalTokens(messages, debouncedInputValue),
+    [messages, debouncedInputValue]
+  );
+  const tokenLimit = getModelTokenLimit(model);
+  const tokenPercentage = (totalTokens / tokenLimit) * 100;
+  const isAt99Percent = tokenPercentage >= 99;
+
   // Update current input ref when input value changes
   useEffect(() => {
     currentInputRef.current = inputValue;
@@ -607,7 +660,8 @@ export default function Component({
       (!freshBillingStatus.can_chat ||
         (freshBillingStatus.chats_remaining !== null &&
           freshBillingStatus.chats_remaining <= 0))) ||
-    isStreaming;
+    isStreaming ||
+    isAt99Percent;
 
   // Disable the input box only when the user is out of chats or when streaming
   const isInputDisabled =
@@ -646,6 +700,9 @@ export default function Component({
   // No longer need token calculation or plan type check since we removed the hard limit
   // Just keeping the TokenWarning component which handles its own calculations
   const placeholderText = (() => {
+    if (isAt99Percent) {
+      return "Chat is too long to continue.";
+    }
     if (billingStatus === null || freshBillingStatus === undefined)
       return "Type your message here...";
     if (freshBillingStatus.can_chat === false) {
@@ -656,15 +713,6 @@ export default function Component({
 
   return (
     <div className="flex flex-col w-full">
-      <TokenWarning
-        messages={messages}
-        currentInput={inputValue}
-        chatId={chatId}
-        billingStatus={freshBillingStatus}
-        onCompress={onCompress}
-        isCompressing={isSummarizing}
-      />
-
       {/* Simple System Prompt Section - just a gear button and input when expanded */}
       {canEditSystemPrompt && (
         <div className="mb-2">
@@ -703,6 +751,13 @@ export default function Component({
           )}
         </div>
       )}
+
+      <TokenWarning
+        chatId={chatId}
+        onCompress={onCompress}
+        isCompressing={isSummarizing}
+        tokenPercentage={tokenPercentage}
+      />
 
       <form
         className={cn(

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -12,7 +12,7 @@ import { useEffect, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import type { Model } from "openai/resources/models.js";
 
-// Model configuration for display names and badges
+// Model configuration for display names, badges, and token limits
 type ModelCfg = {
   displayName: string;
   badge?: string;
@@ -20,29 +20,42 @@ type ModelCfg = {
   requiresPro?: boolean;
   requiresStarter?: boolean;
   supportsVision?: boolean;
+  tokenLimit: number;
 };
 
 export const MODEL_CONFIG: Record<string, ModelCfg> = {
   "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4": {
-    displayName: "Llama 3.3 70B"
+    displayName: "Llama 3.3 70B",
+    tokenLimit: 70000
   },
   "google/gemma-3-27b-it": {
     displayName: "Gemma 3 27B",
     badge: "Starter",
-    requiresStarter: true
+    requiresStarter: true,
+    tokenLimit: 70000
   },
   "leon-se/gemma-3-27b-it-fp8-dynamic": {
     displayName: "Gemma 3 27B",
     badge: "Starter",
     requiresStarter: true,
-    supportsVision: true
+    supportsVision: true,
+    tokenLimit: 70000
   },
   "deepseek-r1-70b": {
     displayName: "DeepSeek R1 70B",
     badge: "Pro",
-    requiresPro: true
+    requiresPro: true,
+    tokenLimit: 64000
   }
 };
+
+// Default token limit for unknown models
+export const DEFAULT_TOKEN_LIMIT = 64000;
+
+// Get token limit for a specific model
+export function getModelTokenLimit(modelId: string): number {
+  return MODEL_CONFIG[modelId]?.tokenLimit || DEFAULT_TOKEN_LIMIT;
+}
 
 import { ChatMessage } from "@/state/LocalStateContextDef";
 


### PR DESCRIPTION
- Replace rough token estimation (text.length/4) with accurate gpt-tokenizer library
- Add model-specific token limits (Llama/Gemma: 70k, DeepSeek: 64k, default: 64k)
- Implement progressive warning thresholds:
  - 50%: "Tip" to compress chat
  - 95%: "Warning" with compress option available
  - 99%: "Error" with disabled submit button (textarea remains editable)
- Add debouncing (300ms) for token calculations to prevent typing lag
- Optimize token calculations with useMemo to avoid unnecessary recalculations
- Extract shared calculateTotalTokens utility function
- Update UI styling for different severity levels
- Reorder TokenWarning to appear directly above chatbox

This is a reimplementation of PR #135 to resolve merge conflicts on the current master branch.

🤖 Generated with [Claude Code](https://claude.ai/code)