### PR TITLE
feat: implement default model selection based on user plan

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -12,80 +12,10 @@ import { useEffect, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import type { Model } from "openai/resources/models.js";
 import { hasAccessToModel as checkModelAccess } from "@/utils/modelDefaults";
+import { MODEL_CONFIG, DEFAULT_TOKEN_LIMIT, getModelTokenLimit } from "@/utils/modelConfig";
 
-// Model configuration for display names, badges, and token limits
-type ModelCfg = {
-  displayName: string;
-  badges?: string[];
-  disabled?: boolean;
-  requiresPro?: boolean;
-  requiresStarter?: boolean;
-  supportsVision?: boolean;
-  tokenLimit: number;
-};
-
-export const MODEL_CONFIG: Record<string, ModelCfg> = {
-  "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4": {
-    displayName: "Llama 3.3 70B",
-    tokenLimit: 70000
-  },
-  "llama3-3-70b": {
-    displayName: "Llama 3.3 70B",
-    tokenLimit: 70000
-  },
-  "google/gemma-3-27b-it": {
-    displayName: "Gemma 3 27B",
-    badges: ["Starter"],
-    requiresStarter: true,
-    tokenLimit: 70000
-  },
-  "leon-se/gemma-3-27b-it-fp8-dynamic": {
-    displayName: "Gemma 3 27B",
-    badges: ["Starter"],
-    requiresStarter: true,
-    supportsVision: true,
-    tokenLimit: 70000
-  },
-  "deepseek-r1-70b": {
-    displayName: "DeepSeek R1 70B",
-    badges: ["Pro"],
-    requiresPro: true,
-    tokenLimit: 64000
-  },
-  "deepseek-r1-0528": {
-    displayName: "DeepSeek R1 0528 671B",
-    badges: ["Pro", "New"],
-    requiresPro: true,
-    tokenLimit: 130000
-  },
-  "gpt-oss-120b": {
-    displayName: "OpenAI GPT-OSS 120B",
-    badges: ["Pro", "New"],
-    requiresPro: true,
-    tokenLimit: 128000
-  },
-  "mistral-small-3-1-24b": {
-    displayName: "Mistral Small 3.1 24B",
-    badges: ["Pro"],
-    requiresPro: true,
-    supportsVision: true,
-    tokenLimit: 128000
-  },
-  "qwen2-5-72b": {
-    displayName: "Qwen 2.5 72B",
-    badges: ["Pro"],
-    requiresPro: true,
-    tokenLimit: 128000
-  }
-};
-
-// Default token limit for unknown models
-export const DEFAULT_TOKEN_LIMIT = 64000;
-
-// Get token limit for a specific model
-export function getModelTokenLimit(modelId: string): number {
-  return MODEL_CONFIG[modelId]?.tokenLimit || DEFAULT_TOKEN_LIMIT;
-}
+// Re-export for backward compatibility
+export { MODEL_CONFIG, DEFAULT_TOKEN_LIMIT, getModelTokenLimit };
 
 import { ChatMessage } from "@/state/LocalStateContextDef";
 
@@ -177,9 +107,7 @@ export function ModelSelector({
   }, [os, setAvailableModels]);
 
   // Check if user has access to a model based on their plan
-  const hasAccessToModel = (modelId: string) => {
-    return checkModelAccess(modelId, billingStatus);
-  };
+  const hasAccessToModel = (modelId: string) => checkModelAccess(modelId, billingStatus);
 
   const getDisplayName = (modelId: string, showLock = false) => {
     const config = MODEL_CONFIG[modelId];

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -11,6 +11,7 @@ import { useOpenSecret } from "@opensecret/react";
 import { useEffect, useRef } from "react";
 import { useNavigate } from "@tanstack/react-router";
 import type { Model } from "openai/resources/models.js";
+import { hasAccessToModel as checkModelAccess } from "@/utils/modelDefaults";
 
 // Model configuration for display names, badges, and token limits
 type ModelCfg = {
@@ -177,29 +178,7 @@ export function ModelSelector({
 
   // Check if user has access to a model based on their plan
   const hasAccessToModel = (modelId: string) => {
-    const config = MODEL_CONFIG[modelId];
-
-    // If no restrictions, allow access
-    if (!config?.requiresPro && !config?.requiresStarter) return true;
-
-    const planName = billingStatus?.product_name?.toLowerCase() || "";
-
-    // Check if user is on Pro, Max, or Team plan (for requiresPro models)
-    if (config?.requiresPro) {
-      return planName.includes("pro") || planName.includes("max") || planName.includes("team");
-    }
-
-    // Check if user is on Starter, Pro, Max, or Team plan (for requiresStarter models)
-    if (config?.requiresStarter) {
-      return (
-        planName.includes("starter") ||
-        planName.includes("pro") ||
-        planName.includes("max") ||
-        planName.includes("team")
-      );
-    }
-
-    return true;
+    return checkModelAccess(modelId, billingStatus);
   };
 
   const getDisplayName = (modelId: string, showLock = false) => {

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -39,7 +39,7 @@ export type HistoryItem = {
 export type LocalState = {
   model: string;
   availableModels: OpenSecretModel[];
-  setModel: (model: string) => void;
+  setModel: (model: string) => Promise<void>;
   setAvailableModels: (models: OpenSecretModel[]) => void;
   userPrompt: string;
   systemPrompt: string | null;
@@ -75,7 +75,7 @@ export type LocalState = {
 export const LocalStateContext = createContext<LocalState>({
   model: "",
   availableModels: [],
-  setModel: () => void 0,
+  setModel: async () => void 0,
   setAvailableModels: () => void 0,
   userPrompt: "",
   systemPrompt: null,

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -75,7 +75,7 @@ export type LocalState = {
 export const LocalStateContext = createContext<LocalState>({
   model: "",
   availableModels: [],
-  setModel: async () => void 0,
+  setModel: () => Promise.resolve(),
   setAvailableModels: () => void 0,
   userPrompt: "",
   systemPrompt: null,

--- a/frontend/src/utils/modelConfig.ts
+++ b/frontend/src/utils/modelConfig.ts
@@ -1,0 +1,73 @@
+// Model configuration for display names, badges, and token limits
+type ModelCfg = {
+  displayName: string;
+  badges?: string[];
+  disabled?: boolean;
+  requiresPro?: boolean;
+  requiresStarter?: boolean;
+  supportsVision?: boolean;
+  tokenLimit: number;
+};
+
+export const MODEL_CONFIG: Record<string, ModelCfg> = {
+  "ibnzterrell/Meta-Llama-3.3-70B-Instruct-AWQ-INT4": {
+    displayName: "Llama 3.3 70B",
+    tokenLimit: 70000
+  },
+  "llama3-3-70b": {
+    displayName: "Llama 3.3 70B",
+    tokenLimit: 70000
+  },
+  "google/gemma-3-27b-it": {
+    displayName: "Gemma 3 27B",
+    badges: ["Starter"],
+    requiresStarter: true,
+    tokenLimit: 70000
+  },
+  "leon-se/gemma-3-27b-it-fp8-dynamic": {
+    displayName: "Gemma 3 27B",
+    badges: ["Starter"],
+    requiresStarter: true,
+    supportsVision: true,
+    tokenLimit: 70000
+  },
+  "deepseek-r1-70b": {
+    displayName: "DeepSeek R1 70B",
+    badges: ["Pro"],
+    requiresPro: true,
+    tokenLimit: 64000
+  },
+  "deepseek-r1-0528": {
+    displayName: "DeepSeek R1 0528 671B",
+    badges: ["Pro", "New"],
+    requiresPro: true,
+    tokenLimit: 130000
+  },
+  "gpt-oss-120b": {
+    displayName: "OpenAI GPT-OSS 120B",
+    badges: ["Pro", "New"],
+    requiresPro: true,
+    tokenLimit: 128000
+  },
+  "mistral-small-3-1-24b": {
+    displayName: "Mistral Small 3.1 24B",
+    badges: ["Pro"],
+    requiresPro: true,
+    supportsVision: true,
+    tokenLimit: 128000
+  },
+  "qwen2-5-72b": {
+    displayName: "Qwen 2.5 72B",
+    badges: ["Pro"],
+    requiresPro: true,
+    tokenLimit: 128000
+  }
+};
+
+// Default token limit for unknown models
+export const DEFAULT_TOKEN_LIMIT = 64000;
+
+// Get token limit for a specific model
+export function getModelTokenLimit(modelId: string): number {
+  return MODEL_CONFIG[modelId]?.tokenLimit || DEFAULT_TOKEN_LIMIT;
+}

--- a/frontend/src/utils/modelDefaults.ts
+++ b/frontend/src/utils/modelDefaults.ts
@@ -1,0 +1,64 @@
+import { BillingStatus } from "@/billing/billingApi";
+import { MODEL_CONFIG } from "@/components/ModelSelector";
+
+/**
+ * Determines the default model for a user based on their plan type and usage history
+ */
+export function getDefaultModelForUser(
+  billingStatus: BillingStatus | null,
+  lastUsedModel: string | null
+): string {
+  // If user has a last used model, prefer that
+  if (lastUsedModel && MODEL_CONFIG[lastUsedModel]) {
+    return lastUsedModel;
+  }
+
+  // If no billing status, assume free plan
+  if (!billingStatus) {
+    return "llama3-3-70b"; // Llama 3.3 70B for free users
+  }
+
+  const planName = billingStatus.product_name?.toLowerCase() || "";
+
+  // Pro, Max, or Team plan users get GPT-OSS 120B
+  if (planName.includes("pro") || planName.includes("max") || planName.includes("team")) {
+    return "gpt-oss-120b";
+  }
+
+  // Starter plan users get Gemma 3
+  if (planName.includes("starter")) {
+    return "google/gemma-3-27b-it";
+  }
+
+  // Free plan users get Llama 3.3 (default fallback)
+  return "llama3-3-70b";
+}
+
+/**
+ * Checks if a user has access to a specific model based on their billing status
+ */
+export function hasAccessToModel(modelId: string, billingStatus: BillingStatus | null): boolean {
+  const config = MODEL_CONFIG[modelId];
+
+  // If no restrictions, allow access
+  if (!config?.requiresPro && !config?.requiresStarter) return true;
+
+  const planName = billingStatus?.product_name?.toLowerCase() || "";
+
+  // Check if user is on Pro, Max, or Team plan (for requiresPro models)
+  if (config?.requiresPro) {
+    return planName.includes("pro") || planName.includes("max") || planName.includes("team");
+  }
+
+  // Check if user is on Starter, Pro, Max, or Team plan (for requiresStarter models)
+  if (config?.requiresStarter) {
+    return (
+      planName.includes("starter") ||
+      planName.includes("pro") ||
+      planName.includes("max") ||
+      planName.includes("team")
+    );
+  }
+
+  return true;
+}


### PR DESCRIPTION
Closes #184

Implements default model selection based on user subscription plan:

- Free plan users default to Llama 3.3 70B
- Starter plan users default to Gemma 3 27B
- Pro/Max/Team plan users default to GPT-OSS 120B
- Existing users' last used model takes priority over plan defaults
- Model selection is automatically persisted to localStorage

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model selection is now saved and restored across sessions, so your last used model is automatically reselected when you return.
  * Model selection dynamically adapts to changes in your billing status.

* **Improvements**
  * Access to models is now managed more consistently based on your billing plan.
  * Default model selection is smarter, taking into account your previous choices and current billing plan.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->