### PR TITLE
fix: Allow status.trymaple.ai in CSP for status badge loading

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://opensecret.cloud https://*.opensecret.cloud https://trymaple.ai https://*.trymaple.ai https://secretgpt.ai https://*.secretgpt.ai https://*.maple-ca8.pages.dev https://raw.githubusercontent.com localhost:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:"
+      "csp": "default-src 'self'; connect-src 'self' https://opensecret.cloud https://*.opensecret.cloud https://trymaple.ai https://*.trymaple.ai https://secretgpt.ai https://*.secretgpt.ai https://*.maple-ca8.pages.dev https://raw.githubusercontent.com localhost:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https://status.trymaple.ai; frame-src 'self' https://status.trymaple.ai; font-src 'self' data:"
     }
   },
   "bundle": {


### PR DESCRIPTION
Fixes #237

Adds https://status.trymaple.ai to both img-src and frame-src directives in the Content Security Policy to resolve the badge loading error in the Tauri iOS/desktop app.

## Changes

- Updated CSP in `src-tauri/tauri.conf.json` to allow status.trymaple.ai domain
- Added `frame-src 'self' https://status.trymaple.ai` for iframe embeds
- Added `https://status.trymaple.ai` to `img-src` for image badges

## Testing

✅ All linting and build checks pass

Generated with [Claude Code](https://claude.ai/code)