### PR TITLE
Fix RPM download link to match actual Tauri-generated filename

### DIFF
--- a/frontend/src/routes/downloads.tsx
+++ b/frontend/src/routes/downloads.tsx
@@ -25,7 +25,7 @@ const FALLBACK_URLS: DownloadUrls = {
   macOS: `${FALLBACK_BASE_URL}/Maple_${FALLBACK_VERSION}_universal.dmg`,
   linuxAppImage: `${FALLBACK_BASE_URL}/Maple_${FALLBACK_VERSION}_amd64.AppImage`,
   linuxDeb: `${FALLBACK_BASE_URL}/Maple_${FALLBACK_VERSION}_amd64.deb`,
-  linuxRpm: `${FALLBACK_BASE_URL}/Maple-${FALLBACK_VERSION}-1.x86_64.rpm`,
+  linuxRpm: `${FALLBACK_BASE_URL}/Maple_${FALLBACK_VERSION}_x86_64.rpm`,
   androidApk: `${FALLBACK_BASE_URL}/app-universal-release.apk`
 };
 

--- a/frontend/src/utils/githubRelease.ts
+++ b/frontend/src/utils/githubRelease.ts
@@ -71,7 +71,7 @@ export async function getLatestDownloadInfo(): Promise<DownloadInfo | null> {
       macOS: `${baseDownloadUrl}/Maple_${version}_universal.dmg`,
       linuxAppImage: `${baseDownloadUrl}/Maple_${version}_amd64.AppImage`,
       linuxDeb: `${baseDownloadUrl}/Maple_${version}_amd64.deb`,
-      linuxRpm: `${baseDownloadUrl}/Maple-${version}-1.x86_64.rpm`,
+      linuxRpm: `${baseDownloadUrl}/Maple_${version}_x86_64.rpm`,
       androidApk: `${baseDownloadUrl}/app-universal-release.apk`
     },
     releaseUrl: release.html_url


### PR DESCRIPTION
Fixes the RPM download link on the downloads page to match the actual filename generated by Tauri.

## Changes
- Updated RPM filename pattern from `Maple-{version}-1.x86_64.rpm` to `Maple_{version}_x86_64.rpm`
- Fixed both fallback URL in downloads page and dynamic URL generation

## Why
The GitHub Actions release workflow uses `assetNamePattern: '[name]_[version]_[arch].[ext]'` which generates filenames with underscores, not dashes. The `-1` suffix was from an older Tauri version.

Fixes #303

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected Linux RPM download URL format to ensure proper package retrieval and installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->