### PR TITLE
Ios plans disabled

### DIFF
--- a/frontend/src/billing/billingApi.ts
+++ b/frontend/src/billing/billingApi.ts
@@ -31,6 +31,7 @@ export type BillingProduct = {
   description: string;
   active: boolean;
   default_price: BillingPriceInfo;
+  is_available?: boolean;
 };
 
 export async function fetchBillingStatus(thirdPartyToken: string): Promise<BillingStatus> {
@@ -61,16 +62,17 @@ export async function fetchBillingStatus(thirdPartyToken: string): Promise<Billi
   }
 }
 
-export async function fetchProducts(): Promise<BillingProduct[]> {
+export async function fetchProducts(version?: string): Promise<BillingProduct[]> {
   try {
-    const response = await fetch(
-      `${import.meta.env.VITE_MAPLE_BILLING_API_URL}/v1/maple/products`,
-      {
-        headers: {
-          "Content-Type": "application/json"
-        }
+    const url = new URL(`${import.meta.env.VITE_MAPLE_BILLING_API_URL}/v1/maple/products`);
+    if (version) {
+      url.searchParams.append("version", version);
+    }
+    const response = await fetch(url.toString(), {
+      headers: {
+        "Content-Type": "application/json"
       }
-    );
+    });
     return response.json() as Promise<BillingProduct[]>;
   } catch (error) {
     console.error("Error fetching billing products:", error);

--- a/frontend/src/billing/billingService.ts
+++ b/frontend/src/billing/billingService.ts
@@ -87,8 +87,8 @@ class BillingService {
     return this.executeWithToken((token) => fetchPortalUrl(token));
   }
 
-  async getProducts(): Promise<BillingProduct[]> {
-    return fetchProducts();
+  async getProducts(version?: string): Promise<BillingProduct[]> {
+    return fetchProducts(version);
   }
 
   async createCheckoutSession(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated iOS payment availability date to July 21, 2025, restricting paid plan purchases in the app until then.
  * Paid plan buttons for iOS users before this date show "Not available in app" and are disabled.
  * Server-driven control added for iOS paid plan availability, dynamically adjusting button text and interactivity.
  * Product fetching now includes app version for iOS to support availability management.

* **Bug Fixes**
  * Confirmed free plans remain accessible to iOS users regardless of payment availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->