### PR TITLE
chore: bump version to 1.1.10

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "1.1.9",
+  "version": "1.1.10",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2230,7 +2230,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maple"
-version = "1.1.9"
+version = "1.1.10"
 dependencies = [
  "log",
  "once_cell",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "1.1.9"
+version = "1.1.10"
 description = "Maple AI"
 authors = ["tony@opensecret.cloud"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.9</string>
+	<string>1.1.10</string>
 	<key>CFBundleVersion</key>
-	<string>1.1.9</string>
+	<string>1.1.10</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -51,8 +51,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 1.1.9
-        CFBundleVersion: 1.1.9
+        CFBundleShortVersionString: 1.1.10
+        CFBundleVersion: 1.1.10
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "1.1.9",
+  "version": "1.1.10",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Bump version from 1.1.9 to 1.1.10 using justfile command.

Updates version across all necessary files:
- package.json
- src-tauri/tauri.conf.json
- src-tauri/Cargo.toml
- src-tauri/gen/apple/project.yml
- src-tauri/gen/apple/maple_iOS/Info.plist
- Updated Cargo.lock via cargo check

Fixes #202

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped application version to 1.1.10 across build and packaging metadata.
  * Aligned versioning for desktop and frontend distributions to ensure consistent release tagging.
  * No changes to features, behavior, or performance; this is a maintenance release.
  * Prepares the app for distribution with updated versioning while keeping configurations and dependencies unchanged.
  * No user-facing impact expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->