### PR TITLE
feat: add OpenAI GPT-OSS 120B model support

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -53,9 +53,15 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
   },
   "deepseek-r1-0528": {
     displayName: "DeepSeek R1 0528 671B",
-    badges: ["Pro", "Beta"],
+    badges: ["Pro", "New"],
     requiresPro: true,
     tokenLimit: 130000
+  },
+  "gpt-oss-120b": {
+    displayName: "OpenAI GPT-OSS 120B",
+    badges: ["Pro", "New"],
+    requiresPro: true,
+    tokenLimit: 128000
   },
   "mistral-small-3-1-24b": {
     displayName: "Mistral Small 3.1 24B",
@@ -213,6 +219,8 @@ export function ModelSelector({
             badgeClass += " bg-gradient-to-r from-purple-500/10 to-blue-500/10 text-purple-600";
           } else if (badge === "Starter") {
             badgeClass += " bg-gradient-to-r from-green-500/10 to-emerald-500/10 text-green-600";
+          } else if (badge === "New") {
+            badgeClass += " bg-gradient-to-r from-blue-500/10 to-cyan-500/10 text-blue-600";
           } else if (badge === "Beta") {
             badgeClass += " bg-gradient-to-r from-yellow-500/10 to-orange-500/10 text-yellow-600";
           } else {

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -49,6 +49,11 @@ export const PRICING_PLANS: PricingPlan[] = [
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
       },
+      {
+        text: "OpenAI GPT-OSS 120B",
+        included: false,
+        icon: <X className="w-4 h-4 text-red-500" />
+      },
       { text: "Gemma 3 27B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       {
         text: "Mistral Small 3.1 24B",
@@ -87,6 +92,11 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-red-500" />
       },
       {
+        text: "OpenAI GPT-OSS 120B",
+        included: false,
+        icon: <X className="w-4 h-4 text-red-500" />
+      },
+      {
         text: "Mistral Small 3.1 24B",
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
@@ -119,6 +129,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       {
         text: "DeepSeek R1 0528 671B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "OpenAI GPT-OSS 120B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -170,6 +185,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       {
         text: "DeepSeek R1 0528 671B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "OpenAI GPT-OSS 120B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -230,6 +250,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       {
         text: "DeepSeek R1 0528 671B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "OpenAI GPT-OSS 120B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },


### PR DESCRIPTION
- Add OpenAI GPT-OSS 120B as a Pro tier model with 128K context
- Add "New" badge to GPT-OSS 120B and DeepSeek R1 0528 models
- Update pricing configuration to include GPT-OSS 120B in Pro, Max, and Team tiers
- Configure model without image support as per specification

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the "OpenAI GPT-OSS 120B" model, marked as "Pro" and "New", with a 128,000 token limit.
  * Updated pricing plans to display availability of "OpenAI GPT-OSS 120B"—included in Pro, Max, and Team plans, but not in Free or Starter.

* **Style**
  * Introduced a new "New" badge with a blue-to-cyan gradient and blue text for eligible models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->