### PR TITLE
Xcode config changes

### DIFF
--- a/docs/troubleshooting-ios-build.md
+++ b/docs/troubleshooting-ios-build.md
@@ -10,7 +10,9 @@ clang: error: version '-sim' in target triple 'arm64-apple-ios13.0-simulator-sim
 
 This happens when the Xcode project file incorrectly lists `arm64-sim` as an architecture, causing a duplicate `-sim` suffix in the target triple.
 
-### Solution
+### Solution (ARM64 Only - Recommended for Apple Silicon Macs)
+
+This solution configures the project to only build for ARM64, which works for real devices and Apple Silicon Mac simulators. This is simpler and avoids x86_64 compatibility issues.
 
 1. **Edit the Xcode project file** (`frontend/src-tauri/gen/apple/maple.xcodeproj/project.pbxproj`):
 
@@ -21,37 +23,44 @@ This happens when the Xcode project file incorrectly lists `arm64-sim` as an arc
        "arm64-sim",
    );
    ```
-   
+
    With:
    ```
-   ARCHS = (
-       arm64,
-       x86_64,
-   );
+   ARCHS = arm64;
    ```
 
 2. **Update VALID_ARCHS**:
-   
+
    Replace:
    ```
    VALID_ARCHS = "arm64  arm64-sim";
    ```
-   
+
    With:
    ```
-   VALID_ARCHS = "arm64 x86_64";
+   VALID_ARCHS = arm64;
    ```
 
 3. **Update EXCLUDED_ARCHS**:
-   
+
    Replace:
    ```
    "EXCLUDED_ARCHS[sdk=iphoneos*]" = "arm64-sim x86_64";
    ```
-   
+
    With:
    ```
    "EXCLUDED_ARCHS[sdk=iphoneos*]" = x86_64;
+   ```
+
+   And replace:
+   ```
+   "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
+   ```
+
+   With:
+   ```
+   "EXCLUDED_ARCHS[sdk=iphonesimulator*]" = "";
    ```
 
 ### Important Notes

--- a/frontend/src-tauri/gen/apple/LaunchScreen.storyboard
+++ b/frontend/src-tauri/gen/apple/LaunchScreen.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17150" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17122"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -12,6 +12,7 @@ settingGroups:
     base:
       PRODUCT_NAME: Maple
       PRODUCT_BUNDLE_IDENTIFIER: cloud.opensecret.maple
+      DEVELOPMENT_TEAM: X773Y823TN
 targetTemplates:
   app:
     type: application
@@ -62,12 +63,11 @@ targets:
     settings:
       base:
         ENABLE_BITCODE: false
-        ARCHS: [arm64, x86_64]
-        VALID_ARCHS: arm64 x86_64
+        ARCHS: [arm64]
+        VALID_ARCHS: arm64 
         LIBRARY_SEARCH_PATHS[arch=x86_64]: $(inherited) $(PROJECT_DIR)/Externals/x86_64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
         LIBRARY_SEARCH_PATHS[arch=arm64]: $(inherited) $(PROJECT_DIR)/Externals/arm64/$(CONFIGURATION) $(SDKROOT)/usr/lib/swift $(TOOLCHAIN_DIR)/usr/lib/swift/$(PLATFORM_NAME) $(TOOLCHAIN_DIR)/usr/lib/swift-5.0/$(PLATFORM_NAME)
         ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: true
-        EXCLUDED_ARCHS[sdk=iphonesimulator*]: arm64
         EXCLUDED_ARCHS[sdk=iphoneos*]: x86_64
       groups: [app]
     dependencies:
@@ -87,4 +87,3 @@ targets:
         outputFiles:
           - $(SRCROOT)/Externals/x86_64/${CONFIGURATION}/libapp.a
           - $(SRCROOT)/Externals/arm64/${CONFIGURATION}/libapp.a
-          - $(SRCROOT)/Externals/arm64-sim/${CONFIGURATION}/libapp.a


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated iOS build troubleshooting to focus on ARM64-only configuration for Apple Silicon.
  - Renamed and expanded the Solution section with step-by-step guidance.
  - Revised example settings to use ARM64 exclusively and clarified exclusions for device and simulator targets.
  - Added an explicit replacement snippet to simplify setup.
  - Clarified that arm64-sim references denote directory names, not architectures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->