### PR TITLE
Bump to 1.99.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "1.99.0",
+  "version": "1.99.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2722,7 +2722,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maple"
-version = "1.99.0"
+version = "1.99.1"
 dependencies = [
  "anyhow",
  "axum",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "1.99.0"
+version = "1.99.1"
 description = "Maple AI"
 authors = ["tony@opensecret.cloud"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.99.0</string>
+	<string>1.99.1</string>
 	<key>CFBundleVersion</key>
-	<string>1.99.0</string>
+	<string>1.99.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 1.99.0
-        CFBundleVersion: 1.99.0
+        CFBundleShortVersionString: 1.99.1
+        CFBundleVersion: 1.99.1
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "1.99.0",
+  "version": "1.99.1",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -68,7 +68,7 @@
       "developmentTeam": "X773Y823TN"
     },
     "android": {
-      "versionCode": 1099000001
+      "versionCode": 1099001000
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented app version to 1.99.1 for a maintenance release.
  * Updated Android build version code to support store deployment.
  * No user-facing changes or behavior modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->