### PR TITLE
fix: prevent auto-scroll when LLM finishes generating response

### DIFF
--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -327,7 +327,7 @@ function ChatComponent() {
   const isLoading = phase === "streaming";
   const isPersisting = phase === "persisting";
 
-  // Auto-scroll when new messages appear (user message or start of streaming)
+  // Auto-scroll when user messages are added or streaming starts
   const prevMessageCountRef = useRef(localChat.messages.length);
   const prevStreamingRef = useRef(false);
 
@@ -336,8 +336,22 @@ function ChatComponent() {
     const hasNewMessage = messageCount > prevMessageCountRef.current;
     const justStartedStreaming = isLoading && !prevStreamingRef.current;
 
-    if (hasNewMessage || justStartedStreaming) {
-      // Always scroll for new user messages or when streaming starts
+    // Only auto-scroll for user messages or when streaming starts
+    // Don't auto-scroll when assistant messages are added (streaming completion)
+    let shouldAutoScroll = false;
+
+    if (justStartedStreaming) {
+      // Always scroll when streaming starts
+      shouldAutoScroll = true;
+    } else if (hasNewMessage) {
+      // Only scroll for new user messages, not assistant messages
+      const latestMessage = localChat.messages[localChat.messages.length - 1];
+      if (latestMessage?.role === "user") {
+        shouldAutoScroll = true;
+      }
+    }
+
+    if (shouldAutoScroll) {
       const container = chatContainerRef.current;
       if (container) {
         requestAnimationFrame(() => {


### PR DESCRIPTION
**Summary**
- Modified auto-scroll logic to only trigger for user messages and streaming start
- Prevents auto-scroll when assistant messages are added (streaming completion)
- Preserves manual scroll-to-bottom button functionality

**Test plan**
- [ ] Test that chat does not auto-scroll when LLM finishes generating response
- [ ] Verify chat still auto-scrolls when user sends a message
- [ ] Verify chat still auto-scrolls when LLM starts responding
- [ ] Verify manual scroll-to-bottom button still works

Fixes #162

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved chat auto-scroll behavior to only trigger when a user sends a message or when streaming starts, preventing unwanted scrolling when assistant messages are added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->