### PR TITLE
Fix preferences save button not resetting after successful save

### DIFF
--- a/frontend/src/components/PreferencesDialog.tsx
+++ b/frontend/src/components/PreferencesDialog.tsx
@@ -123,7 +123,11 @@ export function PreferencesDialog({ open, onOpenChange }: PreferencesDialogProps
             <Textarea
               id="prompt"
               value={prompt}
-              onChange={(e) => setPrompt(e.target.value)}
+              onChange={(e) => {
+                setPrompt(e.target.value);
+                setSuccess(false);
+                setError(null);
+              }}
               placeholder="Enter your custom system prompt here..."
               className="min-h-[200px] resize-y"
               disabled={isLoading}


### PR DESCRIPTION
Reset success and error states when user edits the system prompt textarea to allow immediate saves after a successful save operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Editing the System Prompt in Preferences now clears any prior success or error messages, preventing stale feedback while typing.
  * UI status indicators reset immediately as the prompt changes, ensuring on-screen feedback reflects the current state before saving or retrying.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->