### PR TITLE
Add direct APK download link to Android section

### DIFF
--- a/frontend/src/routes/downloads.tsx
+++ b/frontend/src/routes/downloads.tsx
@@ -251,6 +251,22 @@ function DownloadPage() {
                 >
                   Join Google Play Beta
                 </a>
+                <div className="w-full border-t border-[hsl(var(--marketing-card-border))] pt-4">
+                  <p className="text-[hsl(var(--marketing-text-muted))] text-sm mb-3 text-center">
+                    Or download the APK directly:
+                  </p>
+                  <a
+                    href="https://github.com/OpenSecretCloud/Maple/releases/download/v1.99.0-android-beta1/app-universal-release.apk"
+                    className="py-2 px-4 rounded-lg text-center font-medium transition-all duration-300 block
+                    dark:bg-white/90 dark:text-black dark:hover:bg-[hsl(var(--purple))]/80 dark:hover:text-[hsl(var(--foreground))] dark:active:bg-white/80
+                    bg-background text-foreground hover:bg-[hsl(var(--purple))] hover:text-[hsl(var(--foreground))] active:bg-background/80
+                    border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Download APK (Beta)
+                  </a>
+                </div>
                 <p className="text-[hsl(var(--marketing-text-muted))] text-xs text-center">
                   Beta version - help us test new features before the official release
                 </p>


### PR DESCRIPTION
Added a direct download link for the Android APK alongside the existing Google Play Beta link, giving users an alternative installation method.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a direct APK (Beta) download option under the Android download card, including a “Download APK (Beta)” button linking to the beta APK.
  * Added an identical APK direct-download block beneath the Mobile Apps section’s Google Play Beta prompt.
  * No changes to existing flows; purely UI additions to expose a beta APK download.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->