### PR TITLE
Add enhanced model selector with categories and thinking toggle

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -35,7 +35,8 @@ import {
   SquarePen,
   Search,
   Loader2,
-  Globe
+  Globe,
+  Brain
 } from "lucide-react";
 import RecordRTC from "recordrtc";
 import { useQueryClient } from "@tanstack/react-query";
@@ -2468,6 +2469,38 @@ export function UnifiedChat() {
                             }
                           />
 
+                          {/* Thinking toggle button - only visible when reasoning model is selected */}
+                          {(localState.model === "deepseek-r1-0528" ||
+                            localState.model === "deepseek-v31-terminus") && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0"
+                              onClick={() => {
+                                const newThinkingState = !localState.thinkingEnabled;
+                                localState.setThinkingEnabled(newThinkingState);
+                                // Switch between R1 (thinking) and V3.1 (no thinking)
+                                localState.setModel(
+                                  newThinkingState ? "deepseek-r1-0528" : "deepseek-v31-terminus"
+                                );
+                              }}
+                              aria-label={
+                                localState.thinkingEnabled
+                                  ? "Disable thinking mode"
+                                  : "Enable thinking mode"
+                              }
+                            >
+                              <Brain
+                                className={`h-4 w-4 ${
+                                  localState.thinkingEnabled
+                                    ? "text-purple-500"
+                                    : "text-muted-foreground"
+                                }`}
+                              />
+                            </Button>
+                          )}
+
                           {/* Attachment dropdown */}
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
@@ -2674,6 +2707,38 @@ export function UnifiedChat() {
                             )
                           }
                         />
+
+                        {/* Thinking toggle button - only visible when reasoning model is selected */}
+                        {(localState.model === "deepseek-r1-0528" ||
+                          localState.model === "deepseek-v31-terminus") && (
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="sm"
+                            className="h-8 w-8 p-0"
+                            onClick={() => {
+                              const newThinkingState = !localState.thinkingEnabled;
+                              localState.setThinkingEnabled(newThinkingState);
+                              // Switch between R1 (thinking) and V3.1 (no thinking)
+                              localState.setModel(
+                                newThinkingState ? "deepseek-r1-0528" : "deepseek-v31-terminus"
+                              );
+                            }}
+                            aria-label={
+                              localState.thinkingEnabled
+                                ? "Disable thinking mode"
+                                : "Enable thinking mode"
+                            }
+                          >
+                            <Brain
+                              className={`h-4 w-4 ${
+                                localState.thinkingEnabled
+                                  ? "text-purple-500"
+                                  : "text-muted-foreground"
+                              }`}
+                            />
+                          </Button>
+                        )}
 
                         {/* Attachment dropdown */}
                         <DropdownMenu>

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -40,6 +40,7 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
       })(),
     availableModels: [llamaModel] as OpenSecretModel[],
     hasWhisperModel: true, // Default to true to avoid hiding button during loading
+    thinkingEnabled: false, // Default to reasoning without thinking (V3.1)
     billingStatus: null as BillingStatus | null,
     searchQuery: "",
     isSearchVisible: false,
@@ -296,6 +297,10 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
     setLocalState((prev) => ({ ...prev, hasWhisperModel: hasWhisper }));
   }
 
+  function setThinkingEnabled(enabled: boolean) {
+    setLocalState((prev) => ({ ...prev, thinkingEnabled: enabled }));
+  }
+
   return (
     <LocalStateContext.Provider
       value={{
@@ -305,6 +310,8 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
         setAvailableModels,
         hasWhisperModel: localState.hasWhisperModel,
         setHasWhisperModel,
+        thinkingEnabled: localState.thinkingEnabled,
+        setThinkingEnabled,
         userPrompt: localState.userPrompt,
         systemPrompt: localState.systemPrompt,
         userImages: localState.userImages,

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -31,6 +31,9 @@ export type LocalState = {
   /** Whether the whisper transcription model is available */
   hasWhisperModel: boolean;
   setHasWhisperModel: (hasWhisper: boolean) => void;
+  /** Whether thinking mode is enabled for reasoning models */
+  thinkingEnabled: boolean;
+  setThinkingEnabled: (enabled: boolean) => void;
   userPrompt: string;
   systemPrompt: string | null;
   userImages: File[];
@@ -71,6 +74,8 @@ export const LocalStateContext = createContext<LocalState>({
   setAvailableModels: () => void 0,
   hasWhisperModel: true,
   setHasWhisperModel: () => void 0,
+  thinkingEnabled: false,
+  setThinkingEnabled: () => void 0,
   userPrompt: "",
   systemPrompt: null,
   userImages: [],


### PR DESCRIPTION
## Changes
- Add category-based model selection (Free, Quick, Reasoning, Math/Coding)
- Add thinking toggle for DeepSeek reasoning models (R1 and V3.1 Terminus)
- Implement sliding menu UI with advanced model view
- Add icons and descriptions for better user experience
- Sync thinking state with model selection

## UI Improvements
- Simplified model selection with intuitive categories
- Brain icon toggle for reasoning models to control thinking output
- Smooth sliding animation between category and advanced views
- Better visual hierarchy with icons (Sparkles, Zap, Brain, Code)

## Technical Details
- Added `thinkingEnabled` state to LocalStateContext
- Updated ModelSelector to support category-based selection
- Added thinking toggle button in UnifiedChat for reasoning models
- Maintains backward compatibility with advanced model selection

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Reorganized model selector into a categorized two-panel UI (Free, Quick, Reasoning, Math/Coding, Advanced) with icons, badges, dynamic trigger label, an Advanced "All Models" panel, sorting that favors vision-capable models, lock indicators, and upgrade prompts.
  * Added a visible thinking-mode toggle in the chat UI (available in two locations) with accessible labels and visual state, synced with reasoning-capable models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->