### PR TITLE
Fix: Pin tauri-cli to v2.8.0 across all CI workflows

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Install Tauri CLI
         run: |
           if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli
+            cargo install tauri-cli --version "2.8.0" --locked
           else
             echo "Tauri CLI already installed"
           fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Install Tauri CLI
         run: |
           if ! command -v cargo-tauri &> /dev/null; then
-            CARGO_CFG_TARGET_OS=linux cargo install tauri-cli
+            CARGO_CFG_TARGET_OS=linux cargo install tauri-cli --version "2.8.0" --locked
           else
             echo "Tauri CLI already installed"
           fi

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -126,7 +126,7 @@ jobs:
         run: bun install
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli
+        run: cargo install tauri-cli --version "2.8.0" --locked
         env:
           CARGO_CFG_TARGET_OS: linux
 

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -42,7 +42,7 @@ jobs:
           xcode-version: '16.4'
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli
+        run: cargo install tauri-cli --version "2.8.0" --locked
         env:
           # Workaround for getrandom v0.2.16 (https://github.com/rust-random/getrandom/issues/641)
           # cargo install builds for the host; on macOS runners target_os is "macos"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,7 +202,7 @@ jobs:
       - name: Install Tauri CLI
         run: |
           if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli
+            cargo install tauri-cli --version "2.8.0" --locked
           else
             echo "Tauri CLI already installed"
           fi

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -100,7 +100,7 @@ jobs:
           xcode-version: '16.4'
 
       - name: Install Tauri CLI
-        run: cargo install tauri-cli
+        run: cargo install tauri-cli --version "2.8.0" --locked
         env:
           # Workaround for getrandom v0.2.16 (https://github.com/rust-random/getrandom/issues/641)
           # cargo install builds for the host; on macOS runners target_os is "macos"


### PR DESCRIPTION
## Problem
The deploy-testflight workflow was failing because `cargo install tauri-cli` was installing the broken v2.9.0, which has a compilation error in tauri-bundler v2.7.0 with tauri_macos_sign::Error.

## Solution
Pin all CI workflows to use `tauri-cli v2.8.0` (the version that works locally) by adding `--version "2.8.0" --locked` to all `cargo install tauri-cli` commands.

## Workflows Updated
- testflight-on-comment.yml
- mobile-build.yml
- desktop-build.yml
- android-build.yml
- release.yml
- claude.yml

## Testing
This ensures consistent tauri-cli versions across all CI/CD pipelines and avoids the v2.9.0 compilation bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI/CD build pipelines to pin build tool dependency to a specific version with locked resolution for improved build reproducibility and stability across all platforms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->