### PR TITLE
fix: iPhone app links open in external browser

### DIFF
--- a/frontend/src/components/Explainer.tsx
+++ b/frontend/src/components/Explainer.tsx
@@ -3,6 +3,7 @@ import { ArrowRight, BotIcon, LockIcon, MinusIcon, ServerIcon, SmartphoneIcon } 
 import { useEffect, useState } from "react";
 import { Loader2, CheckCircle, XCircle } from "lucide-react";
 import { useOpenSecret } from "@opensecret/react";
+import { openExternalLink } from "@/utils/externalLinks";
 
 function ArrowAndLock() {
   return (
@@ -91,20 +92,8 @@ export function InfoContent() {
       <div className="w-full pt-4 flex gap-4 items-center justify-between">
         <VerificationStatus />
         <button
-          onClick={async () => {
-            try {
-              // Use Tauri opener plugin to open external URLs in the device's default browser
-              const { invoke } = await import("@tauri-apps/api/core");
-              await invoke("plugin:opener|open_url", { url: "https://blog.trymaple.ai" });
-            } catch (error) {
-              // Fallback for non-Tauri environments (e.g., web)
-              console.warn(
-                "Failed to open URL with Tauri opener, falling back to window.open:",
-                error
-              );
-              window.open("https://blog.trymaple.ai", "_blank", "noopener,noreferrer");
-            }
-          }}
+          onClick={() => openExternalLink("https://blog.trymaple.ai")}
+          role="link"
           className="text-center hover:underline font-medium text-sm"
         >
           Learn more

--- a/frontend/src/components/Explainer.tsx
+++ b/frontend/src/components/Explainer.tsx
@@ -90,14 +90,25 @@ export function InfoContent() {
       </div>
       <div className="w-full pt-4 flex gap-4 items-center justify-between">
         <VerificationStatus />
-        <a
-          href="https://blog.trymaple.ai"
+        <button
+          onClick={async () => {
+            try {
+              // Use Tauri opener plugin to open external URLs in the device's default browser
+              const { invoke } = await import("@tauri-apps/api/core");
+              await invoke("plugin:opener|open_url", { url: "https://blog.trymaple.ai" });
+            } catch (error) {
+              // Fallback for non-Tauri environments (e.g., web)
+              console.warn(
+                "Failed to open URL with Tauri opener, falling back to window.open:",
+                error
+              );
+              window.open("https://blog.trymaple.ai", "_blank", "noopener,noreferrer");
+            }
+          }}
           className="text-center hover:underline font-medium text-sm"
-          target="_blank"
-          rel="noopener noreferrer"
         >
           Learn more
-        </a>
+        </button>
       </div>
     </>
   );

--- a/frontend/src/components/SimplifiedFooter.tsx
+++ b/frontend/src/components/SimplifiedFooter.tsx
@@ -1,23 +1,14 @@
-export function SimplifiedFooter() {
-  const handleExternalLink = async (url: string) => {
-    try {
-      // Use Tauri opener plugin to open external URLs in the device's default browser
-      const { invoke } = await import("@tauri-apps/api/core");
-      await invoke("plugin:opener|open_url", { url });
-    } catch (error) {
-      // Fallback for non-Tauri environments (e.g., web)
-      console.warn("Failed to open URL with Tauri opener, falling back to window.open:", error);
-      window.open(url, "_blank", "noopener,noreferrer");
-    }
-  };
+import { openExternalLink } from "@/utils/externalLinks";
 
+export function SimplifiedFooter() {
   return (
     <div className="w-full border-t border-[hsl(var(--marketing-card-border))] py-6 mt-auto">
       <div className="max-w-[45rem] mx-auto px-4 text-center">
         <p className="text-[hsl(var(--marketing-text-muted))]/70 text-sm">
           © {new Date().getFullYear()} Maple AI. All rights reserved. Powered by{" "}
           <button
-            onClick={() => handleExternalLink("https://opensecret.cloud")}
+            onClick={() => openExternalLink("https://opensecret.cloud")}
+            role="link"
             className="text-[hsl(var(--purple))] hover:text-[hsl(var(--purple))]/80 dark:text-[hsl(var(--blue))] dark:hover:text-[hsl(var(--blue))]/80 transition-colors underline"
           >
             OpenSecret
@@ -31,13 +22,15 @@ export function SimplifiedFooter() {
             Downloads
           </a>
           <button
-            onClick={() => handleExternalLink("https://opensecret.cloud/terms")}
+            onClick={() => openExternalLink("https://opensecret.cloud/terms")}
+            role="link"
             className="text-[hsl(var(--marketing-text-muted))] hover:text-foreground text-sm transition-colors"
           >
             Terms of Service
           </button>
           <button
-            onClick={() => handleExternalLink("https://opensecret.cloud/privacy")}
+            onClick={() => openExternalLink("https://opensecret.cloud/privacy")}
+            role="link"
             className="text-[hsl(var(--marketing-text-muted))] hover:text-foreground text-sm transition-colors"
           >
             Privacy Policy

--- a/frontend/src/components/SimplifiedFooter.tsx
+++ b/frontend/src/components/SimplifiedFooter.tsx
@@ -1,17 +1,27 @@
 export function SimplifiedFooter() {
+  const handleExternalLink = async (url: string) => {
+    try {
+      // Use Tauri opener plugin to open external URLs in the device's default browser
+      const { invoke } = await import("@tauri-apps/api/core");
+      await invoke("plugin:opener|open_url", { url });
+    } catch (error) {
+      // Fallback for non-Tauri environments (e.g., web)
+      console.warn("Failed to open URL with Tauri opener, falling back to window.open:", error);
+      window.open(url, "_blank", "noopener,noreferrer");
+    }
+  };
+
   return (
     <div className="w-full border-t border-[hsl(var(--marketing-card-border))] py-6 mt-auto">
       <div className="max-w-[45rem] mx-auto px-4 text-center">
         <p className="text-[hsl(var(--marketing-text-muted))]/70 text-sm">
           © {new Date().getFullYear()} Maple AI. All rights reserved. Powered by{" "}
-          <a
-            href="https://opensecret.cloud"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-[hsl(var(--purple))] hover:text-[hsl(var(--purple))]/80 dark:text-[hsl(var(--blue))] dark:hover:text-[hsl(var(--blue))]/80 transition-colors"
+          <button
+            onClick={() => handleExternalLink("https://opensecret.cloud")}
+            className="text-[hsl(var(--purple))] hover:text-[hsl(var(--purple))]/80 dark:text-[hsl(var(--blue))] dark:hover:text-[hsl(var(--blue))]/80 transition-colors underline"
           >
             OpenSecret
-          </a>
+          </button>
         </p>
         <div className="flex justify-center gap-6 mt-2">
           <a
@@ -20,22 +30,18 @@ export function SimplifiedFooter() {
           >
             Downloads
           </a>
-          <a
-            href="https://opensecret.cloud/terms"
-            target="_blank"
-            rel="noopener noreferrer"
+          <button
+            onClick={() => handleExternalLink("https://opensecret.cloud/terms")}
             className="text-[hsl(var(--marketing-text-muted))] hover:text-foreground text-sm transition-colors"
           >
             Terms of Service
-          </a>
-          <a
-            href="https://opensecret.cloud/privacy"
-            target="_blank"
-            rel="noopener noreferrer"
+          </button>
+          <button
+            onClick={() => handleExternalLink("https://opensecret.cloud/privacy")}
             className="text-[hsl(var(--marketing-text-muted))] hover:text-foreground text-sm transition-colors"
           >
             Privacy Policy
-          </a>
+          </button>
         </div>
       </div>
     </div>

--- a/frontend/src/utils/externalLinks.ts
+++ b/frontend/src/utils/externalLinks.ts
@@ -1,0 +1,21 @@
+/**
+ * Opens an external URL using the Tauri opener plugin when available,
+ * with fallback to window.open for web environments.
+ *
+ * @param url - The external URL to open
+ */
+export const openExternalLink = async (url: string): Promise<void> => {
+  try {
+    // Use Tauri opener plugin to open external URLs in the device's default browser
+    const { invoke } = await import("@tauri-apps/api/core");
+    await invoke("plugin:opener|open_url", { url });
+  } catch (error) {
+    // Fallback for non-Tauri environments (e.g., web)
+    console.warn("Failed to open URL with Tauri opener, falling back to window.open:", error);
+    try {
+      window.open(url, "_blank", "noopener,noreferrer");
+    } catch (windowError) {
+      console.error("Failed to open URL with window.open:", windowError);
+    }
+  }
+};

--- a/frontend/src/utils/externalLinks.ts
+++ b/frontend/src/utils/externalLinks.ts
@@ -1,16 +1,32 @@
 /**
- * Opens an external URL using the Tauri opener plugin when available,
- * with fallback to window.open for web environments.
+ * Opens an external URL using the Tauri opener plugin when running on iOS in a Tauri environment,
+ * with fallback to window.open for web environments and other platforms.
  *
  * @param url - The external URL to open
  */
 export const openExternalLink = async (url: string): Promise<void> => {
   try {
-    // Use Tauri opener plugin to open external URLs in the device's default browser
-    const { invoke } = await import("@tauri-apps/api/core");
-    await invoke("plugin:opener|open_url", { url });
+    // Check if we're in a Tauri environment first
+    const { isTauri } = await import("@tauri-apps/api/core");
+    const tauriEnv = await isTauri();
+
+    if (tauriEnv) {
+      // Check if we're on iOS
+      const { type } = await import("@tauri-apps/plugin-os");
+      const platform = await type();
+
+      if (platform === "ios") {
+        // Use Tauri opener plugin for iOS
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("plugin:opener|open_url", { url });
+        return;
+      }
+    }
+
+    // Fallback for non-iOS or non-Tauri environments
+    window.open(url, "_blank", "noopener,noreferrer");
   } catch (error) {
-    // Fallback for non-Tauri environments (e.g., web)
+    // Final fallback if everything fails
     console.warn("Failed to open URL with Tauri opener, falling back to window.open:", error);
     try {
       window.open(url, "_blank", "noopener,noreferrer");


### PR DESCRIPTION
Fixes #149

This PR fixes the broken website links at the bottom of the iPhone app that only worked with long press.

## Changes
- Replace `target="_blank"` external links with Tauri opener plugin in SimplifiedFooter.tsx
- Fix "Learn more" button in Explainer.tsx to use opener plugin
- Ensure external links open in device's default browser instead of new tabs
- Add fallback to window.open() for non-Tauri environments
- Keep Downloads link unchanged as it works correctly with internal routing

The links now work with normal tap on iPhone and open in Safari as expected!

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * External links in the Explainer and Footer sections now open via buttons that provide a consistent experience across desktop and web platforms.

* **Style**
  * Preserved original styling for external link buttons, including underlining the "OpenSecret" button in the footer.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->