### PR TITLE
feat: Add OpenAI reasoning content support

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,12 +2,16 @@
 
 echo "Running pre-commit hook..."
 
+# Add bun to PATH
+export PATH="$HOME/.bun/bin:$PATH"
+
 # Navigate to frontend directory
 cd frontend || exit 1
 
 # Check if bun is installed
 if ! command -v bun &> /dev/null; then
     echo "Error: bun is not installed. Please install bun before committing."
+    echo "$HOME/.bun/bin/bun"
     exit 1
 fi
 


### PR DESCRIPTION
Handle OpenAI reasoning models (GPT-OSS) by capturing reasoning_text.delta events and wrapping them in <think> tags to reuse existing thinking UI.

- Capture reasoning content from chunk.reasoning_text.delta events
- Wrap reasoning in <think> tags for consistent parsing
- Combine reasoning and regular content during streaming
- Maintain existing DeepSeek thinking compatibility

Resolves #182

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat responses to display reasoning content inline, visually marked with special tags during message streaming.

* **Chores**
  * Improved pre-commit checks to better detect and report missing dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->