### PR TITLE
feat: add email parameter to Stripe API credits purchase

### DIFF
--- a/frontend/src/billing/billingApi.ts
+++ b/frontend/src/billing/billingApi.ts
@@ -629,6 +629,7 @@ export type ApiCreditSettings = {
 
 export type PurchaseCreditsRequest = {
   credits: number;
+  email: string;
   success_url: string;
   cancel_url: string;
 };

--- a/frontend/src/components/apikeys/ApiCreditsSection.tsx
+++ b/frontend/src/components/apikeys/ApiCreditsSection.tsx
@@ -132,6 +132,7 @@ export function ApiCreditsSection({ showSuccessMessage = false }: ApiCreditsSect
       if (method === "stripe") {
         const response = await billingService.purchaseApiCredits({
           credits: finalPackage.credits,
+          email: userEmail || "",
           success_url: successUrl,
           cancel_url: cancelUrl || successUrl
         });


### PR DESCRIPTION
Pass user email to Stripe checkout for API credits purchases, matching the existing Zaprite implementation. This ensures consistent data collection across both payment methods.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Credit purchase checkout now includes an email field.
  - Your account email is automatically prefilled in Stripe checkout when available.
  - Email is sent with credit purchase requests to ensure purchases are associated with your account.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->