### PR TITLE
Fix system prompt clearing error by using delete API for empty prompts

### DIFF
--- a/frontend/src/components/ComparisonChart.tsx
+++ b/frontend/src/components/ComparisonChart.tsx
@@ -169,13 +169,11 @@ export function ComparisonChart() {
               {/* Header Row */}
               <div
                 className="grid border-b border-[hsl(var(--marketing-card-border))]"
-                style={{ 
+                style={{
                   gridTemplateColumns: "minmax(200px, 1.5fr) repeat(6, minmax(80px, 1fr))"
                 }}
               >
-                <div className="p-3 font-medium text-foreground bg-[hsl(var(--marketing-card-highlight))]/30 text-sm">
-                  
-                </div>
+                <div className="p-3 font-medium text-foreground bg-[hsl(var(--marketing-card-highlight))]/30 text-sm"></div>
                 {products.map((product) => (
                   <div
                     key={product.key}
@@ -197,7 +195,7 @@ export function ComparisonChart() {
                   className={`grid border-b border-[hsl(var(--marketing-card-border))] ${
                     index % 2 === 0 ? "bg-[hsl(var(--marketing-card-highlight))]/20" : ""
                   }`}
-                  style={{ 
+                  style={{
                     gridTemplateColumns: "minmax(200px, 1.5fr) repeat(6, minmax(80px, 1fr))"
                   }}
                 >

--- a/frontend/src/components/PreferencesDialog.tsx
+++ b/frontend/src/components/PreferencesDialog.tsx
@@ -67,18 +67,27 @@ export function PreferencesDialog({ open, onOpenChange }: PreferencesDialogProps
     setIsSaving(true);
     try {
       if (instructionId) {
-        // Update existing instruction
-        await os.updateInstruction(instructionId, {
-          prompt: prompt
-        });
+        // If prompt is empty, delete the instruction
+        if (prompt.trim() === "") {
+          await os.deleteInstruction(instructionId);
+          setInstructionId(null);
+          setPrompt("");
+        } else {
+          // Update existing instruction
+          await os.updateInstruction(instructionId, {
+            prompt: prompt
+          });
+        }
       } else {
-        // Create new instruction
-        const newInstruction = await os.createInstruction({
-          name: "User Preferences",
-          prompt: prompt,
-          is_default: true
-        });
-        setInstructionId(newInstruction.id);
+        // Only create new instruction if prompt is not empty
+        if (prompt.trim() !== "") {
+          const newInstruction = await os.createInstruction({
+            name: "User Preferences",
+            prompt: prompt,
+            is_default: true
+          });
+          setInstructionId(newInstruction.id);
+        }
       }
       setSuccess(true);
     } catch (error) {


### PR DESCRIPTION
Resolves #270 where clearing the system prompt in User Preferences would fail. Now properly calls deleteInstruction() when prompt is empty instead of attempting to update with an empty string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preferences: Empty prompts no longer create new instructions, and clearing an existing prompt now deletes the saved instruction, keeping settings clean and accurate.

* **Refactor**
  * Minor internal cleanup in the comparison chart component with no functional or visual impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->