### PR TITLE
fix: Prevent chat overwrite during loading phase

### DIFF
--- a/frontend/src/hooks/useChatSession.ts
+++ b/frontend/src/hooks/useChatSession.ts
@@ -316,7 +316,8 @@ export function useChatSession(
     currentStreamingMessage,
     appendUserMessage,
     streamAssistant,
-    streamingError
+    streamingError,
+    isPending
   };
 }
 

--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -190,7 +190,8 @@ function ChatComponent() {
     phase,
     currentStreamingMessage,
     appendUserMessage,
-    streamingError
+    streamingError,
+    isPending
   } = useChatSession(chatId, {
     getChatById,
     persistChat,
@@ -587,7 +588,7 @@ END OF INSTRUCTIONS`;
           <ChatBox
             onSubmit={sendMessage}
             messages={localChat.messages}
-            isStreaming={isLoading || isPersisting || isSummarizing}
+            isStreaming={isLoading || isPersisting || isSummarizing || isPending}
             onCompress={compressChat}
             isSummarizing={isSummarizing}
             imageConversionError={imageConversionError}


### PR DESCRIPTION
Fixes issue where users could overwrite chats while they're still loading.

## Changes
- Expose `isPending` state from useChatSession hook
- Include `isPending` in `isStreaming` prop to disable input during chat loading
- Prevents users from accidentally overwriting chats while they're still loading

Closes #198

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Chat now displays a streaming/state indicator during pending operations, providing clearer feedback while messages are loading, persisting, or summarizing.
  - Improved responsiveness of the chat UI by incorporating pending status into streaming behavior, reducing moments of ambiguity during transitions.
  - More consistent status handling ensures users see accurate progress indicators across various chat actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->