### PR TITLE
feat: add Enter key form submission to verification code input

### DIFF
--- a/frontend/src/components/VerificationModal.tsx
+++ b/frontend/src/components/VerificationModal.tsx
@@ -79,6 +79,13 @@ export function VerificationModal() {
     }
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      handleVerifyCode();
+    }
+  };
+
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent className="sm:max-w-[425px] [&>button]:hidden">
@@ -97,6 +104,7 @@ export function VerificationModal() {
                 id="verification-code"
                 value={verificationCode}
                 onChange={(e) => setVerificationCode(e.target.value)}
+                onKeyDown={handleKeyDown}
                 placeholder="Enter verification code"
               />
               <Button onClick={handleVerifyCode} disabled={isVerifying || !verificationCode.trim()}>


### PR DESCRIPTION
Added Enter key functionality to the verification code input in `VerificationModal.tsx`.

## Changes
- Added `handleKeyDown` event handler to verification code input
- Enter key now submits form via `handleVerifyCode` function
- Uses `preventDefault()` to prevent Enter from triggering resend
- Maintains existing validation logic and user experience

## Testing
The modal is used in both locations mentioned in the issue:
- Main dashboard (`/routes/index.tsx`)
- Pricing page (`/routes/pricing.tsx`)

Fixes #205

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now press Enter in the verification code input to submit the code instantly, streamlining the verification flow and reducing reliance on mouse clicks. This aligns with common form behavior and speeds up sign-in/verification for keyboard users. No visual changes or alterations to existing error handling or messaging; the update simply adds Enter-to-submit support within the verification modal for a smoother, more efficient experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->