### PR TITLE
fix: remove 'Model:' text from dropdown for better mobile display

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -266,7 +266,6 @@ export function ModelSelector({
   // Always show the same format, whether dropdown or not
   const modelDisplay = (
     <div className="flex items-center gap-1">
-      <span className="text-xs text-muted-foreground">Model:</span>
       <div className="text-xs font-medium">{getDisplayName(model)}</div>
     </div>
   );


### PR DESCRIPTION
- Remove redundant 'Model:' label to reduce dropdown width
- Improves UI on smaller phone screens

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Removed the "Model:" label from the model selector, displaying only the model name for a cleaner appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->