### PR TITLE
feat: Make DeepSeek the default model for paying users

### DIFF
--- a/frontend/src/hooks/useChatSession.ts
+++ b/frontend/src/hooks/useChatSession.ts
@@ -1,6 +1,6 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { Chat, ChatMessage, DEFAULT_MODEL_ID } from "@/state/LocalStateContext";
+import { Chat, ChatMessage, FREE_USER_DEFAULT_MODEL_ID } from "@/state/LocalStateContext";
 import { ChatContentPart } from "@/state/LocalStateContextDef";
 import { fileToDataURL } from "@/utils/file";
 import { BillingStatus } from "@/billing/billingApi";
@@ -380,7 +380,7 @@ async function generateTitle(
 
     // Use the OpenAI API to generate a concise title - use the default model
     const stream = openai.beta.chat.completions.stream({
-      model: DEFAULT_MODEL_ID, // Use the default model instead of user selected model
+      model: FREE_USER_DEFAULT_MODEL_ID, // Use the free user default model for title generation
       messages: [
         {
           role: "system",

--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -5,7 +5,7 @@ import ChatBox from "@/components/ChatBox";
 import { useOpenAI } from "@/ai/useOpenAi";
 import { useLocalState } from "@/state/useLocalState";
 import { Markdown, stripThinkingTags } from "@/components/markdown";
-import { ChatMessage, DEFAULT_MODEL_ID } from "@/state/LocalStateContext";
+import { ChatMessage, FREE_USER_DEFAULT_MODEL_ID } from "@/state/LocalStateContext";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { useQueryClient } from "@tanstack/react-query";
 import { Button } from "@/components/ui/button";
@@ -422,7 +422,7 @@ END OF INSTRUCTIONS`;
       // 2. Stream the summary
       let summary = "";
       const stream = openai.beta.chat.completions.stream({
-        model: DEFAULT_MODEL_ID, // Use the default model instead of user selected model
+        model: FREE_USER_DEFAULT_MODEL_ID, // Use the free user default model for summarization
         messages: summarizationMessages,
         temperature: 0.3,
         max_tokens: 600,


### PR DESCRIPTION
- Free users: Continue using "llama3-3-70b" as default model
- Paid users: Now use "deepseek-r1-0528" (DeepSeek R1 0528 671B) as default
- Added getDefaultModelId() function to determine appropriate default based on billing status
- Model automatically updates when billing status changes (e.g., user upgrades)
- Preserves user choice: only updates if user is still using default models

Fixes #188

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Default AI model now adapts to your subscription: free users default to Llama 3.3 70B; paid users default to DeepSeek R1-0528.
  - The app automatically updates your default model when your billing status changes.
  - New chats and saved conversations without a selected model will use the appropriate default based on your plan.
  - Model picker now includes both default options.
  - Title generation and chat summarization align with the current default model for consistent results across the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->