### PR TITLE
Remove unused iOS background audio capability

### DIFF
--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -64,9 +64,5 @@
 	<string>Maple needs access to your camera to take photos for your AI conversations.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Maple needs access to your microphone to record voice messages for your AI conversations.</string>
-	<key>UIBackgroundModes</key>
-	<array>
-		<string>audio</string>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Removes the UIBackgroundModes audio capability from the iOS Info.plist since it's not being used by the app. Apple may reject apps with unused background modes, so this improves App Store compliance.