### PR TITLE
Skip flaky browser use tests in CI

### DIFF
--- a/.github/workflows/browseruse-tests.yml
+++ b/.github/workflows/browseruse-tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   browseruse-tests:
+    if: false  # Temporarily disabled - tests are flaky and need updates
     runs-on: ubuntu-latest
     
     steps:


### PR DESCRIPTION
## Summary
- Temporarily disables the browser use tests that are causing CI failures
- Tests are flaky and several updates behind

## Changes
Added `if: false` condition to the `browseruse-tests` job in `.github/workflows/browseruse-tests.yml`

This will completely skip the job while preserving the workflow configuration for when the tests are updated and ready to be re-enabled.

## Test plan
- [x] Workflow file updated successfully
- [x] Pre-commit hooks pass

Fixes #222

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Disabled a CI test job to prevent it from running during builds. No changes to application behavior or user experience.

- **Chores**
  - Updated CI workflow configuration to adjust test execution. This maintenance change does not affect features or performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->