### PR TITLE
Move Bitcoin toggle below pricing options

### DIFF
--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -635,21 +635,6 @@ function PricingPage() {
           </div>
         )}
 
-        <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-center">
-          <div className="inline-flex items-center gap-4 px-6 py-2.5 rounded-full bg-[hsl(var(--marketing-card))]/50 backdrop-blur-sm border border-[hsl(var(--marketing-card-border))]">
-            <div className="flex items-center gap-2 text-[hsl(var(--bitcoin))] text-base font-light">
-              <Bitcoin className="w-4.5 h-4.5" />
-              <span>Pay with Bitcoin</span>
-            </div>
-            <Switch
-              id="bitcoin-toggle"
-              checked={useBitcoin}
-              onCheckedChange={setUseBitcoin}
-              className="data-[state=checked]:bg-[hsl(var(--bitcoin))] data-[state=unchecked]:border-foreground/30 scale-100"
-            />
-          </div>
-        </div>
-
         {(() => {
           const filteredPlans = PRICING_PLANS.filter((plan) => {
             // Always hide Starter plan unless user is currently on Starter
@@ -869,6 +854,21 @@ function PricingPage() {
             </div>
           );
         })()}
+
+        <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 flex justify-center mt-8">
+          <div className="inline-flex items-center gap-4 px-6 py-2.5 rounded-full bg-[hsl(var(--marketing-card))]/50 backdrop-blur-sm border border-[hsl(var(--marketing-card-border))]">
+            <div className="flex items-center gap-2 text-[hsl(var(--bitcoin))] text-base font-light">
+              <Bitcoin className="w-4.5 h-4.5" />
+              <span>Pay with Bitcoin</span>
+            </div>
+            <Switch
+              id="bitcoin-toggle"
+              checked={useBitcoin}
+              onCheckedChange={setUseBitcoin}
+              className="data-[state=checked]:bg-[hsl(var(--bitcoin))] data-[state=unchecked]:border-foreground/30 scale-100"
+            />
+          </div>
+        </div>
 
         <PricingFAQ />
       </FullPageMain>


### PR DESCRIPTION
Fixes #267

### Changes
- Moved Bitcoin toggle from top of pricing page to between pricing plans and FAQ section
- Reduced prominence of Bitcoin payment option as requested
- Added proper spacing for visual separation

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Repositioned the Bitcoin payment toggle to appear below the pricing grid for a clearer flow.
  * Added spacing above the toggle to improve visual separation.
  * No changes to pricing display logic or checkout behavior; only the toggle’s placement and spacing were adjusted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->