### PR TITLE
fix: update Gemma models to 20k input tokens

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -36,14 +36,14 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     displayName: "Gemma 3 27B",
     badges: ["Starter"],
     requiresStarter: true,
-    tokenLimit: 70000
+    tokenLimit: 20000
   },
   "leon-se/gemma-3-27b-it-fp8-dynamic": {
     displayName: "Gemma 3 27B",
     badges: ["Starter"],
     requiresStarter: true,
     supportsVision: true,
-    tokenLimit: 70000
+    tokenLimit: 20000
   },
   "deepseek-r1-0528": {
     displayName: "DeepSeek R1 0528 671B",


### PR DESCRIPTION
Updated both Gemma 3 27B model configurations from 70,000 to 20,000 token limit to optimize performance and resource usage.

Resolves #192

Generated with [Claude Code](https://claude.ai/code)