### PR TITLE
feat: add Mistral Small 3.1 24B and Qwen 2.5 72B models for Pro/Team …

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -228,7 +228,7 @@ export default function Component({
     availableModels
   } = useLocalState();
 
-  const isGemma = MODEL_CONFIG[model]?.supportsVision || false;
+  const supportsVision = MODEL_CONFIG[model]?.supportsVision || false;
   const [images, setImages] = useState<File[]>([]);
   const [imageUrls, setImageUrls] = useState<Map<File, string>>(new Map());
   const [uploadedDocument, setUploadedDocument] = useState<{
@@ -917,7 +917,7 @@ export default function Component({
                       navigate({ to: "/pricing" });
                     } else {
                       // If not on a vision model, switch to one first
-                      if (!isGemma) {
+                      if (!supportsVision) {
                         const visionModelId = findFirstVisionModel();
                         if (visionModelId) {
                           setModel(visionModelId);

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -46,6 +46,19 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     badge: "Pro",
     requiresPro: true,
     tokenLimit: 64000
+  },
+  "mistral-small-3-1-24b": {
+    displayName: "Mistral Small 3.1 24B",
+    badge: "Pro",
+    requiresPro: true,
+    supportsVision: true,
+    tokenLimit: 128000
+  },
+  "qwen2-5-72b": {
+    displayName: "Qwen 2.5 72B",
+    badge: "Pro",
+    requiresPro: true,
+    tokenLimit: 128000
   }
 };
 

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -133,6 +133,11 @@ export function ModelSelector({
               return false;
             }
 
+            // Filter out transcription models like Whisper
+            if (modelWithTasks.tasks.includes("transcribe")) {
+              return false;
+            }
+
             return true;
           });
 

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -44,6 +44,12 @@ export const PRICING_PLANS: PricingPlan[] = [
       { text: "Rename Chats", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       { text: "Gemma 3 27B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       { text: "DeepSeek R1 70B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
+      {
+        text: "Mistral Small 3.1 24B",
+        included: false,
+        icon: <X className="w-4 h-4 text-red-500" />
+      },
+      { text: "Qwen 2.5 72B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       { text: "Image Upload", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       { text: "Document Upload", included: false, icon: <X className="w-4 h-4 text-red-500" /> }
     ],
@@ -71,6 +77,12 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       { text: "DeepSeek R1 70B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
+      {
+        text: "Mistral Small 3.1 24B",
+        included: false,
+        icon: <X className="w-4 h-4 text-red-500" />
+      },
+      { text: "Qwen 2.5 72B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       { text: "Image Upload", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       { text: "Document Upload", included: false, icon: <X className="w-4 h-4 text-red-500" /> }
     ],
@@ -99,6 +111,16 @@ export const PRICING_PLANS: PricingPlan[] = [
       { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       {
         text: "DeepSeek R1 70B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Mistral Small 3.1 24B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Qwen 2.5 72B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -140,6 +162,16 @@ export const PRICING_PLANS: PricingPlan[] = [
       { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       {
         text: "DeepSeek R1 70B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Mistral Small 3.1 24B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Qwen 2.5 72B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },


### PR DESCRIPTION
…users

- Add Mistral Small 3.1 24B with vision support and 128k context window
- Add Qwen 2.5 72B with 128k context window (text-only)
- Update pricing config to show model availability across tiers
- Fix misleading isGemma variable name to supportsVision for clarity

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the "Mistral Small 3.1 24B" and "Qwen 2.5 72B" models, both available to Pro and Team plan users.
  * Updated pricing plan details to reflect the availability of these new models across all subscription tiers.
  * Excluded transcription models from the available model selection.

* **Refactor**
  * Improved clarity in model capability naming related to vision support in the chat interface.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->