### PR TITLE
fix: prevent system prompt icon layout shift with invisible placeholder

### DIFF
--- a/frontend/src/components/ChatBox.tsx
+++ b/frontend/src/components/ChatBox.tsx
@@ -717,43 +717,42 @@ export default function Component({
   return (
     <div className="flex flex-col w-full">
       {/* Simple System Prompt Section - just a gear button and input when expanded */}
-      {canEditSystemPrompt && (
-        <div className="mb-2">
-          <div className="flex items-center gap-2 mb-1">
-            <button
-              type="button"
-              onClick={() => setIsSystemPromptExpanded(!isSystemPromptExpanded)}
-              className="flex items-center gap-1.5 text-xs font-medium transition-colors text-muted-foreground hover:text-foreground cursor-pointer"
-              title="System Prompt"
-              aria-label="Toggle system prompt"
-              aria-expanded={isSystemPromptExpanded}
-            >
-              <Bot className="size-6" />
-              {systemPromptValue.trim() && (
-                <div className="size-2 bg-primary rounded-full" title="System prompt active" />
-              )}
-            </button>
-          </div>
-
-          {isSystemPromptExpanded && (
-            <textarea
-              ref={systemPromptRef}
-              value={systemPromptValue}
-              onChange={(e) => setSystemPromptValue(e.target.value)}
-              placeholder="Enter instructions for the AI (e.g., 'You are a helpful coding assistant...')"
-              rows={2}
-              className="w-full p-2 text-sm border border-muted-foreground/20 rounded-md bg-muted/50 placeholder:text-muted-foreground/70 focus:outline-none focus:ring-1 focus:ring-ring resize-none transition-colors"
-              style={{
-                height: "auto",
-                resize: "none",
-                overflowY: "auto",
-                maxHeight: "8rem",
-                minHeight: "3rem"
-              }}
-            />
-          )}
+      <div className={cn("mb-2", !canEditSystemPrompt && "invisible")}>
+        <div className="flex items-center gap-2 mb-1">
+          <button
+            type="button"
+            disabled={!canEditSystemPrompt}
+            onClick={() => setIsSystemPromptExpanded(!isSystemPromptExpanded)}
+            className="flex items-center gap-1.5 text-xs font-medium transition-colors text-muted-foreground hover:text-foreground cursor-pointer disabled:cursor-default"
+            title="System Prompt"
+            aria-label="Toggle system prompt"
+            aria-expanded={isSystemPromptExpanded}
+          >
+            <Bot className="size-6" />
+            {systemPromptValue.trim() && (
+              <div className="size-2 bg-primary rounded-full" title="System prompt active" />
+            )}
+          </button>
         </div>
-      )}
+
+        {isSystemPromptExpanded && (
+          <textarea
+            ref={systemPromptRef}
+            value={systemPromptValue}
+            onChange={(e) => setSystemPromptValue(e.target.value)}
+            placeholder="Enter instructions for the AI (e.g., 'You are a helpful coding assistant...')"
+            rows={2}
+            className="w-full p-2 text-sm border border-muted-foreground/20 rounded-md bg-muted/50 placeholder:text-muted-foreground/70 focus:outline-none focus:ring-1 focus:ring-ring resize-none transition-colors"
+            style={{
+              height: "auto",
+              resize: "none",
+              overflowY: "auto",
+              maxHeight: "8rem",
+              minHeight: "3rem"
+            }}
+          />
+        )}
+      </div>
 
       <TokenWarning
         chatId={chatId}


### PR DESCRIPTION
Fixes layout shift issue when system prompt icon loads for paid users by implementing invisible placeholder approach.

## Changes
- Always render system prompt container div to reserve space
- Use `invisible` CSS class instead of conditional rendering
- Prevent layout shift when billing status loads for paid users
- Maintain accessibility with proper button disabled state

Fixes #143

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Improved consistency of the system prompt section by always displaying the toggle button, which is now disabled and visually indicated as such when editing is not allowed.

* **User Interface**
  * The system prompt toggle button remains visible but is disabled when editing is unavailable, ensuring a more consistent user experience.
  * The system prompt container is always rendered, improving layout stability regardless of editing permissions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->