### PR TITLE
Skip email verification in local development

### DIFF
--- a/frontend/src/components/VerificationModal.tsx
+++ b/frontend/src/components/VerificationModal.tsx
@@ -15,7 +15,11 @@ import { AlertDestructive } from "./AlertDestructive";
 
 export function VerificationModal() {
   const os = useOpenSecret();
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(() => {
+    if (!os.auth.user) return false;
+    // Skip email verification in local development
+    return !import.meta.env.DEV && !os.auth.user.user.email_verified;
+  });
   const [isResending, setIsResending] = useState(false);
   const [justResent, setJustResent] = useState(false);
   const [verificationCode, setVerificationCode] = useState("");

--- a/frontend/src/components/VerificationModal.tsx
+++ b/frontend/src/components/VerificationModal.tsx
@@ -31,13 +31,15 @@ export function VerificationModal() {
       setError(null);
       setJustResent(false);
     } else {
-      setIsOpen(!os.auth.user.user.email_verified);
+      // Skip email verification in local development
+      const shouldRequireVerification = !import.meta.env.DEV && !os.auth.user.user.email_verified;
+      setIsOpen(shouldRequireVerification);
     }
   }, [os.auth.user]);
 
   const handleOpenChange = (open: boolean) => {
-    // Only allow closing if the email is verified
-    if (!open && os.auth.user?.user.email_verified) {
+    // Allow closing if the email is verified or in local development
+    if (!open && (os.auth.user?.user.email_verified || import.meta.env.DEV)) {
       setIsOpen(false);
       // Reset form state when modal closes
       setVerificationCode("");


### PR DESCRIPTION
This PR addresses issue #213 by disabling email verification when running in local development mode.

## Changes
- Modified VerificationModal to skip email verification when `import.meta.env.DEV` is true
- Users can now sign up locally without needing to verify their email address
- Preserves existing email verification behavior for dev/prod environments
- Allows modal to be closed in development mode if needed

Fixes #213

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Verification modal now opens only in production for users with unverified emails, avoiding unnecessary prompts.
  * In local development the modal can be closed regardless of verification status, preventing it from blocking usage.
  * Closing the modal in production remains restricted until email is verified; form state resets when the modal closes.
  * No changes to public interfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->