### PR TITLE
Increase delete button hitbox in chat history list

### DIFF
--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -464,7 +464,7 @@ export function ChatHistoryList({
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
-                  className={`z-50 bg-background/80 absolute right-2 top-1/2 transform -translate-y-1/2 text-primary transition-opacity ${
+                  className={`z-50 bg-background/80 absolute right-2 top-1/2 transform -translate-y-1/2 text-primary transition-opacity p-2 ${
                     isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100"
                   }`}
                   onClick={(e) => {
@@ -541,7 +541,7 @@ export function ChatHistoryList({
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
                         <button
-                          className={`z-50 bg-background/80 absolute right-2 top-1/2 transform -translate-y-1/2 text-primary transition-opacity ${
+                          className={`z-50 bg-background/80 absolute right-2 top-1/2 transform -translate-y-1/2 text-primary transition-opacity p-2 ${
                             isMobile ? "opacity-100" : "opacity-0 group-hover:opacity-100"
                           }`}
                           onClick={(e) => {


### PR DESCRIPTION
## Summary
Increased the clickable area of the delete button in the chat history list to make it easier to click without accidentally opening the chat.

## Changes
- Added `p-2` padding to dropdown menu trigger buttons in `ChatHistoryList.tsx`
- Increases clickable area from 16px to ~32px while keeping icon size the same
- Applied to both regular and archived chat sections

Fixes #281

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Enhanced padding on dropdown action buttons in the chat history and archived chats sections for improved visual spacing and click target area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->