### PR TITLE
fix: resolve getrandom v0.2.16 compilation issues in CI/CD

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -110,7 +110,7 @@ jobs:
       - name: Install Tauri CLI
         run: |
           if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli
+            CARGO_CFG_TARGET_OS=linux cargo install tauri-cli
           else
             echo "Tauri CLI already installed"
           fi

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -127,6 +127,8 @@ jobs:
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli
+        env:
+          CARGO_CFG_TARGET_OS: linux
 
       - name: Build Tauri App (Linux)
         working-directory: ./frontend

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -43,6 +43,8 @@ jobs:
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli
+        env:
+          CARGO_CFG_TARGET_OS: darwin
 
       - name: Set up API Key
         run: |

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -44,7 +44,9 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli
         env:
-          CARGO_CFG_TARGET_OS: darwin
+          # Workaround for getrandom v0.2.16 (https://github.com/rust-random/getrandom/issues/641)
+          # cargo install builds for the host; on macOS runners target_os is "macos"
+          CARGO_CFG_TARGET_OS: macos
 
       - name: Set up API Key
         run: |

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -101,6 +101,8 @@ jobs:
 
       - name: Install Tauri CLI
         run: cargo install tauri-cli
+        env:
+          CARGO_CFG_TARGET_OS: darwin
 
       - name: Set up API Key
         run: |

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -102,7 +102,9 @@ jobs:
       - name: Install Tauri CLI
         run: cargo install tauri-cli
         env:
-          CARGO_CFG_TARGET_OS: darwin
+          # Workaround for getrandom v0.2.16 (https://github.com/rust-random/getrandom/issues/641)
+          # cargo install builds for the host; on macOS runners target_os is "macos"
+          CARGO_CFG_TARGET_OS: macos
 
       - name: Set up API Key
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
         };
         
         # Use specific rust version required by Tauri
-        rustToolchain = pkgs.rust-bin.stable."1.78.0".default.override {
+        rustToolchain = pkgs.rust-bin.stable."1.85.0".default.override {
           extensions = [ "rust-src" ];
         };
       in


### PR DESCRIPTION
- Update Rust to 1.85.0 in flake.nix to support edition2024 feature
- Add CARGO_CFG_TARGET_OS workaround for getrandom compilation:
  - Set to 'darwin' for iOS builds on macOS runners
  - Set to 'linux' for Linux builds
- Fixes build failures related to getrandom crate platform detection

This addresses the issue where getrandom v0.2.16 fails to correctly detect the target platform, causing multiple module definition errors. See: https://github.com/rust-random/getrandom/issues/641

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI build pipelines to set the appropriate target OS during Tauri CLI installation across desktop, mobile, and TestFlight workflows, improving cross‑platform build consistency and reducing install failures.
  * Upgraded the development Rust toolchain to 1.85.0, enhancing stability, performance, and compatibility for local and CI builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->