### PR TITLE
feat: remove DeepSeek R1 70B model from dropdown and pricing

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -45,12 +45,6 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     supportsVision: true,
     tokenLimit: 70000
   },
-  "deepseek-r1-70b": {
-    displayName: "DeepSeek R1 70B",
-    badges: ["Pro"],
-    requiresPro: true,
-    tokenLimit: 64000
-  },
   "deepseek-r1-0528": {
     displayName: "DeepSeek R1 0528 671B",
     badges: ["Pro", "New"],

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -43,7 +43,6 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       { text: "Rename Chats", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
       { text: "Image Upload", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
-      { text: "DeepSeek R1 70B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       {
         text: "DeepSeek R1 0528 671B",
         included: false,
@@ -85,7 +84,6 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       { text: "Gemma 3 27B", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
-      { text: "DeepSeek R1 70B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
       {
         text: "DeepSeek R1 0528 671B",
         included: false,
@@ -122,11 +120,6 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       { text: "Image Upload", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
-      {
-        text: "DeepSeek R1 70B",
-        included: true,
-        icon: <Check className="w-4 h-4 text-green-500" />
-      },
       {
         text: "DeepSeek R1 0528 671B",
         included: true,
@@ -178,11 +171,6 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       { text: "Image Upload", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
-      {
-        text: "DeepSeek R1 70B",
-        included: true,
-        icon: <Check className="w-4 h-4 text-green-500" />
-      },
       {
         text: "DeepSeek R1 0528 671B",
         included: true,
@@ -243,11 +231,6 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       { text: "Image Upload", included: true, icon: <Check className="w-4 h-4 text-green-500" /> },
-      {
-        text: "DeepSeek R1 70B",
-        included: true,
-        icon: <Check className="w-4 h-4 text-green-500" />
-      },
       {
         text: "DeepSeek R1 0528 671B",
         included: true,


### PR DESCRIPTION
Removed the smaller DeepSeek R1 70B model while keeping the larger DeepSeek R1 0528 671B model available for Pro users.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed DeepSeek R1 70B from the model selector; it now appears as Coming Soon and cannot be selected.
  * Default token limit applies if this model ID is referenced elsewhere.
* **Documentation**
  * Updated pricing plans to remove DeepSeek R1 70B from all feature lists across tiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->