### PR TITLE
feat: add Qwen3 Coder 480B model with 128K context

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -63,6 +63,12 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     badges: ["Pro"],
     requiresPro: true,
     tokenLimit: 128000
+  },
+  "qwen3-coder-480b": {
+    displayName: "Qwen3 Coder 480B",
+    badges: ["Pro", "New"],
+    requiresPro: true,
+    tokenLimit: 128000
   }
 };
 

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -59,7 +59,12 @@ export const PRICING_PLANS: PricingPlan[] = [
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
       },
-      { text: "Qwen 2.5 72B", included: false, icon: <X className="w-4 h-4 text-red-500" /> }
+      { text: "Qwen 2.5 72B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
+      {
+        text: "Qwen3 Coder 480B",
+        included: false,
+        icon: <X className="w-4 h-4 text-red-500" />
+      }
     ],
     ctaText: "Start Free"
   },
@@ -100,6 +105,11 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-red-500" />
       },
       { text: "Qwen 2.5 72B", included: false, icon: <X className="w-4 h-4 text-red-500" /> },
+      {
+        text: "Qwen3 Coder 480B",
+        included: false,
+        icon: <X className="w-4 h-4 text-red-500" />
+      },
       { text: "Image Upload", included: false, icon: <X className="w-4 h-4 text-red-500" /> }
     ],
     ctaText: "Start Chatting"
@@ -138,6 +148,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       {
         text: "Qwen 2.5 72B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Qwen3 Coder 480B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       }
@@ -189,6 +204,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       {
         text: "Qwen 2.5 72B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Qwen3 Coder 480B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       }
@@ -249,6 +269,11 @@ export const PRICING_PLANS: PricingPlan[] = [
       },
       {
         text: "Qwen 2.5 72B",
+        included: true,
+        icon: <Check className="w-4 h-4 text-green-500" />
+      },
+      {
+        text: "Qwen3 Coder 480B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       }


### PR DESCRIPTION
- Added to ModelSelector with Pro/Team/Max plan restrictions
- Added 'Pro' and 'New' badges to highlight the model
- Configured 128K token limit for context window
- Updated pricing page to show availability by plan tier

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Qwen3 Coder 480B model to the model selector.
  * Pro-only access with “Pro” and “New” badges displayed.
  * Supports up to 128k tokens.

* **Documentation**
  * Updated pricing page to reflect Qwen3 Coder 480B availability: included in Pro, Max, and Team plans; not included in Free and Starter.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->