### PR TITLE
Fix markdown table rendering on mobile and desktop

### DIFF
--- a/frontend/src/chat.css
+++ b/frontend/src/chat.css
@@ -609,6 +609,7 @@
 .markdown-body table td {
   padding: 6px 13px;
   border: 1px solid var(--color-border-default);
+  white-space: nowrap;
 }
 
 .markdown-body table tr {

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -269,10 +269,16 @@ function ResponsiveTable({ children, className, ...rest }: JSX.IntrinsicElements
   const { node, inline, ...safeRest } = rest as Record<string, unknown>;
 
   return (
-    <div className="overflow-x-auto max-w-full w-0 min-w-full rounded-md border border-border/50">
-      <table className={className} {...(safeRest as object)}>
-        {children}
-      </table>
+    <div className="my-4 w-full max-w-full overflow-hidden">
+      <div className="overflow-x-auto overflow-y-hidden rounded-md border border-border/50 shadow-sm">
+        <table
+          className={className || ""}
+          style={{ width: "max-content" }}
+          {...(safeRest as object)}
+        >
+          {children}
+        </table>
+      </div>
     </div>
   );
 }

--- a/frontend/src/routes/_auth.chat.$chatId.tsx
+++ b/frontend/src/routes/_auth.chat.$chatId.tsx
@@ -102,7 +102,9 @@ function UserMessage({ message, chatId }: { message: ChatMessage; chatId: string
         <div>
           <UserIcon />
         </div>
-        <div className="flex flex-col gap-2">{renderContent(message.content, chatId)}</div>
+        <div className="flex flex-col gap-2 min-w-0 flex-1 overflow-hidden">
+          {renderContent(message.content, chatId)}
+        </div>
       </div>
     </div>
   );
@@ -295,7 +297,7 @@ function SystemMessage({
         <div>
           <AsteriskIcon />
         </div>
-        <div className="flex flex-col gap-2">
+        <div className="flex flex-col gap-2 min-w-0 flex-1 overflow-hidden">
           <Markdown content={text} loading={loading} chatId={chatId} />
           <div className="flex gap-2 items-center">
             <Button
@@ -790,7 +792,7 @@ END OF INSTRUCTIONS`;
         )}
         <div
           ref={chatContainerRef}
-          className="flex-1 min-h-0 overflow-y-auto flex flex-col relative"
+          className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden flex flex-col relative"
         >
           <div className="mt-4 md:mt-8 w-full h-10 flex items-center justify-center relative">
             {/* Mobile new chat button */}


### PR DESCRIPTION
Tables were overflowing message boundaries and getting squished on mobile. This fix ensures tables stay within container bounds with proper scrolling.

Changes:
- Add overflow constraints to message containers to prevent content breakout
- Update ResponsiveTable to maintain natural column widths with horizontal scroll
- Add white-space: nowrap to table cells to prevent text wrapping
- Add overflow-x-hidden to chat container to prevent horizontal page scroll

Tables now behave consistently with code blocks - contained within message boundaries with horizontal scrolling when content is wider than container.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Prevented text wrapping in markdown tables to avoid layout breakage.
  - Enabled horizontal scrolling for wide tables and hid unwanted horizontal overflow in chat.
  - Constrained chat message containers to prevent content overflow and clipping.

- Style
  - Refreshed table presentation with rounded borders, subtle shadow, and consistent spacing.

- Refactor
  - Reworked responsive table wrappers to separate outer spacing from inner scrollable area; no API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->