### PR TITLE
Fix pre-commit hook to work from any directory

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,8 +2,9 @@
 
 echo "Running pre-commit hook..."
 
-# Navigate to frontend directory
-cd frontend || exit 1
+# Navigate to frontend directory from repo root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+cd "$REPO_ROOT/frontend" || exit 1
 
 # Check if bun is installed
 if ! command -v bun &> /dev/null; then


### PR DESCRIPTION
## Summary
- Fixed pre-commit hook failing when run from the frontend directory
- Hook now uses `git rev-parse --show-toplevel` to find repo root before navigating to frontend
- This fixes the issue where Claude in GitHub Actions fails to commit

## Problem
The pre-commit hook was failing in GitHub Actions because Claude Code starts in the `frontend/` directory (due to `working-directory: ./frontend` in a previous step). When the hook tried to `cd frontend`, it failed since there's no `frontend/frontend` subdirectory.

## Solution  
Updated the hook to always navigate from the repository root:
```bash
REPO_ROOT=$(git rev-parse --show-toplevel)
cd "$REPO_ROOT/frontend" || exit 1
```

## Test plan
- [x] Tested hook works from repo root: ✅
- [x] Tested hook works from frontend directory: ✅
- [x] All pre-commit checks pass (format, build)

Fixes #223

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of local pre-commit checks by making path resolution robust, ensuring formatting and build validations run consistently regardless of the working directory.
  * Reduces intermittent failures during commits and provides a smoother developer workflow with consistent enforcement of code style and build integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->