### PR TITLE
WIP: Add Lingo i18n support (BREAKING)

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -29,6 +29,7 @@
         "clsx": "^2.1.1",
         "gpt-tokenizer": "^3.0.1",
         "katex": "^0.16.25",
+        "lingo.dev": "^0.114.5",
         "lucide-react": "^0.436.0",
         "openai": "5.20.0",
         "react": "^18.3.1",
@@ -77,9 +78,31 @@
     "mdast-util-gfm-autolink-literal": "2.0.0",
   },
   "packages": {
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@1.2.12", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-YSzjlko7JvuiyQFmI9RN1tNZdEiZxc+6xld/0tq/VkJaHpEzGAb1yiNxxvmYVcjvfu/PcvCxAAYXmTYQQ63IHQ=="],
+
+    "@ai-sdk/google": ["@ai-sdk/google@1.2.22", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-Ppxu3DIieF1G9pyQ5O1Z646GYR0gkC57YdBqXJ82qvCdhEhZHu0TWhmnOoeIWe2olSbuDeoOY+MfJrW8dzS3Hw=="],
+
+    "@ai-sdk/groq": ["@ai-sdk/groq@1.2.9", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-7MoDaxm8yWtiRbD1LipYZG0kBl+Xe0sv/EeyxnHnGPZappXdlgtdOgTZVjjXkT3nWP30jjZi9A45zoVrBMb3Xg=="],
+
+    "@ai-sdk/mistral": ["@ai-sdk/mistral@1.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-lv857D9UJqCVxiq2Fcu7mSPTypEHBUqLl1K+lCaP6X/7QAkcaxI36QDONG+tOhGHJOXTsS114u8lrUTaEiGXbg=="],
+
+    "@ai-sdk/openai": ["@ai-sdk/openai@1.3.24", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "zod": "^3.0.0" } }, "sha512-GYXnGJTHRTZc4gJMSmFRgEQudjqd4PUN0ZjQhPwOAYH1yOAvQoG/Ikqs+HyISRbLPCrhbZnPKCNHuRU4OfpW0Q=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@1.1.3", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-qZMxYJ0qqX/RfnuIaab+zp8UAeJn/ygXXAffR5I4N0n1IrvA6qBsjc8hXLmBiMV2zoXlifkacF7sEFnYnjBcqg=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@2.2.8", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "nanoid": "^3.3.8", "secure-json-parse": "^2.7.0" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-fqhG+4sCVv8x7nFzYnFo19ryhAa3w096Kmc3hWxMQfW/TubPOmt3A6tYZhl4mUfQWWQMsuSkLrtjlWuXBVSGQA=="],
+
+    "@ai-sdk/react": ["@ai-sdk/react@1.2.12", "", { "dependencies": { "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/ui-utils": "1.2.11", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["zod"] }, "sha512-jK1IZZ22evPZoQW3vlkZ7wvjYGYF+tRBKXtrcolduIkQ/m/sOAVcVeVDUDvh1T91xCnWCdUGCPZg2avZ90mv3g=="],
+
+    "@ai-sdk/ui-utils": ["@ai-sdk/ui-utils@1.2.11", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "zod": "^3.23.8" } }, "sha512-3zcwCc8ezzFlwp3ZD15wAPjf2Au4s3vAbKsXQVyhxODHcmu0iyPO2Eua6D/vicq/AUm/BAo60r97O6HU+EI0+w=="],
+
+    "@alcalzone/ansi-tokenize": ["@alcalzone/ansi-tokenize@0.1.3", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@asamuzakjp/css-color": ["@asamuzakjp/css-color@3.2.0", "", { "dependencies": { "@csstools/css-calc": "^2.1.3", "@csstools/css-color-parser": "^3.0.9", "@csstools/css-parser-algorithms": "^3.0.4", "@csstools/css-tokenizer": "^3.0.3", "lru-cache": "^10.4.3" } }, "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.26.2", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.25.9", "js-tokens": "^4.0.0", "picocolors": "^1.0.0" } }, "sha512-RJlIHRueQgwWitWgF8OdFYGZX328Ax5BCemNGlqHfplnRT9ESi8JkFlvaVYbS+UubVY6dpv87Fs2u5M29iNFVQ=="],
 
@@ -87,9 +110,11 @@
 
     "@babel/core": ["@babel/core@7.26.9", "", { "dependencies": { "@ampproject/remapping": "^2.2.0", "@babel/code-frame": "^7.26.2", "@babel/generator": "^7.26.9", "@babel/helper-compilation-targets": "^7.26.5", "@babel/helper-module-transforms": "^7.26.0", "@babel/helpers": "^7.26.9", "@babel/parser": "^7.26.9", "@babel/template": "^7.26.9", "@babel/traverse": "^7.26.9", "@babel/types": "^7.26.9", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-lWBYIrF7qK5+GjY5Uy+/hEgp8OJWOD/rpy74GplYRhEauvbHDeFB8t5hPOZxCZ0Oxf4Cc36tK51/l3ymJysrKw=="],
 
-    "@babel/generator": ["@babel/generator@7.26.9", "", { "dependencies": { "@babel/parser": "^7.26.9", "@babel/types": "^7.26.9", "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25", "jsesc": "^3.0.2" } }, "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg=="],
+    "@babel/generator": ["@babel/generator@7.28.5", "", { "dependencies": { "@babel/parser": "^7.28.5", "@babel/types": "^7.28.5", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ=="],
 
     "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.26.5", "", { "dependencies": { "@babel/compat-data": "^7.26.5", "@babel/helper-validator-option": "^7.25.9", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
 
     "@babel/helper-module-imports": ["@babel/helper-module-imports@7.25.9", "", { "dependencies": { "@babel/traverse": "^7.25.9", "@babel/types": "^7.25.9" } }, "sha512-tnUA4RsrmflIM6W6RFTLFSXITtl0wKjgpnLgXyowocVPrbYrLUXSBXDgTs8BlbmIzIdlBySRQjINYs2BAkiLtw=="],
 
@@ -105,7 +130,7 @@
 
     "@babel/helpers": ["@babel/helpers@7.26.9", "", { "dependencies": { "@babel/template": "^7.26.9", "@babel/types": "^7.26.9" } }, "sha512-Mz/4+y8udxBKdmzt/UjPACs4G3j5SshJJEFFKxlCGPydG4JAHXxjWjAwjd09tf6oINvl1VfMJo+nB7H2YKQ0dA=="],
 
-    "@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+    "@babel/parser": ["@babel/parser@7.28.5", "", { "dependencies": { "@babel/types": "^7.28.5" }, "bin": "./bin/babel-parser.js" }, "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ=="],
 
     "@babel/plugin-syntax-jsx": ["@babel/plugin-syntax-jsx@7.25.9", "", { "dependencies": { "@babel/helper-plugin-utils": "^7.25.9" }, "peerDependencies": { "@babel/core": "^7.0.0-0" } }, "sha512-ld6oezHQMZsZfp6pWtbjaNDF2tiiCYYDqQszHt5VV437lewP9aSi2Of99CK0D0XB21k7FLgnLcmQKyKzynfeAA=="],
 
@@ -120,6 +145,30 @@
     "@babel/traverse": ["@babel/traverse@7.26.9", "", { "dependencies": { "@babel/code-frame": "^7.26.2", "@babel/generator": "^7.26.9", "@babel/parser": "^7.26.9", "@babel/template": "^7.26.9", "@babel/types": "^7.26.9", "debug": "^4.3.1", "globals": "^11.1.0" } }, "sha512-ZYW7L+pL8ahU5fXmNbPF+iZFHCv5scFak7MZ9bwaRPLUhHh7QQEMjZUg0HevihoqCM5iSYHN61EyCoZvqC+bxg=="],
 
     "@babel/types": ["@babel/types@7.26.9", "", { "dependencies": { "@babel/helper-string-parser": "^7.25.9", "@babel/helper-validator-identifier": "^7.25.9" } }, "sha512-Y3IR1cRnOxOCDvMmNiym7XpXQ93iGDDPHx+Zj+NM+rg0fBaShfQLkg+hKPaZCEvg5N/LeCo4+Rj/i3FuJsIQaw=="],
+
+    "@biomejs/js-api": ["@biomejs/js-api@3.0.0", "", { "peerDependencies": { "@biomejs/wasm-bundler": "^2.2.0", "@biomejs/wasm-nodejs": "^2.2.0", "@biomejs/wasm-web": "^2.2.0" }, "optionalPeers": ["@biomejs/wasm-bundler", "@biomejs/wasm-nodejs", "@biomejs/wasm-web"] }, "sha512-5QcGJFj9IO+yXl76ICjvkdE38uxRcTDsBzcCZHEZ+ma+Te/nbvJg4A3KtAds9HCrEF0JKLWiyjMhAbqazuJvYA=="],
+
+    "@biomejs/wasm-nodejs": ["@biomejs/wasm-nodejs@2.3.5", "", {}, "sha512-oEryO1M/vq0iUPxgDMPIJIqGmcLcwn/en9DYLBAaBMSzm1pu0ArnJ3nWpBUjoh977oelyZHKILzNiu0dCNCi0g=="],
+
+    "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
+
+    "@csstools/color-helpers": ["@csstools/color-helpers@5.1.0", "", {}, "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA=="],
+
+    "@csstools/css-calc": ["@csstools/css-calc@2.1.4", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ=="],
+
+    "@csstools/css-color-parser": ["@csstools/css-color-parser@3.1.0", "", { "dependencies": { "@csstools/color-helpers": "^5.1.0", "@csstools/css-calc": "^2.1.4" }, "peerDependencies": { "@csstools/css-parser-algorithms": "^3.0.5", "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA=="],
+
+    "@csstools/css-parser-algorithms": ["@csstools/css-parser-algorithms@3.0.5", "", { "peerDependencies": { "@csstools/css-tokenizer": "^3.0.4" } }, "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ=="],
+
+    "@csstools/css-tokenizer": ["@csstools/css-tokenizer@3.0.4", "", {}, "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw=="],
+
+    "@datocms/cma-client": ["@datocms/cma-client@4.0.2", "", { "dependencies": { "@datocms/rest-client-utils": "^4.0.2", "uuid": "^9.0.1" } }, "sha512-AhtI7hGZxjHcScE+Wkk01BFgkiL+tNft0oMDyuKlVEKF0zRCqRHipwf8lwfO5zQP4XFQ6Qn4Fh/B8oF30q/BIA=="],
+
+    "@datocms/cma-client-node": ["@datocms/cma-client-node@4.0.2", "", { "dependencies": { "@datocms/cma-client": "^4.0.2", "@datocms/rest-client-utils": "^4.0.2", "mime-types": "^2.1.35", "tmp-promise": "^3.0.3" } }, "sha512-tiduimUbtH28Uc5gcBZu5QriMXdjb1vnw60hp6n5CKicVDQTm7703W3yp0fVWyDCW4gKLS66rfKzAobPn9zgyA=="],
+
+    "@datocms/rest-client-utils": ["@datocms/rest-client-utils@4.0.2", "", { "dependencies": { "async-scheduler": "^1.4.4" } }, "sha512-aKg8bl9mHebWSnBgX1f3Y9hGkX0b+fHlEmhTvZ2JqzrVcu7RZjEWe612RFpyuTISv3hgIRbgmcE7KDfJe/WnfA=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.7.0", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-oAYoQnCYaQZKVS53Fq23ceWMRxq5EhQsE0x0RdQ55jT7wagMu5k+fS39v1fiSLrtrLQlXwVINenqhLMtTrV/1Q=="],
 
     "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
 
@@ -193,6 +242,12 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
 
+    "@gitbeaker/core": ["@gitbeaker/core@39.34.3", "", { "dependencies": { "@gitbeaker/requester-utils": "^39.34.3", "qs": "^6.11.2", "xcase": "^2.0.1" } }, "sha512-/3qBXme2MjO38QU2F/MYGon9a4wHKrgtwNzdHHdjpbYJ2/wOGNgbEWSZcibcFkiWVgAjbPXdYqC5sY8hcwGO1w=="],
+
+    "@gitbeaker/requester-utils": ["@gitbeaker/requester-utils@39.34.3", "", { "dependencies": { "picomatch-browser": "^2.2.6", "qs": "^6.11.2", "rate-limiter-flexible": "^4.0.0", "xcase": "^2.0.1" } }, "sha512-nMnTkTo4UixHPwPYsYIjp8UdKrmSw3TjvRESexliAeNNq4/LVeyVUyRqBUa1ZI8MXt1nPPnPX3wh8s7rqlm7uA=="],
+
+    "@gitbeaker/rest": ["@gitbeaker/rest@39.34.3", "", { "dependencies": { "@gitbeaker/core": "^39.34.3", "@gitbeaker/requester-utils": "^39.34.3" } }, "sha512-SuceThS6WhJtqNNcKmW8j0yUU7aXA4k5a29OWcd6bn7peQ3MXlIpbfvLLRnmuUaYUuxHLnUzZhAfuxaNf4DVtQ=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
@@ -200,6 +255,78 @@
     "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
 
     "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.1", "", {}, "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.0.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.0.4" }, "os": "darwin", "cpu": "x64" }, "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.0.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.0.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.0.5", "", { "os": "linux", "cpu": "arm" }, "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.0.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.0.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.0.4", "", { "os": "linux", "cpu": "x64" }, "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.0.5" }, "os": "linux", "cpu": "arm" }, "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.0.4" }, "os": "linux", "cpu": "s390x" }, "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.0.4" }, "os": "linux", "cpu": "arm64" }, "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.33.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.0.4" }, "os": "linux", "cpu": "x64" }, "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.33.5", "", { "dependencies": { "@emnapi/runtime": "^1.2.0" }, "cpu": "none" }, "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.33.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.33.5", "", { "os": "win32", "cpu": "x64" }, "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg=="],
+
+    "@inkjs/ui": ["@inkjs/ui@2.0.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-spinners": "^3.0.0", "deepmerge": "^4.3.1", "figures": "^6.1.0" }, "peerDependencies": { "ink": ">=5" } }, "sha512-5+8fJmwtF9UvikzLfph9sA+LS+l37Ij/szQltkuXLOAXwNkBX9innfzh4pLGXIB59vKEQUtc6D4qGvhD7h3pAg=="],
+
+    "@inquirer/ansi": ["@inquirer/ansi@1.0.2", "", {}, "sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ=="],
+
+    "@inquirer/checkbox": ["@inquirer/checkbox@4.3.1", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.1", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-rOcLotrptYIy59SGQhKlU0xBg1vvcVl2FdPIEclUvKHh0wo12OfGkId/01PIMJ/V+EimJ77t085YabgnQHBa5A=="],
+
+    "@inquirer/confirm": ["@inquirer/confirm@5.1.20", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-HDGiWh2tyRZa0M1ZnEIUCQro25gW/mN8ODByicQrbR1yHx4hT+IOpozCMi5TgBtUdklLwRI2mv14eNpftDluEw=="],
+
+    "@inquirer/core": ["@inquirer/core@10.3.1", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "cli-width": "^4.1.0", "mute-stream": "^3.0.0", "signal-exit": "^4.1.0", "wrap-ansi": "^6.2.0", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-hzGKIkfomGFPgxKmnKEKeA+uCYBqC+TKtRx5LgyHRCrF6S2MliwRIjp3sUaWwVzMp7ZXVs8elB0Tfe682Rpg4w=="],
+
+    "@inquirer/editor": ["@inquirer/editor@4.2.22", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/external-editor": "^1.0.3", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-8yYZ9TCbBKoBkzHtVNMF6PV1RJEUvMlhvmS3GxH4UvXMEHlS45jFyqFy0DU+K42jBs5slOaA78xGqqqWAx3u6A=="],
+
+    "@inquirer/expand": ["@inquirer/expand@4.0.22", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-9XOjCjvioLjwlq4S4yXzhvBmAXj5tG+jvva0uqedEsQ9VD8kZ+YT7ap23i0bIXOtow+di4+u3i6u26nDqEfY4Q=="],
+
+    "@inquirer/external-editor": ["@inquirer/external-editor@1.0.3", "", { "dependencies": { "chardet": "^2.1.1", "iconv-lite": "^0.7.0" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-RWbSrDiYmO4LbejWY7ttpxczuwQyZLBUyygsA9Nsv95hpzUWwnNTVQmAq3xuh7vNwCp07UTmE5i11XAEExx4RA=="],
+
+    "@inquirer/figures": ["@inquirer/figures@1.0.15", "", {}, "sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g=="],
+
+    "@inquirer/input": ["@inquirer/input@4.3.0", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-h4fgse5zeGsBSW3cRQqu9a99OXRdRsNCvHoBqVmz40cjYjYFzcfwD0KA96BHIPlT7rZw0IpiefQIqXrjbzjS4Q=="],
+
+    "@inquirer/number": ["@inquirer/number@3.0.22", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-oAdMJXz++fX58HsIEYmvuf5EdE8CfBHHXjoi9cTcQzgFoHGZE+8+Y3P38MlaRMeBvAVnkWtAxMUF6urL2zYsbg=="],
+
+    "@inquirer/password": ["@inquirer/password@4.0.22", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.1", "@inquirer/type": "^3.0.10" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-CbdqK1ioIr0Y3akx03k/+Twf+KSlHjn05hBL+rmubMll7PsDTGH0R4vfFkr+XrkB0FOHrjIwVP9crt49dgt+1g=="],
+
+    "@inquirer/prompts": ["@inquirer/prompts@7.10.0", "", { "dependencies": { "@inquirer/checkbox": "^4.3.1", "@inquirer/confirm": "^5.1.20", "@inquirer/editor": "^4.2.22", "@inquirer/expand": "^4.0.22", "@inquirer/input": "^4.3.0", "@inquirer/number": "^3.0.22", "@inquirer/password": "^4.0.22", "@inquirer/rawlist": "^4.1.10", "@inquirer/search": "^3.2.1", "@inquirer/select": "^4.4.1" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-X2HAjY9BClfFkJ2RP3iIiFxlct5JJVdaYYXhA7RKxsbc9KL+VbId79PSoUGH/OLS011NFbHHDMDcBKUj3T89+Q=="],
+
+    "@inquirer/rawlist": ["@inquirer/rawlist@4.1.10", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-Du4uidsgTMkoH5izgpfyauTL/ItVHOLsVdcY+wGeoGaG56BV+/JfmyoQGniyhegrDzXpfn3D+LFHaxMDRygcAw=="],
+
+    "@inquirer/search": ["@inquirer/search@3.2.1", "", { "dependencies": { "@inquirer/core": "^10.3.1", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-cKiuUvETublmTmaOneEermfG2tI9ABpb7fW/LqzZAnSv4ZaJnbEis05lOkiBuYX5hNdnX0Q9ryOQyrNidb55WA=="],
+
+    "@inquirer/select": ["@inquirer/select@4.4.1", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.1", "@inquirer/figures": "^1.0.15", "@inquirer/type": "^3.0.10", "yoctocolors-cjs": "^2.1.3" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-E9hbLU4XsNe2SAOSsFrtYtYQDVi1mfbqJrPDvXKnGlnRiApBdWMJz7r3J2Ff38AqULkPUD3XjQMD4492TymD7Q=="],
+
+    "@inquirer/type": ["@inquirer/type@3.0.10", "", { "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA=="],
 
     "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
 
@@ -211,7 +338,39 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lingo.dev/_compiler": ["@lingo.dev/_compiler@0.7.15", "", { "dependencies": { "@ai-sdk/google": "^1.2.19", "@ai-sdk/groq": "^1.2.3", "@ai-sdk/mistral": "^1.2.8", "@babel/generator": "^7.26.5", "@babel/parser": "^7.26.7", "@babel/traverse": "^7.27.4", "@babel/types": "^7.26.7", "@lingo.dev/_sdk": "0.12.6", "@lingo.dev/_spec": "0.41.1", "@openrouter/ai-sdk-provider": "^0.7.1", "@prettier/sync": "^0.6.1", "ai": "^4.2.10", "dedent": "^1.6.0", "dotenv": "^16.4.5", "fast-xml-parser": "^5.0.8", "ini": "^5.0.0", "lodash": "^4.17.21", "node-machine-id": "^1.1.12", "object-hash": "^3.0.0", "ollama-ai-provider": "^1.2.0", "posthog-node": "^5.5.1", "prettier": "^3.4.2", "unplugin": "^2.1.2", "zod": "^3.25.76" } }, "sha512-z4jOjEcScHs6Xny5Yj5RT62jsV4GRRMhKyP/zfk+DZRSyAcQkKrkDdL0Vk3hN9FIp/fUwUbW9L703sV5qSROqQ=="],
+
+    "@lingo.dev/_locales": ["@lingo.dev/_locales@0.1.0", "", {}, "sha512-t23Ugk+xDi0kdzy6KPJtcszz+3FD8ScBi5t/oru5KswMaw7Kpub9/95PeP3hcoKfMxL5lObFYcqPI8w5YOuZ+g=="],
+
+    "@lingo.dev/_react": ["@lingo.dev/_react@0.5.0", "", { "dependencies": { "js-cookie": "^3.0.5", "lodash": "^4.17.21" }, "peerDependencies": { "next": "15.2.4" } }, "sha512-s25v0XMTML/Dh5mBgt1CXwahEm9r3Z9b9hCxx1LG4QhW+UjqCKh9cTWyvyoYAVtJCzArKIEIZUFzBiZorDWG0g=="],
+
+    "@lingo.dev/_sdk": ["@lingo.dev/_sdk@0.12.6", "", { "dependencies": { "@lingo.dev/_spec": "0.41.1", "@paralleldrive/cuid2": "^2.2.2", "jsdom": "^25.0.1", "zod": "^3.25.76" } }, "sha512-gqojh46mxUkMwUgp3hjGzBnBEpYyPL9dipCYI7nmw3Fcx8qSzdXdyuz0iK5TVJh7Sl78ikwdQduORQMV8ZaX8g=="],
+
+    "@lingo.dev/_spec": ["@lingo.dev/_spec@0.41.1", "", { "dependencies": { "zod": "^3.25.76", "zod-to-json-schema": "^3.24.5" } }, "sha512-9SFJiSftjgnAKKXMN0n24wZBskvGDEop49qxRXPUtkSiCrukQGzjINeliZgdvMQFuDqszuF/G838pxn1BOrb2w=="],
+
+    "@markdoc/markdoc": ["@markdoc/markdoc@0.5.4", "", { "optionalDependencies": { "@types/linkify-it": "^3.0.1", "@types/markdown-it": "12.2.3" }, "peerDependencies": { "@types/react": "*", "react": "*" }, "optionalPeers": ["@types/react", "react"] }, "sha512-36YFNlqFk//gVNGm5xZaTWVwbAVF2AOmVjf1tiUrS6tCoD/YSkVy2E3CkAfhc5MlKcjparL/QFHCopxL4zRyaQ=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.21.1", "", { "dependencies": { "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.0.1", "express-rate-limit": "^7.5.0", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.23.8", "zod-to-json-schema": "^3.24.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-UyLFcJLDvUuZbGnaQqXFT32CpPpGj7VS19roLut6gkQVhb439xUzYWbsUvdI3ZPL+2hnFosuugtYWE0Mcs1rmQ=="],
+
+    "@next/env": ["@next/env@15.2.4", "", {}, "sha512-+SFtMgoiYP3WoSswuNmxJOCwi06TdWE733D+WPjpXIe4LXGULwEaofiiAy6kbS0+XjM5xF5n3lKuBwN2SnqD9g=="],
+
+    "@next/swc-darwin-arm64": ["@next/swc-darwin-arm64@15.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-1AnMfs655ipJEDC/FHkSr0r3lXBgpqKo4K1kiwfUf3iE68rDFXZ1TtHdMvf7D0hMItgDZ7Vuq3JgNMbt/+3bYw=="],
+
+    "@next/swc-darwin-x64": ["@next/swc-darwin-x64@15.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-3qK2zb5EwCwxnO2HeO+TRqCubeI/NgCe+kL5dTJlPldV/uwCnUgC7VbEzgmxbfrkbjehL4H9BPztWOEtsoMwew=="],
+
+    "@next/swc-linux-arm64-gnu": ["@next/swc-linux-arm64-gnu@15.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-HFN6GKUcrTWvem8AZN7tT95zPb0GUGv9v0d0iyuTb303vbXkkbHDp/DxufB04jNVD+IN9yHy7y/6Mqq0h0YVaQ=="],
+
+    "@next/swc-linux-arm64-musl": ["@next/swc-linux-arm64-musl@15.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-Oioa0SORWLwi35/kVB8aCk5Uq+5/ZIumMK1kJV+jSdazFm2NzPDztsefzdmzzpx5oGCJ6FkUC7vkaUseNTStNA=="],
+
+    "@next/swc-linux-x64-gnu": ["@next/swc-linux-x64-gnu@15.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-yb5WTRaHdkgOqFOZiu6rHV1fAEK0flVpaIN2HB6kxHVSy/dIajWbThS7qON3W9/SNOH2JWkVCyulgGYekMePuw=="],
+
+    "@next/swc-linux-x64-musl": ["@next/swc-linux-x64-musl@15.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-Dcdv/ix6srhkM25fgXiyOieFUkz+fOYkHlydWCtB0xMST6X9XYI3yPDKBZt1xuhOytONsIFJFB08xXYsxUwJLw=="],
+
+    "@next/swc-win32-arm64-msvc": ["@next/swc-win32-arm64-msvc@15.2.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-dW0i7eukvDxtIhCYkMrZNQfNicPDExt2jPb9AZPpL7cfyUo7QSNl1DjsHjmmKp6qNAqUESyT8YFl/Aw91cNJJg=="],
+
+    "@next/swc-win32-x64-msvc": ["@next/swc-win32-x64-msvc@15.2.4", "", { "os": "win32", "cpu": "x64" }, "sha512-SbnWkJmkS7Xl3kre8SdMF6F/XDh1DTFEhp0jRTj/uB8iPKoU2bb2NDfcu+iifv1+mxQEd1g2vvSxcZbXSKyWiQ=="],
 
     "@noble/curves": ["@noble/curves@1.8.1", "", { "dependencies": { "@noble/hashes": "1.7.1" } }, "sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ=="],
 
@@ -223,7 +382,63 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@octokit/app": ["@octokit/app@15.1.6", "", { "dependencies": { "@octokit/auth-app": "^7.2.1", "@octokit/auth-unauthenticated": "^6.1.3", "@octokit/core": "^6.1.5", "@octokit/oauth-app": "^7.1.6", "@octokit/plugin-paginate-rest": "^12.0.0", "@octokit/types": "^14.0.0", "@octokit/webhooks": "^13.6.1" } }, "sha512-WELCamoCJo9SN0lf3SWZccf68CF0sBNPQuLYmZ/n87p5qvBJDe9aBtr5dHkh7T9nxWZ608pizwsUbypSzZAiUw=="],
+
+    "@octokit/auth-app": ["@octokit/auth-app@7.2.2", "", { "dependencies": { "@octokit/auth-oauth-app": "^8.1.4", "@octokit/auth-oauth-user": "^5.1.4", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "toad-cache": "^3.7.0", "universal-github-app-jwt": "^2.2.0", "universal-user-agent": "^7.0.0" } }, "sha512-p6hJtEyQDCJEPN9ijjhEC/kpFHMHN4Gca9r+8S0S8EJi7NaWftaEmexjxxpT1DFBeJpN4u/5RE22ArnyypupJw=="],
+
+    "@octokit/auth-oauth-app": ["@octokit/auth-oauth-app@8.1.4", "", { "dependencies": { "@octokit/auth-oauth-device": "^7.1.5", "@octokit/auth-oauth-user": "^5.1.4", "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-71iBa5SflSXcclk/OL3lJzdt4iFs56OJdpBGEBl1wULp7C58uiswZLV6TdRaiAzHP1LT8ezpbHlKuxADb+4NkQ=="],
+
+    "@octokit/auth-oauth-device": ["@octokit/auth-oauth-device@7.1.5", "", { "dependencies": { "@octokit/oauth-methods": "^5.1.5", "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-lR00+k7+N6xeECj0JuXeULQ2TSBB/zjTAmNF2+vyGPDEFx1dgk1hTDmL13MjbSmzusuAmuJD8Pu39rjp9jH6yw=="],
+
+    "@octokit/auth-oauth-user": ["@octokit/auth-oauth-user@5.1.6", "", { "dependencies": { "@octokit/auth-oauth-device": "^7.1.5", "@octokit/oauth-methods": "^5.1.5", "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-/R8vgeoulp7rJs+wfJ2LtXEVC7pjQTIqDab7wPKwVG6+2v/lUnCOub6vaHmysQBbb45FknM3tbHW8TOVqYHxCw=="],
+
+    "@octokit/auth-token": ["@octokit/auth-token@5.1.2", "", {}, "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw=="],
+
+    "@octokit/auth-unauthenticated": ["@octokit/auth-unauthenticated@6.1.3", "", { "dependencies": { "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0" } }, "sha512-d5gWJla3WdSl1yjbfMpET+hUSFCE15qM0KVSB0H1shyuJihf/RL1KqWoZMIaonHvlNojkL9XtLFp8QeLe+1iwA=="],
+
+    "@octokit/core": ["@octokit/core@6.1.6", "", { "dependencies": { "@octokit/auth-token": "^5.0.0", "@octokit/graphql": "^8.2.2", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "before-after-hook": "^3.0.2", "universal-user-agent": "^7.0.0" } }, "sha512-kIU8SLQkYWGp3pVKiYzA5OSaNF5EE03P/R8zEmmrG6XwOg5oBjXyQVVIauQ0dgau4zYhpZEhJrvIYt6oM+zZZA=="],
+
+    "@octokit/endpoint": ["@octokit/endpoint@10.1.4", "", { "dependencies": { "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-OlYOlZIsfEVZm5HCSR8aSg02T2lbUWOsCQoPKfTXJwDzcHQBrVBGdGXb89dv2Kw2ToZaRtudp8O3ZIYoaOjKlA=="],
+
+    "@octokit/graphql": ["@octokit/graphql@8.2.2", "", { "dependencies": { "@octokit/request": "^9.2.3", "@octokit/types": "^14.0.0", "universal-user-agent": "^7.0.0" } }, "sha512-Yi8hcoqsrXGdt0yObxbebHXFOiUA+2v3n53epuOg1QUgOB6c4XzvisBNVXJSl8RYA5KrDuSL2yq9Qmqe5N0ryA=="],
+
+    "@octokit/oauth-app": ["@octokit/oauth-app@7.1.6", "", { "dependencies": { "@octokit/auth-oauth-app": "^8.1.3", "@octokit/auth-oauth-user": "^5.1.3", "@octokit/auth-unauthenticated": "^6.1.2", "@octokit/core": "^6.1.4", "@octokit/oauth-authorization-url": "^7.1.1", "@octokit/oauth-methods": "^5.1.4", "@types/aws-lambda": "^8.10.83", "universal-user-agent": "^7.0.0" } }, "sha512-OMcMzY2WFARg80oJNFwWbY51TBUfLH4JGTy119cqiDawSFXSIBujxmpXiKbGWQlvfn0CxE6f7/+c6+Kr5hI2YA=="],
+
+    "@octokit/oauth-authorization-url": ["@octokit/oauth-authorization-url@7.1.1", "", {}, "sha512-ooXV8GBSabSWyhLUowlMIVd9l1s2nsOGQdlP2SQ4LnkEsGXzeCvbSbCPdZThXhEFzleGPwbapT0Sb+YhXRyjCA=="],
+
+    "@octokit/oauth-methods": ["@octokit/oauth-methods@5.1.5", "", { "dependencies": { "@octokit/oauth-authorization-url": "^7.0.0", "@octokit/request": "^9.2.3", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0" } }, "sha512-Ev7K8bkYrYLhoOSZGVAGsLEscZQyq7XQONCBBAl2JdMg7IT3PQn/y8P0KjloPoYpI5UylqYrLeUcScaYWXwDvw=="],
+
+    "@octokit/openapi-types": ["@octokit/openapi-types@25.1.0", "", {}, "sha512-idsIggNXUKkk0+BExUn1dQ92sfysJrje03Q0bv0e+KPLrvyqZF8MnBpFz8UNfYDwB3Ie7Z0TByjWfzxt7vseaA=="],
+
+    "@octokit/openapi-webhooks-types": ["@octokit/openapi-webhooks-types@11.0.0", "", {}, "sha512-ZBzCFj98v3SuRM7oBas6BHZMJRadlnDoeFfvm1olVxZnYeU6Vh97FhPxyS5aLh5pN51GYv2I51l/hVUAVkGBlA=="],
+
+    "@octokit/plugin-paginate-graphql": ["@octokit/plugin-paginate-graphql@5.2.4", "", { "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-pLZES1jWaOynXKHOqdnwZ5ULeVR6tVVCMm+AUbp0htdcyXDU95WbkYdU4R2ej1wKj5Tu94Mee2Ne0PjPO9cCyA=="],
+
+    "@octokit/plugin-paginate-rest": ["@octokit/plugin-paginate-rest@12.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-MPd6WK1VtZ52lFrgZ0R2FlaoiWllzgqFHaSZxvp72NmoDeZ0m8GeJdg4oB6ctqMTYyrnDYp592Xma21mrgiyDA=="],
+
+    "@octokit/plugin-rest-endpoint-methods": ["@octokit/plugin-rest-endpoint-methods@14.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-iQt6ovem4b7zZYZQtdv+PwgbL5VPq37th1m2x2TdkgimIDJpsi2A6Q/OI/23i/hR6z5mL0EgisNR4dcbmckSZQ=="],
+
+    "@octokit/plugin-retry": ["@octokit/plugin-retry@7.2.1", "", { "dependencies": { "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": ">=6" } }, "sha512-wUc3gv0D6vNHpGxSaR3FlqJpTXGWgqmk607N9L3LvPL4QjaxDgX/1nY2mGpT37Khn+nlIXdljczkRnNdTTV3/A=="],
+
+    "@octokit/plugin-throttling": ["@octokit/plugin-throttling@10.0.0", "", { "dependencies": { "@octokit/types": "^14.0.0", "bottleneck": "^2.15.3" }, "peerDependencies": { "@octokit/core": "^6.1.3" } }, "sha512-Kuq5/qs0DVYTHZuBAzCZStCzo2nKvVRo/TDNhCcpC2TKiOGz/DisXMCvjt3/b5kr6SCI1Y8eeeJTHBxxpFvZEg=="],
+
+    "@octokit/request": ["@octokit/request@9.2.4", "", { "dependencies": { "@octokit/endpoint": "^10.1.4", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "fast-content-type-parse": "^2.0.0", "universal-user-agent": "^7.0.2" } }, "sha512-q8ybdytBmxa6KogWlNa818r0k1wlqzNC+yNkcQDECHvQo8Vmstrg18JwqJHdJdUiHD2sjlwBgSm9kHkOKe2iyA=="],
+
+    "@octokit/request-error": ["@octokit/request-error@6.1.8", "", { "dependencies": { "@octokit/types": "^14.0.0" } }, "sha512-WEi/R0Jmq+IJKydWlKDmryPcmdYSVjL3ekaiEL1L9eo1sUnqMJ+grqmC9cjk7CA7+b2/T397tO5d8YLOH3qYpQ=="],
+
+    "@octokit/types": ["@octokit/types@14.1.0", "", { "dependencies": { "@octokit/openapi-types": "^25.1.0" } }, "sha512-1y6DgTy8Jomcpu33N+p5w58l6xyt55Ar2I91RPiIA0xCJBXyUAhXCcmZaDWSANiha7R9a6qJJ2CRomGPZ6f46g=="],
+
+    "@octokit/webhooks": ["@octokit/webhooks@13.9.1", "", { "dependencies": { "@octokit/openapi-webhooks-types": "11.0.0", "@octokit/request-error": "^6.1.7", "@octokit/webhooks-methods": "^5.1.1" } }, "sha512-Nss2b4Jyn4wB3EAqAPJypGuCJFalz/ZujKBQQ5934To7Xw9xjf4hkr/EAByxQY7hp7MKd790bWGz7XYSTsHmaw=="],
+
+    "@octokit/webhooks-methods": ["@octokit/webhooks-methods@5.1.1", "", {}, "sha512-NGlEHZDseJTCj8TMMFehzwa9g7On4KJMPVHDSrHxCQumL6uSQR8wIkP/qesv52fXqV1BPf4pTxwtS31ldAt9Xg=="],
+
+    "@openrouter/ai-sdk-provider": ["@openrouter/ai-sdk-provider@0.7.5", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8" }, "peerDependencies": { "ai": "^4.3.17", "zod": "^3.25.34" } }, "sha512-zm8vBhQ+GhxN03Y41xviB0nDa20uN77QnMXsIwDeJPqsul8+KycrYFxY4ulXpumeKxjKyOhfyA7a7CJpcYq2ng=="],
+
     "@opensecret/react": ["@opensecret/react@1.5.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-fcN4IYvlom1e2pdGeMSmQ572V4fOALn/0AshyIut0EZjfgMU7camxi1JjXX7lJtgSUyW3Nys7Kiej3wo5sXIwQ=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
+    "@paralleldrive/cuid2": ["@paralleldrive/cuid2@2.3.1", "", { "dependencies": { "@noble/hashes": "^1.1.5" } }, "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 
@@ -248,6 +463,10 @@
     "@peculiar/x509": ["@peculiar/x509@1.12.3", "", { "dependencies": { "@peculiar/asn1-cms": "^2.3.13", "@peculiar/asn1-csr": "^2.3.13", "@peculiar/asn1-ecc": "^2.3.14", "@peculiar/asn1-pkcs9": "^2.3.13", "@peculiar/asn1-rsa": "^2.3.13", "@peculiar/asn1-schema": "^2.3.13", "@peculiar/asn1-x509": "^2.3.13", "pvtsutils": "^1.3.5", "reflect-metadata": "^0.2.2", "tslib": "^2.7.0", "tsyringe": "^4.8.0" } }, "sha512-+Mzq+W7cNEKfkNZzyLl6A6ffqc3r21HGZUezgfKxpZrkORfOqgRXnS80Zu0IV6a9Ue9QBJeKD7kN0iWfc3bhRQ=="],
 
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@posthog/core": ["@posthog/core@1.5.2", "", { "dependencies": { "cross-spawn": "^7.0.6" } }, "sha512-iedUP3EnOPPxTA2VaIrsrd29lSZnUV+ZrMnvY56timRVeZAXoYCkmjfIs3KBAsF8OUT5h1GXLSkoQdrV0r31OQ=="],
+
+    "@prettier/sync": ["@prettier/sync@0.6.1", "", { "dependencies": { "make-synchronized": "^0.8.0" }, "peerDependencies": { "prettier": "*" } }, "sha512-yF9G8vK/LYUTF3Cijd7VC9La3b20F20/J/fgoR4H0B8JGOWnZVZX6+I6+vODPosjmMcpdlUV+gUqJQZp3kLOcw=="],
 
     "@radix-ui/number": ["@radix-ui/number@1.1.0", "", {}, "sha512-V3gRzhVNU1ldS5XhAPTom1fOIo4ccrjjJgmE+LI2h/WaFpHmx0MQApT+KZHnx8abG6Avtfcz4WoEciMnpFT3HQ=="],
 
@@ -385,6 +604,10 @@
 
     "@stablelib/wipe": ["@stablelib/wipe@2.0.1", "", {}, "sha512-1eU2K9EgOcV4qc9jcP6G72xxZxEm5PfeI5H55l08W95b4oRJaqhmlWRc4xZAm6IVSKhVNxMi66V67hCzzuMTAg=="],
 
+    "@swc/counter": ["@swc/counter@0.1.3", "", {}, "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ=="],
+
+    "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
+
     "@tanstack/history": ["@tanstack/history@1.99.13", "", {}, "sha512-JMd7USmnp8zV8BRGIjALqzPxazvKtQ7PGXQC7n39HpbqdsmfV2ePCzieO84IvN+mwsTrXErpbjI4BfKCa+ZNCg=="],
 
     "@tanstack/query-core": ["@tanstack/query-core@5.66.4", "", {}, "sha512-skM/gzNX4shPkqmdTCSoHtJAPMTtmIJNS0hE+xwTTUVYwezArCT34NMermABmBVUg5Ls5aiUXEDXfqwR1oVkcA=="],
@@ -445,6 +668,8 @@
 
     "@tauri-apps/plugin-os": ["@tauri-apps/plugin-os@2.3.2", "", { "dependencies": { "@tauri-apps/api": "^2.8.0" } }, "sha512-n+nXWeuSeF9wcEsSPmRnBEGrRgOy6jjkSU+UVCOV8YUGKb2erhDOxis7IqRXiRVHhY8XMKks00BJ0OAdkpf6+A=="],
 
+    "@types/aws-lambda": ["@types/aws-lambda@8.10.157", "", {}, "sha512-ofjcRCO1N7tMZDSO11u5bFHPDfUFD3Q9YK9g4S4w8UDKuG3CNlw2lNK1sd3Itdo7JORygZmG4h9ZykS8dlXvMA=="],
+
     "@types/babel__core": ["@types/babel__core@7.20.5", "", { "dependencies": { "@babel/parser": "^7.20.7", "@babel/types": "^7.20.7", "@types/babel__generator": "*", "@types/babel__template": "*", "@types/babel__traverse": "*" } }, "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA=="],
 
     "@types/babel__generator": ["@types/babel__generator@7.6.8", "", { "dependencies": { "@babel/types": "^7.0.0" } }, "sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw=="],
@@ -457,6 +682,10 @@
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
+    "@types/diff-match-patch": ["@types/diff-match-patch@1.0.36", "", {}, "sha512-xFdR6tkm0MWvBfO8xXCSsinYxHcqkQUlcHeSpMC2ukzOb6lwQAfDmW+Qt0AvlGd8HpsS28qKsB+oPeJn9I39jg=="],
+
+    "@types/ejs": ["@types/ejs@3.1.5", "", {}, "sha512-nv+GSx77ZtXiJzwKdsASqi+YQ5Z7vwHsTP0JY2SiQgjGckkBRKZnk8nIM+7oUZ1VCtuTz0+By4qVR7fqzp/Dfg=="],
+
     "@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
     "@types/estree-jsx": ["@types/estree-jsx@1.0.5", "", { "dependencies": { "@types/estree": "*" } }, "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg=="],
@@ -467,7 +696,13 @@
 
     "@types/katex": ["@types/katex@0.16.7", "", {}, "sha512-HMwFiRujE5PjrgwHQ25+bsLJgowjGjm5Z8FVSf0N6PwgJrwxH0QxzHYDcKsTfV3wva0vzrpqMTJS2jXPr5BMEQ=="],
 
+    "@types/linkify-it": ["@types/linkify-it@3.0.5", "", {}, "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw=="],
+
+    "@types/markdown-it": ["@types/markdown-it@12.2.3", "", { "dependencies": { "@types/linkify-it": "*", "@types/mdurl": "*" } }, "sha512-GKMHFfv3458yYy+v/N8gjufHO6MSZKCOXpZc5GXIWWy8uldwfmPn98vp81gZ5f9SVw8YYBctgfJ22a2d7AOMeQ=="],
+
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
+
+    "@types/mdurl": ["@types/mdurl@2.0.0", "", {}, "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
 
@@ -480,6 +715,8 @@
     "@types/react-dom": ["@types/react-dom@18.3.5", "", { "peerDependencies": { "@types/react": "^18.0.0" } }, "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q=="],
 
     "@types/recordrtc": ["@types/recordrtc@5.6.14", "", {}, "sha512-Reiy1sl11xP0r6w8DW3iQjc1BgXFyNC7aDuutysIjpFoqyftbQps9xPA2FoBkfVXpJM61betgYPNt+v65zvMhA=="],
+
+    "@types/tinycolor2": ["@types/tinycolor2@1.4.6", "", {}, "sha512-iEN8J0BoMnsWBqjVbWH/c0G0Hh7O21lpR2/+PrvAVgWdzL7eexIFm4JN/Wn10PTcmNdtS6U67r499mlWMXOxNw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
@@ -507,11 +744,25 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.3.4", "", { "dependencies": { "@babel/core": "^7.26.0", "@babel/plugin-transform-react-jsx-self": "^7.25.9", "@babel/plugin-transform-react-jsx-source": "^7.25.9", "@types/babel__core": "^7.20.5", "react-refresh": "^0.14.2" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0" } }, "sha512-SCCPBJtYLdE8PX/7ZQAs1QAZ8Jqwih+0VBLum1EGqmCCQal+MIUqLCzj3ZUy8ufbC0cAM4LRlSTm7IQJwWT4ug=="],
 
+    "@xmldom/xmldom": ["@xmldom/xmldom@0.8.11", "", {}, "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
+
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
+    "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
+
+    "ai": ["ai@4.3.19", "", { "dependencies": { "@ai-sdk/provider": "1.1.3", "@ai-sdk/provider-utils": "2.2.8", "@ai-sdk/react": "1.2.12", "@ai-sdk/ui-utils": "1.2.11", "@opentelemetry/api": "1.9.0", "jsondiffpatch": "0.6.0" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "zod": "^3.23.8" }, "optionalPeers": ["react"] }, "sha512-dIE2bfNpqHN3r6IINp9znguYdhIOheKW2LDigAMrgt/upT3B8eBGPSCblENvaZGoq+hxaN9fSMzjWpbqloP+7Q=="],
+
     "ajv": ["ajv@6.12.6", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
+
+    "ansi-escapes": ["ansi-escapes@6.2.1", "", {}, "sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
@@ -531,6 +782,14 @@
 
     "asn1js": ["asn1js@3.0.5", "", { "dependencies": { "pvtsutils": "^1.3.2", "pvutils": "^1.1.3", "tslib": "^2.4.0" } }, "sha512-FVnvrKJwpt9LP2lAMl8qZswRNm3T4q9CON+bxldk2iwk3FFpuwhx2FfinyitizWHsVYyaY+y5JzDR0rCMV5yTQ=="],
 
+    "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
+
+    "async-scheduler": ["async-scheduler@1.4.4", "", {}, "sha512-KVWlF6WKlUGJA8FOJYVVk7xDm3PxITWXp9hTeDsXMtUPvItQ2x6g2rIeNAa0TtAiiWvHJqhyA3wo+pj0rA7Ldg=="],
+
+    "asynckit": ["asynckit@0.4.0", "", {}, "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="],
+
+    "auto-bind": ["auto-bind@5.0.1", "", {}, "sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg=="],
+
     "autoprefixer": ["autoprefixer@10.4.20", "", { "dependencies": { "browserslist": "^4.23.3", "caniuse-lite": "^1.0.30001646", "fraction.js": "^4.3.7", "normalize-range": "^0.1.2", "picocolors": "^1.0.1", "postcss-value-parser": "^4.2.0" }, "peerDependencies": { "postcss": "^8.1.0" }, "bin": { "autoprefixer": "bin/autoprefixer" } }, "sha512-XY25y5xSv/wEoqzDyXXME4AFfkZI0P23z6Fs3YgymDnKJkCGOnkL0iTxCa85UTqaSgfcqyf3UA6+c7wUvx/16g=="],
 
     "babel-dead-code-elimination": ["babel-dead-code-elimination@1.0.9", "", { "dependencies": { "@babel/core": "^7.23.7", "@babel/parser": "^7.23.6", "@babel/traverse": "^7.23.7", "@babel/types": "^7.23.6" } }, "sha512-JLIhax/xullfInZjtu13UJjaLHDeTzt3vOeomaSUdO/nAMEL/pWC/laKrSvWylXMnVWyL5bpmG9njqBZlUQOdg=="],
@@ -539,7 +798,19 @@
 
     "balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
 
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
+
+    "before-after-hook": ["before-after-hook@2.2.3", "", {}, "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ=="],
+
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
+
+    "bitbucket": ["bitbucket@2.12.0", "", { "dependencies": { "before-after-hook": "^2.1.0", "deepmerge": "^4.2.2", "is-plain-object": "^3.0.0", "node-fetch": "^2.6.0", "url-template": "^2.0.8" } }, "sha512-YqaiTPEmn5mkwdU2gGcJZcQ6B8/DhCHhc3SSYqSpnef6nSTTSa/2GSBoLEgPLqAuqrQITGKq8MgYkfDMtnJPuw=="],
+
+    "blacklist": ["blacklist@1.1.4", "", {}, "sha512-DWdfwimA1WQxVC69Vs1Fy525NbYwisMSCdYQmW9zyzOByz9OB/tQwrKZ3T3pbTkuFjnkJFlJuyiDjPiXL5kzew=="],
+
+    "body-parser": ["body-parser@2.2.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^1.0.5", "debug": "^4.4.0", "http-errors": "^2.0.0", "iconv-lite": "^0.6.3", "on-finished": "^2.4.1", "qs": "^6.14.0", "raw-body": "^3.0.0", "type-is": "^2.0.0" } }, "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg=="],
+
+    "bottleneck": ["bottleneck@2.19.5", "", {}, "sha512-VHiNCbI1lKdl44tGrhNfU3lup0Tj/ZBMJB5/2ZbNXRCPuRCO7ed2mgcK4r17y+KB2EfuYuRaVlwNbAeaWGSpbw=="],
 
     "brace-expansion": ["brace-expansion@1.1.11", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA=="],
 
@@ -547,9 +818,23 @@
 
     "browserslist": ["browserslist@4.24.4", "", { "dependencies": { "caniuse-lite": "^1.0.30001688", "electron-to-chromium": "^1.5.73", "node-releases": "^2.0.19", "update-browserslist-db": "^1.1.1" }, "bin": { "browserslist": "cli.js" } }, "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A=="],
 
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
     "bun-types": ["bun-types@1.2.2", "", { "dependencies": { "@types/node": "*", "@types/ws": "~8.5.10" } }, "sha512-RCbMH5elr9gjgDGDhkTTugA21XtJAy/9jkKe/G3WR2q17VPGhcquf9Sir6uay9iW+7P/BV0CAHA1XlHXMAVKHg=="],
 
+    "bundle-name": ["bundle-name@4.1.0", "", { "dependencies": { "run-applescript": "^7.0.0" } }, "sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q=="],
+
+    "busboy": ["busboy@1.6.0", "", { "dependencies": { "streamsearch": "^1.1.0" } }, "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
+
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
+
+    "camelcase": ["camelcase@8.0.0", "", {}, "sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA=="],
 
     "camelcase-css": ["camelcase-css@2.0.1", "", {}, "sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA=="],
 
@@ -569,15 +854,47 @@
 
     "character-reference-invalid": ["character-reference-invalid@2.0.1", "", {}, "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw=="],
 
+    "chardet": ["chardet@0.7.0", "", {}, "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="],
+
     "chokidar": ["chokidar@3.6.0", "", { "dependencies": { "anymatch": "~3.1.2", "braces": "~3.0.2", "glob-parent": "~5.1.2", "is-binary-path": "~2.1.0", "is-glob": "~4.0.1", "normalize-path": "~3.0.0", "readdirp": "~3.6.0" }, "optionalDependencies": { "fsevents": "~2.3.2" } }, "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw=="],
+
+    "ci-info": ["ci-info@3.9.0", "", {}, "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ=="],
 
     "class-variance-authority": ["class-variance-authority@0.7.1", "", { "dependencies": { "clsx": "^2.1.1" } }, "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg=="],
 
+    "cli-boxes": ["cli-boxes@3.0.0", "", {}, "sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g=="],
+
+    "cli-cursor": ["cli-cursor@4.0.0", "", { "dependencies": { "restore-cursor": "^4.0.0" } }, "sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg=="],
+
+    "cli-progress": ["cli-progress@3.12.0", "", { "dependencies": { "string-width": "^4.2.3" } }, "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A=="],
+
+    "cli-spinners": ["cli-spinners@3.3.0", "", {}, "sha512-/+40ljC3ONVnYIttjMWrlL51nItDAbBrq2upN8BPyvGU/2n5Oxw3tbNwORCaNuNqLJnxGqOfjUuhsv7l5Q4IsQ=="],
+
+    "cli-table3": ["cli-table3@0.6.5", "", { "dependencies": { "string-width": "^4.2.0" }, "optionalDependencies": { "@colors/colors": "1.5.0" } }, "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ=="],
+
+    "cli-truncate": ["cli-truncate@3.1.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^5.0.0" } }, "sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA=="],
+
+    "cli-width": ["cli-width@4.1.0", "", {}, "sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ=="],
+
+    "client-only": ["client-only@0.0.1", "", {}, "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="],
+
+    "clone": ["clone@2.1.2", "", {}, "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "code-excerpt": ["code-excerpt@4.0.0", "", { "dependencies": { "convert-to-spaces": "^2.0.1" } }, "sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA=="],
+
+    "color": ["color@4.2.3", "", { "dependencies": { "color-convert": "^2.0.1", "color-string": "^1.9.0" } }, "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A=="],
 
     "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
 
     "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "color-string": ["color-string@1.9.1", "", { "dependencies": { "color-name": "^1.0.0", "simple-swizzle": "^0.2.2" } }, "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg=="],
+
+    "colorette": ["colorette@2.0.20", "", {}, "sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w=="],
+
+    "combined-stream": ["combined-stream@1.0.8", "", { "dependencies": { "delayed-stream": "~1.0.0" } }, "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg=="],
 
     "comma-separated-tokens": ["comma-separated-tokens@2.0.3", "", {}, "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg=="],
 
@@ -585,21 +902,61 @@
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
+    "content-disposition": ["content-disposition@1.0.0", "", { "dependencies": { "safe-buffer": "5.2.1" } }, "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
+
+    "convert-to-spaces": ["convert-to-spaces@2.0.1", "", {}, "sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ=="],
+
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.5", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
     "cssesc": ["cssesc@3.0.0", "", { "bin": { "cssesc": "bin/cssesc" } }, "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="],
 
+    "cssstyle": ["cssstyle@4.6.0", "", { "dependencies": { "@asamuzakjp/css-color": "^3.2.0", "rrweb-cssom": "^0.8.0" } }, "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg=="],
+
     "csstype": ["csstype@3.1.3", "", {}, "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="],
+
+    "csv-parse": ["csv-parse@5.6.0", "", {}, "sha512-l3nz3euub2QMg5ouu5U09Ew9Wf6/wQ8I++ch1loQ0ljmzhmfZYrH9fflS22i/PQEvsPvxCwxgz5q7UB8K1JO4Q=="],
+
+    "csv-stringify": ["csv-stringify@6.6.0", "", {}, "sha512-YW32lKOmIBgbxtu3g5SaiqWNwa/9ISQt2EcgOq0+RAIFufFp9is6tqNnKahqE5kuKvrnYAzs28r+s6pXJR8Vcw=="],
+
+    "data-urls": ["data-urls@5.0.0", "", { "dependencies": { "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0" } }, "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg=="],
+
+    "date-fns": ["date-fns@4.1.0", "", {}, "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="],
 
     "debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
+
     "decode-named-character-reference": ["decode-named-character-reference@1.0.2", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-O8x12RzrUF8xyVcY0KJowWsmaJxQbmy0/EtnNtHRpsOcT7dFk5W598coHqBVpmWo1oQQfsCqfCmkZN5DJrZVdg=="],
+
+    "dedent": ["dedent@1.7.0", "", { "peerDependencies": { "babel-plugin-macros": "^3.1.0" }, "optionalPeers": ["babel-plugin-macros"] }, "sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ=="],
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "default-browser": ["default-browser@5.2.1", "", { "dependencies": { "bundle-name": "^4.1.0", "default-browser-id": "^5.0.0" } }, "sha512-WY/3TUME0x3KPYdRRxEJJvXRHV4PyPoUsxtZa78lwItwRQRHhd2U9xOscaT/YTf8uCXIAjeJOFBVEh/7FtD8Xg=="],
+
+    "default-browser-id": ["default-browser-id@5.0.0", "", {}, "sha512-A6p/pu/6fyBcA1TRz/GqWYPViplrftcW2gZC9q79ngNCKAeR/X3gcEdXQHl4KNXV+3wgIJ1CPkJQ3IHM6lcsyA=="],
+
+    "define-lazy-prop": ["define-lazy-prop@3.0.0", "", {}, "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg=="],
+
+    "delayed-stream": ["delayed-stream@1.0.0", "", {}, "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="],
+
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
 
@@ -609,19 +966,45 @@
 
     "diff": ["diff@7.0.0", "", {}, "sha512-PJWHUb1RFevKCwaFA9RlG5tCd+FO5iRh9A8HEtkmBH2Li03iJriB6m6JIN4rGz3K3JLawI7/veA1xzRKP6ISBw=="],
 
+    "diff-match-patch": ["diff-match-patch@1.0.5", "", {}, "sha512-IayShXAgj/QMXgB0IWmKx+rOPuGMhqm5w6jvFxmVenXKIzRqTAAsbBPT3kWQeGANj3jGgvcvv4yK6SxqYmikgw=="],
+
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
+
+    "dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
+
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
 
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
+
+    "ejs": ["ejs@3.1.10", "", { "dependencies": { "jake": "^10.8.5" }, "bin": { "ejs": "bin/cli.js" } }, "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA=="],
+
     "electron-to-chromium": ["electron-to-chromium@1.5.101", "", {}, "sha512-L0ISiQrP/56Acgu4/i/kfPwWSgrzYZUnQrC0+QPFuhqlLP1Ir7qzPPDVS9BcKIyWTRU8+o6CC8dKw38tSWhYIA=="],
 
-    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+    "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
+    "encoding": ["encoding@0.1.13", "", { "dependencies": { "iconv-lite": "^0.6.2" } }, "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A=="],
 
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "environment": ["environment@1.1.0", "", {}, "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA=="],
+
+    "es-set-tostringtag": ["es-set-tostringtag@2.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6", "has-tostringtag": "^1.0.2", "hasown": "^2.0.2" } }, "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA=="],
 
     "esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -637,6 +1020,8 @@
 
     "espree": ["espree@10.3.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^4.2.0" } }, "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg=="],
 
+    "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
+
     "esquery": ["esquery@1.6.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg=="],
 
     "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
@@ -645,9 +1030,39 @@
 
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
+    "estree-util-scope": ["estree-util-scope@1.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0" } }, "sha512-2CAASclonf+JFWBNJPndcOpA8EMJwa0Q8LUFJEKqXLW6+qBvbFZuF5gItbQOs/umBUkjviCSDCbBwU2cXbmrhQ=="],
+
+    "estree-util-value-to-estree": ["estree-util-value-to-estree@3.5.0", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-aMV56R27Gv3QmfmF1MY12GWkGzzeAezAX+UplqHVASfjc9wNzI/X6hC0S9oxq61WT4aQesLGslWP9tKk6ghRZQ=="],
+
+    "estree-util-visit": ["estree-util-visit@2.0.0", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/unist": "^3.0.0" } }, "sha512-m5KgiH85xAhhW8Wta0vShLcUvOsh3LLPI2YVwcbio1l7E09NTLL1EyMZFM1OyWowoH0skScNbhOPl4kcBgzTww=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "eventemitter3": ["eventemitter3@5.0.1", "", {}, "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.0.6", "", {}, "sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg=="],
+
+    "express": ["express@5.1.0", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.0", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA=="],
+
+    "express-rate-limit": ["express-rate-limit@7.5.1", "", { "peerDependencies": { "express": ">= 4.11" } }, "sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "external-editor": ["external-editor@3.1.0", "", { "dependencies": { "chardet": "^0.7.0", "iconv-lite": "^0.4.24", "tmp": "^0.0.33" } }, "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew=="],
+
+    "fast-content-type-parse": ["fast-content-type-parse@2.0.1", "", {}, "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -657,13 +1072,29 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.0", "", {}, "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA=="],
+
+    "fast-xml-parser": ["fast-xml-parser@5.3.1", "", { "dependencies": { "strnum": "^2.1.0" }, "bin": { "fxparser": "src/cli/cli.js" } }, "sha512-jbNkWiv2Ec1A7wuuxk0br0d0aTMUtQ4IkL+l/i1r9PRf6pLXjDgsBsWwO+UyczmQlnehi4Tbc8/KIvxGQe+I/A=="],
+
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
+
+    "fault": ["fault@2.0.1", "", { "dependencies": { "format": "^0.2.0" } }, "sha512-WtySTkS4OKev5JtpHXnib4Gxiurzh5NCGvWrFaZ34m6JehfTUhKZvn9njTfw48t6JumVQOmrKqpmGcdwxnhqBQ=="],
+
+    "figlet": ["figlet@1.9.3", "", { "dependencies": { "commander": "^14.0.0" }, "bin": { "figlet": "bin/index.js" } }, "sha512-majPgOpVtrZN1iyNGbsUP6bOtZ6eaJgg5HHh0vFvm5DJhh8dc+FJpOC4GABvMZ/A7XHAJUuJujhgUY/2jPWgMA=="],
+
+    "figures": ["figures@6.1.0", "", { "dependencies": { "is-unicode-supported": "^2.0.0" } }, "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg=="],
 
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
+    "filelist": ["filelist@1.0.4", "", { "dependencies": { "minimatch": "^5.0.1" } }, "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q=="],
+
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
+    "finalhandler": ["finalhandler@2.1.0", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q=="],
+
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat": ["flat@6.0.1", "", { "bin": { "flat": "cli.js" } }, "sha512-/3FfIa8mbrg3xE7+wAhWeV+bd7L2Mof+xtZb5dRDKZ+wDvYJK4WDYeIOuOhre5Yv5aQObZrlbRmk3RTSiuQBtw=="],
 
     "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
 
@@ -671,7 +1102,15 @@
 
     "foreground-child": ["foreground-child@3.3.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "signal-exit": "^4.0.1" } }, "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg=="],
 
+    "form-data": ["form-data@4.0.4", "", { "dependencies": { "asynckit": "^0.4.0", "combined-stream": "^1.0.8", "es-set-tostringtag": "^2.1.0", "hasown": "^2.0.2", "mime-types": "^2.1.12" } }, "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow=="],
+
+    "format": ["format@0.2.2", "", {}, "sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww=="],
+
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
     "fraction.js": ["fraction.js@4.3.7", "", {}, "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -679,9 +1118,17 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
 
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
+
     "get-tsconfig": ["get-tsconfig@4.10.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A=="],
+
+    "gettext-parser": ["gettext-parser@8.0.0", "", { "dependencies": { "content-type": "^1.0.5", "encoding": "^0.1.13", "readable-stream": "^4.5.2", "safe-buffer": "^5.2.1" } }, "sha512-eFmhDi2xQ+2reMRY2AbJ2oa10uFOl1oyGbAKdCZiNOk94NJHi7aN0OBELSC9v35ZAPQdr+uRBi93/Gu4SlBdrA=="],
 
     "glob": ["glob@10.4.5", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg=="],
 
@@ -691,11 +1138,21 @@
 
     "goober": ["goober@2.1.16", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "gpt-tokenizer": ["gpt-tokenizer@3.0.1", "", {}, "sha512-5jdaspBq/w4sWw322SvQj1Fku+CN4OAfYZeeEg8U7CWtxBz+zkxZ3h0YOHD43ee+nZYZ5Ud70HRN0ANcdIj4qg=="],
+
+    "gradient-string": ["gradient-string@3.0.0", "", { "dependencies": { "chalk": "^5.3.0", "tinygradient": "^1.1.5" } }, "sha512-frdKI4Qi8Ihp4C6wZNB565de/THpIaw3DjP5ku87M+N9rNSGmPTjfkq61SdRXB7eCaL8O1hkKDvf6CDMtOzIAg=="],
 
     "graphemer": ["graphemer@1.4.0", "", {}, "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag=="],
 
+    "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
+
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
+
+    "has-tostringtag": ["has-tostringtag@1.0.2", "", { "dependencies": { "has-symbols": "^1.0.3" } }, "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -713,6 +1170,8 @@
 
     "hast-util-sanitize": ["hast-util-sanitize@5.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@ungap/structured-clone": "^1.0.0", "unist-util-position": "^5.0.0" } }, "sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg=="],
 
+    "hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
+
     "hast-util-to-jsx-runtime": ["hast-util-to-jsx-runtime@2.3.2", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "comma-separated-tokens": "^2.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "hast-util-whitespace": "^3.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "property-information": "^6.0.0", "space-separated-tokens": "^2.0.0", "style-to-object": "^1.0.0", "unist-util-position": "^5.0.0", "vfile-message": "^4.0.0" } }, "sha512-1ngXYb+V9UT5h+PxNRa1O1FYguZK/XL+gkeqvp7EdHlB9oHUG0eYRo/vY5inBdcqo3RkPMC58/H94HvkbfGdyg=="],
 
     "hast-util-to-text": ["hast-util-to-text@4.0.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "hast-util-is-element": "^3.0.0", "unist-util-find-after": "^5.0.0" } }, "sha512-KK6y/BN8lbaq654j7JgBydev7wuNMcID54lkRav1P0CaE1e47P72AWWPiGKXTJU271ooYzcvTAn/Zt0REnvc7A=="],
@@ -723,7 +1182,21 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
+    "html-encoding-sniffer": ["html-encoding-sniffer@4.0.0", "", { "dependencies": { "whatwg-encoding": "^3.1.1" } }, "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
+
+    "http-errors": ["http-errors@2.0.0", "", { "dependencies": { "depd": "2.0.0", "inherits": "2.0.4", "setprototypeof": "1.2.0", "statuses": "2.0.1", "toidentifier": "1.0.1" } }, "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ=="],
+
+    "http-proxy-agent": ["http-proxy-agent@7.0.2", "", { "dependencies": { "agent-base": "^7.1.0", "debug": "^4.3.4" } }, "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig=="],
+
+    "https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
+
+    "iconv-lite": ["iconv-lite@0.4.24", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3" } }, "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA=="],
+
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -731,17 +1204,43 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "indent-string": ["indent-string@5.0.0", "", {}, "sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg=="],
+
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
+    "ini": ["ini@5.0.0", "", {}, "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw=="],
+
+    "ink": ["ink@4.4.1", "", { "dependencies": { "@alcalzone/ansi-tokenize": "^0.1.3", "ansi-escapes": "^6.0.0", "auto-bind": "^5.0.1", "chalk": "^5.2.0", "cli-boxes": "^3.0.0", "cli-cursor": "^4.0.0", "cli-truncate": "^3.1.0", "code-excerpt": "^4.0.0", "indent-string": "^5.0.0", "is-ci": "^3.0.1", "is-lower-case": "^2.0.2", "is-upper-case": "^2.0.2", "lodash": "^4.17.21", "patch-console": "^2.0.0", "react-reconciler": "^0.29.0", "scheduler": "^0.23.0", "signal-exit": "^3.0.7", "slice-ansi": "^6.0.0", "stack-utils": "^2.0.6", "string-width": "^5.1.2", "type-fest": "^0.12.0", "widest-line": "^4.0.1", "wrap-ansi": "^8.1.0", "ws": "^8.12.0", "yoga-wasm-web": "~0.3.3" }, "peerDependencies": { "@types/react": ">=18.0.0", "react": ">=18.0.0", "react-devtools-core": "^4.19.1" }, "optionalPeers": ["@types/react", "react-devtools-core"] }, "sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA=="],
+
+    "ink-progress-bar": ["ink-progress-bar@3.0.0", "", { "dependencies": { "blacklist": "^1.1.4", "prop-types": "^15.7.2" } }, "sha512-GzByB3uEofqjyWC3VmdhYpBq+kzszu5Nwt/NruTDWa7fbw1E6sx6U1n6Kcsfj9D3qwR17dtC5w9uFVMyRA5HZw=="],
+
+    "ink-spinner": ["ink-spinner@5.0.0", "", { "dependencies": { "cli-spinners": "^2.7.0" }, "peerDependencies": { "ink": ">=4.0.0", "react": ">=18.0.0" } }, "sha512-EYEasbEjkqLGyPOUc8hBJZNuC5GvXGMLu0w5gdTNskPc7Izc5vO3tdQEYnzvshucyGCBXc86ig0ujXPMWaQCdA=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
+
+    "inquirer": ["inquirer@12.11.0", "", { "dependencies": { "@inquirer/ansi": "^1.0.2", "@inquirer/core": "^10.3.1", "@inquirer/prompts": "^7.10.0", "@inquirer/type": "^3.0.10", "mute-stream": "^3.0.0", "run-async": "^4.0.6", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" }, "optionalPeers": ["@types/node"] }, "sha512-E5oT7r+NxIxTuZsl/2Hg76kdT57DGc5mn5pCEz0LqZjR8hN7prgMXhUZ6A7rj/qL3X4P5lToIWNkO10uZJSzdA=="],
+
+    "interactive-commander": ["interactive-commander@0.5.194", "", { "dependencies": { "@inquirer/prompts": "^7.2.1", "commander": "^12.1.0", "parse-my-command": "^0.3.31" } }, "sha512-zg3dNIZrnjWzP9unNDbVBEJvjuc3QuVe16xz46Rt+IZXqGYpwiuA/MURblaL4X+HY7FOD2zbI8Lx3uVbOLDfqw=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
 
+    "is-arrayish": ["is-arrayish@0.3.4", "", {}, "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA=="],
+
     "is-binary-path": ["is-binary-path@2.1.0", "", { "dependencies": { "binary-extensions": "^2.0.0" } }, "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw=="],
+
+    "is-ci": ["is-ci@3.0.1", "", { "dependencies": { "ci-info": "^3.2.0" }, "bin": { "is-ci": "bin.js" } }, "sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ=="],
 
     "is-core-module": ["is-core-module@2.16.1", "", { "dependencies": { "hasown": "^2.0.2" } }, "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w=="],
 
     "is-decimal": ["is-decimal@2.0.1", "", {}, "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A=="],
+
+    "is-docker": ["is-docker@3.0.0", "", { "bin": { "is-docker": "cli.js" } }, "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ=="],
+
+    "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
     "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
 
@@ -751,23 +1250,51 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-inside-container": ["is-inside-container@1.0.0", "", { "dependencies": { "is-docker": "^3.0.0" }, "bin": { "is-inside-container": "cli.js" } }, "sha512-KIYLCCJghfHZxqjYBE7rEy0OBuTd5xCHS7tHVgvCLkx7StIoaxwNW3hCALgEUjFfeRk+MG/Qxmp/vtETEF3tRA=="],
+
+    "is-interactive": ["is-interactive@2.0.0", "", {}, "sha512-qP1vozQRI+BMOPcjFzrjXuQvdak2pHNUMZoeG2eRbiSqyvbEf/wQtEOTOX1guk6E3t36RkaqiSt8A/6YElNxLQ=="],
+
+    "is-lower-case": ["is-lower-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ=="],
+
     "is-number": ["is-number@7.0.0", "", {}, "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="],
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
+
+    "is-plain-object": ["is-plain-object@3.0.1", "", {}, "sha512-Xnpx182SBMrr/aBik8y+GuR4U1L9FqMSojwDQwPMmxyC6bvEqly9UBCxhauBF5vNh2gwWJNX6oDV7O+OM4z34g=="],
+
+    "is-potential-custom-element-name": ["is-potential-custom-element-name@1.0.1", "", {}, "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ=="],
+
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
+    "is-unicode-supported": ["is-unicode-supported@2.1.0", "", {}, "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ=="],
+
+    "is-upper-case": ["is-upper-case@2.0.2", "", { "dependencies": { "tslib": "^2.0.3" } }, "sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ=="],
+
+    "is-url": ["is-url@1.2.4", "", {}, "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="],
+
+    "is-wsl": ["is-wsl@3.1.0", "", { "dependencies": { "is-inside-container": "^1.0.0" } }, "sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
+    "jake": ["jake@10.9.4", "", { "dependencies": { "async": "^3.2.6", "filelist": "^1.0.4", "picocolors": "^1.1.1" }, "bin": { "jake": "bin/cli.js" } }, "sha512-wpHYzhxiVQL+IV05BLE2Xn34zW1S223hvjtqk0+gsPrwd/8JNLXJgZZM/iPFsYc1xyphF+6M6EvdE5E9MBGkDA=="],
+
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "js-cookie": ["js-cookie@3.0.5", "", {}, "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
     "js-yaml": ["js-yaml@4.1.0", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA=="],
 
+    "jsdom": ["jsdom@25.0.1", "", { "dependencies": { "cssstyle": "^4.1.0", "data-urls": "^5.0.0", "decimal.js": "^10.4.3", "form-data": "^4.0.0", "html-encoding-sniffer": "^4.0.0", "http-proxy-agent": "^7.0.2", "https-proxy-agent": "^7.0.5", "is-potential-custom-element-name": "^1.0.1", "nwsapi": "^2.2.12", "parse5": "^7.1.2", "rrweb-cssom": "^0.7.1", "saxes": "^6.0.0", "symbol-tree": "^3.2.4", "tough-cookie": "^5.0.0", "w3c-xmlserializer": "^5.0.0", "webidl-conversions": "^7.0.0", "whatwg-encoding": "^3.1.1", "whatwg-mimetype": "^4.0.0", "whatwg-url": "^14.0.0", "ws": "^8.18.0", "xml-name-validator": "^5.0.0" }, "peerDependencies": { "canvas": "^2.11.2" }, "optionalPeers": ["canvas"] }, "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw=="],
+
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
@@ -775,9 +1302,17 @@
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
 
+    "jsonc-parser": ["jsonc-parser@3.3.1", "", {}, "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ=="],
+
+    "jsondiffpatch": ["jsondiffpatch@0.6.0", "", { "dependencies": { "@types/diff-match-patch": "^1.0.36", "chalk": "^5.3.0", "diff-match-patch": "^1.0.5" }, "bin": { "jsondiffpatch": "bin/jsondiffpatch.js" } }, "sha512-3QItJOXp2AP1uv7waBkao5nCvhEv+QmJAd38Ybq7wNI74Q+BBmnLn4EDKz6yI9xGAIQoUF87qHt+kc1IVxB4zQ=="],
+
+    "jsonrepair": ["jsonrepair@3.13.1", "", { "bin": { "jsonrepair": "bin/cli.js" } }, "sha512-WJeiE0jGfxYmtLwBTEk8+y/mYcaleyLXWaqp5bJu0/ZTSeG0KQq/wWQ8pmnkKenEdN6pdnn6QtcoSUkbqDHWNw=="],
+
     "katex": ["katex@0.16.25", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-woHRUZ/iF23GBP1dkDQMh1QBad9dmr8/PAwNA54VrSOVYgI12MAcE14TqnDdQOdzyEonGzMepYnqBMYdsoAr8Q=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
+
+    "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -785,9 +1320,19 @@
 
     "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
 
+    "lingo.dev": ["lingo.dev@0.114.5", "", { "dependencies": { "@ai-sdk/anthropic": "^1.2.11", "@ai-sdk/google": "^1.2.19", "@ai-sdk/mistral": "^1.2.8", "@ai-sdk/openai": "^1.3.22", "@babel/generator": "^7.27.1", "@babel/parser": "^7.27.1", "@babel/traverse": "^7.27.4", "@babel/types": "^7.27.1", "@biomejs/js-api": "^3.0.0", "@biomejs/wasm-nodejs": "^2.2.4", "@datocms/cma-client-node": "^4.0.1", "@gitbeaker/rest": "^39.34.3", "@inkjs/ui": "^2.0.0", "@inquirer/prompts": "^7.8.0", "@lingo.dev/_compiler": "0.7.15", "@lingo.dev/_locales": "0.1.0", "@lingo.dev/_react": "0.5.0", "@lingo.dev/_sdk": "0.12.6", "@lingo.dev/_spec": "0.41.1", "@markdoc/markdoc": "^0.5.4", "@modelcontextprotocol/sdk": "^1.5.0", "@openrouter/ai-sdk-provider": "^0.7.1", "@paralleldrive/cuid2": "^2.2.2", "@types/ejs": "^3.1.5", "ai": "^4.3.15", "bitbucket": "^2.12.0", "chalk": "^5.4.1", "chokidar": "^4.0.3", "cli-progress": "^3.12.0", "cli-table3": "^0.6.5", "cors": "^2.8.5", "csv-parse": "^5.6.0", "csv-stringify": "^6.5.2", "date-fns": "^4.1.0", "dedent": "^1.5.3", "diff": "^7.0.0", "dotenv": "^16.4.7", "ejs": "^3.1.10", "express": "^5.1.0", "external-editor": "^3.1.0", "figlet": "^1.8.2", "flat": "^6.0.1", "gettext-parser": "^8.0.0", "glob": "<11.0.0", "gradient-string": "^3.0.0", "gray-matter": "^4.0.3", "ini": "^5.0.0", "ink": "^4.2.0", "ink-progress-bar": "^3.0.0", "ink-spinner": "^5.0.0", "inquirer": "^12.6.0", "interactive-commander": "^0.5.194", "is-url": "^1.2.4", "jsdom": "^25.0.1", "json5": "^2.2.3", "jsonc-parser": "^3.3.1", "jsonrepair": "^3.11.2", "listr2": "^8.3.2", "lodash": "^4.17.21", "marked": "^15.0.6", "mdast-util-from-markdown": "^2.0.2", "mdast-util-gfm": "^3.1.0", "micromark-extension-gfm": "^3.0.0", "node-machine-id": "^1.1.12", "node-webvtt": "^1.9.4", "object-hash": "^3.0.0", "octokit": "^4.0.2", "ollama-ai-provider": "^1.2.0", "open": "^10.2.0", "ora": "^8.1.1", "p-limit": "^6.2.0", "php-array-reader": "^2.1.2", "plist": "^3.1.0", "posthog-node": "^5.8.1", "prettier": "^3.4.2", "react": "^18.3.1", "rehype-stringify": "^10.0.1", "remark-disable-tokenizers": "^1.1.1", "remark-frontmatter": "^5.0.0", "remark-gfm": "^4.0.1", "remark-mdx": "^3.1.0", "remark-mdx-frontmatter": "^5.1.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-stringify": "^11.0.0", "sax": "^1.4.1", "srt-parser-2": "^1.2.3", "unified": "^11.0.5", "unist-util-visit": "^5.0.0", "vfile": "^6.0.3", "xliff": "^6.2.1", "xml2js": "^0.6.2", "xpath": "^0.0.34", "yaml": "^2.7.0", "zod": "^3.25.76" }, "bin": { "lingo.dev": "bin/cli.mjs" } }, "sha512-otKrdpd2O43BHfYFJ27rSWwHOYQ1TqS4Uao5A+U2ZQqh+9Z1Dl9+LZCgc7o1HhUl8Uh+G+b2PjYD86Zivc8bkA=="],
+
+    "listr2": ["listr2@8.3.3", "", { "dependencies": { "cli-truncate": "^4.0.0", "colorette": "^2.0.20", "eventemitter3": "^5.0.1", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^9.0.0" } }, "sha512-LWzX2KsqcB1wqQ4AHgYb4RsDXauQiqhjLk+6hjbaeHG4zpjjVAB6wC/gz6X0l+Du1cN3pUB5ZlrvTbhGSNnUQQ=="],
+
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
+    "lodash": ["lodash@4.17.21", "", {}, "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="],
+
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
+
+    "log-symbols": ["log-symbols@6.0.0", "", { "dependencies": { "chalk": "^5.3.0", "is-unicode-supported": "^1.3.0" } }, "sha512-i24m8rpwhmPIS4zscNzK6MSEhk0DUWa/8iYQWxhffV8jkI4Phvs3F+quL5xvS0gdQR0FyTCMMH33Y78dDTzzIw=="],
+
+    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
 
     "longest-streak": ["longest-streak@3.1.0", "", {}, "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="],
 
@@ -799,11 +1344,19 @@
 
     "lucide-react": ["lucide-react@0.436.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc" } }, "sha512-N292bIxoqm1aObAg0MzFtvhYwgQE6qnIOWx/GLj5ONgcTPH6N0fD9bVq/GfdeC9ZORBXozt/XeEKDpiB3x3vlQ=="],
 
+    "make-synchronized": ["make-synchronized@0.8.0", "", {}, "sha512-DZu4lwc0ffoFz581BSQa/BJl+1ZqIkoRQ+VejMlH0VrP4E86StAODnZujZ4sepumQj8rcP7wUnUBGM8Gu+zKUA=="],
+
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
     "mdast-util-from-markdown": ["mdast-util-from-markdown@2.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "mdast-util-to-string": "^4.0.0", "micromark": "^4.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA=="],
+
+    "mdast-util-frontmatter": ["mdast-util-frontmatter@2.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "escape-string-regexp": "^5.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0" } }, "sha512-LRqI9+wdgC25P0URIJY9vwocIzCcksduHQ9OF2joxQoyTNVduwLAFUzjoopuRJbJAReaKrNQKAZKL3uCMugWJA=="],
 
     "mdast-util-gfm": ["mdast-util-gfm@3.1.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-gfm-autolink-literal": "^2.0.0", "mdast-util-gfm-footnote": "^2.0.0", "mdast-util-gfm-strikethrough": "^2.0.0", "mdast-util-gfm-table": "^2.0.0", "mdast-util-gfm-task-list-item": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ=="],
 
@@ -818,6 +1371,8 @@
     "mdast-util-gfm-task-list-item": ["mdast-util-gfm-task-list-item@2.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ=="],
 
     "mdast-util-math": ["mdast-util-math@3.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "longest-streak": "^3.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.1.0", "unist-util-remove-position": "^5.0.0" } }, "sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w=="],
+
+    "mdast-util-mdx": ["mdast-util-mdx@3.0.0", "", { "dependencies": { "mdast-util-from-markdown": "^2.0.0", "mdast-util-mdx-expression": "^2.0.0", "mdast-util-mdx-jsx": "^3.0.0", "mdast-util-mdxjs-esm": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-JfbYLAW7XnYTTbUsmpu0kdBUVe+yKVJZBItEjwyYJiDJuZ9w4eeaqks4HQO+R7objWgS2ymV60GYpI14Ug554w=="],
 
     "mdast-util-mdx-expression": ["mdast-util-mdx-expression@2.0.1", "", { "dependencies": { "@types/estree-jsx": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "mdast-util-from-markdown": "^2.0.0", "mdast-util-to-markdown": "^2.0.0" } }, "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ=="],
 
@@ -835,11 +1390,17 @@
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
 
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
+
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
     "micromark": ["micromark@4.0.1", "", { "dependencies": { "@types/debug": "^4.0.0", "debug": "^4.0.0", "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-decode-numeric-character-reference": "^2.0.0", "micromark-util-encode": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-sanitize-uri": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-eBPdkcoCNvYcxQOAKAlceo5SNdzZWfF+FcSupREAzdAh9rRmE239CEQAiTwIgblwnoM8zzj35sZ5ZwvSEOF6Kw=="],
 
     "micromark-core-commonmark": ["micromark-core-commonmark@2.0.2", "", { "dependencies": { "decode-named-character-reference": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-destination": "^2.0.0", "micromark-factory-label": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-factory-title": "^2.0.0", "micromark-factory-whitespace": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-chunked": "^2.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-html-tag-name": "^2.0.0", "micromark-util-normalize-identifier": "^2.0.0", "micromark-util-resolve-all": "^2.0.0", "micromark-util-subtokenize": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-FKjQKbxd1cibWMM1P9N+H8TwlgGgSkWZMmfuVucLCHaYqeSvJ0hFeHsIa65pA2nYbes0f8LDHPMrd9X7Ujxg9w=="],
+
+    "micromark-extension-frontmatter": ["micromark-extension-frontmatter@2.0.0", "", { "dependencies": { "fault": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-C4AkuM3dA58cgZha7zVnuVxBhDsbttIMiytjgsM2XbHAB2faRVaHRle40558FBN+DJcrLNCoqG5mlrpdU4cRtg=="],
 
     "micromark-extension-gfm": ["micromark-extension-gfm@3.0.0", "", { "dependencies": { "micromark-extension-gfm-autolink-literal": "^2.0.0", "micromark-extension-gfm-footnote": "^2.0.0", "micromark-extension-gfm-strikethrough": "^2.0.0", "micromark-extension-gfm-table": "^2.0.0", "micromark-extension-gfm-tagfilter": "^2.0.0", "micromark-extension-gfm-task-list-item": "^2.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w=="],
 
@@ -857,9 +1418,21 @@
 
     "micromark-extension-math": ["micromark-extension-math@3.1.0", "", { "dependencies": { "@types/katex": "^0.16.0", "devlop": "^1.0.0", "katex": "^0.16.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg=="],
 
+    "micromark-extension-mdx-expression": ["micromark-extension-mdx-expression@3.0.1", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-dD/ADLJ1AeMvSAKBwO22zG22N4ybhe7kFIZ3LsDI0GlsNr2A3KYxb0LdC1u5rj4Nw+CHKY0RVdnHX8vj8ejm4Q=="],
+
+    "micromark-extension-mdx-jsx": ["micromark-extension-mdx-jsx@3.0.2", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "estree-util-is-identifier-name": "^3.0.0", "micromark-factory-mdx-expression": "^2.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-e5+q1DjMh62LZAJOnDraSSbDMvGJ8x3cbjygy2qFEi7HCeUT4BDKCvMozPozcD6WmOt6sVvYDNBKhFSz3kjOVQ=="],
+
+    "micromark-extension-mdx-md": ["micromark-extension-mdx-md@2.0.0", "", { "dependencies": { "micromark-util-types": "^2.0.0" } }, "sha512-EpAiszsB3blw4Rpba7xTOUptcFeBFi+6PY8VnJ2hhimH+vCQDirWgsMpz7w1XcZE7LVrSAUGb9VJpG9ghlYvYQ=="],
+
+    "micromark-extension-mdxjs": ["micromark-extension-mdxjs@3.0.0", "", { "dependencies": { "acorn": "^8.0.0", "acorn-jsx": "^5.0.0", "micromark-extension-mdx-expression": "^3.0.0", "micromark-extension-mdx-jsx": "^3.0.0", "micromark-extension-mdx-md": "^2.0.0", "micromark-extension-mdxjs-esm": "^3.0.0", "micromark-util-combine-extensions": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-A873fJfhnJ2siZyUrJ31l34Uqwy4xIFmvPY1oj+Ean5PHcPBYzEsvqvWGaWcfEIr11O5Dlw3p2y0tZWpKHDejQ=="],
+
+    "micromark-extension-mdxjs-esm": ["micromark-extension-mdxjs-esm@3.0.0", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-core-commonmark": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-DJFl4ZqkErRpq/dAPyeWp15tGrcrrJho1hKK5uBS70BCtfrIFg81sqcTVu3Ta+KD1Tk5vAtBNElWxtAa+m8K9A=="],
+
     "micromark-factory-destination": ["micromark-factory-destination@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA=="],
 
     "micromark-factory-label": ["micromark-factory-label@2.0.1", "", { "dependencies": { "devlop": "^1.0.0", "micromark-util-character": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg=="],
+
+    "micromark-factory-mdx-expression": ["micromark-factory-mdx-expression@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "devlop": "^1.0.0", "micromark-factory-space": "^2.0.0", "micromark-util-character": "^2.0.0", "micromark-util-events-to-acorn": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "unist-util-position-from-estree": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-kQnEtA3vzucU2BkrIa8/VaSAsP+EJ3CKOvhMuJgOEGg9KDC6OAY6nSnNDVRiVNRqj7Y4SlSzcStaH/5jge8JdQ=="],
 
     "micromark-factory-space": ["micromark-factory-space@2.0.1", "", { "dependencies": { "micromark-util-character": "^2.0.0", "micromark-util-types": "^2.0.0" } }, "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg=="],
 
@@ -881,6 +1454,8 @@
 
     "micromark-util-encode": ["micromark-util-encode@2.0.1", "", {}, "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw=="],
 
+    "micromark-util-events-to-acorn": ["micromark-util-events-to-acorn@2.0.3", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/unist": "^3.0.0", "devlop": "^1.0.0", "estree-util-visit": "^2.0.0", "micromark-util-symbol": "^2.0.0", "micromark-util-types": "^2.0.0", "vfile-message": "^4.0.0" } }, "sha512-jmsiEIiZ1n7X1Rr5k8wVExBQCg5jy4UXVADItHmNk1zkwEVhBuIUKRu3fqv+hs4nxLISi2DQGlqIOGiFxgbfHg=="],
+
     "micromark-util-html-tag-name": ["micromark-util-html-tag-name@2.0.1", "", {}, "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA=="],
 
     "micromark-util-normalize-identifier": ["micromark-util-normalize-identifier@2.0.1", "", { "dependencies": { "micromark-util-symbol": "^2.0.0" } }, "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q=="],
@@ -897,11 +1472,21 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
+
+    "mime-types": ["mime-types@2.1.35", "", { "dependencies": { "mime-db": "1.52.0" } }, "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw=="],
+
+    "mimic-fn": ["mimic-fn@2.1.0", "", {}, "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="],
+
+    "mimic-function": ["mimic-function@5.0.1", "", {}, "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA=="],
+
     "minimatch": ["minimatch@3.1.2", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mute-stream": ["mute-stream@3.0.0", "", {}, "sha512-dkEJPVvun4FryqBmZ5KhDo0K9iDXAwn08tMLDinNdRBNPcYEDiWYysLcc6k3mjTMlbP9KyylvRpd4wFtwrT9rw=="],
 
     "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
 
@@ -909,21 +1494,51 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
+    "next": ["next@15.2.4", "", { "dependencies": { "@next/env": "15.2.4", "@swc/counter": "0.1.3", "@swc/helpers": "0.5.15", "busboy": "1.6.0", "caniuse-lite": "^1.0.30001579", "postcss": "8.4.31", "styled-jsx": "5.1.6" }, "optionalDependencies": { "@next/swc-darwin-arm64": "15.2.4", "@next/swc-darwin-x64": "15.2.4", "@next/swc-linux-arm64-gnu": "15.2.4", "@next/swc-linux-arm64-musl": "15.2.4", "@next/swc-linux-x64-gnu": "15.2.4", "@next/swc-linux-x64-musl": "15.2.4", "@next/swc-win32-arm64-msvc": "15.2.4", "@next/swc-win32-x64-msvc": "15.2.4", "sharp": "^0.33.5" }, "peerDependencies": { "@opentelemetry/api": "^1.1.0", "@playwright/test": "^1.41.2", "babel-plugin-react-compiler": "*", "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0", "sass": "^1.3.0" }, "optionalPeers": ["@opentelemetry/api", "@playwright/test", "babel-plugin-react-compiler", "sass"], "bin": { "next": "dist/bin/next" } }, "sha512-VwL+LAaPSxEkd3lU2xWbgEOtrM8oedmyhBqaVNmgKB+GvZlCy9rgaEc+y2on0wv+l0oSFqLtYD6dcC1eAedUaQ=="],
+
+    "node-fetch": ["node-fetch@2.7.0", "", { "dependencies": { "whatwg-url": "^5.0.0" }, "peerDependencies": { "encoding": "^0.1.0" }, "optionalPeers": ["encoding"] }, "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A=="],
+
+    "node-machine-id": ["node-machine-id@1.1.12", "", {}, "sha512-QNABxbrPa3qEIfrE6GOJ7BYIuignnJw7iQ2YPbc3Nla1HzRJjXzZOiikfF8m7eAMfichLt3M4VgLOetqgDmgGQ=="],
+
     "node-releases": ["node-releases@2.0.19", "", {}, "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw=="],
+
+    "node-webvtt": ["node-webvtt@1.9.4", "", { "dependencies": { "commander": "^7.1.0" }, "bin": { "webvtt-segment": "bin/webvtt-segment.js" } }, "sha512-EjrJdKdxSyd8j4LMLW6s2Ah4yNoeVXp18Ob04CQl1In18xcUmKzEE8pcsxxnFVqanTyjbGYph2VnvtwIXR4EjA=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
 
     "normalize-range": ["normalize-range@0.1.2", "", {}, "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA=="],
 
+    "nwsapi": ["nwsapi@2.2.22", "", {}, "sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ=="],
+
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "octokit": ["octokit@4.1.4", "", { "dependencies": { "@octokit/app": "^15.1.6", "@octokit/core": "^6.1.5", "@octokit/oauth-app": "^7.1.6", "@octokit/plugin-paginate-graphql": "^5.2.4", "@octokit/plugin-paginate-rest": "^12.0.0", "@octokit/plugin-rest-endpoint-methods": "^14.0.0", "@octokit/plugin-retry": "^7.2.1", "@octokit/plugin-throttling": "^10.0.0", "@octokit/request-error": "^6.1.8", "@octokit/types": "^14.0.0", "@octokit/webhooks": "^13.8.3" } }, "sha512-cRvxRte6FU3vAHRC9+PMSY3D+mRAs2Rd9emMoqp70UGRvJRM3sbAoim2IXRZNNsf8wVfn4sGxVBHRAP+JBVX/g=="],
+
+    "ollama-ai-provider": ["ollama-ai-provider@1.2.0", "", { "dependencies": { "@ai-sdk/provider": "^1.0.0", "@ai-sdk/provider-utils": "^2.0.0", "partial-json": "0.1.7" }, "peerDependencies": { "zod": "^3.0.0" }, "optionalPeers": ["zod"] }, "sha512-jTNFruwe3O/ruJeppI/quoOUxG7NA6blG3ZyQj3lei4+NnJo7bi3eIRWqlVpRlu/mbzbFXeJSBuYQWF6pzGKww=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
+
+    "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
+
+    "open": ["open@10.2.0", "", { "dependencies": { "default-browser": "^5.2.1", "define-lazy-prop": "^3.0.0", "is-inside-container": "^1.0.0", "wsl-utils": "^0.1.0" } }, "sha512-YgBpdJHPyQ2UE5x+hlSXcnejzAvD0b22U2OuAP+8OnlJT+PjWPxtgmGqKKc+RgTM63U9gN0YzrYc71R2WT/hTA=="],
 
     "openai": ["openai@5.20.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-Bmc2zLM/YWgFrDpXr9hwXqGGDdMmMpE9+qoZPsaHpn0Y/Qk1Vu26hNqXo7+nHdli+sLsXINvS1f8kR3NKhGKmA=="],
 
     "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
 
-    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+    "ora": ["ora@8.2.0", "", { "dependencies": { "chalk": "^5.3.0", "cli-cursor": "^5.0.0", "cli-spinners": "^2.9.2", "is-interactive": "^2.0.0", "is-unicode-supported": "^2.0.0", "log-symbols": "^6.0.0", "stdin-discarder": "^0.2.2", "string-width": "^7.2.0", "strip-ansi": "^7.1.0" } }, "sha512-weP+BZ8MVNnlCm8c0Qdc1WSWq4Qn7I+9CJGm7Qali6g44e/PUzbjNqJX5NJ9ljlNMosfJvg1fKEGILklK9cwnw=="],
+
+    "os-tmpdir": ["os-tmpdir@1.0.2", "", {}, "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="],
+
+    "p-limit": ["p-limit@6.2.0", "", { "dependencies": { "yocto-queue": "^1.1.1" } }, "sha512-kuUqqHNUqoIWp/c467RI4X6mmyuojY5jGutNU0wVTmEOOfcuwLqyMVoAi9MKi2Ak+5i9+nhmrK4ufZE8069kHA=="],
 
     "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
 
@@ -933,7 +1548,15 @@
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse-my-command": ["parse-my-command@0.3.31", "", { "dependencies": { "camelcase": "^8.0.0", "commander": "^12.1.0" } }, "sha512-B8voraH5aWFpEveAFoLGH055sLtoSs8/kJ03Zi8zvDxYHGsAJHvz7QEqtiMNbCN7fvC8i9erGfoquDzWP9Dvng=="],
+
     "parse5": ["parse5@7.2.1", "", { "dependencies": { "entities": "^4.5.0" } }, "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ=="],
+
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
+    "partial-json": ["partial-json@0.1.7", "", {}, "sha512-Njv/59hHaokb/hRUjce3Hdv12wd60MtM9Z5Olmn+nehe0QDAsRtRbJPvJ0Z91TusF0SuZRIvnM+S4l6EIP8leA=="],
+
+    "patch-console": ["patch-console@2.0.0", "", {}, "sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
@@ -943,13 +1566,25 @@
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
+    "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
+
+    "php-array-reader": ["php-array-reader@2.1.2", "", { "dependencies": { "php-parser": "^3.1.5" } }, "sha512-bev2MQhNmxlGiAQwi41z7J242jAEopCs5bT515Er/d4uiFl1z09SWQcr1VnycRJ0EA9ARlm8zDBvM40/y+l9/Q=="],
+
+    "php-parser": ["php-parser@3.2.5", "", {}, "sha512-M1ZYlALFFnESbSdmRtTQrBFUHSriHgPhgqtTF/LCbZM4h7swR5PHtUceB2Kzby5CfqcsYwBn7OXTJ0+8Sajwkw=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
+    "picomatch-browser": ["picomatch-browser@2.2.6", "", {}, "sha512-0ypsOQt9D4e3hziV8O4elD9uN0z/jtUEfxVRtNaAAtXIyUx9m/SzlO020i8YNL2aL/E6blOvvHQcin6HZlFy/w=="],
+
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
+
+    "plist": ["plist@3.1.0", "", { "dependencies": { "@xmldom/xmldom": "^0.8.8", "base64-js": "^1.5.1", "xmlbuilder": "^15.1.1" } }, "sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ=="],
 
     "postcss": ["postcss@8.5.2", "", { "dependencies": { "nanoid": "^3.3.8", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-MjOadfU3Ys9KYoX0AdkBlFEF1Vx37uCCeN4ZHnmwm9FfpbsGWMZeBLMmmpY+6Ocqod7mkdZ0DT31OlbsFrLlkA=="],
 
@@ -965,11 +1600,19 @@
 
     "postcss-value-parser": ["postcss-value-parser@4.2.0", "", {}, "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ=="],
 
+    "posthog-node": ["posthog-node@5.11.2", "", { "dependencies": { "@posthog/core": "1.5.2" } }, "sha512-z+XekcBUmGePMsjPlGaEF2bJFiDHKHYPQjS4OEw4YPDQz8s7Owuim/L7xNX+6UJkyIRniBza9iC7bW8yrGTv1g=="],
+
     "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
 
     "prettier": ["prettier@3.5.1", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw=="],
 
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
+
+    "prop-types": ["prop-types@15.8.1", "", { "dependencies": { "loose-envify": "^1.4.0", "object-assign": "^4.1.1", "react-is": "^16.13.1" } }, "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg=="],
+
     "property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
+
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
@@ -977,13 +1620,25 @@
 
     "pvutils": ["pvutils@1.1.3", "", {}, "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="],
 
+    "qs": ["qs@6.14.0", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.2.1", "", {}, "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg=="],
+
+    "rate-limiter-flexible": ["rate-limiter-flexible@4.0.1", "", {}, "sha512-2/dGHpDFpeA0+755oUkW+EKyklqLS9lu0go9pDsbhqQjZcxfRyJ6LA4JI0+HAdZ2bemD/oOjUeZQB2lCZqXQfQ=="],
+
+    "raw-body": ["raw-body@3.0.1", "", { "dependencies": { "bytes": "3.1.2", "http-errors": "2.0.0", "iconv-lite": "0.7.0", "unpipe": "1.0.0" } }, "sha512-9G8cA+tuMS75+6G/TzW8OtLzmBDMo8p1JRxN5AZ+LAp8uxGA8V8GZm4GQ4/N5QNQEnLmg6SS7wyuSmbKepiKqA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
     "react-dom": ["react-dom@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw=="],
 
+    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+
     "react-markdown": ["react-markdown@9.0.3", "", { "dependencies": { "@types/hast": "^3.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-Yk7Z94dbgYTOrdk41Z74GoKA7rThnsbbqBTRYuxoe08qvfQ9tJVhmAKw6BJS/ZORG7kTy/s1QvYzSuaoBA1qfw=="],
+
+    "react-reconciler": ["react-reconciler@0.29.2", "", { "dependencies": { "loose-envify": "^1.1.0", "scheduler": "^0.23.2" }, "peerDependencies": { "react": "^18.3.1" } }, "sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg=="],
 
     "react-refresh": ["react-refresh@0.14.2", "", {}, "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA=="],
 
@@ -994,6 +1649,8 @@
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
 
     "read-cache": ["read-cache@1.0.0", "", { "dependencies": { "pify": "^2.3.0" } }, "sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA=="],
+
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
 
     "readdirp": ["readdirp@3.6.0", "", { "dependencies": { "picomatch": "^2.2.1" } }, "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA=="],
 
@@ -1007,17 +1664,29 @@
 
     "rehype-sanitize": ["rehype-sanitize@6.0.0", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-sanitize": "^5.0.0" } }, "sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg=="],
 
+    "rehype-stringify": ["rehype-stringify@10.0.1", "", { "dependencies": { "@types/hast": "^3.0.0", "hast-util-to-html": "^9.0.0", "unified": "^11.0.0" } }, "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA=="],
+
     "remark-breaks": ["remark-breaks@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-newline-to-break": "^2.0.0", "unified": "^11.0.0" } }, "sha512-IjEjJOkH4FuJvHZVIW0QCDWxcG96kCq7An/KVH2NfJe6rKZU2AsHeB3OEjPNRxi4QC34Xdx7I2KGYn6IpT7gxQ=="],
+
+    "remark-disable-tokenizers": ["remark-disable-tokenizers@1.1.1", "", { "dependencies": { "clone": "^2.1.2" } }, "sha512-KhxfswvMKNTicVaprWc21i8zbBLIf6wwCbn3cvnCP1400Sgd2eCSm4maKUkj3uNkVyCKp3u5BNRaXPxJ9gM99A=="],
+
+    "remark-frontmatter": ["remark-frontmatter@5.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-frontmatter": "^2.0.0", "micromark-extension-frontmatter": "^2.0.0", "unified": "^11.0.0" } }, "sha512-XTFYvNASMe5iPN0719nPrdItC9aU0ssC4v14mH1BCi1u0n1gAocqcujWUrByftZTbLhRtiKRyjYTSIOcr69UVQ=="],
 
     "remark-gfm": ["remark-gfm@4.0.1", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-gfm": "^3.0.0", "micromark-extension-gfm": "^3.0.0", "remark-parse": "^11.0.0", "remark-stringify": "^11.0.0", "unified": "^11.0.0" } }, "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg=="],
 
     "remark-math": ["remark-math@6.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-math": "^3.0.0", "micromark-extension-math": "^3.0.0", "unified": "^11.0.0" } }, "sha512-MMqgnP74Igy+S3WwnhQ7kqGlEerTETXMvJhrUzDikVZ2/uogJCb+WHUg97hK9/jcfc0dkD73s3LN8zU49cTEtA=="],
 
+    "remark-mdx": ["remark-mdx@3.1.1", "", { "dependencies": { "mdast-util-mdx": "^3.0.0", "micromark-extension-mdxjs": "^3.0.0" } }, "sha512-Pjj2IYlUY3+D8x00UJsIOg5BEvfMyeI+2uLPn9VO9Wg4MEtN/VTIq2NEJQfde9PnX15KgtHyl9S0BcTnWrIuWg=="],
+
+    "remark-mdx-frontmatter": ["remark-mdx-frontmatter@5.2.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "estree-util-value-to-estree": "^3.0.0", "toml": "^3.0.0", "unified": "^11.0.0", "unist-util-mdx-define": "^1.0.0", "yaml": "^2.0.0" } }, "sha512-U/hjUYTkQqNjjMRYyilJgLXSPF65qbLPdoESOkXyrwz2tVyhAnm4GUKhfXqOOS9W34M3545xEMq+aMpHgVjEeQ=="],
+
     "remark-parse": ["remark-parse@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-from-markdown": "^2.0.0", "micromark-util-types": "^2.0.0", "unified": "^11.0.0" } }, "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA=="],
 
-    "remark-rehype": ["remark-rehype@11.1.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ=="],
+    "remark-rehype": ["remark-rehype@11.1.2", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw=="],
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
+
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
 
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
@@ -1025,29 +1694,89 @@
 
     "resolve-pkg-maps": ["resolve-pkg-maps@1.0.0", "", {}, "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw=="],
 
+    "restore-cursor": ["restore-cursor@4.0.0", "", { "dependencies": { "onetime": "^5.1.0", "signal-exit": "^3.0.2" } }, "sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg=="],
+
     "reusify": ["reusify@1.0.4", "", {}, "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="],
+
+    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
     "rollup": ["rollup@4.34.8", "", { "dependencies": { "@types/estree": "1.0.6" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.34.8", "@rollup/rollup-android-arm64": "4.34.8", "@rollup/rollup-darwin-arm64": "4.34.8", "@rollup/rollup-darwin-x64": "4.34.8", "@rollup/rollup-freebsd-arm64": "4.34.8", "@rollup/rollup-freebsd-x64": "4.34.8", "@rollup/rollup-linux-arm-gnueabihf": "4.34.8", "@rollup/rollup-linux-arm-musleabihf": "4.34.8", "@rollup/rollup-linux-arm64-gnu": "4.34.8", "@rollup/rollup-linux-arm64-musl": "4.34.8", "@rollup/rollup-linux-loongarch64-gnu": "4.34.8", "@rollup/rollup-linux-powerpc64le-gnu": "4.34.8", "@rollup/rollup-linux-riscv64-gnu": "4.34.8", "@rollup/rollup-linux-s390x-gnu": "4.34.8", "@rollup/rollup-linux-x64-gnu": "4.34.8", "@rollup/rollup-linux-x64-musl": "4.34.8", "@rollup/rollup-win32-arm64-msvc": "4.34.8", "@rollup/rollup-win32-ia32-msvc": "4.34.8", "@rollup/rollup-win32-x64-msvc": "4.34.8", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-489gTVMzAYdiZHFVA/ig/iYFllCcWFHMvUHI1rpFmkoUtRlQxqh6/yiNqnYibjMZ2b/+FUQwldG+aLsEt6bglQ=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
+    "rrweb-cssom": ["rrweb-cssom@0.7.1", "", {}, "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg=="],
+
+    "run-applescript": ["run-applescript@7.1.0", "", {}, "sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q=="],
+
+    "run-async": ["run-async@4.0.6", "", {}, "sha512-IoDlSLTs3Yq593mb3ZoKWKXMNu3UpObxhgA/Xuid5p4bbfi2jdY1Hj0m1K+0/tEuQTxIGMhQDqGjKb7RuxGpAQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "rxjs": ["rxjs@7.8.2", "", { "dependencies": { "tslib": "^2.1.0" } }, "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA=="],
+
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sax": ["sax@1.4.3", "", {}, "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ=="],
+
+    "saxes": ["saxes@6.0.0", "", { "dependencies": { "xmlchars": "^2.2.0" } }, "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
+    "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
+
+    "secure-json-parse": ["secure-json-parse@2.7.0", "", {}, "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="],
+
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "send": ["send@1.2.0", "", { "dependencies": { "debug": "^4.3.5", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.0", "mime-types": "^3.0.1", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.1" } }, "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw=="],
+
+    "serve-static": ["serve-static@2.2.0", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
+    "sharp": ["sharp@0.33.5", "", { "dependencies": { "color": "^4.2.3", "detect-libc": "^2.0.3", "semver": "^7.6.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.33.5", "@img/sharp-darwin-x64": "0.33.5", "@img/sharp-libvips-darwin-arm64": "1.0.4", "@img/sharp-libvips-darwin-x64": "1.0.4", "@img/sharp-libvips-linux-arm": "1.0.5", "@img/sharp-libvips-linux-arm64": "1.0.4", "@img/sharp-libvips-linux-s390x": "1.0.4", "@img/sharp-libvips-linux-x64": "1.0.4", "@img/sharp-libvips-linuxmusl-arm64": "1.0.4", "@img/sharp-libvips-linuxmusl-x64": "1.0.4", "@img/sharp-linux-arm": "0.33.5", "@img/sharp-linux-arm64": "0.33.5", "@img/sharp-linux-s390x": "0.33.5", "@img/sharp-linux-x64": "0.33.5", "@img/sharp-linuxmusl-arm64": "0.33.5", "@img/sharp-linuxmusl-x64": "0.33.5", "@img/sharp-wasm32": "0.33.5", "@img/sharp-win32-ia32": "0.33.5", "@img/sharp-win32-x64": "0.33.5" } }, "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw=="],
 
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
-    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+    "side-channel": ["side-channel@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3", "side-channel-list": "^1.0.0", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw=="],
+
+    "side-channel-list": ["side-channel-list@1.0.0", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.3" } }, "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
+
+    "signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
+
+    "simple-swizzle": ["simple-swizzle@0.2.4", "", { "dependencies": { "is-arrayish": "^0.3.1" } }, "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw=="],
+
+    "slice-ansi": ["slice-ansi@6.0.0", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
-    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+    "sprintf-js": ["sprintf-js@1.0.3", "", {}, "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="],
+
+    "srt-parser-2": ["srt-parser-2@1.2.3", "", { "bin": { "srt-parser-2": "bin/index.js" } }, "sha512-dANP1AyJTI503H0/kXwRza+7QxDB3BqeFvEKTF4MI9lQcBe8JbRUQTKVIGzGABJCwBovEYavZ2Qsdm/s8XKz8A=="],
+
+    "stack-utils": ["stack-utils@2.0.6", "", { "dependencies": { "escape-string-regexp": "^2.0.0" } }, "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
+
+    "stdin-discarder": ["stdin-discarder@0.2.2", "", {}, "sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ=="],
+
+    "streamsearch": ["streamsearch@1.1.0", "", {}, "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="],
+
+    "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "stringify-entities": ["stringify-entities@4.0.4", "", { "dependencies": { "character-entities-html4": "^2.0.0", "character-entities-legacy": "^3.0.0" } }, "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg=="],
 
@@ -1055,15 +1784,25 @@
 
     "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
+    "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
+
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "strnum": ["strnum@2.1.1", "", {}, "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw=="],
+
     "style-to-object": ["style-to-object@1.0.8", "", { "dependencies": { "inline-style-parser": "0.2.4" } }, "sha512-xT47I/Eo0rwJmaXC4oilDGDWLohVhR6o/xAQcPQN8q6QBuZVL8qMYL85kLmST5cPjAorwvqIA4qXTRQoYHaL6g=="],
+
+    "styled-jsx": ["styled-jsx@5.1.6", "", { "dependencies": { "client-only": "0.0.1" }, "peerDependencies": { "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0" } }, "sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA=="],
 
     "sucrase": ["sucrase@3.35.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "glob": "^10.3.10", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-8EbVDiu9iN/nESwxeSxDKe0dunta1GOlHufmSSXxMD2z2/tMZpDMpvXQGsc+ajGo8y2uYUmixaSRUc/QPoQ0GA=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
+
+    "swr": ["swr@2.3.6", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.4.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-wfHRmHWk/isGNMwlLGlZX5Gzz/uTgo0o2IRuTMcf4CPuPFJZlq0rDaKUx+ozB5nBOReNV1kiOyzMfj+MBMikLw=="],
+
+    "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "tailwind-merge": ["tailwind-merge@2.6.0", "", {}, "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA=="],
 
@@ -1075,11 +1814,35 @@
 
     "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
 
+    "throttleit": ["throttleit@2.1.0", "", {}, "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw=="],
+
     "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
 
     "tiny-warning": ["tiny-warning@1.0.3", "", {}, "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="],
 
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
+
+    "tinygradient": ["tinygradient@1.1.5", "", { "dependencies": { "@types/tinycolor2": "^1.4.0", "tinycolor2": "^1.0.0" } }, "sha512-8nIfc2vgQ4TeLnk2lFj4tRLvvJwEfQuabdsmvDdQPT0xlk9TaNtpGd6nNRxXoK6vQhN6RSzj+Cnp5tTQmpxmbw=="],
+
+    "tldts": ["tldts@6.1.86", "", { "dependencies": { "tldts-core": "^6.1.86" }, "bin": { "tldts": "bin/cli.js" } }, "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ=="],
+
+    "tldts-core": ["tldts-core@6.1.86", "", {}, "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="],
+
+    "tmp": ["tmp@0.0.33", "", { "dependencies": { "os-tmpdir": "~1.0.2" } }, "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw=="],
+
+    "tmp-promise": ["tmp-promise@3.0.3", "", { "dependencies": { "tmp": "^0.2.0" } }, "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ=="],
+
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "toad-cache": ["toad-cache@3.7.0", "", {}, "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw=="],
+
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
+    "toml": ["toml@3.0.0", "", {}, "sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w=="],
+
+    "tough-cookie": ["tough-cookie@5.1.2", "", { "dependencies": { "tldts": "^6.1.32" } }, "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A=="],
+
+    "tr46": ["tr46@5.1.1", "", { "dependencies": { "punycode": "^2.3.1" } }, "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
@@ -1099,6 +1862,10 @@
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
 
+    "type-fest": ["type-fest@0.12.0", "", {}, "sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg=="],
+
+    "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
+
     "typescript": ["typescript@5.7.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw=="],
 
     "typescript-eslint": ["typescript-eslint@8.24.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.24.0", "@typescript-eslint/parser": "8.24.0", "@typescript-eslint/utils": "8.24.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0", "typescript": ">=4.8.4 <5.8.0" } }, "sha512-/lmv4366en/qbB32Vz5+kCNZEMf6xYHwh1z48suBwZvAtnXKbP+YhGe8OLE2BqC67LMqKkCNLtjejdwsdW6uOQ=="],
@@ -1111,7 +1878,11 @@
 
     "unist-util-is": ["unist-util-is@6.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-2qCTHimwdxLfz+YzdGfkqNlH0tLi9xjTnHddPmJwtIG9MGsdbutfTc4P+haPD7l7Cjxf/WZj+we5qfVPvvxfYw=="],
 
+    "unist-util-mdx-define": ["unist-util-mdx-define@1.1.2", "", { "dependencies": { "@types/estree": "^1.0.0", "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "estree-util-is-identifier-name": "^3.0.0", "estree-util-scope": "^1.0.0", "estree-walker": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-9ncH7i7TN5Xn7/tzX5bE3rXgz1X/u877gYVAUB3mLeTKYJmQHmqKTDBi6BTGXV7AeolBCI9ErcVsOt2qryoD0g=="],
+
     "unist-util-position": ["unist-util-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA=="],
+
+    "unist-util-position-from-estree": ["unist-util-position-from-estree@2.0.0", "", { "dependencies": { "@types/unist": "^3.0.0" } }, "sha512-KaFVRjoqLyF6YXCbVLNad/eS4+OfPQQn2yOd7zF/h5T/CSL2v8NpN6a5TPvtbXthAGw5nG+PuTtq+DdIZr+cRQ=="],
 
     "unist-util-remove-position": ["unist-util-remove-position@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-visit": "^5.0.0" } }, "sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q=="],
 
@@ -1121,11 +1892,19 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
 
+    "universal-github-app-jwt": ["universal-github-app-jwt@2.2.2", "", {}, "sha512-dcmbeSrOdTnsjGjUfAlqNDJrhxXizjAz94ija9Qw8YkZ1uu0d+GoZzyH+Jb9tIIqvGsadUfwg+22k5aDqqwzbw=="],
+
+    "universal-user-agent": ["universal-user-agent@7.0.3", "", {}, "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A=="],
+
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unplugin": ["unplugin@2.2.0", "", { "dependencies": { "acorn": "^8.14.0", "webpack-virtual-modules": "^0.6.2" } }, "sha512-m1ekpSwuOT5hxkJeZGRxO7gXbXT3gF26NjQ7GdVHoLoF8/nopLcd/QfPigpCy7i51oFHiRJg/CyHhj4vs2+KGw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
+    "url-template": ["url-template@2.0.8", "", {}, "sha512-XdVKMF4SJ0nP/O7XIPB0JwAEuT9lDIYnNsK8yGVe43y0AWoKeJNdv3ZNWh7ksJ6KqQFjOO6ox/VEitLnaVNufw=="],
 
     "use-callback-ref": ["use-callback-ref@1.3.3", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg=="],
 
@@ -1137,6 +1916,8 @@
 
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-location": ["vfile-location@5.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile": "^6.0.0" } }, "sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg=="],
@@ -1145,11 +1926,23 @@
 
     "vite": ["vite@5.4.14", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["@types/node", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": { "vite": "bin/vite.js" } }, "sha512-EK5cY7Q1D8JNhSaPKVK4pwBFvaTmZxEnoKXLG/U9gmdDcihQGNzFlgIvaxezFR4glP1LsuiedwMBqCXH3wZccA=="],
 
+    "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
+
     "web-namespaces": ["web-namespaces@2.0.1", "", {}, "sha512-bKr1DkiNa2krS7qxNtdrtHAmzuYGFQLiQ13TsorsdT6ULTkPLKuu5+GsFpDlg6JFjUTwX2DyhMPG2be8uPrqsQ=="],
+
+    "webidl-conversions": ["webidl-conversions@7.0.0", "", {}, "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="],
 
     "webpack-virtual-modules": ["webpack-virtual-modules@0.6.2", "", {}, "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ=="],
 
+    "whatwg-encoding": ["whatwg-encoding@3.1.1", "", { "dependencies": { "iconv-lite": "0.6.3" } }, "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ=="],
+
+    "whatwg-mimetype": ["whatwg-mimetype@4.0.0", "", {}, "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg=="],
+
+    "whatwg-url": ["whatwg-url@14.2.0", "", { "dependencies": { "tr46": "^5.1.0", "webidl-conversions": "^7.0.0" } }, "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw=="],
+
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "widest-line": ["widest-line@4.0.1", "", { "dependencies": { "string-width": "^5.0.1" } }, "sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig=="],
 
     "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
 
@@ -1157,17 +1950,71 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
+    "ws": ["ws@8.18.3", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg=="],
+
+    "wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
+
+    "xcase": ["xcase@2.0.1", "", {}, "sha512-UmFXIPU+9Eg3E9m/728Bii0lAIuoc+6nbrNUKaRPJOFp91ih44qqGlWtxMB6kXFrRD6po+86ksHM5XHCfk6iPw=="],
+
+    "xliff": ["xliff@6.2.2", "", { "dependencies": { "xml-js": "1.6.11" } }, "sha512-8j1NITWDF3oRV3wkE514g1yYpk9pv3MKiOrVVaxY8YWtcQs1Ux12tfVmIwKeP5/GVfS7g0N6oRm1TqjR2MeEaw=="],
+
+    "xml-js": ["xml-js@1.6.11", "", { "dependencies": { "sax": "^1.2.4" }, "bin": { "xml-js": "./bin/cli.js" } }, "sha512-7rVi2KMfwfWFl+GpPg6m80IVMWXLRjO+PxTq7V2CDhoGak0wzYzFgUY2m4XJ47OGdXd8eLE8EmwfAmdjw7lC1g=="],
+
+    "xml-name-validator": ["xml-name-validator@5.0.0", "", {}, "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg=="],
+
+    "xml2js": ["xml2js@0.6.2", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA=="],
+
+    "xmlbuilder": ["xmlbuilder@15.1.1", "", {}, "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg=="],
+
+    "xmlchars": ["xmlchars@2.2.0", "", {}, "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="],
+
+    "xpath": ["xpath@0.0.34", "", {}, "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.7.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA=="],
 
-    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+    "yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
+
+    "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
+
+    "yoga-wasm-web": ["yoga-wasm-web@0.3.3", "", {}, "sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA=="],
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.24.6", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-h/z3PKvcTcTetyjl1fkj79MHNEjm+HpD6NXheWjzOekY7kV+lwDYnHw+ivHkijnCSMz1yJaWBD9vu/Fcmk+vEg=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "@alcalzone/ansi-tokenize/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "@alcalzone/ansi-tokenize/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "@ampproject/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@asamuzakjp/css-color/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@babel/core/@babel/generator": ["@babel/generator@7.26.9", "", { "dependencies": { "@babel/parser": "^7.26.9", "@babel/types": "^7.26.9", "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25", "jsesc": "^3.0.2" } }, "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg=="],
+
+    "@babel/core/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
+    "@babel/generator/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@babel/generator/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@babel/parser/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@babel/template/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
+    "@babel/traverse/@babel/generator": ["@babel/generator@7.26.9", "", { "dependencies": { "@babel/parser": "^7.26.9", "@babel/types": "^7.26.9", "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25", "jsesc": "^3.0.2" } }, "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg=="],
+
+    "@babel/traverse/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
     "@babel/traverse/globals": ["globals@11.12.0", "", {}, "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="],
+
+    "@datocms/cma-client/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
 
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
 
@@ -1176,6 +2023,38 @@
     "@eslint/plugin-kit/@eslint/core": ["@eslint/core@0.10.0", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-gFHJ+xBOo4G3WRlR1e/3G8A6/KZAH6zcE/hkLRCZTi/B9avAG365QhFA8uOGzTMqgTghpn7/fSnscW++dpMSAw=="],
 
     "@humanfs/node/@humanwhocodes/retry": ["@humanwhocodes/retry@0.3.1", "", {}, "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA=="],
+
+    "@inkjs/ui/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@inquirer/core/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
+
+    "@inquirer/external-editor/chardet": ["chardet@2.1.1", "", {}, "sha512-PsezH1rqdV9VvyNhxxOW32/d75r01NY7TQCmOqomRo15ZSOKbpTFVsfjghxo6JloQUCGnH4k1LGu0R4yCLlWQQ=="],
+
+    "@inquirer/external-editor/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
+
+    "@isaacs/cliui/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@lingo.dev/_compiler/@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
+
+    "@lingo.dev/_compiler/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "@lingo.dev/_compiler/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@lingo.dev/_sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@lingo.dev/_spec/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@octokit/core/before-after-hook": ["before-after-hook@3.0.2", "", {}, "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A=="],
+
+    "@openrouter/ai-sdk-provider/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-checkbox/@radix-ui/primitive": ["@radix-ui/primitive@1.1.3", "", {}, "sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg=="],
 
@@ -1247,27 +2126,137 @@
 
     "@radix-ui/react-use-size/@radix-ui/react-use-layout-effect": ["@radix-ui/react-use-layout-effect@1.1.1", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ=="],
 
+    "@tanstack/router-utils/@babel/generator": ["@babel/generator@7.26.9", "", { "dependencies": { "@babel/parser": "^7.26.9", "@babel/types": "^7.26.9", "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.25", "jsesc": "^3.0.2" } }, "sha512-kEWdzjOAUMW4hAyrzJ0ZaTOu9OmpyDIQicIh0zg0EEcEkYXZb2TjtBhnHi2ViX7PKwZqF4xwqfAm299/QMP3lg=="],
+
+    "@tanstack/router-utils/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
+    "@types/babel__core/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
+    "@types/babel__template/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
     "@typescript-eslint/typescript-estree/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
+    "accepts/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
+
+    "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
+
+    "babel-dead-code-elimination/@babel/parser": ["@babel/parser@7.26.9", "", { "dependencies": { "@babel/types": "^7.26.9" }, "bin": "./bin/babel-parser.js" }, "sha512-81NWa1njQblgZbQHxWHpxxCzNsa3ZwvFqpUg7P+NNUU6f3UU2jBEg4OlF/J6rl8+PQGh1q6/zWScd001YwcA5A=="],
+
+    "body-parser/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
+    "cli-truncate/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "cssstyle/rrweb-cssom": ["rrweb-cssom@0.8.0", "", {}, "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw=="],
+
+    "encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "express/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
 
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
+    "figlet/commander": ["commander@14.0.2", "", {}, "sha512-TywoWNNRbhoD0BXs1P3ZEScW8W5iKrnbithIl0YH+uCmBd0QpPOA8yc82DS3BIE5Ma6FnBVUsJ7wVUDz4dvOWQ=="],
+
+    "filelist/minimatch": ["minimatch@5.1.6", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g=="],
+
+    "foreground-child/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
     "glob/minimatch": ["minimatch@9.0.5", "", { "dependencies": { "brace-expansion": "^2.0.1" } }, "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow=="],
+
+    "gradient-string/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "gray-matter/js-yaml": ["js-yaml@3.14.1", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g=="],
+
+    "hast-util-to-html/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "http-errors/statuses": ["statuses@2.0.1", "", {}, "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="],
+
+    "ink/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "ink/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "ink-spinner/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "interactive-commander/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "jsondiffpatch/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "lingo.dev/@babel/traverse": ["@babel/traverse@7.28.5", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/generator": "^7.28.5", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.28.5", "@babel/template": "^7.27.2", "@babel/types": "^7.28.5", "debug": "^4.3.1" } }, "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ=="],
+
+    "lingo.dev/@babel/types": ["@babel/types@7.28.5", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA=="],
+
+    "lingo.dev/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "lingo.dev/chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "lingo.dev/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "listr2/cli-truncate": ["cli-truncate@4.0.0", "", { "dependencies": { "slice-ansi": "^5.0.0", "string-width": "^7.0.0" } }, "sha512-nPdaFdQ0h/GEigbPClz11D0v/ZJEwxmeVZGeMo3Z5StPtUTkA9o1lD6QwoirYiSDzbcwn2XcjwmCp68W1IS4TA=="],
+
+    "listr2/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
+
+    "log-symbols/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
+
+    "log-update/ansi-escapes": ["ansi-escapes@7.2.0", "", { "dependencies": { "environment": "^1.0.0" } }, "sha512-g6LhBsl+GBPRWGWsBtutpzBYuIIdBkLEvad5C/va/74Db018+5TZiyA26cZJAr3Rft5lprVqOIPxf5Vid6tqAw=="],
+
+    "log-update/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
+
+    "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "mdast-util-find-and-replace/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
 
+    "mdast-util-frontmatter/escape-string-regexp": ["escape-string-regexp@5.0.0", "", {}, "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="],
+
     "micromark-extension-math/katex": ["katex@0.16.21", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A=="],
+
+    "next/postcss": ["postcss@8.4.31", "", { "dependencies": { "nanoid": "^3.3.6", "picocolors": "^1.0.0", "source-map-js": "^1.0.2" } }, "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ=="],
+
+    "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
+
+    "node-webvtt/commander": ["commander@7.2.0", "", {}, "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="],
+
+    "ora/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "ora/cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
+
+    "ora/cli-spinners": ["cli-spinners@2.9.2", "", {}, "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg=="],
+
+    "ora/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "p-locate/p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
+    "parse-my-command/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
     "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "raw-body/iconv-lite": ["iconv-lite@0.7.0", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ=="],
+
+    "react-markdown/remark-rehype": ["remark-rehype@11.1.1", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "mdast-util-to-hast": "^13.0.0", "unified": "^11.0.0", "vfile": "^6.0.0" } }, "sha512-g/osARvjkBXb6Wo0XvAeXQohVta8i84ACbenPpoSsxTOQH/Ae0/RGP4WZgnMH5pMLpsj4FG7OHmcIcXxpza8eQ=="],
 
     "rehype-katex/katex": ["katex@0.16.21", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A=="],
 
-    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "send/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
+
+    "sharp/semver": ["semver@7.7.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
+    "slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "stack-utils/escape-string-regexp": ["escape-string-regexp@2.0.0", "", {}, "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="],
+
+    "string-width/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -1275,15 +2264,51 @@
 
     "sucrase/commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
 
+    "tmp-promise/tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
+
     "tsx/esbuild": ["esbuild@0.23.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.23.1", "@esbuild/android-arm": "0.23.1", "@esbuild/android-arm64": "0.23.1", "@esbuild/android-x64": "0.23.1", "@esbuild/darwin-arm64": "0.23.1", "@esbuild/darwin-x64": "0.23.1", "@esbuild/freebsd-arm64": "0.23.1", "@esbuild/freebsd-x64": "0.23.1", "@esbuild/linux-arm": "0.23.1", "@esbuild/linux-arm64": "0.23.1", "@esbuild/linux-ia32": "0.23.1", "@esbuild/linux-loong64": "0.23.1", "@esbuild/linux-mips64el": "0.23.1", "@esbuild/linux-ppc64": "0.23.1", "@esbuild/linux-riscv64": "0.23.1", "@esbuild/linux-s390x": "0.23.1", "@esbuild/linux-x64": "0.23.1", "@esbuild/netbsd-x64": "0.23.1", "@esbuild/openbsd-arm64": "0.23.1", "@esbuild/openbsd-x64": "0.23.1", "@esbuild/sunos-x64": "0.23.1", "@esbuild/win32-arm64": "0.23.1", "@esbuild/win32-ia32": "0.23.1", "@esbuild/win32-x64": "0.23.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-VVNz/9Sa0bs5SELtn3f7qhJCDPCF5oMEl5cO9/SSinpE9hbPVvxbd572HH5AKiP7WD8INO53GgfDDhRjkylHEg=="],
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "type-is/mime-types": ["mime-types@3.0.1", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA=="],
+
+    "whatwg-encoding/iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
+
+    "widest-line/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
-    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+    "wrap-ansi/string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "xml2js/xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
+    "@babel/core/@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@babel/generator/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/generator/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/traverse/@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "@isaacs/cliui/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@lingo.dev/_compiler/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "@lingo.dev/_compiler/@babel/traverse/@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "@lingo.dev/_compiler/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@lingo.dev/_compiler/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@radix-ui/react-checkbox/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1299,11 +2324,73 @@
 
     "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
+    "@tanstack/router-utils/@babel/generator/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
+
+    "accepts/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
+
+    "cli-truncate/slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "cli-truncate/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "express/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "filelist/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
     "glob/minimatch/brace-expansion": ["brace-expansion@2.0.1", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA=="],
 
+    "gray-matter/js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
+
+    "ink/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "lingo.dev/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.27.1", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
+
+    "lingo.dev/@babel/traverse/@babel/template": ["@babel/template@7.27.2", "", { "dependencies": { "@babel/code-frame": "^7.27.1", "@babel/parser": "^7.27.2", "@babel/types": "^7.27.1" } }, "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw=="],
+
+    "lingo.dev/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "lingo.dev/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "lingo.dev/chokidar/readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "listr2/cli-truncate/slice-ansi": ["slice-ansi@5.0.0", "", { "dependencies": { "ansi-styles": "^6.0.0", "is-fullwidth-code-point": "^4.0.0" } }, "sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ=="],
+
+    "listr2/cli-truncate/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "listr2/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "listr2/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "log-update/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "log-update/slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "log-update/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@5.1.0", "", { "dependencies": { "get-east-asian-width": "^1.3.1" } }, "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ=="],
+
+    "log-update/wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
+
+    "node-fetch/whatwg-url/tr46": ["tr46@0.0.3", "", {}, "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="],
+
+    "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
+
+    "ora/cli-cursor/restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
+
+    "ora/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "p-locate/p-limit/yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
+    "send/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "string-width/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "tsx/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.23.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-6VhYk1diRqrhBAqpJEdjASR/+WVRtfjpqKuNw11cLiaWpAT/Uu+nokB+UJnevzy/P9C/ty6AOe0dwueMrGh/iQ=="],
 
@@ -1351,10 +2438,38 @@
 
     "tsx/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.23.1", "", { "os": "win32", "cpu": "x64" }, "sha512-BHpFFeslkWrXWyUPnbKm+xYYVYruCinGcftSBaa8zoF9hZO4BcSCFUvHVTtzpIY6YzUnYtuEhZ+C9iEXjxnasg=="],
 
-    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+    "type-is/mime-types/mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "widest-line/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
     "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
+    "wrap-ansi/string-width/emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "@lingo.dev/_compiler/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "@radix-ui/react-tabs/@radix-ui/react-primitive/@radix-ui/react-slot/@radix-ui/react-compose-refs": ["@radix-ui/react-compose-refs@1.1.2", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg=="],
+
+    "lingo.dev/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "listr2/cli-truncate/slice-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
+
+    "listr2/cli-truncate/slice-ansi/is-fullwidth-code-point": ["is-fullwidth-code-point@4.0.0", "", {}, "sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ=="],
+
+    "listr2/cli-truncate/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "listr2/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "log-update/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "log-update/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "log-update/wrap-ansi/string-width/emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
+
+    "ora/cli-cursor/restore-cursor/onetime": ["onetime@7.0.0", "", { "dependencies": { "mimic-function": "^5.0.0" } }, "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ=="],
+
+    "ora/cli-cursor/restore-cursor/signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
   }
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -42,6 +42,7 @@
     "clsx": "^2.1.1",
     "gpt-tokenizer": "^3.0.1",
     "katex": "^0.16.25",
+    "lingo.dev": "^0.114.5",
     "lucide-react": "^0.436.0",
     "openai": "5.20.0",
     "react": "^18.3.1",

--- a/frontend/src/components/TopNav.tsx
+++ b/frontend/src/components/TopNav.tsx
@@ -4,6 +4,7 @@ import { Button } from "./ui/button";
 import { useOpenSecret } from "@opensecret/react";
 import { Menu, X } from "lucide-react";
 import { useState } from "react";
+import { LocaleSwitcher } from "lingo.dev/react/client";
 
 export function TopNav() {
   const os = useOpenSecret();
@@ -65,6 +66,11 @@ export function TopNav() {
             </div>
 
             <div className="flex items-center gap-4">
+              {/* Language Switcher */}
+              <div className="hidden sm:block">
+                <LocaleSwitcher locales={["en", "es"]} />
+              </div>
+
               {/* Login/Chat Button */}
               {os.auth.user ? (
                 <Button
@@ -116,6 +122,9 @@ export function TopNav() {
               >
                 Guides
               </a>
+              <div className="pt-4 border-t border-[#E2E2E2]/10">
+                <LocaleSwitcher locales={["en", "es"]} />
+              </div>
             </div>
           </div>
         )}

--- a/frontend/src/lingo/dictionary.js
+++ b/frontend/src/lingo/dictionary.js
@@ -1,0 +1,5070 @@
+export default {
+  version: 0.1,
+  files: {
+    "components/AccountDialog.tsx": {
+      entries: {
+        "12/declaration/body/9/argument/1/1/1": {
+          content: {
+            en: "Update Your Account",
+            es: "Actualiza tu cuenta"
+          },
+          hash: "5158811ccd3dc7f34c43104ec752117e"
+        },
+        "12/declaration/body/9/argument/1/1/3": {
+          content: {
+            en: "Change your email or upgrade your plan.",
+            es: "Cambia tu correo electrónico o mejora tu plan."
+          },
+          hash: "ba3fdcbebb09316395aaca9a69a15af3"
+        },
+        "12/declaration/body/9/argument/1/3/1/expression/right/1": {
+          content: {
+            en: "Email",
+            es: "Correo electrónico"
+          },
+          hash: "e7f34943a0c2fb849db1839ff6ef5cb5"
+        },
+        "12/declaration/body/9/argument/1/3/1/expression/right/5/expression/right/1/expression/consequent":
+          {
+            content: {
+              en: "Unverified - <element:button>Resend verification email</element:button>",
+              es: "No verificado - <element:button>Reenviar correo de verificación</element:button>"
+            },
+            hash: "b9ed21d5af83c3edcc2ccdee1c0d8b93"
+          },
+        "12/declaration/body/9/argument/1/3/3/1": {
+          content: {
+            en: "Plan",
+            es: "Plan"
+          },
+          hash: "c6a08c771f97d86b02cf10d8f5f2d788"
+        },
+        "12/declaration/body/9/argument/1/3/3/3/3/1/1": {
+          content: {
+            en: "Plan",
+            es: "Plan"
+          },
+          hash: "c6a08c771f97d86b02cf10d8f5f2d788"
+        },
+        "12/declaration/body/9/argument/1/3/5/1": {
+          content: {
+            en: "User Preferences",
+            es: "Preferencias de usuario"
+          },
+          hash: "165daa4cf8fb29b9ade6d953afca2954"
+        },
+        "12/declaration/body/9/argument/1/3/5/3/expression/right/1": {
+          content: {
+            en: "Change Password",
+            es: "Cambiar contraseña"
+          },
+          hash: "78a4bf8cad46e6b1bcc1f3958be55aa3"
+        },
+        "12/declaration/body/9/argument/1/3/5/5": {
+          content: {
+            en: "<element:Trash></element:Trash> Delete Account",
+            es: "<element:Trash></element:Trash> Eliminar cuenta"
+          },
+          hash: "d977430f34258d84d78cc5bfed6758a7"
+        },
+        "12/declaration/body/9/argument/1/5/1": {
+          content: {
+            en: "Save Changes",
+            es: "Guardar cambios"
+          },
+          hash: "e0e373a41634205df41b708880165e43"
+        }
+      }
+    },
+    "components/AccountMenu.tsx": {
+      entries: {
+        "19/body/4/argument/1/1": {
+          content: {
+            en: "Are you sure?",
+            es: "¿Estás seguro?"
+          },
+          hash: "6d5cd13628a7887711fd0c29f1123652"
+        },
+        "19/body/4/argument/1/3": {
+          content: {
+            en: "This will delete your entire chat history.",
+            es: "Esto eliminará todo tu historial de chat."
+          },
+          hash: "a3d5a7d87030107b0cfa5b59041b4a2b"
+        },
+        "19/body/4/argument/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "19/body/4/argument/3/3": {
+          content: {
+            en: "Delete",
+            es: "Eliminar"
+          },
+          hash: "8bcf303dd10a645b5baacb02b47d72c9"
+        },
+        "20/declaration/body/20/argument/1/1/1/5/1": {
+          content: {
+            en: "<element:User></element:User> Account<expression/>",
+            es: "<element:User></element:User> Cuenta<expression/>"
+          },
+          hash: "b853b058e40dd9b194a9e1eb327f1019"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/13/3": {
+          content: {
+            en: "Log out",
+            es: "Cerrar sesión"
+          },
+          hash: "9a236bb8f8bec867ec0d0950d38bcc71"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/1/1/3": {
+          content: {
+            en: "Profile",
+            es: "Perfil"
+          },
+          hash: "d7878693f91303a438852d617f6d35df"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/11/1/3": {
+          content: {
+            en: "Delete History",
+            es: "Eliminar historial"
+          },
+          hash: "94887d927b8010412f4cfd70c816f54d"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/3/expression/right/1/3": {
+          content: {
+            en: "Upgrade your plan",
+            es: "Mejorar tu plan"
+          },
+          hash: "555f4914d0f19b9566c5ca7678339e29"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/7/expression/right/1/1/3": {
+          content: {
+            en: "Manage Team",
+            es: "Gestionar equipo"
+          },
+          hash: "02d78d6b589015b06bd06a6d34ce2dcb"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/7/expression/right/1/3/expression/right": {
+          content: {
+            en: "Setup Required",
+            es: "Configuración requerida"
+          },
+          hash: "f3241d4072ebea7dcd02878ba025c5f7"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/9/expression/right/3": {
+          content: {
+            en: "API Management",
+            es: "Gestión de API"
+          },
+          hash: "b3d76fe5a47de22d9a422c902b3ae82d"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/9/1/3": {
+          content: {
+            en: "About Us",
+            es: "Sobre nosotros"
+          },
+          hash: "8f89131a66d4659be07cd5af2c7ea898"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/1/1/3": {
+          content: {
+            en: "Back",
+            es: "Atrás"
+          },
+          hash: "f541015a827e37cb3b1234e56bc2aa3c"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/1/1/3": {
+          content: {
+            en: "About Maple",
+            es: "Acerca de Maple"
+          },
+          hash: "253c5a54e1e11e54a05f00c4afccad8b"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/3/3": {
+          content: {
+            en: "Privacy Policy",
+            es: "Política de privacidad"
+          },
+          hash: "7459744a63ef8af4e517a09024bd7c08"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/5/3": {
+          content: {
+            en: "Terms of Service",
+            es: "Términos de servicio"
+          },
+          hash: "5add91f519e39025708e54a7eb7a9fc5"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/7/1/3": {
+          content: {
+            en: "Contact Us",
+            es: "Contáctanos"
+          },
+          hash: "2a75337dc9603915c4ec1d1905afb7b9"
+        }
+      }
+    },
+    "components/AppleAuthProvider.tsx": {
+      entries: {
+        "14/declaration/body/9/argument/alternate": {
+          content: {
+            en: "<element:Apple></element:Apple> Log in with Apple",
+            es: "<element:Apple></element:Apple> Iniciar sesión con Apple"
+          },
+          hash: "19ad2aed2e69c9abe9fefe8071a6829a"
+        }
+      }
+    },
+    "components/AuthMain.tsx": {
+      entries: {
+        "4/declaration/body/0/argument/1/1/1-alt": {
+          content: {
+            en: "Maple AI logo",
+            es: "Logo de Maple AI"
+          },
+          hash: "b5b1f436ba922b2e4a0eb1615efb346a"
+        },
+        "4/declaration/body/0/argument/1/1/3-alt": {
+          content: {
+            en: "Maple AI logo",
+            es: "Logo de Maple AI"
+          },
+          hash: "b5b1f436ba922b2e4a0eb1615efb346a"
+        }
+      }
+    },
+    "components/ChangePasswordDialog.tsx": {
+      entries: {
+        "8/declaration/body/10/argument/1/1/1": {
+          content: {
+            en: "Change Password",
+            es: "Cambiar contraseña"
+          },
+          hash: "a552fc5c4189ebc3e2e6018edda7d18f"
+        },
+        "8/declaration/body/10/argument/1/1/3": {
+          content: {
+            en: "Enter your current password and a new password to update your account.",
+            es: "Introduce tu contraseña actual y una nueva contraseña para actualizar tu cuenta."
+          },
+          hash: "36291f0d0974db90a0173f145c47dd35"
+        },
+        "8/declaration/body/10/argument/1/3/3/expression/right/1": {
+          content: {
+            en: "Password changed successfully. This dialog will close shortly.",
+            es: "Contraseña cambiada con éxito. Este diálogo se cerrará en breve."
+          },
+          hash: "01af737e898cfe4e3c50dd062170dcba"
+        },
+        "8/declaration/body/10/argument/1/3/5/1": {
+          content: {
+            en: "Current Password",
+            es: "Contraseña actual"
+          },
+          hash: "2e186f3990c3fcacb1f892c94f7ecae1"
+        },
+        "8/declaration/body/10/argument/1/3/7/1": {
+          content: {
+            en: "New Password",
+            es: "Nueva contraseña"
+          },
+          hash: "80d809edd5d1b66123b18faaac10537b"
+        },
+        "8/declaration/body/10/argument/1/3/9/1": {
+          content: {
+            en: "Confirm New Password",
+            es: "Confirmar nueva contraseña"
+          },
+          hash: "d3194bdcb74c9a912c67d7e1b030b88a"
+        }
+      }
+    },
+    "components/ChatHistoryList.tsx": {
+      entries: {
+        "13/declaration/body/32/consequent/0/argument": {
+          content: {
+            en: "Loading chat history...",
+            es: "Cargando historial de chat..."
+          },
+          hash: "4601c8eb6d6e81c91ef4f0fe43141918"
+        },
+        "13/declaration/body/34/consequent/0/argument/1": {
+          content: {
+            en: 'No chats found matching "{trimmedQuery}"',
+            es: 'No se encontraron chats que coincidan con "{trimmedQuery}"'
+          },
+          hash: "4236da1be65d3240cfe260c42910ef18"
+        },
+        "13/declaration/body/34/consequent/0/argument/3": {
+          content: {
+            en: "Try a different search term",
+            es: "Prueba con un término de búsqueda diferente"
+          },
+          hash: "87132887ef8f4ebb921b7ca2378423e8"
+        },
+        "13/declaration/body/35/argument/1/expression/0/body/4/argument/3/3/1/3": {
+          content: {
+            en: "Rename Chat",
+            es: "Renombrar chat"
+          },
+          hash: "bb846c81ebb761285702bf2eb9315d9e"
+        },
+        "13/declaration/body/35/argument/1/expression/0/body/4/argument/3/3/3/3": {
+          content: {
+            en: "Delete Chat",
+            es: "Eliminar chat"
+          },
+          hash: "38f623dc2fe274087d6dfbcae8700202"
+        },
+        "13/declaration/body/35/argument/9/expression/right/1/3": {
+          content: {
+            en: "Archived ({filteredArchivedChats.length})",
+            es: "Archivados ({filteredArchivedChats.length})"
+          },
+          hash: "36a012d3a66004474d6fcc6d6731dc60"
+        },
+        "13/declaration/body/35/argument/9/expression/right/3/expression/right/1/expression/0/body/1/argument/3/3/1/3":
+          {
+            content: {
+              en: "Rename Chat",
+              es: "Renombrar chat"
+            },
+            hash: "bb846c81ebb761285702bf2eb9315d9e"
+          },
+        "13/declaration/body/35/argument/9/expression/right/3/expression/right/1/expression/0/body/1/argument/3/3/3/3":
+          {
+            content: {
+              en: "Delete Chat",
+              es: "Eliminar chat"
+            },
+            hash: "38f623dc2fe274087d6dfbcae8700202"
+          }
+      }
+    },
+    "components/ComparisonChart.tsx": {
+      entries: {
+        "3/0/init/body/0/0/0/argument/1-aria-label": {
+          content: {
+            en: "Available",
+            es: "Disponible"
+          },
+          hash: "216de63cd5d8bf0bc1cfb470cb2d924b"
+        },
+        "3/0/init/body/0/1/0/argument/1-aria-label": {
+          content: {
+            en: "Not Available",
+            es: "No disponible"
+          },
+          hash: "c84536a39463bb93f07245a2aa00ccae"
+        },
+        "3/0/init/body/0/2/0/argument/1-aria-label": {
+          content: {
+            en: "Unknown or Unclear",
+            es: "Desconocido o poco claro"
+          },
+          hash: "6392f5a447b526482b68fa3127f548f2"
+        },
+        "3/0/init/body/0/3/0/argument/1-aria-label": {
+          content: {
+            en: "Paid Feature",
+            es: "Función de pago"
+          },
+          hash: "aa985c4cdc283d220057e9f5678333fc"
+        },
+        "3/0/init/body/0/4/0/argument/1-aria-label": {
+          content: {
+            en: "Partially Available",
+            es: "Parcialmente disponible"
+          },
+          hash: "beb971200802fc1b7a61bd3245e38a23"
+        },
+        "4/declaration/body/1/argument/1/1/1": {
+          content: {
+            en: "How We <element:span>Compare</element:span>",
+            es: "Cómo nos <element:span>comparamos</element:span>"
+          },
+          hash: "586672042bd9ce2cd832651246444f5d"
+        },
+        "4/declaration/body/1/argument/1/1/3": {
+          content: {
+            en: "See how Maple stacks up against other AI chat platforms when it comes to privacy, security, and developer features.",
+            es: "Mira cómo Maple se compara con otras plataformas de chat con IA en términos de privacidad, seguridad y funciones para desarrolladores."
+          },
+          hash: "3dcc0cdb851d5f26930e5830249b5d78"
+        },
+        "4/declaration/body/1/argument/1/7/1/3": {
+          content: {
+            en: "Available",
+            es: "Disponible"
+          },
+          hash: "216de63cd5d8bf0bc1cfb470cb2d924b"
+        },
+        "4/declaration/body/1/argument/1/7/3/3": {
+          content: {
+            en: "Not Available",
+            es: "No disponible"
+          },
+          hash: "c84536a39463bb93f07245a2aa00ccae"
+        },
+        "4/declaration/body/1/argument/1/7/5/3": {
+          content: {
+            en: "Partially Available",
+            es: "Parcialmente disponible"
+          },
+          hash: "beb971200802fc1b7a61bd3245e38a23"
+        },
+        "4/declaration/body/1/argument/1/7/7/3": {
+          content: {
+            en: "Claim Unverifiable",
+            es: "Afirmación no verificable"
+          },
+          hash: "43325b1dfe49cf3939d1780bb9fef887"
+        },
+        "4/declaration/body/1/argument/1/7/9/3": {
+          content: {
+            en: "Expensive Paid Feature",
+            es: "Función de pago costosa"
+          },
+          hash: "bfadf2181f393a8fa8a30393f91f573e"
+        }
+      }
+    },
+    "components/ContextLimitDialog.tsx": {
+      entries: {
+        "4/declaration/body/1/argument/1/1/1/3": {
+          content: {
+            en: "Message Too Large",
+            es: "Mensaje demasiado grande"
+          },
+          hash: "1257a62fcf3670013efe6e58ab2d9fbf"
+        },
+        "4/declaration/body/1/argument/1/1/3": {
+          content: {
+            en: "Your message exceeds the context limit for the current model.",
+            es: "Tu mensaje excede el límite de contexto para el modelo actual."
+          },
+          hash: "c5e95058e718b8c72ef8e390576c3804"
+        },
+        "4/declaration/body/1/argument/1/3/1/1": {
+          content: {
+            en: "Here's what you can try:",
+            es: "Esto es lo que puedes intentar:"
+          },
+          hash: "5789340d0946ed2b791b8dd5dbc7984e"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/1/3": {
+          content: {
+            en: "<element:strong>Shorten your message</element:strong> - Try reducing the amount of text or content",
+            es: "<element:strong>Acorta tu mensaje</element:strong> - Intenta reducir la cantidad de texto o contenido"
+          },
+          hash: "b0b4bf6746e8e920355f040e21ef118f"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/3/expression/right/3": {
+          content: {
+            en: "<element:strong>Use a smaller document</element:strong> - Try uploading a shorter document or extracting only the relevant sections",
+            es: "<element:strong>Usa un documento más pequeño</element:strong> - Intenta subir un documento más corto o extraer solo las secciones relevantes"
+          },
+          hash: "3248aabeb54185e4f79d553f9196273a"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/5/expression/right/3": {
+          content: {
+            en: "<element:strong>Switch to a model with more context</element:strong> - Try DeepSeek R1, Mistral, or other models that support 128k tokens",
+            es: "<element:strong>Cambia a un modelo con más contexto</element:strong> - Prueba DeepSeek R1, Mistral u otros modelos que admitan 128k tokens"
+          },
+          hash: "d22f01c5837e7b6e3a08a5a36449d2cb"
+        },
+        "4/declaration/body/1/argument/1/5/1": {
+          content: {
+            en: "Got it",
+            es: "Entendido"
+          },
+          hash: "6359071421abf7a7dbf4181c22bd79d2"
+        }
+      }
+    },
+    "components/CreditUsage.tsx": {
+      entries: {
+        "2/declaration/body/7/argument/1/1": {
+          content: {
+            en: "Credit Usage",
+            es: "Uso de crédito"
+          },
+          hash: "1abaf86d3e77f16e115dbfadbb08b94f"
+        },
+        "2/declaration/body/7/argument/1/3": {
+          content: {
+            en: "{roundedPercent}%",
+            es: "{roundedPercent}%"
+          },
+          hash: "5ffe4a4526d680df3dc6d6e7880cbc9a"
+        }
+      }
+    },
+    "components/DeleteAccountDialog.tsx": {
+      entries: {
+        "10/declaration/body/10/argument/1/3/1/expression/right/1/1": {
+          content: {
+            en: "Warning: This will permanently delete your account and all associated data. You will lose access to any paid features, chat history, and settings.",
+            es: "Advertencia: esto eliminará permanentemente tu cuenta y todos los datos asociados. Perderás acceso a cualquier función de pago, historial de chat y configuraciones."
+          },
+          hash: "b06a326a6e8f7938805479896126d5a0"
+        },
+        "10/declaration/body/10/argument/1/3/1/expression/right/3/1": {
+          content: {
+            en: "Type DELETE to confirm",
+            es: "Escribe DELETE para confirmar"
+          },
+          hash: "e3b109c0649f38e2126d482cf60bf745"
+        },
+        "10/declaration/body/10/argument/1/3/3/expression/right/1": {
+          content: {
+            en: "Confirmation Code",
+            es: "Código de confirmación"
+          },
+          hash: "d20561439ce7a3b3b5795b28a22c6572"
+        },
+        "10/declaration/body/10/argument/1/3/3/expression/right/3-placeholder": {
+          content: {
+            en: "Enter code from email",
+            es: "Introduce el código del correo electrónico"
+          },
+          hash: "a90fc584939036afdd5520f814131f77"
+        },
+        "10/declaration/body/10/argument/1/3/5/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "10/declaration/body/10/argument/1/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "10/declaration/body/10/argument/1/5/3/expression/alternate/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Processing...",
+            es: "<element:Loader2></element:Loader2> Procesando..."
+          },
+          hash: "f16934ef4750ea88a7e6eb8fd365d46a"
+        },
+        "10/declaration/body/10/argument/1/5/3/expression/consequent/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Processing...",
+            es: "<element:Loader2></element:Loader2> Procesando..."
+          },
+          hash: "f16934ef4750ea88a7e6eb8fd365d46a"
+        }
+      }
+    },
+    "components/DeleteChatDialog.tsx": {
+      entries: {
+        "2/declaration/body/1/argument/1/1/1": {
+          content: {
+            en: "Are you sure you want to delete this chat?",
+            es: "¿Estás seguro de que quieres eliminar este chat?"
+          },
+          hash: "f24abe5f3cfad07d6038f038e24681a6"
+        },
+        "2/declaration/body/1/argument/1/1/3": {
+          content: {
+            en: 'This will permanently delete "{chatTitle}". This action cannot be undone.',
+            es: 'Esto eliminará permanentemente "{chatTitle}". Esta acción no se puede deshacer.'
+          },
+          hash: "30c51b10fa2a66d01aac589d405655b6"
+        },
+        "2/declaration/body/1/argument/1/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "2/declaration/body/1/argument/1/3/3": {
+          content: {
+            en: "Delete",
+            es: "Eliminar"
+          },
+          hash: "1ba028f51d433fd043e2e7b404264ce2"
+        }
+      }
+    },
+    "components/DocumentPlatformDialog.tsx": {
+      entries: {
+        "6/declaration/body/3/argument/1/1/1/3": {
+          content: {
+            en: "Document Upload on Mobile & Desktop",
+            es: "Carga de documentos en móvil y escritorio"
+          },
+          hash: "911006c3eba8d21ab5ea49e5469ee9dc"
+        },
+        "6/declaration/body/3/argument/1/3/1/1/3": {
+          content: {
+            en: "Desktop",
+            es: "Escritorio"
+          },
+          hash: "0a43dae170adffd6e82fc484440a2af7"
+        },
+        "6/declaration/body/3/argument/1/3/1/1/5": {
+          content: {
+            en: "macOS • Linux",
+            es: "macOS • Linux"
+          },
+          hash: "55d55dc21190360046e0486aefa6602e"
+        },
+        "6/declaration/body/3/argument/1/3/1/3/3": {
+          content: {
+            en: "Mobile",
+            es: "Móvil"
+          },
+          hash: "7d34c49cdc321c9359a418d3dac87619"
+        },
+        "6/declaration/body/3/argument/1/3/1/3/5": {
+          content: {
+            en: "iOS • Android (beta)",
+            es: "iOS • Android (beta)"
+          },
+          hash: "d5cc1e2c14302ea774b7a726aa82f770"
+        },
+        "6/declaration/body/3/argument/1/3/3/1": {
+          content: {
+            en: "Features include:",
+            es: "Las características incluyen:"
+          },
+          hash: "6b1b3632e6da94f635e80cecf7e3c984"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/1/3": {
+          content: {
+            en: "Local PDF processing - files are processed on your device",
+            es: "Procesamiento local de PDF - los archivos se procesan en tu dispositivo"
+          },
+          hash: "bbe04736536b65551a2fd22502170b89"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/3/3": {
+          content: {
+            en: "Support for PDF, TXT, and Markdown files",
+            es: "Soporte para archivos PDF, TXT y Markdown"
+          },
+          hash: "8f7be8c59e1fcad93911a58a2355fdab"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/5/3": {
+          content: {
+            en: "Extracted text is secured with end-to-end encryption",
+            es: "El texto extraído está protegido con cifrado de extremo a extremo"
+          },
+          hash: "4e6efe3c389848d9c434a393947350c3"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/7/3": {
+          content: {
+            en: "Files up to 10MB supported",
+            es: "Compatibilidad con archivos de hasta 10MB"
+          },
+          hash: "7fb3cf94226180eb202d4d9dccecbb9d"
+        },
+        "6/declaration/body/3/argument/1/3/5/expression/right/1": {
+          content: {
+            en: "Upgrade to Pro to unlock document upload along with voice recording, powerful models, and more.",
+            es: "Actualiza a Pro para desbloquear la carga de documentos junto con grabación de voz, modelos potentes y más."
+          },
+          hash: "d85055cf0d255e584b819059421f1d80"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/alternate/1": {
+          content: {
+            en: "Maybe Later",
+            es: "Quizás más tarde"
+          },
+          hash: "a2610146668da9773f12281ef291a303"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/alternate/3": {
+          content: {
+            en: "<element:Sparkles></element:Sparkles> View Plans",
+            es: "<element:Sparkles></element:Sparkles> Ver planes"
+          },
+          hash: "d9a9529c70b4ffa005261f06e0498e8e"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/consequent/1": {
+          content: {
+            en: "Close",
+            es: "Cerrar"
+          },
+          hash: "1a97bc2b1ad01b81b070928d056cc66b"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/consequent/3": {
+          content: {
+            en: "<element:Smartphone></element:Smartphone> Get Apps",
+            es: "<element:Smartphone></element:Smartphone> Obtener aplicaciones"
+          },
+          hash: "60f04515d4630472820c495e5df0d2e2"
+        }
+      }
+    },
+    "components/ErrorFallback.tsx": {
+      entries: {
+        "2/declaration/body/1/argument/1/5/1/1": {
+          content: {
+            en: "Go home",
+            es: "Ir a inicio"
+          },
+          hash: "3236b297d477ec810e1ebb9603328949"
+        }
+      }
+    },
+    "components/ExternalUrlConfirmDialog.tsx": {
+      entries: {
+        "3/declaration/body/1/argument/1/1/1": {
+          content: {
+            en: "Open External Link?",
+            es: "¿Abrir enlace externo?"
+          },
+          hash: "5c03291ff80a229d23714c1c54e53f81"
+        },
+        "3/declaration/body/1/argument/1/1/3": {
+          content: {
+            en: "You are about to open an external URL in your browser:<element:div>{url}</element:div>",
+            es: "Estás a punto de abrir una URL externa en tu navegador:<element:div>{url}</element:div>"
+          },
+          hash: "5f8d92bec36df568707cad661083f78f"
+        },
+        "3/declaration/body/1/argument/1/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "806df1c96f83121893c2a72a5ca8e443"
+        },
+        "3/declaration/body/1/argument/1/3/3": {
+          content: {
+            en: "Open",
+            es: "Abrir"
+          },
+          hash: "9a8c3b16091ea6cef3f771fc6715ab67"
+        }
+      }
+    },
+    "components/Footer.tsx": {
+      entries: {
+        "4/declaration/body/1/argument/1/1/1/1-alt": {
+          content: {
+            en: "Maple",
+            es: "Maple"
+          },
+          hash: "d5b65a7ddef623ff7b488cbf15a4b4c9"
+        },
+        "4/declaration/body/1/argument/1/1/1/3-alt": {
+          content: {
+            en: "Maple",
+            es: "Maple"
+          },
+          hash: "d5b65a7ddef623ff7b488cbf15a4b4c9"
+        },
+        "4/declaration/body/1/argument/1/1/1/5": {
+          content: {
+            en: "Private AI chat with end-to-end encryption. Your conversations stay yours.",
+            es: "Chat de IA privado con cifrado de extremo a extremo. Tus conversaciones siguen siendo tuyas."
+          },
+          hash: "aa239d8e7f65539c3d533d319b052293"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/1-aria-label": {
+          content: {
+            en: "Twitter",
+            es: "Twitter"
+          },
+          hash: "ba3d4aed69a50759b53a0b7c319a3ad9"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/3-aria-label": {
+          content: {
+            en: "GitHub",
+            es: "GitHub"
+          },
+          hash: "6e1cf3c00fa6fbe24afcc78ea3b5f3e4"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/5-aria-label": {
+          content: {
+            en: "Discord",
+            es: "Discord"
+          },
+          hash: "06ec7d95ab44931ed9d1925e4063d703"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/7-aria-label": {
+          content: {
+            en: "Email",
+            es: "Email"
+          },
+          hash: "e7f34943a0c2fb849db1839ff6ef5cb5"
+        },
+        "4/declaration/body/1/argument/1/1/3/1": {
+          content: {
+            en: "Product",
+            es: "Producto"
+          },
+          hash: "4e5f845a09d417dde0a1310bc9ca4bfe"
+        },
+        "4/declaration/body/1/argument/1/1/3/3": {
+          content: {
+            en: "Pricing",
+            es: "Precios"
+          },
+          hash: "d54416fc69270a57577dd7f00c55323b"
+        },
+        "4/declaration/body/1/argument/1/1/3/5": {
+          content: {
+            en: "Downloads",
+            es: "Descargas"
+          },
+          hash: "97d42bd141f1505f7855cb42919a15ef"
+        },
+        "4/declaration/body/1/argument/1/1/3/7": {
+          content: {
+            en: "Security Proof",
+            es: "Prueba de seguridad"
+          },
+          hash: "17881c043d1ebce370c29ebcc1c0c8e3"
+        },
+        "4/declaration/body/1/argument/1/1/3/9": {
+          content: {
+            en: "Teams",
+            es: "Equipos"
+          },
+          hash: "85ff3e7bf1a7b54b75f61c70150da851"
+        },
+        "4/declaration/body/1/argument/1/1/5/1": {
+          content: {
+            en: "Resources",
+            es: "Recursos"
+          },
+          hash: "ec7fb05ed963bb6781a35782b3475502"
+        },
+        "4/declaration/body/1/argument/1/1/5/3": {
+          content: {
+            en: "Blog",
+            es: "Blog"
+          },
+          hash: "2b852f205e105696fd4d0a687e1bb0a4"
+        },
+        "4/declaration/body/1/argument/1/1/5/5": {
+          content: {
+            en: "OpenSecret",
+            es: "OpenSecret"
+          },
+          hash: "b3aa3b29fc2852e8d8f47b6f6a47c8a2"
+        },
+        "4/declaration/body/1/argument/1/1/5/7": {
+          content: {
+            en: "Community",
+            es: "Comunidad"
+          },
+          hash: "5c2225c0ed64a283433f87be1f617b30"
+        },
+        "4/declaration/body/1/argument/1/1/5/9": {
+          content: {
+            en: "About",
+            es: "Acerca de"
+          },
+          hash: "2498a5a49400c3b1161d65b52b5b047c"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/expression/right-title": {
+          content: {
+            en: "BetterStack Status",
+            es: "Estado de BetterStack"
+          },
+          hash: "e2e7d7b3cb2e6ab077252abbfa7ea3e6"
+        },
+        "4/declaration/body/1/argument/1/3/1/5": {
+          content: {
+            en: "© <function:Date.getFullYear/> Maple AI. All rights reserved. Powered by <element:a>OpenSecret</element:a>",
+            es: "© <function:Date.getFullYear/> Maple AI. Todos los derechos reservados. Desarrollado por <element:a>OpenSecret</element:a>"
+          },
+          hash: "3e76d6a6e751214cce2ab2d8273293da"
+        }
+      }
+    },
+    "components/GlobalNotification.tsx": {
+      entries: {
+        "5/declaration/body/8/argument/1/5/3": {
+          content: {
+            en: "Close",
+            es: "Cerrar"
+          },
+          hash: "2c2e22f8424a1031de89063bd0022e16"
+        }
+      }
+    },
+    "components/GuestCredentialsDialog.tsx": {
+      entries: {
+        "8/declaration/body/4/argument/1/1/1": {
+          content: {
+            en: "<element:AlertTriangle></element:AlertTriangle> Save Your Anonymous Account ID",
+            es: "<element:AlertTriangle></element:AlertTriangle> Guarda tu ID de cuenta anónima"
+          },
+          hash: "4480128866595353d58e20d1bc8f1f36"
+        },
+        "8/declaration/body/4/argument/1/1/3": {
+          content: {
+            en: "This is your ONLY chance to see your Account ID. Save it now!",
+            es: "Esta es tu ÚNICA oportunidad de ver tu ID de cuenta. ¡Guárdala ahora!"
+          },
+          hash: "992d93d9b64a760bf6c26fbed29bc9ad"
+        },
+        "8/declaration/body/4/argument/1/3/11/1": {
+          content: {
+            en: "How to save your Account ID:",
+            es: "Cómo guardar tu ID de cuenta:"
+          },
+          hash: "2c60a8e8957f3a02e0fb30b961d6044e"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/1": {
+          content: {
+            en: "Copy it to a password manager (recommended)",
+            es: "Cópiala en un gestor de contraseñas (recomendado)"
+          },
+          hash: "ddd56cd88ecbe2b6a55cf6f93951e761"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/3": {
+          content: {
+            en: "Write it down on paper and store it safely",
+            es: "Escríbela en papel y guárdala en un lugar seguro"
+          },
+          hash: "6ff7aca1e65f7829e729c64497eff70b"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/5": {
+          content: {
+            en: "Save it in a secure note or encrypted file",
+            es: "Guárdala en una nota segura o archivo cifrado"
+          },
+          hash: "4b6b69ea7915c60ef37d690f5a765968"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/7": {
+          content: {
+            en: "Take a screenshot and store it securely",
+            es: "Toma una captura de pantalla y guárdala de forma segura"
+          },
+          hash: "76fc5fd919aa8da74dfc218cd04c85f6"
+        },
+        "8/declaration/body/4/argument/1/3/15/3": {
+          content: {
+            en: "I have securely saved my Account ID and understand I cannot recover my account without it",
+            es: "He guardado de forma segura mi ID de cuenta y entiendo que no podré recuperar mi cuenta sin ella"
+          },
+          hash: "131c442fca6288e1cc87954586227240"
+        },
+        "8/declaration/body/4/argument/1/3/3/1/3/1": {
+          content: {
+            en: "Critical: Save your Account ID immediately!",
+            es: "Crítico: ¡Guarda tu ID de cuenta inmediatamente!"
+          },
+          hash: "b4890dcde40b01dcc59d50d7f2d5a034"
+        },
+        "8/declaration/body/4/argument/1/3/3/1/3/3": {
+          content: {
+            en: "Your Account ID will <element:strong>never be shown again</element:strong> after you close this dialog. If you lose it, you will <element:strong>permanently lose access</element:strong> to your account. We cannot recover it for you.",
+            es: "Tu ID de cuenta <element:strong>nunca se mostrará de nuevo</element:strong> después de cerrar este diálogo. Si la pierdes, <element:strong>perderás permanentemente el acceso</element:strong> a tu cuenta. No podemos recuperarla por ti."
+          },
+          hash: "9a33cb496faaf80a81cbab72f6f842ba"
+        },
+        "8/declaration/body/4/argument/1/3/7/1": {
+          content: {
+            en: "Your Account ID",
+            es: "Tu ID de cuenta"
+          },
+          hash: "3231cf1b9ea54c7349cd88382e499bde"
+        },
+        "8/declaration/body/4/argument/1/3/7/5": {
+          content: {
+            en: "You will need this Account ID along with your password to sign in.",
+            es: "Necesitarás esta ID de cuenta junto con tu contraseña para iniciar sesión."
+          },
+          hash: "5851e6b64b7758189e8a0c9a64a67159"
+        },
+        "8/declaration/body/4/argument/1/5/1": {
+          content: {
+            en: "Continue to Payment",
+            es: "Continuar al pago"
+          },
+          hash: "0e12dcc9cacb6ccf8e3b52efdff222f6"
+        }
+      }
+    },
+    "components/GuestPaymentWarningDialog.tsx": {
+      entries: {
+        "6/declaration/body/4/argument/1/1/1": {
+          content: {
+            en: "<element:AlertTriangle></element:AlertTriangle> Subscription Required",
+            es: "<element:AlertTriangle></element:AlertTriangle> Suscripción requerida"
+          },
+          hash: "b5f579815fa3651b67befff52227e0ef"
+        },
+        "6/declaration/body/4/argument/1/1/3": {
+          content: {
+            en: "Anonymous accounts require a paid subscription to use Maple AI.",
+            es: "Las cuentas anónimas requieren una suscripción de pago para usar Maple AI."
+          },
+          hash: "9ee35c8f6671ad8cdb5a28e40911d7f4"
+        },
+        "6/declaration/body/4/argument/1/3/1/1": {
+          content: {
+            en: "Your anonymous account is not activated yet and cannot use the chat feature.",
+            es: "Tu cuenta anónima aún no está activada y no puede usar la función de chat."
+          },
+          hash: "607bcb4dc06ca138364f1fb4619fe10f"
+        },
+        "6/declaration/body/4/argument/1/3/1/3": {
+          content: {
+            en: "To start chatting with Maple AI, you need to subscribe to a paid plan. Anonymous accounts must pay for a full year using Bitcoin.",
+            es: "Para comenzar a chatear con Maple AI, necesitas suscribirte a un plan de pago. Las cuentas anónimas deben pagar por un año completo usando Bitcoin."
+          },
+          hash: "5010fa12dc9b96d9441c58dab548482f"
+        },
+        "6/declaration/body/4/argument/1/3/3/1": {
+          content: {
+            en: "<element:CreditCard></element:CreditCard> View Pricing & Subscribe",
+            es: "<element:CreditCard></element:CreditCard> Ver precios y suscribirse"
+          },
+          hash: "488de6b75c456f753b49b70f41b22707"
+        },
+        "6/declaration/body/4/argument/1/3/3/3": {
+          content: {
+            en: "<element:LogOut></element:LogOut> Log Out",
+            es: "<element:LogOut></element:LogOut> Cerrar sesión"
+          },
+          hash: "70c2a4ef60d2e77e06c421cbdc48fc2e"
+        }
+      }
+    },
+    "components/GuestSignupWarningDialog.tsx": {
+      entries: {
+        "7/declaration/body/5/argument/1/1/1": {
+          content: {
+            en: "<element:AlertTriangle></element:AlertTriangle> Anonymous Account - Important Warnings",
+            es: "<element:AlertTriangle></element:AlertTriangle> Cuenta anónima - Advertencias importantes"
+          },
+          hash: "89d08d8d099f665762446e156ea5af60"
+        },
+        "7/declaration/body/5/argument/1/1/3": {
+          content: {
+            en: "Please read and acknowledge all warnings before creating an anonymous account.",
+            es: "Por favor, lee y acepta todas las advertencias antes de crear una cuenta anónima."
+          },
+          hash: "ba969596dd56228ae85d6b340a657c3b"
+        },
+        "7/declaration/body/5/argument/1/3/1/11/3/1": {
+          content: {
+            en: "I understand I <element:strong>MUST backup my Account ID</element:strong> after signup. My Account ID will only be shown once, and if I lose it, I will permanently lose access to my account. We cannot recover it.",
+            es: "Entiendo que <element:strong>DEBO hacer una copia de seguridad de mi ID de cuenta</element:strong> después del registro. Mi ID de cuenta solo se mostrará una vez, y si la pierdo, perderé permanentemente el acceso a mi cuenta. No podemos recuperarla."
+          },
+          hash: "f9692bba773da91ede90a65f479930d1"
+        },
+        "7/declaration/body/5/argument/1/3/1/3/3/1": {
+          content: {
+            en: "I understand I <element:strong>MUST pay for a full year in Bitcoin only</element:strong>. Nocredit card, no Stripe, no monthly payment options, and <element:strong>no free trial</element:strong> are available for anonymous accounts.",
+            es: "Entiendo que <element:strong>DEBO pagar por un año completo solo con Bitcoin</element:strong>. No hay tarjeta de crédito, no hay Stripe, no hay opciones de pago mensual y <element:strong>no hay prueba gratuita</element:strong> disponible para cuentas anónimas."
+          },
+          hash: "892d98e9cf82c589896b2e13c0dc8317"
+        },
+        "7/declaration/body/5/argument/1/3/1/7/3/1": {
+          content: {
+            en: "I understand there is <element:strong>absolutely no support</element:strong> available for anonymous accounts. If I have issues, I cannot contact support for help.",
+            es: "Entiendo que <element:strong>absolutamente no hay soporte</element:strong> disponible para cuentas anónimas. Si tengo problemas, no puedo contactar con soporte para obtener ayuda."
+          },
+          hash: "b6cc435b17005665a3228d6ca91668dd"
+        },
+        "7/declaration/body/5/argument/1/3/3/1/1": {
+          content: {
+            en: "Why these restrictions?",
+            es: "¿Por qué estas restricciones?"
+          },
+          hash: "79d470dbf318f9311710151df3b2d93a"
+        },
+        "7/declaration/body/5/argument/1/3/3/3": {
+          content: {
+            en: "Anonymous accounts are designed for users who prioritize privacy and don't want to provide an email address. This comes with trade-offs in support and payment options.",
+            es: "Las cuentas anónimas están diseñadas para usuarios que priorizan la privacidad y no quieren proporcionar una dirección de correo electrónico. Esto conlleva compensaciones en soporte y opciones de pago."
+          },
+          hash: "48ae4e3516e2cffdaa0e6f068248ec8b"
+        },
+        "7/declaration/body/5/argument/1/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "806df1c96f83121893c2a72a5ca8e443"
+        },
+        "7/declaration/body/5/argument/1/5/3": {
+          content: {
+            en: "I Understand and Accept",
+            es: "Entiendo y acepto"
+          },
+          hash: "b8554aa4e3fdbc8ceae9607272e1408c"
+        }
+      }
+    },
+    "components/Marketing.tsx": {
+      entries: {
+        "11/body/0/argument/1": {
+          content: {
+            en: "“{quote}”",
+            es: "“{quote}”"
+          },
+          hash: "ffd37b87597a079be4eef1216a8dd023"
+        },
+        "12/body/1/argument/1/expression/right": {
+          content: {
+            en: "Most Popular",
+            es: "Más popular"
+          },
+          hash: "058119799e4ef10eac64f18f79603517"
+        },
+        "12/body/1/argument/13/expression/consequent": {
+          content: {
+            en: "Coming Soon",
+            es: "Próximamente"
+          },
+          hash: "f6ec66a15a0a03cbb1dfe9822f9f80b4"
+        },
+        "12/body/1/argument/5/3/expression/alternate/right": {
+          content: {
+            en: "/mo",
+            es: "/mes"
+          },
+          hash: "ed85f2a8ca60f479ded99b66261a808a"
+        },
+        "12/body/1/argument/5/3/expression/consequent": {
+          content: {
+            en: "/user /mo",
+            es: "/usuario /mes"
+          },
+          hash: "e8d71d1cad8164af9b5b0f8bfceb695c"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/1": {
+          content: {
+            en: "We <element:span>Prove</element:span> Our Security",
+            es: "Nosotros <element:span>demostramos</element:span> nuestra seguridad"
+          },
+          hash: "8bd03ed27440eb1b9bd458d9f53fb12f"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/3": {
+          content: {
+            en: "Unlike other services that merely claim to be secure, we provide cryptographic proof. Our commitment to transparency means you don't have to trust us - you can verify it yourself.",
+            es: "A diferencia de otros servicios que simplemente afirman ser seguros, nosotros proporcionamos prueba criptográfica. Nuestro compromiso con la transparencia significa que no tienes que confiar en nosotros - puedes verificarlo tú mismo."
+          },
+          hash: "d33e8138684fb8aa55bb1495f36db785"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/5": {
+          content: {
+            en: "Live Secure Enclave Verification",
+            es: "Verificación en vivo del enclave seguro"
+          },
+          hash: "cac8ea5ae40e9daad5ab474a936ff231"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/9": {
+          content: {
+            en: "Learn more about our verification system <element:ArrowRight></element:ArrowRight>",
+            es: "Aprende más sobre nuestro sistema de verificación <element:ArrowRight></element:ArrowRight>"
+          },
+          hash: "94143f2b142256bf6a2603cf94c9acfc"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/3/1": {
+          content: {
+            en: "Secure Server",
+            es: "Servidor seguro"
+          },
+          hash: "6ca41cc4aacdfa241463fe4f5f83d958"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/1/3/7/5": {
+          content: {
+            en: "Encrypted Connection",
+            es: "Conexión cifrada"
+          },
+          hash: "498be7db34d3644b9d665a4df261304e"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/1/7/7/1/5": {
+          content: {
+            en: "Encrypted Connection",
+            es: "Conexión cifrada"
+          },
+          hash: "f6589cdb5c6f59ba06edcf5980e36468"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/5/1": {
+          content: {
+            en: "0x7B4...",
+            es: "0x7B4..."
+          },
+          hash: "40b475ba8e7b4f3b8cb6929617e954d6"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/5/3": {
+          content: {
+            en: "ECDSA P-384",
+            es: "ECDSA P-384"
+          },
+          hash: "908901f4bc6cf504a237e9de70cf99b6"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/5/5": {
+          content: {
+            en: "SHA-384",
+            es: "SHA-384"
+          },
+          hash: "830a750cf52d1108d470e32e7187a86f"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/5": {
+          content: {
+            en: "<element:Shield></element:Shield> Secure Enclave Verified",
+            es: "<element:Shield></element:Shield> Enclave seguro verificado"
+          },
+          hash: "e24ac133bb6f207574c038f8e72220e7"
+        },
+        "14/declaration/body/3/argument/19/1/1/1": {
+          content: {
+            en: "What Our <element:span>Users Say</element:span>",
+            es: "Lo que <element:span>dicen nuestros usuarios</element:span>"
+          },
+          hash: "cbdee2295a42b712352a162f9d23b9d2"
+        },
+        "14/declaration/body/3/argument/19/1/1/3": {
+          content: {
+            en: "Hear from those who've made privacy a priority with Maple AI.<element:br></element:br> (Quotes are real, names are changed for privacy)",
+            es: "Escucha a quienes han hecho de la privacidad una prioridad con Maple AI.<element:br></element:br> (Las citas son reales, los nombres se han cambiado por privacidad)"
+          },
+          hash: "888002d03da7727aa8b42b67017036a8"
+        },
+        "14/declaration/body/3/argument/23/1/1/1": {
+          content: {
+            en: "Simple, <element:span>Transparent</element:span> Pricing",
+            es: "Precios <element:span>transparentes</element:span> y simples"
+          },
+          hash: "cd68e507b8a594a215505890d6c138dd"
+        },
+        "14/declaration/body/3/argument/23/1/1/3": {
+          content: {
+            en: "No hidden fees. Choose the plan that works for your needs.",
+            es: "Sin cargos ocultos. Elige el plan que se adapte a tus necesidades."
+          },
+          hash: "69a895cda00e495b187af19ac5fe5a80"
+        },
+        "14/declaration/body/3/argument/27/1/1/1/1": {
+          content: {
+            en: "Ready to Chat <element:span>Securely?</element:span>",
+            es: "¿Listo para chatear <element:span>de forma segura?</element:span>"
+          },
+          hash: "b733d787de3768e898a8737bb51e1071"
+        },
+        "14/declaration/body/3/argument/27/1/1/1/3": {
+          content: {
+            en: "Join privacy-conscious users who've made the switch to truly secure AI chat.",
+            es: "Únete a los usuarios conscientes de la privacidad que han cambiado a un chat de IA verdaderamente seguro."
+          },
+          hash: "85a0d74d645110beaf69051ab9c6f371"
+        },
+        "14/declaration/body/3/argument/27/1/1/1/5/1": {
+          content: {
+            en: "<element:MessageSquareMore></element:MessageSquareMore> Start Chatting Securely",
+            es: "<element:MessageSquareMore></element:MessageSquareMore> Comienza a chatear de forma segura"
+          },
+          hash: "b711c2e2e8b0d4d515018607d8cbe033"
+        },
+        "14/declaration/body/3/argument/27/1/1/1/5/3": {
+          content: {
+            en: "Log In",
+            es: "Iniciar sesión"
+          },
+          hash: "0029e5a35676c0051e761fcd046ef9ee"
+        },
+        "14/declaration/body/3/argument/3/1/1/1/1/1": {
+          content: {
+            en: "Private AI Chat",
+            es: "Chat de IA privado"
+          },
+          hash: "0fd89b999b090fb17fc5d64d4b361a9c"
+        },
+        "14/declaration/body/3/argument/3/1/1/1/1/6": {
+          content: {
+            en: "that's truly secure",
+            es: "realmente seguro"
+          },
+          hash: "49134c881a5902c45476fafa2287dc8c"
+        },
+        "14/declaration/body/3/argument/3/1/1/1/3": {
+          content: {
+            en: "End-to-end encryption means your conversations are confidential and protected at every step. Only you can access your data — not even we can read your chats.",
+            es: "El cifrado de extremo a extremo significa que tus conversaciones son confidenciales y están protegidas en cada paso. Solo tú puedes acceder a tus datos — ni siquiera nosotros podemos leer tus chats."
+          },
+          hash: "ccff3b59fd2645cb388145c88313352a"
+        },
+        "14/declaration/body/3/argument/3/1/1/3/1": {
+          content: {
+            en: "<element:Sparkles></element:Sparkles> Start Secure Chat",
+            es: "<element:Sparkles></element:Sparkles> Iniciar chat seguro"
+          },
+          hash: "d2611b1015de5a7aee791d6e479b5161"
+        },
+        "14/declaration/body/3/argument/3/1/1/3/3": {
+          content: {
+            en: "Log In",
+            es: "Iniciar sesión"
+          },
+          hash: "0029e5a35676c0051e761fcd046ef9ee"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/1/1-alt": {
+          content: {
+            en: "User avatar",
+            es: "Avatar de usuario"
+          },
+          hash: "f59c849b0b69ee500101491d571959a3"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/1/3-alt": {
+          content: {
+            en: "User avatar",
+            es: "Avatar de usuario"
+          },
+          hash: "f59c849b0b69ee500101491d571959a3"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/1/5-alt": {
+          content: {
+            en: "User avatar",
+            es: "Avatar de usuario"
+          },
+          hash: "f59c849b0b69ee500101491d571959a3"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/3": {
+          content: {
+            en: "Trusted by professionals who handle sensitive client information",
+            es: "De confianza para profesionales que manejan información sensible de clientes"
+          },
+          hash: "b60a993295b36690cb4917563ba92bba"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/1/3": {
+          content: {
+            en: "Encrypted Chat",
+            es: "Chat cifrado"
+          },
+          hash: "a858b6d5a63448ea48c527e612fd22fc"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/1/1": {
+          content: {
+            en: "AI",
+            es: "IA"
+          },
+          hash: "18e72ed3f198250caaf6c7fbf52b7d48"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/1/3": {
+          content: {
+            en: "How can I help you today? Your conversation is fully encrypted.",
+            es: "¿Cómo puedo ayudarte hoy? Tu conversación está completamente cifrada."
+          },
+          hash: "b6c56029811f28a46ba0dcb9c337804e"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/3/1": {
+          content: {
+            en: "I need to discuss some sensitive information. Is this really secure?",
+            es: "Necesito discutir información sensible. ¿Es esto realmente seguro?"
+          },
+          hash: "361dfcd0482fd50063cdb2a186d7a7b4"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/3/3": {
+          content: {
+            en: "U",
+            es: "U"
+          },
+          hash: "390c9785562c73825f5108c07c4f5e8e"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/5/1": {
+          content: {
+            en: "AI",
+            es: "IA"
+          },
+          hash: "18e72ed3f198250caaf6c7fbf52b7d48"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/5/3": {
+          content: {
+            en: "Yes, absolutely. Your messages are end-to-end encrypted. Even the server admins can't read your conversations. We use secure enclaves and open-source code to verify this.",
+            es: "Sí, absolutamente. Tus mensajes están cifrados de extremo a extremo. Incluso los administradores del servidor no pueden leer tus conversaciones. Utilizamos enclaves seguros y código de código abierto para verificar esto."
+          },
+          hash: "e36e8b543a5d58988b61ace0f169092a"
+        },
+        "14/declaration/body/3/argument/3/1/3/3": {
+          content: {
+            en: "<element:Lock></element:Lock> End-to-End Encrypted",
+            es: "<element:Lock></element:Lock> Cifrado de extremo a extremo"
+          },
+          hash: "276c817e4b79fa65d11cf52f91789286"
+        },
+        "14/declaration/body/3/argument/3/3/1/3": {
+          content: {
+            en: "Desktop",
+            es: "Escritorio"
+          },
+          hash: "0a43dae170adffd6e82fc484440a2af7"
+        },
+        "14/declaration/body/3/argument/3/3/3/1-alt": {
+          content: {
+            en: "Download on the App Store",
+            es: "Descargar en la App Store"
+          },
+          hash: "aa7eb35109f6069021d46c7b6b793fdf"
+        },
+        "14/declaration/body/3/argument/7/1/1/1": {
+          content: {
+            en: "Privacy at <element:span>Every Layer</element:span>",
+            es: "Privacidad en <element:span>cada capa</element:span>"
+          },
+          hash: "950602d813af95fafda77147353c356d"
+        },
+        "14/declaration/body/3/argument/7/1/1/3": {
+          content: {
+            en: "Your security is our primary concern. We've engineered Maple to ensure your data remains yours alone, protected by cutting-edge encryption.",
+            es: "Tu seguridad es nuestra principal preocupación. Hemos diseñado Maple para garantizar que tus datos permanezcan solo tuyos, protegidos por cifrado de vanguardia."
+          },
+          hash: "6df81a7b90812ad496558f372810d9ef"
+        },
+        "14/declaration/body/3/argument/7/1/3/1-description": {
+          content: {
+            en: "All communications are encrypted locally on your device before being transmitted, ensuring your data is secured from the start.",
+            es: "Todas las comunicaciones se cifran localmente en tu dispositivo antes de ser transmitidas, asegurando que tus datos estén protegidos desde el principio."
+          },
+          hash: "5cc8acb1b78cf7470cb3c3f051fea534"
+        },
+        "14/declaration/body/3/argument/7/1/3/1-title": {
+          content: {
+            en: "Your Device",
+            es: "Tu dispositivo"
+          },
+          hash: "7b28181f4c28b245635dfa4339181440"
+        },
+        "14/declaration/body/3/argument/7/1/3/3-description": {
+          content: {
+            en: "Our servers can't read your data. We use secure enclaves in confidential computing environments to verify our infrastructure integrity.",
+            es: "Nuestros servidores no pueden leer tus datos. Utilizamos enclaves seguros en entornos de computación confidencial para verificar la integridad de nuestra infraestructura."
+          },
+          hash: "75e57ba7948939d97bf2f00c6c06d84a"
+        },
+        "14/declaration/body/3/argument/7/1/3/3-title": {
+          content: {
+            en: "Secure Server",
+            es: "Servidor seguro"
+          },
+          hash: "d6943523162f401109159d9c42148f5d"
+        },
+        "14/declaration/body/3/argument/7/1/3/5-description": {
+          content: {
+            en: "Even during AI processing, your data remains encrypted. The entire pipeline through to the GPU is designed with privacy as the priority.",
+            es: "Incluso durante el procesamiento de IA, tus datos permanecen cifrados. Todo el proceso hasta la GPU está diseñado con la privacidad como prioridad."
+          },
+          hash: "03d97086e0b5cfc8b0e1048f05a0ec57"
+        },
+        "14/declaration/body/3/argument/7/1/3/5-title": {
+          content: {
+            en: "AI Processing",
+            es: "Procesamiento de IA"
+          },
+          hash: "c16b63ed0fd0b69a3f642fa467572ceb"
+        }
+      }
+    },
+    "components/ModelSelector.tsx": {
+      entries: {
+        "15/declaration/body/17/0/init/body/2/alternate/2/expression/0": {
+          content: {
+            en: "Coming Soon",
+            es: "Próximamente"
+          },
+          hash: "f6ec66a15a0a03cbb1dfe9822f9f80b4"
+        },
+        "15/declaration/body/19/argument/1/3/1/expression/alternate/3/3": {
+          content: {
+            en: "Back",
+            es: "Atrás"
+          },
+          hash: "f541015a827e37cb3b1234e56bc2aa3c"
+        },
+        "15/declaration/body/19/argument/1/3/1/expression/consequent/9/3/1": {
+          content: {
+            en: "Advanced",
+            es: "Avanzado"
+          },
+          hash: "16e9b03eda6f6c1324cce54b96bbccd6"
+        },
+        "15/declaration/body/19/argument/1/3/1/expression/consequent/9/3/3": {
+          content: {
+            en: "All models",
+            es: "Todos los modelos"
+          },
+          hash: "e521e05d8850aec6cc82ac111210fdb4"
+        }
+      }
+    },
+    "components/NotFoundFallback.tsx": {
+      entries: {
+        "2/declaration/body/1/argument/1/1/1": {
+          content: {
+            en: "404",
+            es: "404"
+          },
+          hash: "b7218679a87e1426b5daa91922d59d31"
+        },
+        "2/declaration/body/1/argument/1/3/1": {
+          content: {
+            en: "Route not found.",
+            es: "Ruta no encontrada."
+          },
+          hash: "d635cc289be6d47da702ca8fac007e6f"
+        },
+        "2/declaration/body/1/argument/1/5/1/1": {
+          content: {
+            en: "Go home",
+            es: "Ir a inicio"
+          },
+          hash: "3236b297d477ec810e1ebb9603328949"
+        }
+      }
+    },
+    "components/PasswordResetConfirmForm.tsx": {
+      entries: {
+        "10/declaration/body/11/consequent/0/argument/1/1": {
+          content: {
+            en: "Password Reset Successful",
+            es: "Restablecimiento de contraseña exitoso"
+          },
+          hash: "82f2c74808b046d94d7ea5b700362cac"
+        },
+        "10/declaration/body/11/consequent/0/argument/1/3": {
+          content: {
+            en: "You can now log in with your new password.",
+            es: "Ahora puedes iniciar sesión con tu nueva contraseña."
+          },
+          hash: "347247837ae94a9b9a1aafadcdadb780"
+        },
+        "10/declaration/body/11/consequent/0/argument/3/1/expression/alternate": {
+          content: {
+            en: "You will be redirected to the login page in a few seconds.",
+            es: "Serás redirigido a la página de inicio de sesión en unos segundos."
+          },
+          hash: "a9fb89ed2101fe8d998fa7f2fd02af98"
+        },
+        "10/declaration/body/11/consequent/0/argument/3/1/expression/consequent/3": {
+          content: {
+            en: "Redirecting to login page...",
+            es: "Redirigiendo a la página de inicio de sesión..."
+          },
+          hash: "f22b35c946fe8671defd7e647d15e43c"
+        },
+        "10/declaration/body/12/argument/1/1": {
+          content: {
+            en: "Confirm Password Reset",
+            es: "Confirmar restablecimiento de contraseña"
+          },
+          hash: "e01d21b5ec434f705960fea531175644"
+        },
+        "10/declaration/body/12/argument/1/3": {
+          content: {
+            en: "Enter the reset code and your new password.",
+            es: "Ingresa el código de restablecimiento y tu nueva contraseña."
+          },
+          hash: "0fb8c4762a50206435d6853bb2644e80"
+        },
+        "10/declaration/body/12/argument/3/1/1/1/1": {
+          content: {
+            en: "Reset Code",
+            es: "Código de restablecimiento"
+          },
+          hash: "ef6e2491a89b9b212bfa1906d2536371"
+        },
+        "10/declaration/body/12/argument/3/1/1/1/3-title": {
+          content: {
+            en: "8-character alphanumeric code",
+            es: "Código alfanumérico de 8 caracteres"
+          },
+          hash: "a71611c0c7a9756b915ec7bee3a9e0ee"
+        },
+        "10/declaration/body/12/argument/3/1/1/3/1": {
+          content: {
+            en: "New Password",
+            es: "Nueva contraseña"
+          },
+          hash: "80d809edd5d1b66123b18faaac10537b"
+        },
+        "10/declaration/body/12/argument/3/1/1/5/1": {
+          content: {
+            en: "Confirm New Password",
+            es: "Confirmar nueva contraseña"
+          },
+          hash: "d3194bdcb74c9a912c67d7e1b030b88a"
+        },
+        "10/declaration/body/12/argument/3/1/1/7/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        }
+      }
+    },
+    "components/PasswordResetRequestForm.tsx": {
+      entries: {
+        "8/declaration/body/8/argument/1/1": {
+          content: {
+            en: "Reset Password",
+            es: "Restablecer contraseña"
+          },
+          hash: "52ec990b25991808a4f49db84986eefc"
+        },
+        "8/declaration/body/8/argument/1/3": {
+          content: {
+            en: "Enter your email address to request a password reset.",
+            es: "Ingresa tu dirección de correo electrónico para solicitar un restablecimiento de contraseña."
+          },
+          hash: "29635d6aea111b1904b187cdcd8c198f"
+        },
+        "8/declaration/body/8/argument/3/1/1/1/1": {
+          content: {
+            en: "Email",
+            es: "Correo electrónico"
+          },
+          hash: "e7f34943a0c2fb849db1839ff6ef5cb5"
+        },
+        "8/declaration/body/8/argument/3/1/1/3/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        }
+      }
+    },
+    "components/PreferencesDialog.tsx": {
+      entries: {
+        "8/declaration/body/10/argument/1/1/1": {
+          content: {
+            en: "User Preferences",
+            es: "Preferencias de usuario"
+          },
+          hash: "c79439f008cdfeba5e04c2aae2985ff5"
+        },
+        "8/declaration/body/10/argument/1/1/3": {
+          content: {
+            en: "Customize your default system prompt for AI conversations.",
+            es: "Personaliza tu instrucción predeterminada del sistema para conversaciones con IA."
+          },
+          hash: "307cf549b42cc59c30bc2d800bc502f7"
+        },
+        "8/declaration/body/10/argument/1/3/3/expression/right/1": {
+          content: {
+            en: "Preferences saved successfully.",
+            es: "Preferencias guardadas correctamente."
+          },
+          hash: "10b9639fd181767f5f4cc358f4de1e84"
+        },
+        "8/declaration/body/10/argument/1/3/5/1": {
+          content: {
+            en: "System Prompt",
+            es: "Instrucción del sistema"
+          },
+          hash: "3980ee4b3313840de80cdbeeb510a573"
+        },
+        "8/declaration/body/10/argument/1/3/5/3-placeholder": {
+          content: {
+            en: "Enter your custom system prompt here...",
+            es: "Ingresa tu instrucción personalizada del sistema aquí..."
+          },
+          hash: "062025304977bae52d0d54fd0169400f"
+        },
+        "8/declaration/body/10/argument/1/3/5/5": {
+          content: {
+            en: "This prompt will be used as the default instruction for your AI conversations.",
+            es: "Esta instrucción se utilizará como indicación predeterminada para tus conversaciones con IA."
+          },
+          hash: "8c9ca93efd5f7ff0bcbbc60d954b7d79"
+        }
+      }
+    },
+    "components/RecordingOverlay.tsx": {
+      entries: {
+        "5/declaration/body/8/argument/3/3/1-aria-label": {
+          content: {
+            en: "Cancel recording",
+            es: "Cancelar grabación"
+          },
+          hash: "0d537afc558e02c6e6bb3b0bc9c69762"
+        },
+        "5/declaration/body/8/argument/3/3/3-aria-label": {
+          content: {
+            en: "Send recording",
+            es: "Enviar grabación"
+          },
+          hash: "e7f5837f04e4a5c74c2ede29e7141546"
+        },
+        "5/declaration/body/8/argument/3/3/3/1/expression/alternate/alternate": {
+          content: {
+            en: "<element:CornerRightUp></element:CornerRightUp> Send",
+            es: "<element:CornerRightUp></element:CornerRightUp> Enviar"
+          },
+          hash: "34cdf390ae616d6f28789d6336ed3627"
+        },
+        "5/declaration/body/8/argument/3/5/11/expression/right/1/expression/alternate": {
+          content: {
+            en: "<element:div></element:div> Recording",
+            es: "<element:div></element:div> Grabando"
+          },
+          hash: "f3ae80da32830222cb596ab56a5049ba"
+        },
+        "5/declaration/body/8/argument/3/5/11/expression/right/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Processing...",
+            es: "<element:Loader2></element:Loader2> Procesando..."
+          },
+          hash: "f16934ef4750ea88a7e6eb8fd365d46a"
+        }
+      }
+    },
+    "components/RenameChatDialog.tsx": {
+      entries: {
+        "7/declaration/body/6/argument/1/1/1": {
+          content: {
+            en: "Rename Chat",
+            es: "Renombrar chat"
+          },
+          hash: "bb846c81ebb761285702bf2eb9315d9e"
+        },
+        "7/declaration/body/6/argument/1/1/3": {
+          content: {
+            en: "Enter a new name for this chat conversation.",
+            es: "Ingresa un nuevo nombre para esta conversación de chat."
+          },
+          hash: "a5e18b57251f5f58b378349fd9084c89"
+        },
+        "7/declaration/body/6/argument/1/3/3/1": {
+          content: {
+            en: "Chat Title",
+            es: "Título del chat"
+          },
+          hash: "f1adc643cdbddc678471eeffcb417c20"
+        },
+        "7/declaration/body/6/argument/1/3/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "07296eb8d91ad98e1b60cd7ab0def914"
+        }
+      }
+    },
+    "components/Sidebar.tsx": {
+      entries: {
+        "9/declaration/body/15/argument/1/3/1/3/3": {
+          content: {
+            en: "New Chat",
+            es: "Nuevo chat"
+          },
+          hash: "3d7b701878aca8e2dbb7c6732f7f3bee"
+        },
+        "9/declaration/body/15/argument/1/5/1": {
+          content: {
+            en: "History",
+            es: "Historial"
+          },
+          hash: "b0578d6d225f512e42f823fbca2e3c32"
+        },
+        "9/declaration/body/15/argument/1/7/expression/right/1-aria-label": {
+          content: {
+            en: "Search chat titles",
+            es: "Buscar títulos de chat"
+          },
+          hash: "cf48ea476325fcd15eb8ae6956a2a161"
+        },
+        "9/declaration/body/15/argument/1/7/expression/right/1-placeholder": {
+          content: {
+            en: "Search chat titles...",
+            es: "Buscar títulos de chat..."
+          },
+          hash: "c3604cf8b46d55603fe18f6f0c56b245"
+        },
+        "9/declaration/body/15/argument/1/7/expression/right/3/expression/right-aria-label": {
+          content: {
+            en: "Clear search",
+            es: "Borrar búsqueda"
+          },
+          hash: "0ee4a80abe134b7edd90c74f03638877"
+        }
+      }
+    },
+    "components/TeamSeatDialog.tsx": {
+      entries: {
+        "8/declaration/body/5/argument/1/1/1": {
+          content: {
+            en: "Select Team Seats",
+            es: "Seleccionar asientos de equipo"
+          },
+          hash: "da3fe1295c0a26ae3b9c737e4bdbe88d"
+        },
+        "8/declaration/body/5/argument/1/1/3": {
+          content: {
+            en: "How many seats would you like to purchase? You can change this at any time.",
+            es: "¿Cuántos asientos te gustaría comprar? Puedes cambiar esto en cualquier momento."
+          },
+          hash: "44f6e205ab0bea3ffdc2fa731bb15031"
+        },
+        "8/declaration/body/5/argument/1/3/1/1/1": {
+          content: {
+            en: "Number of Seats",
+            es: "Número de asientos"
+          },
+          hash: "6f7555af8847258d6a56e563487e18ca"
+        },
+        "8/declaration/body/5/argument/1/3/1/1/5": {
+          content: {
+            en: "Minimum 2 seats, maximum 100 seats",
+            es: "Mínimo 2 asientos, máximo 100 asientos"
+          },
+          hash: "951876786ca2a50e913363f021718aec"
+        },
+        "8/declaration/body/5/argument/1/3/1/3/3": {
+          content: {
+            en: "Each seat is billed per user per month. You can adjust the number of seats anytime in your billing settings.",
+            es: "Cada asiento se factura por usuario por mes. Puedes ajustar el número de asientos en cualquier momento en tu configuración de facturación."
+          },
+          hash: "a18e5de0f9831ee2039e8768b664aefe"
+        },
+        "8/declaration/body/5/argument/1/3/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "07296eb8d91ad98e1b60cd7ab0def914"
+        },
+        "8/declaration/body/5/argument/1/3/3/3": {
+          content: {
+            en: "Continue to Checkout",
+            es: "Continuar al pago"
+          },
+          hash: "812e650be774be4279912fa52e376574"
+        }
+      }
+    },
+    "components/TopNav.tsx": {
+      entries: {
+        "6/declaration/body/5/argument/1/1/1/1/1/3-alt": {
+          content: {
+            en: "Maple",
+            es: "Maple"
+          },
+          hash: "d5b65a7ddef623ff7b488cbf15a4b4c9"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/1": {
+          content: {
+            en: "Pricing",
+            es: "Precios"
+          },
+          hash: "ce27f1aeacccc542a174c4b2bce022b0"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/3": {
+          content: {
+            en: "Proof",
+            es: "Prueba"
+          },
+          hash: "b5e978c348a23f69c4d203e00d34c127"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/5": {
+          content: {
+            en: "Teams",
+            es: "Equipos"
+          },
+          hash: "b63448c05270497973ac4407047dae02"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/7": {
+          content: {
+            en: "Guides",
+            es: "Guías"
+          },
+          hash: "8fd61954275895ccb460f566e481aade"
+        },
+        "6/declaration/body/5/argument/1/1/1/7/3/expression/alternate": {
+          content: {
+            en: "Log In",
+            es: "Iniciar sesión"
+          },
+          hash: "0f30c64101c63fde988467e4c0150879"
+        },
+        "6/declaration/body/5/argument/1/1/1/7/3/expression/consequent": {
+          content: {
+            en: "Chat",
+            es: "Chat"
+          },
+          hash: "387d7e99f5c2d20bd17b5d80e199df51"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/1": {
+          content: {
+            en: "Pricing",
+            es: "Precios"
+          },
+          hash: "7bffd0574da45aadff376937c9b445b5"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/3": {
+          content: {
+            en: "Proof",
+            es: "Prueba"
+          },
+          hash: "32a7fe96bf21354cf52291beea73f14d"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/5": {
+          content: {
+            en: "Teams",
+            es: "Equipos"
+          },
+          hash: "4f2f1815ec7aeb09fd90299038888f8a"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/7": {
+          content: {
+            en: "Guides",
+            es: "Guías"
+          },
+          hash: "7b4680f0ea350e4797d66a8c555780d4"
+        }
+      }
+    },
+    "components/UnifiedChat.tsx": {
+      entries: {
+        "35/body/3/consequent/4/argument/1/3": {
+          content: {
+            en: "Tool Result",
+            es: "Resultado de la herramienta"
+          },
+          hash: "d8626fd27af08620fba41e528e93b13f"
+        },
+        "36/0/init/0/body/1/argument/5/expression/0/body/4/consequent/3/argument/1/3/1/9/expression/right/3":
+          {
+            content: {
+              en: "Chat Canceled",
+              es: "Chat cancelado"
+            },
+            hash: "20a72b66179eec4f226e20f1e131cc15"
+          },
+        "36/0/init/0/body/1/argument/9/expression/right/1/3/1": {
+          content: {
+            en: "Maple",
+            es: "Maple"
+          },
+          hash: "d5b65a7ddef623ff7b488cbf15a4b4c9"
+        },
+        "38/declaration/body/91/argument/7/11/expression/right/1/5-aria-label": {
+          content: {
+            en: "New chat",
+            es: "Nuevo chat"
+          },
+          hash: "3137bd8485c6f0fee4b0bbcce4eecdad"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/1/1/11/1-placeholder": {
+          content: {
+            en: "Message Maple...",
+            es: "Mensaje a Maple..."
+          },
+          hash: "d1b963159f49a60a54d13ca56a47ea6b"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/1/1/11/5/1/9/3/1/3": {
+          content: {
+            en: "Add Images",
+            es: "Añadir imágenes"
+          },
+          hash: "9f2b8d6e3a50342a3f569f4704ad4f83"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/1/1/11/5/1/9/3/3/3": {
+          content: {
+            en: "Add Document",
+            es: "Añadir documento"
+          },
+          hash: "5463aa69d668b45549bc7943b1bc9cc6"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/3": {
+          content: {
+            en: "AI can make mistakes. Check important info.",
+            es: "La IA puede cometer errores. Verifica la información importante."
+          },
+          hash: "3f9bcc7f3dbc4af3aaf3ae196abb77d2"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/3/3/1-alt": {
+          content: {
+            en: "Maple",
+            es: "Maple"
+          },
+          hash: "d5b65a7ddef623ff7b488cbf15a4b4c9"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/3/3/3-alt": {
+          content: {
+            en: "Maple",
+            es: "Maple"
+          },
+          hash: "d5b65a7ddef623ff7b488cbf15a4b4c9"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/3/7": {
+          content: {
+            en: "Private AI Chat",
+            es: "Chat privado con IA"
+          },
+          hash: "80ad8600613bf3c538923374f6b21091"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/1": {
+          content: {
+            en: "How can I help you today?",
+            es: "¿Cómo puedo ayudarte hoy?"
+          },
+          hash: "4baa45b6e6d953ea40b802910f235026"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/5/1/11/1-placeholder": {
+          content: {
+            en: "Message Maple...",
+            es: "Mensaje a Maple..."
+          },
+          hash: "d1b963159f49a60a54d13ca56a47ea6b"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/5/1/11/5/1/9/3/1/3": {
+          content: {
+            en: "Add Images",
+            es: "Añadir imágenes"
+          },
+          hash: "9f2b8d6e3a50342a3f569f4704ad4f83"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/5/1/11/5/1/9/3/3/3": {
+          content: {
+            en: "Add Document",
+            es: "Añadir documento"
+          },
+          hash: "5463aa69d668b45549bc7943b1bc9cc6"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/9": {
+          content: {
+            en: "Encrypted at every step",
+            es: "Encriptado en cada paso"
+          },
+          hash: "f7ebad57a99c0dad1e797bcab3c291b4"
+        }
+      }
+    },
+    "components/UpgradePromptDialog.tsx": {
+      entries: {
+        "6/declaration/body/11/argument/1/5/3/expression/alternate": {
+          content: {
+            en: "Maybe Later",
+            es: "Quizás más tarde"
+          },
+          hash: "71f6a4cd0395ee97f578382f13e410f7"
+        },
+        "6/declaration/body/11/argument/1/5/3/expression/consequent": {
+          content: {
+            en: "Start New Chat",
+            es: "Iniciar nuevo chat"
+          },
+          hash: "15cf7d809d21324fdebb32ac25ef9d3a"
+        }
+      }
+    },
+    "components/VerificationModal.tsx": {
+      entries: {
+        "8/declaration/body/12/argument/1/1/1": {
+          content: {
+            en: "Verify Your Email",
+            es: "Verifica tu correo electrónico"
+          },
+          hash: "1682e88a6eb7c961ae918fefc7325e2f"
+        },
+        "8/declaration/body/12/argument/1/1/3": {
+          content: {
+            en: "Please check your email (<expression/>) to verify your account. You'll need to verify your email to continue using Maple AI.",
+            es: "Por favor, revisa tu correo electrónico (<expression/>) para verificar tu cuenta. Necesitarás verificar tu correo electrónico para continuar usando Maple AI."
+          },
+          hash: "3625c767230ae20dfb0743b6b9429617"
+        },
+        "8/declaration/body/12/argument/1/3/1/1": {
+          content: {
+            en: "Verification Code",
+            es: "Código de verificación"
+          },
+          hash: "4cebef0f16689fbb49d5f1eee10618d2"
+        },
+        "8/declaration/body/12/argument/1/3/1/3/1-placeholder": {
+          content: {
+            en: "Enter verification code",
+            es: "Ingresa el código de verificación"
+          },
+          hash: "4a787736e92ea6fcffc8c294c5382d35"
+        },
+        "8/declaration/body/12/argument/1/3/1/3/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Verifying...",
+            es: "<element:Loader2></element:Loader2> Verificando..."
+          },
+          hash: "29e1824a993ee98fcbe31246e694b8e8"
+        },
+        "8/declaration/body/12/argument/1/3/1/5/expression/right-title": {
+          content: {
+            en: "Verification Failed",
+            es: "Verificación fallida"
+          },
+          hash: "7157733f774f9bc07f1202eb2b0156d8"
+        },
+        "8/declaration/body/12/argument/1/3/3/1/expression/alternate/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Sending...",
+            es: "<element:Loader2></element:Loader2> Enviando..."
+          },
+          hash: "54fbbcae8a2b258c9ad68aa8e88c2d98"
+        },
+        "8/declaration/body/12/argument/1/3/3/1/expression/consequent": {
+          content: {
+            en: "<element:CheckCircle></element:CheckCircle> Verification email sent! Please check your inbox.",
+            es: "<element:CheckCircle></element:CheckCircle> ¡Correo de verificación enviado! Por favor, revisa tu bandeja de entrada."
+          },
+          hash: "53d2274d9952831dfce3f8c486a7e7ab"
+        },
+        "8/declaration/body/12/argument/1/3/3/3": {
+          content: {
+            en: "<element:LogOut></element:LogOut> Log Out",
+            es: "<element:LogOut></element:LogOut> Cerrar sesión"
+          },
+          hash: "70c2a4ef60d2e77e06c421cbdc48fc2e"
+        }
+      }
+    },
+    "components/VerificationStatus.tsx": {
+      entries: {
+        "4/declaration/body/3/argument/1/expression/right/3": {
+          content: {
+            en: "Verifying...",
+            es: "Verificando..."
+          },
+          hash: "421ed451e3e4b14dc2dcf25956fca011"
+        },
+        "4/declaration/body/3/argument/3/expression/right/3": {
+          content: {
+            en: "Verified",
+            es: "Verificado"
+          },
+          hash: "9566bd61c1f754dd5082eea5101f15a8"
+        },
+        "4/declaration/body/3/argument/5/expression/right/3": {
+          content: {
+            en: "Verification failed",
+            es: "Verificación fallida"
+          },
+          hash: "e8cc2a0c12f97985b404320423cd927b"
+        }
+      }
+    },
+    "components/apikeys/ApiCreditsSection.tsx": {
+      entries: {
+        "14/declaration/body/16/consequent/0/argument/1": {
+          content: {
+            en: "Failed to load credit balance",
+            es: "Error al cargar el saldo de créditos"
+          },
+          hash: "8f7737b74c5f8dbd535011192f8c4feb"
+        },
+        "14/declaration/body/17/argument/11/1/1/1": {
+          content: {
+            en: "API Credit Balance",
+            es: "Saldo de créditos API"
+          },
+          hash: "d62938e4e89008963a3536b9a37609ce"
+        },
+        "14/declaration/body/17/argument/11/1/1/5": {
+          content: {
+            en: "$1 per 1,000 credits • Use for API requests",
+            es: "$1 por 1.000 créditos • Usar para solicitudes API"
+          },
+          hash: "90611563496f13d602bca63f5270dd1a"
+        },
+        "14/declaration/body/17/argument/15/1": {
+          content: {
+            en: "Purchase Credits",
+            es: "Comprar créditos"
+          },
+          hash: "b1e12db2744789a7ef83c7ef4e148d7d"
+        },
+        "14/declaration/body/17/argument/15/13/1": {
+          content: {
+            en: "<expression/> Pay with Card",
+            es: "<expression/> Pagar con tarjeta"
+          },
+          hash: "3a5f4da319a3cde3bfc3b674345b5c11"
+        },
+        "14/declaration/body/17/argument/15/13/3": {
+          content: {
+            en: "<expression/> Pay with Bitcoin",
+            es: "<expression/> Pagar con Bitcoin"
+          },
+          hash: "ce41dbff4e60c7d138cdf0a0c803247c"
+        },
+        "14/declaration/body/17/argument/15/15": {
+          content: {
+            en: "Minimum purchase: <function:MIN_PURCHASE_CREDITS.toLocaleString/> credits (${MIN_PURCHASE_AMOUNT})",
+            es: "Compra mínima: <function:MIN_PURCHASE_CREDITS.toLocaleString/> créditos (${MIN_PURCHASE_AMOUNT})"
+          },
+          hash: "aed82ddf982a63072c0c990f0830e8c5"
+        },
+        "14/declaration/body/17/argument/15/5/1/expression/0/body/3": {
+          content: {
+            en: "${pkg.price}",
+            es: "${pkg.price}"
+          },
+          hash: "ce3025799d70859c869af0b2fea2ad8a"
+        },
+        "14/declaration/body/17/argument/15/9/1/1/1": {
+          content: {
+            en: "Custom Amount",
+            es: "Cantidad personalizada"
+          },
+          hash: "1e687d79d9cf32433a264d8237c4dbc5"
+        },
+        "14/declaration/body/17/argument/15/9/1/1/3": {
+          content: {
+            en: "$10 - $1,000",
+            es: "$10 - $1.000"
+          },
+          hash: "90485af5b6db9ac425c475d6a0378795"
+        },
+        "14/declaration/body/17/argument/15/9/3/expression/right/1-placeholder": {
+          content: {
+            en: "Enter amount ($10-$1000)",
+            es: "Ingresa cantidad ($10-$1000)"
+          },
+          hash: "d8f463730f6320d9eb03df8f2d250d06"
+        },
+        "14/declaration/body/17/argument/3/expression/right/3": {
+          content: {
+            en: "Payment successful! Your credits have been added to your account.",
+            es: "¡Pago exitoso! Tus créditos han sido añadidos a tu cuenta."
+          },
+          hash: "41c33f9916e21be33cee7b689bcc57c0"
+        }
+      }
+    },
+    "components/apikeys/ApiKeyDashboard.tsx": {
+      entries: {
+        "17/declaration/body/15/consequent/0/argument/1/1": {
+          content: {
+            en: "API Management",
+            es: "Gestión de API"
+          },
+          hash: "b3d76fe5a47de22d9a422c902b3ae82d"
+        },
+        "17/declaration/body/15/consequent/0/argument/1/3": {
+          content: {
+            en: "Loading...",
+            es: "Cargando..."
+          },
+          hash: "82b4ea7ed1439094d7c4be13aaba9a66"
+        },
+        "17/declaration/body/16/consequent/0/argument/1/1": {
+          content: {
+            en: "API Management",
+            es: "Gestión de API"
+          },
+          hash: "b3d76fe5a47de22d9a422c902b3ae82d"
+        },
+        "17/declaration/body/16/consequent/0/argument/1/3": {
+          content: {
+            en: "Failed to load API keys. Please try again.",
+            es: "Error al cargar las claves API. Por favor, inténtalo de nuevo."
+          },
+          hash: "8322eea00959820ef842faeefe7b8f4c"
+        },
+        "17/declaration/body/17/consequent/0/argument/1/1": {
+          content: {
+            en: "<element:Sparkles></element:Sparkles> Unlock API Access",
+            es: "<element:Sparkles></element:Sparkles> Desbloquea el acceso a la API"
+          },
+          hash: "0274bf067d1e310de1545372646d82df"
+        },
+        "17/declaration/body/17/consequent/0/argument/1/3": {
+          content: {
+            en: "Upgrade to a paid plan to access powerful API features",
+            es: "Actualiza a un plan de pago para acceder a potentes funciones de API"
+          },
+          hash: "698e00ba75464005be84670b54998c44"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/1/3/1": {
+          content: {
+            en: "Programmatic Access",
+            es: "Acceso programático"
+          },
+          hash: "1df98067396fd9e97cb41e70f1a31c61"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/1/3/3": {
+          content: {
+            en: "Integrate Maple directly into your applications and workflows",
+            es: "Integra Maple directamente en tus aplicaciones y flujos de trabajo"
+          },
+          hash: "d1101c6783a160e6c8b7f2f95903e12e"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/3/3/1": {
+          content: {
+            en: "Secure API Keys",
+            es: "Claves API seguras"
+          },
+          hash: "dbda0a8b4ff81e045e096a86e6351156"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/3/3/3": {
+          content: {
+            en: "Create and manage multiple API keys with granular control",
+            es: "Crea y gestiona múltiples claves API con control granular"
+          },
+          hash: "30b1956cae67146fa288f3850bc15a3f"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/5/3/1": {
+          content: {
+            en: "Pay-As-You-Go Credits",
+            es: "Créditos de pago por uso"
+          },
+          hash: "e1f3fc567c914b7e8bf6819538eb18c8"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/5/3/3": {
+          content: {
+            en: "Purchase credits for API usage at just $1 per 1,000 credits",
+            es: "Compra créditos para uso de API por solo $1 por cada 1.000 créditos"
+          },
+          hash: "9ef5e9e01d766e99f0e29b8723c71ff9"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/3/1": {
+          content: {
+            en: "Starting at just <element:span>$20/month</element:span> with the Pro plan",
+            es: "Desde solo <element:span>$20/mes</element:span> con el plan Pro"
+          },
+          hash: "1b713c5c3b91d5a63ee8681b02ea324b"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/3/3": {
+          content: {
+            en: "<element:Sparkles></element:Sparkles> View Pricing Plans",
+            es: "<element:Sparkles></element:Sparkles> Ver planes de precios"
+          },
+          hash: "f78620789ac574033cc70301bd966211"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/3/5": {
+          content: {
+            en: "Unlock API access, increased limits, and premium features",
+            es: "Desbloquea acceso a la API, límites aumentados y funciones premium"
+          },
+          hash: "77d863f605e0b8ca081def71b01fdc33"
+        },
+        "17/declaration/body/18/argument/1/1": {
+          content: {
+            en: "API Access",
+            es: "Acceso a la API"
+          },
+          hash: "8c6d03728c3d9470616eb5cee5f9f65d"
+        },
+        "17/declaration/body/18/argument/1/3": {
+          content: {
+            en: "Manage API keys and configure access to Maple services. <element:a>Read more</element:a>",
+            es: "Gestiona claves API y configura el acceso a los servicios de Maple. <element:a>Leer más</element:a>"
+          },
+          hash: "7d485d8d77ddd89a88186933317b4f0c"
+        },
+        "17/declaration/body/18/argument/3/1/1": {
+          content: {
+            en: "<element:CreditCard></element:CreditCard> Credits",
+            es: "<element:CreditCard></element:CreditCard> Créditos"
+          },
+          hash: "a6b8c01787a844905f87b723efa0f352"
+        },
+        "17/declaration/body/18/argument/3/1/3": {
+          content: {
+            en: "<element:Key></element:Key> API Keys",
+            es: "<element:Key></element:Key> Claves API"
+          },
+          hash: "22d9e6c4357e815f7c5f9ffbc471d960"
+        },
+        "17/declaration/body/18/argument/3/1/5/expression/right": {
+          content: {
+            en: "<element:Server></element:Server> Local Proxy",
+            es: "<element:Server></element:Server> Proxy local"
+          },
+          hash: "52ae547330d1d64f8c6260b6b206dad6"
+        },
+        "17/declaration/body/18/argument/3/5/1/1/1": {
+          content: {
+            en: "API Keys",
+            es: "Claves API"
+          },
+          hash: "f961b547cd312cc8b9b79f0c9e0b2cc3"
+        },
+        "17/declaration/body/18/argument/3/5/1/1/13/1": {
+          content: {
+            en: "API keys allow you to integrate Maple into your applications and workflows.",
+            es: "Las claves API te permiten integrar Maple en tus aplicaciones y flujos de trabajo."
+          },
+          hash: "532fd72f4ed64b693d834f6d175f3a7c"
+        },
+        "17/declaration/body/18/argument/3/5/1/1/13/3": {
+          content: {
+            en: "Keep your API keys secure and never share them publicly. Treat them like passwords.",
+            es: "Mantén tus claves API seguras y nunca las compartas públicamente. Trátalas como contraseñas."
+          },
+          hash: "9915de285ab7eb3f3419cfcbb134b77b"
+        },
+        "17/declaration/body/18/argument/3/5/1/1/5": {
+          content: {
+            en: "<element:Plus></element:Plus> Create New API Key",
+            es: "<element:Plus></element:Plus> Crear nueva clave API"
+          },
+          hash: "93282b8bbb4336a1b63b21a727b9bf2e"
+        }
+      }
+    },
+    "components/apikeys/ApiKeysList.tsx": {
+      entries: {
+        "7/declaration/body/5/argument/1/1/1/expression/0/body/1/3": {
+          content: {
+            en: "<element:Calendar></element:Calendar> Created <function:formatDate/>",
+            es: "<element:Calendar></element:Calendar> Creada <function:formatDate/>"
+          },
+          hash: "15ff43c6dbc1a99a067c0b1cb18bd932"
+        },
+        "7/declaration/body/5/argument/5/1/1/1": {
+          content: {
+            en: "Delete API Key",
+            es: "Eliminar clave API"
+          },
+          hash: "ec13e8592107ad09f8c9bf0c1ac57628"
+        },
+        "7/declaration/body/5/argument/5/1/1/3": {
+          content: {
+            en: 'Are you sure you want to delete the API key "{deleteKeyName}"? This action cannot be undone and any applications using this key will stop working immediately.',
+            es: '¿Estás seguro de que quieres eliminar la clave API "{deleteKeyName}"? Esta acción no se puede deshacer y cualquier aplicación que use esta clave dejará de funcionar inmediatamente.'
+          },
+          hash: "372f67f2e6e46e1cf67415e20682f09c"
+        },
+        "7/declaration/body/5/argument/5/1/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "7/declaration/body/5/argument/5/1/3/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Deleting...",
+            es: "<element:Loader2></element:Loader2> Eliminando..."
+          },
+          hash: "b24acf9993cbd2c3fede3b9b2757749b"
+        }
+      }
+    },
+    "components/apikeys/CreateApiKeyDialog.tsx": {
+      entries: {
+        "9/declaration/body/9/argument/1/1/1": {
+          content: {
+            en: "Create API Key",
+            es: "Crear clave API"
+          },
+          hash: "dd7204449746f211b13a10cef9902021"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/1/1/3": {
+          content: {
+            en: "Make sure to copy your API key now. You won't be able to see it again!",
+            es: "Asegúrate de copiar tu clave API ahora. ¡No podrás verla de nuevo!"
+          },
+          hash: "8face93349f3f03405daf6f86cbc5e82"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/1/3/1": {
+          content: {
+            en: "Your API Key",
+            es: "Tu clave API"
+          },
+          hash: "7d4b6ffc6c77197385ddab84128c80ff"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/1/5/1": {
+          content: {
+            en: "Use this key to authenticate with the Maple API. <element:a>Read here</element:a>",
+            es: "Usa esta clave para autenticarte con la API de Maple. <element:a>Leer aquí</element:a>"
+          },
+          hash: "f464ef680f7541fae3abe08066f15b9a"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/3/1": {
+          content: {
+            en: "Done",
+            es: "Hecho"
+          },
+          hash: "dfdcfd01b8af0544912bccd21af26744"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/3/1/1": {
+          content: {
+            en: "Key Name",
+            es: "Nombre de la clave"
+          },
+          hash: "6601f961f0f2a40a93880a1c22259eb7"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/3/1/3-placeholder": {
+          content: {
+            en: "e.g., Production App, Development",
+            es: "p. ej., Aplicación de producción, Desarrollo"
+          },
+          hash: "62fad45f1891a921bb1425997260ac29"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/3/1/5": {
+          content: {
+            en: "/100 characters",
+            es: "/100 caracteres"
+          },
+          hash: "2a218fefd5437ebbfa65edb06b881982"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "5936f87dccc089542c7871a72ed1dacf"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/5/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Creating...",
+            es: "<element:Loader2></element:Loader2> Creando..."
+          },
+          hash: "64477295ccbee49bfde20cc48d97bd1f"
+        }
+      }
+    },
+    "components/apikeys/ProxyConfigSection.tsx": {
+      entries: {
+        "10/declaration/body/14/argument/11/expression/right/1/1/1": {
+          content: {
+            en: "Python Example:",
+            es: "Ejemplo en Python:"
+          },
+          hash: "69fee08b294c5d8bb988c55e41902bca"
+        },
+        "10/declaration/body/14/argument/11/expression/right/3/1/1": {
+          content: {
+            en: "cURL Example:",
+            es: "Ejemplo en cURL:"
+          },
+          hash: "6dc5e73a33fe46607cb313d870aa5b9c"
+        },
+        "10/declaration/body/14/argument/5/1": {
+          content: {
+            en: "<element:Server></element:Server> Local OpenAI Proxy",
+            es: "<element:Server></element:Server> Proxy local de OpenAI"
+          },
+          hash: "d9ee93931bc82d8dfd287f4cc658d748"
+        },
+        "10/declaration/body/14/argument/7/11/expression/right/1": {
+          content: {
+            en: "Proxy URL",
+            es: "URL del proxy"
+          },
+          hash: "15fb7768aefd0ad72c62381c1b339a96"
+        },
+        "10/declaration/body/14/argument/7/11/expression/right/5": {
+          content: {
+            en: "Use this URL as your OpenAI base URL in any client",
+            es: "Usa esta URL como tu URL base de OpenAI en cualquier cliente"
+          },
+          hash: "609e5108827a7ce2bffaef48e21002dd"
+        },
+        "10/declaration/body/14/argument/7/15/1/expression/alternate": {
+          content: {
+            en: "<expression/> Stop Proxy",
+            es: "<expression/> Detener proxy"
+          },
+          hash: "90cd77da69ec989176c0d0cc035ac3f9"
+        },
+        "10/declaration/body/14/argument/7/15/1/expression/consequent": {
+          content: {
+            en: "<expression/> Start Proxy",
+            es: "<expression/> Iniciar proxy"
+          },
+          hash: "721beefcc63d28812dc288e3bc105413"
+        },
+        "10/declaration/body/14/argument/7/19/1": {
+          content: {
+            en: "Enable CORS (for web clients)",
+            es: "Habilitar CORS (para clientes web)"
+          },
+          hash: "2a8ce094e96da3b682ebdc40e1d70001"
+        },
+        "10/declaration/body/14/argument/7/23/1/1": {
+          content: {
+            en: "Auto-start proxy when app launches",
+            es: "Iniciar proxy automáticamente al lanzar la aplicación"
+          },
+          hash: "6f56604c2f4ab3576686e457fffef071"
+        },
+        "10/declaration/body/14/argument/7/23/1/3": {
+          content: {
+            en: "Proxy will start automatically on app launch if configured",
+            es: "El proxy se iniciará automáticamente al lanzar la aplicación si está configurado"
+          },
+          hash: "f6f186c388c64a30b7bd6733ae6e15a4"
+        },
+        "10/declaration/body/14/argument/7/3/1/1": {
+          content: {
+            en: "Host",
+            es: "Host"
+          },
+          hash: "b8e35955c05907867a731a19f6023d51"
+        },
+        "10/declaration/body/14/argument/7/3/1/3-placeholder": {
+          content: {
+            en: "127.0.0.1",
+            es: "127.0.0.1"
+          },
+          hash: "0a1db25f677dd312e232eff2549e3645"
+        },
+        "10/declaration/body/14/argument/7/3/3/1": {
+          content: {
+            en: "Port",
+            es: "Puerto"
+          },
+          hash: "29b1e7e48599145af6b06eebc1fb42d9"
+        },
+        "10/declaration/body/14/argument/7/3/3/3/1-placeholder": {
+          content: {
+            en: "8080",
+            es: "8080"
+          },
+          hash: "c72f517d783f817b070589a8ccb21429"
+        },
+        "10/declaration/body/14/argument/7/7/expression/right/1": {
+          content: {
+            en: "API Key Status",
+            es: "Estado de la clave API"
+          },
+          hash: "3ca677efa954ec7a8640f1b3a297abd5"
+        },
+        "10/declaration/body/14/argument/7/7/expression/right/3": {
+          content: {
+            en: "API key configured",
+            es: "Clave API configurada"
+          },
+          hash: "f19737501d9d6c458bfa64c01bb731b4"
+        }
+      }
+    },
+    "components/icons/LinkedIn.tsx": {
+      entries: {
+        "1/declaration/body/0/argument/1": {
+          content: {
+            en: "LinkedIn",
+            es: "LinkedIn"
+          },
+          hash: "f29b78f253094277c2e9ef79d10b5e4f"
+        }
+      }
+    },
+    "components/icons/X.tsx": {
+      entries: {
+        "1/declaration/body/0/argument/1": {
+          content: {
+            en: "X",
+            es: "X"
+          },
+          hash: "dc96f9cb0985d77c30f55927723f0175"
+        }
+      }
+    },
+    "components/markdown.tsx": {
+      entries: {
+        "16/body/6/argument/1/5/1/expression/consequent": {
+          content: {
+            en: "Thinking for {durationText} seconds<element:span><element:span>.</element:span><element:span>.</element:span><element:span>.</element:span></element:span>",
+            es: "Pensando durante {durationText} segundos<element:span><element:span>.</element:span><element:span>.</element:span><element:span>.</element:span></element:span>"
+          },
+          hash: "798fa677e8609fdb7fe9bb4c9f92f0a9"
+        },
+        "20/declaration/body/3/argument/1/1/1/expression/alternate/3": {
+          content: {
+            en: "Copy Code",
+            es: "Copiar código"
+          },
+          hash: "1722a0fe065d4c44df3d5e4a887dd1ae"
+        },
+        "20/declaration/body/3/argument/1/1/1/expression/consequent/3": {
+          content: {
+            en: "Copied",
+            es: "Copiado"
+          },
+          hash: "29208e06d704c4fc4b8b534dc7acc4ef"
+        }
+      }
+    },
+    "components/team/TeamDashboard.tsx": {
+      entries: {
+        "12/declaration/body/14/consequent/0/argument/1/1": {
+          content: {
+            en: "Team Information",
+            es: "Información del equipo"
+          },
+          hash: "02941905c52e6d720733451585944ea4"
+        },
+        "12/declaration/body/14/consequent/0/argument/3/3/1/1/3/expression/right": {
+          content: {
+            en: "Member since <function:Date.toLocaleDateString/>",
+            es: "Miembro desde <function:Date.toLocaleDateString/>"
+          },
+          hash: "c843b25e81c85c4e51defa26dc1e790f"
+        },
+        "12/declaration/body/14/consequent/0/argument/3/3/1/3": {
+          content: {
+            en: "<element:User></element:User> Member",
+            es: "<element:User></element:User> Miembro"
+          },
+          hash: "65e65f05f4f820ff2628514b06072b88"
+        },
+        "12/declaration/body/14/consequent/0/argument/3/7/1": {
+          content: {
+            en: "Need to leave this team? You'll need an invitation to rejoin.",
+            es: "¿Necesitas abandonar este equipo? Necesitarás una invitación para volver a unirte."
+          },
+          hash: "cb76f477232b58641fe386756839a7ed"
+        },
+        "12/declaration/body/15/argument/1/1": {
+          content: {
+            en: "Team Dashboard",
+            es: "Panel del equipo"
+          },
+          hash: "08561a2cc60760729b969123d1fa8f7e"
+        },
+        "12/declaration/body/15/argument/3/11/expression/right": {
+          content: {
+            en: "<element:UserPlus></element:UserPlus> Invite Members",
+            es: "<element:UserPlus></element:UserPlus> Invitar miembros"
+          },
+          hash: "a06154b89dec35d511851352dc81713b"
+        },
+        "12/declaration/body/15/argument/3/3/expression/right/3": {
+          content: {
+            en: "Seat limit exceeded. Remove members or purchase additional seats.",
+            es: "Límite de asientos excedido. Elimina miembros o compra asientos adicionales."
+          },
+          hash: "364db56307cbda1fd54389e1e26eaf35"
+        },
+        "12/declaration/body/15/argument/3/7/1/1/1/expression/consequent/3/1": {
+          content: {
+            en: "/100 characters",
+            es: "/100 caracteres"
+          },
+          hash: "82567f89a5f47eb61c1e23b328177c33"
+        },
+        "12/declaration/body/15/argument/3/7/1/1/3/expression/right": {
+          content: {
+            en: "Created <function:Date.toLocaleDateString/>",
+            es: "Creado <function:Date.toLocaleDateString/>"
+          },
+          hash: "f0afb30d4012e5f5472883fded055b35"
+        },
+        "12/declaration/body/15/argument/3/7/1/3/expression/right": {
+          content: {
+            en: "<element:Crown></element:Crown> Admin",
+            es: "<element:Crown></element:Crown> Administrador"
+          },
+          hash: "37b4ce10351c75274ef4979a30619be4"
+        },
+        "12/declaration/body/15/argument/3/7/5/1/1": {
+          content: {
+            en: "Seat Usage",
+            es: "Uso de asientos"
+          },
+          hash: "96f4f25d117c3c298a63ef05ce4d6ea7"
+        },
+        "12/declaration/body/15/argument/3/7/5/1/3": {
+          content: {
+            en: "{seatsUsed}/{seatsPurchased} (<function:Math.round/>%)",
+            es: "{seatsUsed}/{seatsPurchased} (<function:Math.round/>%)"
+          },
+          hash: "ca14f0b8b7164d2cf3cf9d9ecd061de7"
+        },
+        "12/declaration/body/6/consequent/0/argument/1/1": {
+          content: {
+            en: "Team Dashboard",
+            es: "Panel del equipo"
+          },
+          hash: "08561a2cc60760729b969123d1fa8f7e"
+        },
+        "12/declaration/body/6/consequent/0/argument/1/3": {
+          content: {
+            en: "Loading team information...",
+            es: "Cargando información del equipo..."
+          },
+          hash: "a5171c2d12afb3e5c1c39663dcc63bf9"
+        }
+      }
+    },
+    "components/team/TeamInviteDialog.tsx": {
+      entries: {
+        "13/declaration/body/12/argument/1/1/1": {
+          content: {
+            en: "Invite Team Members",
+            es: "Invitar miembros al equipo"
+          },
+          hash: "2485e3adb99027f9615976fd070f5649"
+        },
+        "13/declaration/body/12/argument/1/1/3": {
+          content: {
+            en: "Send invitations to new team members. They'll receive an email to join your team.",
+            es: "Envía invitaciones a nuevos miembros del equipo. Recibirán un correo electrónico para unirse a tu equipo."
+          },
+          hash: "f5e929e728458af70f8e8360ca2e9f3b"
+        },
+        "13/declaration/body/12/argument/1/3/1/1/1": {
+          content: {
+            en: "Email Addresses",
+            es: "Direcciones de correo electrónico"
+          },
+          hash: "934acb216360e4613727994fc77a78ac"
+        },
+        "13/declaration/body/12/argument/1/3/1/1/5": {
+          content: {
+            en: "Enter one email per line or separate with commas",
+            es: "Introduce un correo por línea o sepáralos con comas"
+          },
+          hash: "0d59ab1a19d27ab7c18a534899228a9c"
+        },
+        "13/declaration/body/12/argument/1/3/1/3/expression/right/3": {
+          content: {
+            en: "You have <element:strong>{seatsAvailable}</element:strong> <expression/> available for new members.",
+            es: "Tienes <element:strong>{seatsAvailable}</element:strong> <expression/> disponibles para nuevos miembros."
+          },
+          hash: "7ce71fabc5d578cc1ece560c7dabe52e"
+        },
+        "13/declaration/body/12/argument/1/3/1/5/expression/right/1/3": {
+          content: {
+            en: "No seats available. Please purchase additional seats or remove existing members before inviting new ones.",
+            es: "No hay asientos disponibles. Por favor, compra asientos adicionales o elimina miembros existentes antes de invitar a nuevos."
+          },
+          hash: "93972c2cfa65cdc875436afad603e59b"
+        },
+        "13/declaration/body/12/argument/1/3/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "07296eb8d91ad98e1b60cd7ab0def914"
+        },
+        "13/declaration/body/12/argument/1/3/3/3/1/expression/alternate": {
+          content: {
+            en: "<element:UserPlus></element:UserPlus> Send Invites",
+            es: "<element:UserPlus></element:UserPlus> Enviar invitaciones"
+          },
+          hash: "24e414e6202f5b671de4eb7ab2a12a64"
+        },
+        "13/declaration/body/12/argument/1/3/3/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Sending Invites...",
+            es: "<element:Loader2></element:Loader2> Enviando invitaciones..."
+          },
+          hash: "6cb0b8e8fabc7bb23c8efe8f7ae88ed8"
+        }
+      }
+    },
+    "components/team/TeamMembersList.tsx": {
+      entries: {
+        "13/declaration/body/16/consequent/0/argument/1": {
+          content: {
+            en: "<element:LogOut></element:LogOut> Leave Team",
+            es: "<element:LogOut></element:LogOut> Abandonar equipo"
+          },
+          hash: "43742ed2c0dd1e0e3038fd6843cfc240"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/1/1": {
+          content: {
+            en: "Leave team?",
+            es: "¿Abandonar equipo?"
+          },
+          hash: "0fdc334a0248b88ecb41d4719077a468"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/1/3": {
+          content: {
+            en: "Are you sure you want to leave the team? You will lose access to all team resources and will need to be invited again to rejoin.",
+            es: "¿Estás seguro de que quieres abandonar el equipo? Perderás acceso a todos los recursos del equipo y necesitarás ser invitado de nuevo para volver a unirte."
+          },
+          hash: "18146b1ef72949f80fa1c261689b29c8"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/5/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Leaving...",
+            es: "<element:Loader2></element:Loader2> Abandonando..."
+          },
+          hash: "c055fb3db095a8447539f61c77e3ee86"
+        },
+        "13/declaration/body/18/argument/1/1/1": {
+          content: {
+            en: "Team Members",
+            es: "Miembros del equipo"
+          },
+          hash: "61333c4a765e10b2ad46774951725233"
+        },
+        "13/declaration/body/18/argument/1/1/3": {
+          content: {
+            en: "{members.length} active <expression/><expression/>",
+            es: "{members.length} <expression/> activos<expression/>"
+          },
+          hash: "8263fa2d5fcde4cdc22ee6957252369d"
+        },
+        "13/declaration/body/18/argument/1/11/expression/right": {
+          content: {
+            en: "No team members yet. Start by inviting your team!",
+            es: "¡Aún no hay miembros en el equipo. Comienza invitando a tu equipo!"
+          },
+          hash: "6e21156444f80ec54f10ebed545b59e2"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/1/1/3/1/expression/right":
+          {
+            content: {
+              en: "<element:Crown></element:Crown> Admin",
+              es: "<element:Crown></element:Crown> Administrador"
+            },
+            hash: "adfc9a780b5f38c7ea2a461e392fd114"
+          },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/1/1/3/3/expression/right":
+          {
+            content: {
+              en: "You",
+              es: "Tú"
+            },
+            hash: "699def1aff09e50b0645fd3819977894"
+          },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/1/3": {
+          content: {
+            en: "Joined <function:Date.toLocaleDateString/>",
+            es: "Se unió <function:Date.toLocaleDateString/>"
+          },
+          hash: "737d46f606174c8e494a8f1c25451a32"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/3/expression/right/3/1":
+          {
+            content: {
+              en: "<element:UserMinus></element:UserMinus> Remove from team",
+              es: "<element:UserMinus></element:UserMinus> Eliminar del equipo"
+            },
+            hash: "556c4e421b70b52fed9058be054a618d"
+          },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/5/expression/right": {
+          content: {
+            en: "<element:LogOut></element:LogOut> Leave team",
+            es: "<element:LogOut></element:LogOut> Abandonar equipo"
+          },
+          hash: "0f14f61d4be887244e98f14ea75d3605"
+        },
+        "13/declaration/body/18/argument/1/9/expression/right/3/1": {
+          content: {
+            en: "Pending Invites",
+            es: "Invitaciones pendientes"
+          },
+          hash: "3f41764c00c258b3e45fa5de69bc72ad"
+        },
+        "13/declaration/body/18/argument/13/1/1/1": {
+          content: {
+            en: "Leave team?",
+            es: "¿Abandonar equipo?"
+          },
+          hash: "0fdc334a0248b88ecb41d4719077a468"
+        },
+        "13/declaration/body/18/argument/13/1/1/3": {
+          content: {
+            en: "Are you sure you want to leave the team? You will lose access to all team resources and will need to be invited again to rejoin.",
+            es: "¿Estás seguro de que quieres abandonar el equipo? Perderás acceso a todos los recursos del equipo y necesitarás ser invitado de nuevo para volver a unirte."
+          },
+          hash: "84563e2da39df867feeabc5c49318619"
+        },
+        "13/declaration/body/18/argument/13/1/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "13/declaration/body/18/argument/13/1/5/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Leaving...",
+            es: "<element:Loader2></element:Loader2> Saliendo..."
+          },
+          hash: "39f25a21a4b0362cb84db1fa279618d0"
+        },
+        "13/declaration/body/18/argument/5/1/1/1": {
+          content: {
+            en: "Remove team member?",
+            es: "¿Eliminar miembro del equipo?"
+          },
+          hash: "d8bc4943cdf3f64faccc58bfb0a0152f"
+        },
+        "13/declaration/body/18/argument/5/1/1/3": {
+          content: {
+            en: "Are you sure you want to remove <expression/> from the team? They will lose access to all team resources immediately.",
+            es: "¿Estás seguro de que quieres eliminar a <expression/> del equipo? Perderán acceso a todos los recursos del equipo inmediatamente."
+          },
+          hash: "0dd5fe62c4ef55b2e4afa50fea036d4b"
+        },
+        "13/declaration/body/18/argument/5/1/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "13/declaration/body/18/argument/5/1/5/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Removing...",
+            es: "<element:Loader2></element:Loader2> Eliminando..."
+          },
+          hash: "c92c29b5384d872cf737a8cb44ff8642"
+        },
+        "13/declaration/body/18/argument/9/1/1/1": {
+          content: {
+            en: "Revoke invitation?",
+            es: "¿Revocar invitación?"
+          },
+          hash: "1ad8c66405cdda7976471af92ea6b5dd"
+        },
+        "13/declaration/body/18/argument/9/1/1/3": {
+          content: {
+            en: "Are you sure you want to revoke the invitation for <expression/>? They will no longer be able to join the team using this invitation.",
+            es: "¿Estás seguro de que quieres revocar la invitación para <expression/>? Ya no podrán unirse al equipo usando esta invitación."
+          },
+          hash: "4fd62b650a257da33c32686f6d98dc6a"
+        },
+        "13/declaration/body/18/argument/9/1/5/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "2e2a849c2223911717de8caa2c71bade"
+        },
+        "13/declaration/body/18/argument/9/1/5/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Revoking...",
+            es: "<element:Loader2></element:Loader2> Revocando..."
+          },
+          hash: "35cb1de4303728093747ac593ef13081"
+        }
+      }
+    },
+    "components/team/TeamSetupDialog.tsx": {
+      entries: {
+        "11/declaration/body/7/argument/1/1/1": {
+          content: {
+            en: "Set Up Your Team",
+            es: "Configura tu equipo"
+          },
+          hash: "ffaab82758a0babebea452eff8868b43"
+        },
+        "11/declaration/body/7/argument/1/1/3": {
+          content: {
+            en: "You've purchased a team plan! Let's create your team to get started. You'll be able to invite members after setup.",
+            es: "¡Has comprado un plan de equipo! Vamos a crear tu equipo para comenzar. Podrás invitar a miembros después de la configuración."
+          },
+          hash: "4e1fa4e1a3ba978789a16397024b1821"
+        },
+        "11/declaration/body/7/argument/1/3/1/1/1": {
+          content: {
+            en: "Team Name",
+            es: "Nombre del equipo"
+          },
+          hash: "d1a5f99dbf503ca53f06b3a98b511d02"
+        },
+        "11/declaration/body/7/argument/1/3/1/1/3-placeholder": {
+          content: {
+            en: "e.g., My Company Team",
+            es: "ej., Equipo de mi empresa"
+          },
+          hash: "8eefccf07ab94f4e8faa6515932bc582"
+        },
+        "11/declaration/body/7/argument/1/3/1/1/5": {
+          content: {
+            en: "This is how your team will be identified. You can change it later.",
+            es: "Así es como se identificará tu equipo. Puedes cambiarlo más tarde."
+          },
+          hash: "d59424f541e1331a2f5f82caba47363b"
+        },
+        "11/declaration/body/7/argument/1/3/1/3/expression/right/3": {
+          content: {
+            en: "Your team plan includes <element:strong>{teamStatus.seats_purchased} seats</element:strong>.You'll be the team admin and can invite up to <expression/> additional members.",
+            es: "Tu plan de equipo incluye <element:strong>{teamStatus.seats_purchased} asientos</element:strong>. Serás el administrador del equipo y podrás invitar hasta <expression/> miembros adicionales."
+          },
+          hash: "33430cb1e8c763164b52c2b882580de8"
+        },
+        "11/declaration/body/7/argument/1/3/3/1": {
+          content: {
+            en: "Cancel",
+            es: "Cancelar"
+          },
+          hash: "07296eb8d91ad98e1b60cd7ab0def914"
+        },
+        "11/declaration/body/7/argument/1/3/3/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Creating Team...",
+            es: "<element:Loader2></element:Loader2> Creando equipo..."
+          },
+          hash: "7cb862aeb455529461e69b3d708d32ea"
+        }
+      }
+    },
+    "components/ui/dialog.tsx": {
+      entries: {
+        "10/0/init/0/body/3/3/3": {
+          content: {
+            en: "Close",
+            es: "Cerrar"
+          },
+          hash: "2c2e22f8424a1031de89063bd0022e16"
+        }
+      }
+    },
+    "routes/_auth.chat.$chatId.tsx": {
+      entries: {
+        "16/body/2/argument/1/3/1/1": {
+          content: {
+            en: "System Prompt",
+            es: "Prompt del sistema"
+          },
+          hash: "3980ee4b3313840de80cdbeeb510a573"
+        },
+        "16/body/2/argument/1/3/3/1/expression/alternate/3/expression/right/3": {
+          content: {
+            en: "see more",
+            es: "ver más"
+          },
+          hash: "bc0fa9371ec59c3567503c5f0b833ad4"
+        },
+        "16/body/2/argument/1/3/3/1/expression/consequent/3/expression/right/3": {
+          content: {
+            en: "show less",
+            es: "mostrar menos"
+          },
+          hash: "12467720a8cf83354b678cedc8e2cef1"
+        },
+        "17/body/13/consequent/0/argument/3/1": {
+          content: {
+            en: "Loading archived chat...",
+            es: "Cargando chat archivado..."
+          },
+          hash: "0fa31f2b4c77c3fc5647e435c03192c0"
+        },
+        "17/body/14/consequent/0/argument/3/1": {
+          content: {
+            en: "Archived chat not found",
+            es: "Chat archivado no encontrado"
+          },
+          hash: "6ce9c7bc91b62d499f8cf4c7b106fb75"
+        },
+        "17/body/16/argument/3/3/1/1/expression/right-aria-label": {
+          content: {
+            en: "New chat",
+            es: "Nuevo chat"
+          },
+          hash: "3137bd8485c6f0fee4b0bbcce4eecdad"
+        },
+        "17/body/16/argument/3/3/5/expression/right-aria-label": {
+          content: {
+            en: "Scroll to bottom",
+            es: "Desplazarse hasta el final"
+          },
+          hash: "9481586f42c7c8b1b91c220346e1e630"
+        },
+        "17/body/16/argument/3/7/1/3/1": {
+          content: {
+            en: "Archived Chat",
+            es: "Chat archivado"
+          },
+          hash: "2a32aeceb23b71b714e8f027bb65f804"
+        },
+        "17/body/16/argument/3/7/1/3/3": {
+          content: {
+            en: "This is a read-only chat from your history. Start a new chat to continue the conversation.",
+            es: "Este es un chat de solo lectura de tu historial. Inicia un nuevo chat para continuar la conversación."
+          },
+          hash: "49bcc34635fa432f67b4fe41defce9c1"
+        },
+        "17/body/16/argument/3/7/1/5": {
+          content: {
+            en: "New Chat",
+            es: "Nuevo chat"
+          },
+          hash: "24492f2089875d64592574b93dc9ac8b"
+        }
+      }
+    },
+    "routes/about.tsx": {
+      entries: {
+        "8/body/0/argument/3/1/openingElement/0/value/expression": {
+          content: {
+            en: "<element:span>About</element:span> Maple AI",
+            es: "<element:span>Acerca de</element:span> Maple AI"
+          },
+          hash: "b04c53944c40234296799789d8a8dc83"
+        },
+        "8/body/0/argument/3/1/openingElement/1/value/expression": {
+          content: {
+            en: "Incredibly powerful AI that doesn't share your data with anyone",
+            es: "IA increíblemente potente que no comparte tus datos con nadie"
+          },
+          hash: "279ba99cbdef4eabf7d95589b1de1c11"
+        },
+        "8/body/0/argument/3/3/11/1": {
+          content: {
+            en: "Built on OpenSecret",
+            es: "Construido sobre OpenSecret"
+          },
+          hash: "e7a5d2ebfbcd6a46894316ce3b83632b"
+        },
+        "8/body/0/argument/3/3/11/3/1-alt": {
+          content: {
+            en: "OpenSecret company logo",
+            es: "Logo de la empresa OpenSecret"
+          },
+          hash: "0199b7730c58b69986e670700252611b"
+        },
+        "8/body/0/argument/3/3/11/3/3/1": {
+          content: {
+            en: "Maple AI is built on OpenSecret, pioneering the future of privacy-preserving apps. Whether artificial intelligence or traditional apps, user data is end-to-end encrypted.",
+            es: "Maple AI está construido sobre OpenSecret, pionero en el futuro de las aplicaciones que preservan la privacidad. Ya sea inteligencia artificial o aplicaciones tradicionales, los datos del usuario están cifrados de extremo a extremo."
+          },
+          hash: "2aef756e6248a98a3d051948e9ca0aed"
+        },
+        "8/body/0/argument/3/3/11/3/3/3": {
+          content: {
+            en: "Learn more about OpenSecret →",
+            es: "Más información sobre OpenSecret →"
+          },
+          hash: "75eba4b3b566429ef04617f18e0b093a"
+        },
+        "8/body/0/argument/3/3/15/1": {
+          content: {
+            en: "Developer Programs",
+            es: "Programas para desarrolladores"
+          },
+          hash: "0cc6fdceed0e0671e851c2bb33bb8ee3"
+        },
+        "8/body/0/argument/3/3/15/3/3/1-alt": {
+          content: {
+            en: "NVIDIA Inception Program logo",
+            es: "Logo del programa NVIDIA Inception"
+          },
+          hash: "5d4d5cb4e748f6def6a562f8659f0ba4"
+        },
+        "8/body/0/argument/3/3/15/3/3/3": {
+          content: {
+            en: "Inception Program",
+            es: "Programa Inception"
+          },
+          hash: "7a48aa62786d2c964bc13d9e8fd00184"
+        },
+        "8/body/0/argument/3/3/15/3/7/1-alt": {
+          content: {
+            en: "Google Cloud for Startups program logo",
+            es: "Logo del programa Google Cloud for Startups"
+          },
+          hash: "d1c8d9fc2f0b8f1f072ec05a837d7adf"
+        },
+        "8/body/0/argument/3/3/15/3/7/3": {
+          content: {
+            en: "Google Cloud for Startups",
+            es: "Google Cloud for Startups"
+          },
+          hash: "245f6fe3b3214a477c90ef37d8500406"
+        },
+        "8/body/0/argument/3/3/19/1": {
+          content: {
+            en: "Built in Austin. Living in Secure Enclaves.",
+            es: "Creado en Austin. Viviendo en enclaves seguros."
+          },
+          hash: "ca6faed46366280fe316192bf08781e9"
+        },
+        "8/body/0/argument/3/3/3/1": {
+          content: {
+            en: "Our Inspiration",
+            es: "Nuestra inspiración"
+          },
+          hash: "0a9ea2ca707dbbc5f80102d81409a18e"
+        },
+        "8/body/0/argument/3/3/3/3/1/1-alt": {
+          content: {
+            en: "Maple autumn forest",
+            es: "Bosque de otoño con arces"
+          },
+          hash: "6a66eb1a8a7a4f742e0c6e8e0a94553f"
+        },
+        "8/body/0/argument/3/3/3/3/1/3": {
+          content: {
+            en: "Autumn Woods <element:br></element:br> by William Trost Richards",
+            es: "Bosques de otoño <element:br></element:br> por William Trost Richards"
+          },
+          hash: "7dcabf6e8fa72fe68d79bc2eb5bcfb96"
+        },
+        "8/body/0/argument/3/3/3/3/1/5-alt": {
+          content: {
+            en: "Maple App Icon",
+            es: "Icono de la aplicación Maple"
+          },
+          hash: "ca8a9521de245a95234bd98ba2d256f2"
+        },
+        "8/body/0/argument/3/3/3/3/3/1": {
+          content: {
+            en: "Maple trees form underground networks of root systems, communicating and sharing resources without the knowledge of animals above. This cooperative approach helps them thrive in challenging environments.",
+            es: "Los arces forman redes subterráneas de sistemas de raíces, comunicándose y compartiendo recursos sin que los animales de la superficie lo sepan. Este enfoque cooperativo les ayuda a prosperar en entornos desafiantes."
+          },
+          hash: "67606dd7ea05fd16bb9dcc9b98c8073b"
+        },
+        "8/body/0/argument/3/3/3/3/3/3": {
+          content: {
+            en: "Maple AI draws inspiration from this natural model of secure, decentralized intelligence. Each account uses a personal encryption key, giving you control over the data. Whether you are handling sensitive information on behalf of clients or your own personal thoughts, communication stays between you and the AI. No data is used for training models nor shared with third parties, not even us.",
+            es: "Maple AI se inspira en este modelo natural de inteligencia segura y descentralizada. Cada cuenta utiliza una clave de cifrado personal, dándote control sobre tus datos. Ya sea que estés manejando información sensible en nombre de clientes o tus propios pensamientos personales, la comunicación se mantiene entre tú y la IA. Ningún dato se utiliza para entrenar modelos ni se comparte con terceros, ni siquiera con nosotros."
+          },
+          hash: "b35cefde8b5bcbfb7ad69981e710f0ae"
+        },
+        "8/body/0/argument/3/3/3/3/3/5": {
+          content: {
+            en: "People shouldn't have to sacrifice their privacy for high-quality AI. Maple upholds the highest standards of privacy and confidentiality, preserving the fundamental human right to freedom of thought. With confidence in AI, you can work together to thrive in your own challenging environments.",
+            es: "Las personas no deberían tener que sacrificar su privacidad por una IA de alta calidad. Maple mantiene los más altos estándares de privacidad y confidencialidad, preservando el derecho humano fundamental a la libertad de pensamiento. Con confianza en la IA, pueden trabajar juntos para prosperar en sus propios entornos desafiantes."
+          },
+          hash: "06dacf3639928686d2b88a364943261a"
+        },
+        "8/body/0/argument/3/3/3/3/3/7-alt": {
+          content: {
+            en: "Maple App Icon",
+            es: "Icono de la aplicación Maple"
+          },
+          hash: "ca8a9521de245a95234bd98ba2d256f2"
+        },
+        "8/body/0/argument/3/3/7/1": {
+          content: {
+            en: "Founders",
+            es: "Fundadores"
+          },
+          hash: "0bfffc402dade83bd68f5c6e6f1df0b9"
+        },
+        "8/body/0/argument/3/3/7/3": {
+          content: {
+            en: "Our team has combined over 30 years experience building scalable cloud and local app solutions that take privacy and security seriously. We have successfully built in the fields of data storage, defense, fintech, education, security, therapy, computer vision, and consumer technology.",
+            es: "Nuestro equipo tiene una experiencia combinada de más de 30 años construyendo soluciones escalables en la nube y aplicaciones locales que toman en serio la privacidad y la seguridad. Hemos construido con éxito en los campos de almacenamiento de datos, defensa, tecnología financiera, educación, seguridad, terapia, visión por computadora y tecnología de consumo."
+          },
+          hash: "12efccf518879a085c4f6cee4ce709ac"
+        },
+        "8/body/0/argument/3/3/7/5/3/1-aria-label": {
+          content: {
+            en: "Mark Suman on X",
+            es: "Mark Suman en X"
+          },
+          hash: "be87ed14fece9ef9ca415a7bd62c1602"
+        },
+        "8/body/0/argument/3/3/7/5/3/1/1-alt": {
+          content: {
+            en: "Mark, Co-founder of Maple AI",
+            es: "Mark, cofundador de Maple AI"
+          },
+          hash: "279163e55ed32085b27082b8cbb108e1"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/1": {
+          content: {
+            en: "Mark Suman",
+            es: "Mark Suman"
+          },
+          hash: "9c9c55353291472794b45f113f02358b"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/3": {
+          content: {
+            en: "CEO",
+            es: "CEO"
+          },
+          hash: "b25e3cb3c8800107503a5ecfd499d872"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/5": {
+          content: {
+            en: "Early employee in Product and Engineering at multiple startups, including Instructure Canvas. Most recently, 6 years in software engineering at Apple with a focus on AI and Privacy.<element:span><element:a><element:X></element:X></element:a><element:a><element:LinkedIn></element:LinkedIn></element:a></element:span>",
+            es: "Empleado temprano en Producto e Ingeniería en varias startups, incluyendo Instructure Canvas. Más recientemente, 6 años en ingeniería de software en Apple con enfoque en IA y Privacidad.<element:span><element:a><element:X></element:X></element:a><element:a><element:LinkedIn></element:LinkedIn></element:a></element:span>"
+          },
+          hash: "c81babc3b93d9c9b6325927207693535"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/5/1/1-aria-label": {
+          content: {
+            en: "Mark Suman on X",
+            es: "Mark Suman en X"
+          },
+          hash: "be87ed14fece9ef9ca415a7bd62c1602"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/5/1/3-aria-label": {
+          content: {
+            en: "Mark Suman on LinkedIn",
+            es: "Mark Suman en LinkedIn"
+          },
+          hash: "3641203d06ac071b49833f807582ab15"
+        },
+        "8/body/0/argument/3/3/7/5/7/1-aria-label": {
+          content: {
+            en: "Anthony Ronning on X",
+            es: "Anthony Ronning en X"
+          },
+          hash: "0777d686054b8f3aa44b59e59078cfe4"
+        },
+        "8/body/0/argument/3/3/7/5/7/1/1-alt": {
+          content: {
+            en: "Anthony, Co-founder of Maple AI",
+            es: "Anthony, cofundador de Maple AI"
+          },
+          hash: "074648f41b51b019ef4fd5b38aa7fbe0"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/1": {
+          content: {
+            en: "Anthony Ronning",
+            es: "Anthony Ronning"
+          },
+          hash: "7edec9a2ce7195f96803012040cb9292"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/3": {
+          content: {
+            en: "CTO",
+            es: "CTO"
+          },
+          hash: "8969cd6bb5a49670ce1e4388839c0862"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/5": {
+          content: {
+            en: "Infrastructure engineer in many startups over the last 9 years. Previous experience in defense, security, networking, and bitcoin companies.<element:span><element:a><element:X></element:X></element:a></element:span>",
+            es: "Ingeniero de infraestructura en muchas startups durante los últimos 9 años. Experiencia previa en empresas de defensa, seguridad, redes y bitcoin.<element:span><element:a><element:X></element:X></element:a></element:span>"
+          },
+          hash: "06cb3e88e26c82d6cfca563197680475"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/5/1/1-aria-label": {
+          content: {
+            en: "Anthony Ronning on X",
+            es: "Anthony Ronning en X"
+          },
+          hash: "0777d686054b8f3aa44b59e59078cfe4"
+        }
+      }
+    },
+    "routes/auth.$provider.callback.tsx": {
+      entries: {
+        "10/body/10/consequent/0/argument/1/1": {
+          content: {
+            en: "{formattedProvider} Authentication Successful",
+            es: "Autenticación con {formattedProvider} exitosa"
+          },
+          hash: "a149592ad26c48aeb88ff5014e7f2a46"
+        },
+        "10/body/10/consequent/0/argument/3/1": {
+          content: {
+            en: "Authentication successful! Redirecting you back to the app...",
+            es: "¡Autenticación exitosa! Redireccionándote de vuelta a la aplicación..."
+          },
+          hash: "6383e381db4ebc158e52b0e8e689a1e2"
+        },
+        "10/body/11/consequent/0/argument/1/1": {
+          content: {
+            en: "Processing {formattedProvider} Login",
+            es: "Procesando inicio de sesión con {formattedProvider}"
+          },
+          hash: "ae9de74df4783f42d2003a4bf7a79963"
+        },
+        "10/body/12/consequent/0/argument/1/1": {
+          content: {
+            en: "Authentication Failed",
+            es: "Autenticación fallida"
+          },
+          hash: "1281af9b80ab0d929824ba6ddb1fad06"
+        },
+        "10/body/12/consequent/0/argument/3/1-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "10/body/12/consequent/0/argument/3/3/1/1": {
+          content: {
+            en: "Try Again",
+            es: "Intentar de nuevo"
+          },
+          hash: "d65fad81c5f8f90405b26bf6e5d70ab9"
+        },
+        "10/body/13/argument/1/1": {
+          content: {
+            en: "{formattedProvider} Authentication Successful",
+            es: "Autenticación con {formattedProvider} exitosa"
+          },
+          hash: "a149592ad26c48aeb88ff5014e7f2a46"
+        },
+        "10/body/13/argument/3": {
+          content: {
+            en: "You have successfully authenticated with {formattedProvider}.<expression/>",
+            es: "Te has autenticado correctamente con {formattedProvider}.<expression/>"
+          },
+          hash: "e90fe5fc2441590fb14e274df5ed9903"
+        }
+      }
+    },
+    "routes/desktop-auth.tsx": {
+      entries: {
+        "8/body/5/consequent/0/argument/1/1": {
+          content: {
+            en: "Apple Sign In",
+            es: "Inicio de sesión con Apple"
+          },
+          hash: "61f0d0f265a96adcf9839fcca4c68a51"
+        },
+        "8/body/5/consequent/0/argument/3/1": {
+          content: {
+            en: "Click the button below to sign in with Apple:",
+            es: "Haz clic en el botón de abajo para iniciar sesión con Apple:"
+          },
+          hash: "ebb2d6da482cc3045d5192f2b5708259"
+        },
+        "8/body/6/argument/1/1": {
+          content: {
+            en: "Redirecting to {provider}",
+            es: "Redireccionando a {provider}"
+          },
+          hash: "40276f1d6fef538ede70403ff11917b1"
+        },
+        "8/body/6/argument/3/1": {
+          content: {
+            en: "Please wait while we redirect you to complete authentication...",
+            es: "Por favor, espera mientras te redireccionamos para completar la autenticación..."
+          },
+          hash: "ec05eb06e45feeac6c35da2ebc6c7408"
+        }
+      }
+    },
+    "routes/downloads.tsx": {
+      entries: {
+        "15/body/5/argument/3/1/openingElement/0/value/expression": {
+          content: {
+            en: "<element:span>Download</element:span> Maple",
+            es: "<element:span>Descargar</element:span> Maple"
+          },
+          hash: "aa56a6de880cd6b1e7a02672cdff904b"
+        },
+        "15/body/5/argument/3/1/openingElement/1/value/expression/1": {
+          content: {
+            en: "Available for macOS and Ubuntu Linux",
+            es: "Disponible para macOS y Ubuntu Linux"
+          },
+          hash: "77d6473f013aab4a6cff5020af4945e9"
+        },
+        "15/body/5/argument/3/1/openingElement/1/value/expression/3": {
+          content: {
+            en: "Access your private AI chat with end-to-end encryption",
+            es: "Accede a tu chat de IA privado con cifrado de extremo a extremo"
+          },
+          hash: "a3a097fc373da5c5d97d8c9d66a00ddf"
+        },
+        "15/body/5/argument/3/13/1/1/1/1": {
+          content: {
+            en: "Web Version",
+            es: "Versión web"
+          },
+          hash: "de993e9fd764ef5fd906a6556f714a13"
+        },
+        "15/body/5/argument/3/13/1/1/1/3": {
+          content: {
+            en: "Don't want to download anything? Use Maple directly in your browser with the same end-to-end encryption.",
+            es: "¿No quieres descargar nada? Usa Maple directamente en tu navegador con el mismo cifrado de extremo a extremo."
+          },
+          hash: "1362782bd31a2fb7b41d41daa07dd979"
+        },
+        "15/body/5/argument/3/13/1/1/1/5": {
+          content: {
+            en: "<element:Globe></element:Globe> Open Web App",
+            es: "<element:Globe></element:Globe> Abrir aplicación web"
+          },
+          hash: "fca480edc33c46a4440bb51d36f88fb3"
+        },
+        "15/body/5/argument/3/13/1/1/3/1/1/3": {
+          content: {
+            en: "trymaple.ai",
+            es: "trymaple.ai"
+          },
+          hash: "bf46d82177b514a7b4ead4cef5e1bd9a"
+        },
+        "15/body/5/argument/3/5/1": {
+          content: {
+            en: "<element:Monitor></element:Monitor> Desktop Apps<element:span>A faster, more focused experience for your private AI chat</element:span>",
+            es: "<element:Monitor></element:Monitor> Aplicaciones de escritorio<element:span>Una experiencia más rápida y enfocada para tu chat de IA privado</element:span>"
+          },
+          hash: "3e7cb8b9eaaf453289115ed0d172e2a4"
+        },
+        "15/body/5/argument/3/5/3/1/3": {
+          content: {
+            en: "macOS",
+            es: "macOS"
+          },
+          hash: "b6e77d1eaa9437bb6714c882aa1dec23"
+        },
+        "15/body/5/argument/3/5/3/1/5": {
+          content: {
+            en: "For Apple Silicon and Intel-based Macs running macOS 11.0 or later.",
+            es: "Para Mac con Apple Silicon e Intel que ejecuten macOS 11.0 o posterior."
+          },
+          hash: "1c7e1739726f0be8dbb84029f2a959f4"
+        },
+        "15/body/5/argument/3/5/3/1/7/1": {
+          content: {
+            en: "Download for macOS",
+            es: "Descargar para macOS"
+          },
+          hash: "c7cc3c87e02168b962b33eb423aa9572"
+        },
+        "15/body/5/argument/3/5/3/1/7/3": {
+          content: {
+            en: "Universal for both Apple Silicon and Intel",
+            es: "Universal para Apple Silicon e Intel"
+          },
+          hash: "2197e2d43bda5f641801f84102b1d94e"
+        },
+        "15/body/5/argument/3/5/3/3/3": {
+          content: {
+            en: "Linux",
+            es: "Linux"
+          },
+          hash: "76c91bba2fb7679708e9264130bfa0c1"
+        },
+        "15/body/5/argument/3/5/3/3/5": {
+          content: {
+            en: "For Ubuntu 24.04+ only. Other Linux distributions are not officially supported.",
+            es: "Solo para Ubuntu 24.04+. Otras distribuciones de Linux no están oficialmente soportadas."
+          },
+          hash: "abb5ae20835f1cee0caf3071d49ff46d"
+        },
+        "15/body/5/argument/3/5/3/3/7/1": {
+          content: {
+            en: "Download AppImage",
+            es: "Descargar AppImage"
+          },
+          hash: "c0c422410114f9e832b2f145ec8f4a70"
+        },
+        "15/body/5/argument/3/5/3/3/7/3/1": {
+          content: {
+            en: ".deb",
+            es: ".deb"
+          },
+          hash: "93064dffa0b02e3ef91a2c30ebcee1a7"
+        },
+        "15/body/5/argument/3/5/3/3/7/3/3": {
+          content: {
+            en: ".rpm",
+            es: ".rpm"
+          },
+          hash: "9f944631768c6ae5617411f1ff4755ed"
+        },
+        "15/body/5/argument/3/5/5/1": {
+          content: {
+            en: "Windows version coming soon. In the meantime, you can use the <element:a>web app</element:a> for full functionality.",
+            es: "Versión para Windows próximamente. Mientras tanto, puedes usar la <element:a>aplicación web</element:a> para todas las funcionalidades."
+          },
+          hash: "d7f980889e9b23c891cc5b4f9f5114d2"
+        },
+        "15/body/5/argument/3/5/5/3": {
+          content: {
+            en: "Current version: <element:span>{currentVersion}</element:span><expression/> • <element:a>Release notes</element:a>",
+            es: "Versión actual: <element:span>{currentVersion}</element:span><expression/> • <element:a>Notas de la versión</element:a>"
+          },
+          hash: "a50040cd44dc1b7bcc0e473237f81367"
+        },
+        "15/body/5/argument/3/9/1/3": {
+          content: {
+            en: "Mobile Apps",
+            es: "Aplicaciones móviles"
+          },
+          hash: "52a6962957416602ed50cd2223f29101"
+        },
+        "15/body/5/argument/3/9/3/1/3": {
+          content: {
+            en: "iOS",
+            es: "iOS"
+          },
+          hash: "a7413e511bd963452b69286de1ebe85b"
+        },
+        "15/body/5/argument/3/9/3/1/5": {
+          content: {
+            en: "Download our native iOS app for iPhones and iPads.",
+            es: "Descarga nuestra aplicación nativa para iOS para iPhones y iPads."
+          },
+          hash: "a4f3672b3f2dcd58524b82e60613891c"
+        },
+        "15/body/5/argument/3/9/3/1/7/1/1-alt": {
+          content: {
+            en: "Download on the App Store",
+            es: "Descargar en el App Store"
+          },
+          hash: "aa7eb35109f6069021d46c7b6b793fdf"
+        },
+        "15/body/5/argument/3/9/3/1/7/3/1": {
+          content: {
+            en: "Want to test the latest features before they hit the App Store? Join our beta program.",
+            es: "¿Quieres probar las últimas funciones antes de que lleguen al App Store? Únete a nuestro programa beta."
+          },
+          hash: "180c74ea190387508f08f6032e314049"
+        },
+        "15/body/5/argument/3/9/3/1/7/3/3/1/1-alt": {
+          content: {
+            en: "Available on TestFlight",
+            es: "Disponible en TestFlight"
+          },
+          hash: "19034c14290546abbdeee32fd328fe35"
+        },
+        "15/body/5/argument/3/9/3/3/3": {
+          content: {
+            en: "Android",
+            es: "Android"
+          },
+          hash: "7f1144cdf1a7df38c98ff2c876ad16e0"
+        },
+        "15/body/5/argument/3/9/3/3/5": {
+          content: {
+            en: "Download our native Android app for phones and tablets.",
+            es: "Descarga nuestra aplicación nativa de Android para teléfonos y tabletas."
+          },
+          hash: "81e141544a3b8476f7f9af5ea4ca8e0b"
+        },
+        "15/body/5/argument/3/9/3/3/7/1": {
+          content: {
+            en: "Join our beta program to test the latest features:",
+            es: "Únete a nuestro programa beta para probar las últimas funciones:"
+          },
+          hash: "625f2dd57c279873f677bd1d9aeed4fc"
+        },
+        "15/body/5/argument/3/9/3/3/7/3": {
+          content: {
+            en: "Join Google Play Beta",
+            es: "Unirse a la beta de Google Play"
+          },
+          hash: "59143bf44854e97d2d60861813542984"
+        },
+        "15/body/5/argument/3/9/3/3/7/5/1": {
+          content: {
+            en: "Or download the APK directly:",
+            es: "O descarga el APK directamente:"
+          },
+          hash: "a3e74450a50201cfe3c23dae762d49e8"
+        },
+        "15/body/5/argument/3/9/3/3/7/5/3": {
+          content: {
+            en: "Download APK (Beta)",
+            es: "Descargar APK (Beta)"
+          },
+          hash: "fa46cd90131bcb7fd1385fc709d7a4e1"
+        },
+        "15/body/5/argument/3/9/3/3/7/7": {
+          content: {
+            en: "Beta version - help us test new features before the official release",
+            es: "Versión beta - ayúdanos a probar nuevas funciones antes del lanzamiento oficial"
+          },
+          hash: "d174740b742a6b013eb8a8f725fa8386"
+        }
+      }
+    },
+    "routes/login.tsx": {
+      entries: {
+        "22/body/14/consequent/0/argument-description": {
+          content: {
+            en: "Choose your preferred login method",
+            es: "Elige tu método de inicio de sesión preferido"
+          },
+          hash: "076e3f88f8adaaea274aef226bd27b02"
+        },
+        "22/body/14/consequent/0/argument-title": {
+          content: {
+            en: "Log In",
+            es: "Iniciar sesión"
+          },
+          hash: "0029e5a35676c0051e761fcd046ef9ee"
+        },
+        "22/body/14/consequent/0/argument/1/expression/right-title": {
+          content: {
+            en: "Note",
+            es: "Nota"
+          },
+          hash: "e0337f202c911423275f834edeffc54b"
+        },
+        "22/body/14/consequent/0/argument/11": {
+          content: {
+            en: "<element:UserCircle></element:UserCircle> Log in as Anonymous",
+            es: "<element:UserCircle></element:UserCircle> Iniciar sesión como anónimo"
+          },
+          hash: "96532529f18a10225c3858e4ef5ae675"
+        },
+        "22/body/14/consequent/0/argument/13": {
+          content: {
+            en: "Need an account? <element:Link>Sign Up</element:Link>",
+            es: "¿Necesitas una cuenta? <element:Link>Registrarse</element:Link>"
+          },
+          hash: "490ead436d12f5f4c87f760eebef8236"
+        },
+        "22/body/14/consequent/0/argument/3": {
+          content: {
+            en: "<element:Mail></element:Mail> Log in with Email",
+            es: "<element:Mail></element:Mail> Iniciar sesión con correo electrónico"
+          },
+          hash: "4b66ac66b5708eda97344d55b8e58be9"
+        },
+        "22/body/14/consequent/0/argument/5": {
+          content: {
+            en: "<element:Github></element:Github> Log in with GitHub",
+            es: "<element:Github></element:Github> Iniciar sesión con GitHub"
+          },
+          hash: "f7bc297e04db8e8a711455060ac9109b"
+        },
+        "22/body/14/consequent/0/argument/7": {
+          content: {
+            en: "<element:Google></element:Google> Log in with Google",
+            es: "<element:Google></element:Google> Iniciar sesión con Google"
+          },
+          hash: "bf44c3b5a03288a0996900bc95d0abc5"
+        },
+        "22/body/14/consequent/0/argument/9/expression/consequent": {
+          content: {
+            en: "<element:Apple></element:Apple> Log in with Apple",
+            es: "<element:Apple></element:Apple> Iniciar sesión con Apple"
+          },
+          hash: "0b48e81eae618420e5050e08e8604e46"
+        },
+        "22/body/15/consequent/0/argument/1-description": {
+          content: {
+            en: "Enter your Account ID and password.",
+            es: "Introduce tu ID de cuenta y contraseña."
+          },
+          hash: "ecda203536a4ee5410677cab0c4d0f51"
+        },
+        "22/body/15/consequent/0/argument/1-title": {
+          content: {
+            en: "Log In as Anonymous",
+            es: "Iniciar sesión como anónimo"
+          },
+          hash: "77da085061775e23bc233e3dfce55a57"
+        },
+        "22/body/15/consequent/0/argument/1/1/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "22/body/15/consequent/0/argument/1/11": {
+          content: {
+            en: "Need an account? <element:Link>Sign up</element:Link>",
+            es: "¿Necesitas una cuenta? <element:Link>Registrarse</element:Link>"
+          },
+          hash: "720b2dca2de6da9c0b26db8337967dc2"
+        },
+        "22/body/15/consequent/0/argument/1/3/1": {
+          content: {
+            en: "Account ID",
+            es: "ID de cuenta"
+          },
+          hash: "e795343893c6a1e18fba01dcabfcf920"
+        },
+        "22/body/15/consequent/0/argument/1/3/3-placeholder": {
+          content: {
+            en: "Your Account ID",
+            es: "Tu ID de cuenta"
+          },
+          hash: "bf9f7aa2a03f6959fb118b80cabec6a7"
+        },
+        "22/body/15/consequent/0/argument/1/5/1": {
+          content: {
+            en: "Password",
+            es: "Contraseña"
+          },
+          hash: "223a61cf906ab9c40d22612c588dff48"
+        },
+        "22/body/15/consequent/0/argument/1/7/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Please wait",
+            es: "<element:Loader2></element:Loader2> Por favor espera"
+          },
+          hash: "4eb8e7c015bc7925cf227ce9330bacaa"
+        },
+        "22/body/15/consequent/0/argument/1/9": {
+          content: {
+            en: "Back",
+            es: "Atrás"
+          },
+          hash: "cbbd1435d979ffb51400d1b07067da11"
+        },
+        "22/body/16/argument/1-description": {
+          content: {
+            en: "Enter your email and password to log in.",
+            es: "Introduce tu correo electrónico y contraseña para iniciar sesión."
+          },
+          hash: "466c611ff1151e3416ecdca61184b9cd"
+        },
+        "22/body/16/argument/1-title": {
+          content: {
+            en: "Log In with Email",
+            es: "Iniciar sesión con correo electrónico"
+          },
+          hash: "82611ff1d55ecf05ecdf6077b3910e95"
+        },
+        "22/body/16/argument/1/1/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "22/body/16/argument/1/11/1": {
+          content: {
+            en: "Need an account? <element:Link>Sign up</element:Link>",
+            es: "¿Necesitas una cuenta? <element:Link>Registrarse</element:Link>"
+          },
+          hash: "720b2dca2de6da9c0b26db8337967dc2"
+        },
+        "22/body/16/argument/1/11/3/1": {
+          content: {
+            en: "Forgot password?",
+            es: "¿Olvidaste tu contraseña?"
+          },
+          hash: "99dfe43fb2d632030841e5ac8121bfd0"
+        },
+        "22/body/16/argument/1/3/1": {
+          content: {
+            en: "Email",
+            es: "Correo electrónico"
+          },
+          hash: "e7f34943a0c2fb849db1839ff6ef5cb5"
+        },
+        "22/body/16/argument/1/3/3-placeholder": {
+          content: {
+            en: "email@example.com",
+            es: "email@example.com"
+          },
+          hash: "1bae7cb01431340f48009940e779bc41"
+        },
+        "22/body/16/argument/1/5/1": {
+          content: {
+            en: "Password",
+            es: "Contraseña"
+          },
+          hash: "223a61cf906ab9c40d22612c588dff48"
+        },
+        "22/body/16/argument/1/7/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Please wait",
+            es: "<element:Loader2></element:Loader2> Por favor espera"
+          },
+          hash: "02dc4bc19a8fd7b885b5097a9543f52d"
+        },
+        "22/body/16/argument/1/9": {
+          content: {
+            en: "Back",
+            es: "Atrás"
+          },
+          hash: "788f9766bae87b169f3a65297bbea35e"
+        }
+      }
+    },
+    "routes/password-reset.confirm.tsx": {
+      entries: {
+        "3/body/1/argument/1": {
+          content: {
+            en: "Confirm Password Reset",
+            es: "Confirmar restablecimiento de contraseña"
+          },
+          hash: "e01d21b5ec434f705960fea531175644"
+        }
+      }
+    },
+    "routes/pricing.tsx": {
+      entries: {
+        "23/body/0/argument/1": {
+          content: {
+            en: "FAQ",
+            es: "Preguntas frecuentes"
+          },
+          hash: "47e0ee2eb40b4e7e732e05e2233fc71c"
+        },
+        "23/body/0/argument/3/1/1": {
+          content: {
+            en: "What is the difference between the plans?",
+            es: "¿Cuál es la diferencia entre los planes?"
+          },
+          hash: "690888a5e3ae02209a250c7323780975"
+        },
+        "23/body/0/argument/3/1/3/1": {
+          content: {
+            en: "The plans are sized to grow with your needs.",
+            es: "Los planes están diseñados para crecer con tus necesidades."
+          },
+          hash: "5bc4750e76d7714e538be42f0fb6f70d"
+        },
+        "23/body/0/argument/3/1/3/3/1": {
+          content: {
+            en: "Free: 25 messages per week, resets Sunday 00:00 UTC. Max length on individual messages.",
+            es: "Gratis: 25 mensajes por semana, se reinicia el domingo a las 00:00 UTC. Longitud máxima en mensajes individuales."
+          },
+          hash: "3057e93f7ef497bb7403f495ae55ee5f"
+        },
+        "23/body/0/argument/3/1/3/3/3": {
+          content: {
+            en: "Pro: Generous usage for power users with a high monthly cap",
+            es: "Pro: Uso generoso para usuarios avanzados con un límite mensual alto"
+          },
+          hash: "b62e500447fde762b2f8a56b225069cd"
+        },
+        "23/body/0/argument/3/1/3/3/5": {
+          content: {
+            en: "Max: 20x more usage than Pro for maximum power users",
+            es: "Max: 20 veces más uso que Pro para usuarios de máxima potencia"
+          },
+          hash: "5b7563f5a4057c52acbe622e7dab877c"
+        },
+        "23/body/0/argument/3/1/3/3/7": {
+          content: {
+            en: "Team: Even more usage per team member with unified billing",
+            es: "Equipo: Aún más uso por miembro del equipo con facturación unificada"
+          },
+          hash: "fe0844b1d8288f94f2fd83c7c2147f0f"
+        },
+        "23/body/0/argument/3/1/3/3/9": {
+          content: {
+            en: "Enterprise: Message us at team@opensecret.cloud",
+            es: "Empresa: Escríbenos a team@opensecret.cloud"
+          },
+          hash: "f8d67fb2fea017c7e425fe198be3207d"
+        },
+        "23/body/0/argument/3/11/1": {
+          content: {
+            en: "Which file types are supported for document and image upload?",
+            es: "¿Qué tipos de archivos son compatibles para la carga de documentos e imágenes?"
+          },
+          hash: "bd37dd8042faef39fa732aa2544ffd12"
+        },
+        "23/body/0/argument/3/11/3/1": {
+          content: {
+            en: "We support a range of file types for both images and documents.",
+            es: "Admitimos una variedad de tipos de archivos tanto para imágenes como para documentos."
+          },
+          hash: "6ca48cc8c89e7d0ee1276e27885ab8e2"
+        },
+        "23/body/0/argument/3/11/3/3/1": {
+          content: {
+            en: "Images:",
+            es: "Imágenes:"
+          },
+          hash: "386b59433323f105e835c038f3d933bc"
+        },
+        "23/body/0/argument/3/11/3/5/1": {
+          content: {
+            en: "Documents (Desktop/Mobile apps only):",
+            es: "Documentos (solo aplicaciones de escritorio/móvil):"
+          },
+          hash: "9570474090fe69fdacfa72960a40357f"
+        },
+        "23/body/0/argument/3/11/3/7": {
+          content: {
+            en: "There is a 1 file limit per chat prompt with a 10MB file size limit per file.",
+            es: "Hay un límite de 1 archivo por chat con un límite de tamaño de 10MB por archivo."
+          },
+          hash: "aa2cd5648d35ad54ebd717a1a547e52d"
+        },
+        "23/body/0/argument/3/13/1": {
+          content: {
+            en: "How did you build this?",
+            es: "¿Cómo construyeron esto?"
+          },
+          hash: "2be7aa9963b9d38a651803639729d89c"
+        },
+        "23/body/0/argument/3/13/3": {
+          content: {
+            en: "Maple is made using <element:a>OpenSecret</element:a> , an encrypted backend for developers. It handles private keys, encrypted data sync, private AI, and more automatically. We're building OpenSecret as a way to bring better privacy to users by turning on encryption by default. If you're a developer, go see how easy it is to build with.",
+            es: "Maple está hecho usando <element:a>OpenSecret</element:a>, un backend cifrado para desarrolladores. Maneja claves privadas, sincronización de datos cifrados, IA privada y más de forma automática. Estamos construyendo OpenSecret como una forma de brindar mejor privacidad a los usuarios activando el cifrado por defecto. Si eres desarrollador, mira lo fácil que es construir con él."
+          },
+          hash: "17e90620beb6dc410d62d397c722d2fc"
+        },
+        "23/body/0/argument/3/3/1": {
+          content: {
+            en: "How private is Maple?",
+            es: "¿Qué tan privado es Maple?"
+          },
+          hash: "31d65d3b348ef33832e1edf671767224"
+        },
+        "23/body/0/argument/3/3/3": {
+          content: {
+            en: "Encrypted end to end. Maple uses confidential computing to secure the code that access user data and LLM data. Your account has its own private key that encrypts your chats and the responses from the AI model. Every user has their own personal data vault that can't be read by anyone else, not even us.",
+            es: "Cifrado de extremo a extremo. Maple utiliza computación confidencial para proteger el código que accede a los datos de usuario y los datos del LLM. Tu cuenta tiene su propia clave privada que cifra tus chats y las respuestas del modelo de IA. Cada usuario tiene su propio almacén personal de datos que nadie más puede leer, ni siquiera nosotros."
+          },
+          hash: "810b1869892465ab7f36ed9654120362"
+        },
+        "23/body/0/argument/3/5/1": {
+          content: {
+            en: "How do you synchronize my chat history across devices?",
+            es: "¿Cómo sincronizan mi historial de chat entre dispositivos?"
+          },
+          hash: "bfb4f3fca2459dcfc612914b356dfca9"
+        },
+        "23/body/0/argument/3/5/3": {
+          content: {
+            en: "We use a secure synchronization protocol that ensures your encrypted chat history is synced across all your devices. This means that you can start a conversation on one device and pick it up where you left off on another device, without compromising your security or privacy.",
+            es: "Utilizamos un protocolo de sincronización seguro que garantiza que tu historial de chat cifrado se sincronice en todos tus dispositivos. Esto significa que puedes comenzar una conversación en un dispositivo y continuarla donde la dejaste en otro dispositivo, sin comprometer tu seguridad o privacidad."
+          },
+          hash: "f6e764779b21bd8c3fb30c1bc4f8e323"
+        },
+        "23/body/0/argument/3/7/1": {
+          content: {
+            en: "Is this safe to use with my company's confidential information?",
+            es: "¿Es seguro usar esto con la información confidencial de mi empresa?"
+          },
+          hash: "b02fe2b0ea143c712c49b7c92ea32297"
+        },
+        "23/body/0/argument/3/7/3": {
+          content: {
+            en: "The service is encrypted end-to-end, so your confidential information is private between you and the AI. Consult your company's security policy.",
+            es: "El servicio está cifrado de extremo a extremo, por lo que tu información confidencial es privada entre tú y la IA. Consulta la política de seguridad de tu empresa."
+          },
+          hash: "083655c895fc69383c51e98414362d92"
+        },
+        "23/body/0/argument/3/9/1": {
+          content: {
+            en: "Can companies use my data to train their AI models?",
+            es: "¿Pueden las empresas usar mis datos para entrenar sus modelos de IA?"
+          },
+          hash: "3ac7b8c69e74f01d02bbcee3333147b4"
+        },
+        "23/body/0/argument/3/9/3": {
+          content: {
+            en: "No. When you chat with AI in Maple, nobody knows what is being said back and forth. Thus data is not able to be used for training new AI models by any company.",
+            es: "No. Cuando chateas con IA en Maple, nadie sabe lo que se está diciendo de un lado a otro. Por lo tanto, los datos no pueden ser utilizados para entrenar nuevos modelos de IA por ninguna empresa."
+          },
+          hash: "e48f71f71917c314491b76f526a3a121"
+        },
+        "24/body/20/0/init/body/0/consequent/0/argument": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Processing...",
+            es: "<element:Loader2></element:Loader2> Procesando..."
+          },
+          hash: "45a24665a0c932ef13f4dddebe5b4d01"
+        },
+        "24/body/25/consequent/0/argument/3/1/openingElement/0/value/expression": {
+          content: {
+            en: "Simple, <element:span>Transparent</element:span> Pricing",
+            es: "Precios simples y <element:span>transparentes</element:span>"
+          },
+          hash: "a968cb0e7a3fcf51afbeea3180e87935"
+        },
+        "24/body/25/consequent/0/argument/3/1/openingElement/1/value/expression/1": {
+          content: {
+            en: "Start with our free tier and upgrade as you grow.",
+            es: "Comienza con nuestro plan gratuito y actualiza a medida que crezcas."
+          },
+          hash: "0abbc16abc0ccf38ecc1fb70f6114129"
+        },
+        "24/body/25/consequent/0/argument/3/1/openingElement/1/value/expression/3": {
+          content: {
+            en: "All plans include end-to-end encrypted AI chat.",
+            es: "Todos los planes incluyen chat de IA cifrado de extremo a extremo."
+          },
+          hash: "ef4f879dfca52257db29b3ddc0be58bf"
+        },
+        "24/body/26/consequent/1/argument/3/1-subtitle": {
+          content: {
+            en: "Choose the plan that's right for you.",
+            es: "Elige el plan que sea adecuado para ti."
+          },
+          hash: "3ce6bdf8b2d76ea1f6781962e40bba2d"
+        },
+        "24/body/26/consequent/1/argument/3/1-title": {
+          content: {
+            en: "Pricing",
+            es: "Precios"
+          },
+          hash: "ce27f1aeacccc542a174c4b2bce022b0"
+        },
+        "24/body/26/consequent/1/argument/3/3/1/1/3/1": {
+          content: {
+            en: "Unable to Load Pricing",
+            es: "No se pudieron cargar los precios"
+          },
+          hash: "c37d8e01cbfd21c17ee180beee235d35"
+        },
+        "24/body/26/consequent/1/argument/3/3/1/1/5": {
+          content: {
+            en: "Retry",
+            es: "Reintentar"
+          },
+          hash: "afc46d3f8880aabf23a2e32a1554a327"
+        },
+        "24/body/27/argument/3/1/openingElement/0/value/expression": {
+          content: {
+            en: "Simple, <element:span>Transparent</element:span> Pricing",
+            es: "Precios simples y <element:span>transparentes</element:span>"
+          },
+          hash: "b650afb47005a8852f3f29158c60bed1"
+        },
+        "24/body/27/argument/3/1/openingElement/1/value/expression/1": {
+          content: {
+            en: "Start with our free tier and upgrade as you grow.",
+            es: "Comienza con nuestro plan gratuito y actualiza a medida que crezcas."
+          },
+          hash: "0abbc16abc0ccf38ecc1fb70f6114129"
+        },
+        "24/body/27/argument/3/1/openingElement/1/value/expression/3": {
+          content: {
+            en: "All plans include end-to-end encrypted AI chat.",
+            es: "Todos los planes incluyen chat de IA cifrado de extremo a extremo."
+          },
+          hash: "ef4f879dfca52257db29b3ddc0be58bf"
+        },
+        "24/body/27/argument/3/11/1/1/3": {
+          content: {
+            en: "Pay with Bitcoin",
+            es: "Pagar con Bitcoin"
+          },
+          hash: "e1ef3146b26ac2d2dfc0ff66d8226ff3"
+        },
+        "24/body/27/argument/3/11/3/expression/right": {
+          content: {
+            en: "Anonymous accounts must pay with Bitcoin (yearly only)",
+            es: "Las cuentas anónimas deben pagar con Bitcoin (solo anualmente)"
+          },
+          hash: "a16c8fdfe0e0c5d7b24aa4b8b3da13c4"
+        },
+        "24/body/27/argument/3/5/expression/right/1/3": {
+          content: {
+            en: "Payment successful! Your subscription has been updated.",
+            es: "¡Pago exitoso! Tu suscripción ha sido actualizada."
+          },
+          hash: "efb377c3d3475eda0d4bbd0c3b949dcf"
+        },
+        "24/body/27/argument/3/7/expression/right/1/3": {
+          content: {
+            en: "Payment canceled. Your subscription remains unchanged.",
+            es: "Pago cancelado. Tu suscripción permanece sin cambios."
+          },
+          hash: "af60d8a3bc8ccb197192645b5cfa7208"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/1/expression/right":
+          {
+            content: {
+              en: "Most Popular",
+              es: "Más popular"
+            },
+            hash: "8057f5b558ba4b395fd0347a9fcca7f7"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/3/expression/right":
+          {
+            content: {
+              en: "Current Plan",
+              es: "Plan actual"
+            },
+            hash: "9ea74e58354048829980b11a5f73cf02"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/5/expression/right":
+          {
+            content: {
+              en: "10% OFF",
+              es: "10% DE DESCUENTO"
+            },
+            hash: "55bf31448c446153aebfc3216e602e17"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/alternate/1":
+          {
+            content: {
+              en: "${monthlyPrice}",
+              es: "${monthlyPrice}"
+            },
+            hash: "ce3025799d70859c869af0b2fea2ad8a"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/alternate/3":
+          {
+            content: {
+              en: "per month",
+              es: "por mes"
+            },
+            hash: "b9b2c98b7b857080492d527d94146680"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/1/1":
+          {
+            content: {
+              en: "${displayPrice}",
+              es: "${displayPrice}"
+            },
+            hash: "923b9a59e22156813b18cd62a5e11010"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/1/3/expression/right":
+          {
+            content: {
+              en: "${monthlyOriginalPrice}",
+              es: "${monthlyOriginalPrice}"
+            },
+            hash: "ac772210d192da47ab363e149102d8b2"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/1/5/3":
+          {
+            content: {
+              en: "per month",
+              es: "por mes"
+            },
+            hash: "ee6c6783c9ecfaba3a709a27abbe0a47"
+          },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/3/1/expression/right/3":
+          {
+            content: {
+              en: "Save 10% with annual billing",
+              es: "Ahorra un 10% con facturación anual"
+            },
+            hash: "4434cc8dd93afff614ffc6bcfea793f7"
+          }
+      }
+    },
+    "routes/proof.tsx": {
+      entries: {
+        "10/body/0/argument/1/1": {
+          content: {
+            en: "Server PCR0 Fingerprint",
+            es: "Huella digital PCR0 del servidor"
+          },
+          hash: "304bd3aefcc6c8c9f1a4061d584de0c2"
+        },
+        "10/body/0/argument/1/5": {
+          content: {
+            en: "For technical details, check out the <element:a>AWS Nitro Enclaves documentation</element:a> .",
+            es: "Para detalles técnicos, consulta la <element:a>documentación de AWS Nitro Enclaves</element:a>."
+          },
+          hash: "d70578f45d341ec502116c18898020c0"
+        },
+        "10/body/0/argument/3/1/1": {
+          content: {
+            en: "Show",
+            es: "Mostrar"
+          },
+          hash: "16dfe5dc481240cd2819a6394f90df92"
+        },
+        "10/body/0/argument/3/1/3": {
+          content: {
+            en: "Hide",
+            es: "Ocultar"
+          },
+          hash: "a6088b934651055bb27314d111be510b"
+        },
+        "10/body/0/argument/3/3/1/1": {
+          content: {
+            en: "Module ID: <element:span>{parsedDocument.moduleId}</element:span>",
+            es: "ID del módulo: <element:span>{parsedDocument.moduleId}</element:span>"
+          },
+          hash: "0cc723580d3f75394b85b4e6f95a03aa"
+        },
+        "10/body/0/argument/3/3/1/11/1/1": {
+          content: {
+            en: "Additional PCR Values",
+            es: "Valores PCR adicionales"
+          },
+          hash: "8c7df8617340d14adfb8a8c2c45a5753"
+        },
+        "10/body/0/argument/3/3/1/11/1/3/1/expression/0/body/right/1": {
+          content: {
+            en: "PCR{pcr.id}: <element:span>{pcr.value}</element:span>",
+            es: "PCR{pcr.id}: <element:span>{pcr.value}</element:span>"
+          },
+          hash: "861f9de3ccfd942eb8874184a304318d"
+        },
+        "10/body/0/argument/3/3/1/13/1": {
+          content: {
+            en: "Certificate Chain:",
+            es: "Cadena de certificados:"
+          },
+          hash: "0a46369f39c666923943e1306329de46"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/1/expression/alternate": {
+          content: {
+            en: "Certificate <expression/>",
+            es: "Certificado <expression/>"
+          },
+          hash: "ea012704234ab561b99a1113792f6f92"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/1/expression/consequent": {
+          content: {
+            en: "Root Certificate",
+            es: "Certificado raíz"
+          },
+          hash: "ca4a9a05f476c783653654476ef3666a"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/11/1": {
+          content: {
+            en: "Show PEM Certificate",
+            es: "Mostrar certificado PEM"
+          },
+          hash: "1bf7534cb3a00d9da3963cc5a589ca0a"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/3": {
+          content: {
+            en: "Subject: {cert.subject}",
+            es: "Asunto: {cert.subject}"
+          },
+          hash: "0d1fa4317c860bbb9a5a59a4a09b0185"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/5": {
+          content: {
+            en: "Valid From: {cert.notBefore}",
+            es: "Válido desde: {cert.notBefore}"
+          },
+          hash: "dc8eab5f9e6c8db6d696465ab0d55b12"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/7": {
+          content: {
+            en: "Valid Until: {cert.notAfter}",
+            es: "Válido hasta: {cert.notAfter}"
+          },
+          hash: "da4e653a99588b9804a5f15badd199e9"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/9/expression/consequent/1": {
+          content: {
+            en: "Calculated SHA-256: <element:span>{parsedDocument.cert0hash}</element:span>",
+            es: "SHA-256 calculado: <element:span>{parsedDocument.cert0hash}</element:span>"
+          },
+          hash: "6b46af3eb4e274ed18db8760334fb721"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/9/expression/consequent/3": {
+          content: {
+            en: "Expected root cert hash: <element:span>{os.expectedRootCertHash}</element:span>",
+            es: "Hash del certificado raíz esperado: <element:span>{os.expectedRootCertHash}</element:span>"
+          },
+          hash: "3e3708740ca25957ccfb9490ab5e52c9"
+        },
+        "10/body/0/argument/3/3/1/3": {
+          content: {
+            en: "Timestamp: {parsedDocument.timestamp}",
+            es: "Marca de tiempo: {parsedDocument.timestamp}"
+          },
+          hash: "01b34b270c0965f7b558c15682c56c16"
+        },
+        "10/body/0/argument/3/3/1/5/expression/right": {
+          content: {
+            en: "Nonce: <element:span>{parsedDocument.nonce}</element:span>",
+            es: "Nonce: <element:span>{parsedDocument.nonce}</element:span>"
+          },
+          hash: "5d97449dcad95da03cd0301b0d6ab330"
+        },
+        "10/body/0/argument/3/3/1/7": {
+          content: {
+            en: "Digest: {parsedDocument.digest}",
+            es: "Resumen: {parsedDocument.digest}"
+          },
+          hash: "000d7c3292f8c6a34222ced9efdc8bcd"
+        },
+        "10/body/0/argument/3/3/1/9/expression/right/1": {
+          content: {
+            en: "Public Key: <element:span>{parsedDocument.publicKey}</element:span>",
+            es: "Clave pública: <element:span>{parsedDocument.publicKey}</element:span>"
+          },
+          hash: "abf609e52225b325d268b5d05a8332c2"
+        },
+        "11/body/3/argument/3/1/openingElement/0/value/expression": {
+          content: {
+            en: "<element:span>Proof</element:span> of Security",
+            es: "<element:span>Prueba</element:span> de seguridad"
+          },
+          hash: "23994e4cefc88b66b192d69a202273e5"
+        },
+        "11/body/3/argument/3/1/openingElement/1/value/expression": {
+          content: {
+            en: "Cryptographic proof that you're talking with a secure server.",
+            es: "Prueba criptográfica de que estás hablando con un servidor seguro."
+          },
+          hash: "99b1e7ea2872ae5e2e2871a37f50b185"
+        },
+        "11/body/3/argument/3/5/expression/right": {
+          content: {
+            en: "Failed to validate attestation document: <expression/>",
+            es: "Error al validar el documento de atestación: <expression/>"
+          },
+          hash: "70fd2e278d4a6ec10be06fc567832e6d"
+        }
+      }
+    },
+    "routes/signup.tsx": {
+      entries: {
+        "25/body/19/consequent/0/argument-description": {
+          content: {
+            en: "Choose your preferred sign-up method",
+            es: "Elige tu método de registro preferido"
+          },
+          hash: "149bc652066463bd0fb34bf55c1fe7af"
+        },
+        "25/body/19/consequent/0/argument-title": {
+          content: {
+            en: "Sign Up",
+            es: "Registrarse"
+          },
+          hash: "0dd2ae69be4618c1f9e615774a4509ca"
+        },
+        "25/body/19/consequent/0/argument/1/expression/right-title": {
+          content: {
+            en: "Note",
+            es: "Nota"
+          },
+          hash: "e0337f202c911423275f834edeffc54b"
+        },
+        "25/body/19/consequent/0/argument/11": {
+          content: {
+            en: "<element:UserCircle></element:UserCircle> Sign up as Anonymous",
+            es: "<element:UserCircle></element:UserCircle> Registrarse como anónimo"
+          },
+          hash: "7782764d4ec63db5a80deddb692aa371"
+        },
+        "25/body/19/consequent/0/argument/13": {
+          content: {
+            en: "Already have an account? <element:Link>Log In</element:Link>",
+            es: "¿Ya tienes una cuenta? <element:Link>Iniciar sesión</element:Link>"
+          },
+          hash: "da0de41cf67b1c8e8c457da9b8222d61"
+        },
+        "25/body/19/consequent/0/argument/3": {
+          content: {
+            en: "<element:Mail></element:Mail> Sign up with Email",
+            es: "<element:Mail></element:Mail> Registrarse con correo electrónico"
+          },
+          hash: "2fa98d1f1ac3c33385e7876dd4e83680"
+        },
+        "25/body/19/consequent/0/argument/5": {
+          content: {
+            en: "<element:Github></element:Github> Sign up with GitHub",
+            es: "<element:Github></element:Github> Registrarse con GitHub"
+          },
+          hash: "df8e8ac46a44f5b7810c3dc7cb0b42e4"
+        },
+        "25/body/19/consequent/0/argument/7": {
+          content: {
+            en: "<element:Google></element:Google> Sign up with Google",
+            es: "<element:Google></element:Google> Registrarse con Google"
+          },
+          hash: "c3210fcf52ba8180ff588a9bfd66535b"
+        },
+        "25/body/19/consequent/0/argument/9/expression/consequent": {
+          content: {
+            en: "<element:Apple></element:Apple> Sign up with Apple",
+            es: "<element:Apple></element:Apple> Registrarse con Apple"
+          },
+          hash: "c67e6f6969f68e77ec82454c1cf0f369"
+        },
+        "25/body/20/consequent/0/argument/1/1-title": {
+          content: {
+            en: "Sign Up as Anonymous",
+            es: "Registrarse como anónimo"
+          },
+          hash: "7e9c05b47d6cb54b9f926fc72b331844"
+        },
+        "25/body/20/consequent/0/argument/1/1/1/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "25/body/20/consequent/0/argument/1/1/3/1": {
+          content: {
+            en: "Create Password",
+            es: "Crear contraseña"
+          },
+          hash: "daf1472309d84128a40ae5ad26b5f2cb"
+        },
+        "25/body/20/consequent/0/argument/1/1/3/3-placeholder": {
+          content: {
+            en: "Create a strong password",
+            es: "Crea una contraseña segura"
+          },
+          hash: "0d61743541fa5e1758c89d8207d1a8e9"
+        },
+        "25/body/20/consequent/0/argument/1/1/3/5": {
+          content: {
+            en: "You'll need this password along with your Account ID to sign in. Your Account ID will be shown in the next step.",
+            es: "Necesitarás esta contraseña junto con tu ID de cuenta para iniciar sesión. Tu ID de cuenta se mostrará en el siguiente paso."
+          },
+          hash: "375d79edd7469e3103190fb321df8ddf"
+        },
+        "25/body/20/consequent/0/argument/1/1/5/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Creating Account...",
+            es: "<element:Loader2></element:Loader2> Creando cuenta..."
+          },
+          hash: "048170dcb220a55dd4880cad8dbb7689"
+        },
+        "25/body/20/consequent/0/argument/1/1/7": {
+          content: {
+            en: "Back",
+            es: "Atrás"
+          },
+          hash: "9e5482679a6b6962fd38c8e6c7ec0aa8"
+        },
+        "25/body/21/argument/1-title": {
+          content: {
+            en: "Sign Up with Email",
+            es: "Registrarse con correo electrónico"
+          },
+          hash: "ef07169abfa69578905cce031f771006"
+        },
+        "25/body/21/argument/1/1/expression/right-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "25/body/21/argument/1/11": {
+          content: {
+            en: "Already have an account? <element:Link>Log In</element:Link>",
+            es: "¿Ya tienes una cuenta? <element:Link>Iniciar sesión</element:Link>"
+          },
+          hash: "da0de41cf67b1c8e8c457da9b8222d61"
+        },
+        "25/body/21/argument/1/3/1": {
+          content: {
+            en: "Email",
+            es: "Correo electrónico"
+          },
+          hash: "e7f34943a0c2fb849db1839ff6ef5cb5"
+        },
+        "25/body/21/argument/1/3/3-placeholder": {
+          content: {
+            en: "email@example.com",
+            es: "email@ejemplo.com"
+          },
+          hash: "1bae7cb01431340f48009940e779bc41"
+        },
+        "25/body/21/argument/1/5/1": {
+          content: {
+            en: "Password",
+            es: "Contraseña"
+          },
+          hash: "223a61cf906ab9c40d22612c588dff48"
+        },
+        "25/body/21/argument/1/7/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Please wait",
+            es: "<element:Loader2></element:Loader2> Por favor espera"
+          },
+          hash: "02dc4bc19a8fd7b885b5097a9543f52d"
+        },
+        "25/body/21/argument/1/9": {
+          content: {
+            en: "Back",
+            es: "Atrás"
+          },
+          hash: "788f9766bae87b169f3a65297bbea35e"
+        }
+      }
+    },
+    "routes/team.invite.$inviteId.tsx": {
+      entries: {
+        "13/body/14/consequent/0/argument/3/1/1/1/3": {
+          content: {
+            en: "Invalid or Expired Invitation",
+            es: "Invitación inválida o caducada"
+          },
+          hash: "a17348f53399042e26f40b68a0fff563"
+        },
+        "13/body/14/consequent/0/argument/3/1/1/1/5": {
+          content: {
+            en: "This invitation link is no longer valid. It may have expired or already been used.",
+            es: "Este enlace de invitación ya no es válido. Puede haber caducado o ya ha sido utilizado."
+          },
+          hash: "eddbaee9a8a9be96bb3437bc37af35c3"
+        },
+        "13/body/14/consequent/0/argument/3/1/1/3/1": {
+          content: {
+            en: "Go to Dashboard",
+            es: "Ir al panel de control"
+          },
+          hash: "2151c2e15e2e854cdb22cce1fb4ab7b5"
+        },
+        "13/body/15/consequent/0/argument/3/1/1/1/3": {
+          content: {
+            en: "Welcome to the Team!",
+            es: "¡Bienvenido al equipo!"
+          },
+          hash: "3f2495dbb3a5b746fcc91f722f0df759"
+        },
+        "13/body/15/consequent/0/argument/3/1/1/1/5": {
+          content: {
+            en: "You've successfully joined <expression/>. Redirecting you to the dashboard...",
+            es: "Te has unido con éxito a <expression/>. Redirigiendo al panel de control..."
+          },
+          hash: "e358a597f6351b37cd77f030c3e9fbfc"
+        },
+        "13/body/16/argument/3/1/1/1/3": {
+          content: {
+            en: "Team Invitation",
+            es: "Invitación de equipo"
+          },
+          hash: "173c38114e2e81e1b98514de9e155ab6"
+        },
+        "13/body/16/argument/3/1/1/1/5": {
+          content: {
+            en: "You've been invited to join a team on Maple AI",
+            es: "Has sido invitado a unirte a un equipo en Maple AI"
+          },
+          hash: "d8a39823b8aa8bbe6fabc55a4f9ea88c"
+        },
+        "13/body/16/argument/3/1/1/3/1/1/1": {
+          content: {
+            en: "Team",
+            es: "Equipo"
+          },
+          hash: "c621ea9404a37af289def443b309bf1b"
+        },
+        "13/body/16/argument/3/1/1/3/1/3/expression/right/1": {
+          content: {
+            en: "Invited by",
+            es: "Invitado por"
+          },
+          hash: "8a42306eb202461322b4a13968502e32"
+        },
+        "13/body/16/argument/3/1/1/3/1/5/1": {
+          content: {
+            en: "Your email",
+            es: "Tu correo electrónico"
+          },
+          hash: "ed269a50d6b679a692b68608e66b64ab"
+        },
+        "13/body/16/argument/3/1/1/3/5/1": {
+          content: {
+            en: "Decline",
+            es: "Rechazar"
+          },
+          hash: "e6ca61edb1c5580b604d32e0818b8260"
+        },
+        "13/body/16/argument/3/1/1/3/5/3/1/expression/alternate": {
+          content: {
+            en: "<element:CheckCircle></element:CheckCircle> Accept Invitation",
+            es: "<element:CheckCircle></element:CheckCircle> Aceptar invitación"
+          },
+          hash: "211b263dbe1fd94fd25bf31c4a760aa2"
+        },
+        "13/body/16/argument/3/1/1/3/5/3/1/expression/consequent": {
+          content: {
+            en: "<element:Loader2></element:Loader2> Joining...",
+            es: "<element:Loader2></element:Loader2> Uniéndose..."
+          },
+          hash: "a2a4b0af9ca2bd126ccac96a803752dd"
+        },
+        "13/body/16/argument/3/1/1/3/7": {
+          content: {
+            en: "By accepting this invitation, you'll join the team and gain access to shared resources.",
+            es: "Al aceptar esta invitación, te unirás al equipo y obtendrás acceso a los recursos compartidos."
+          },
+          hash: "39e0f88f2a982d8a455d4ad5088f54ea"
+        }
+      }
+    },
+    "routes/teams.tsx": {
+      entries: {
+        "11/body/0/argument/3/1/openingElement/0/value/expression": {
+          content: {
+            en: "Secure AI for <element:span>Teams</element:span>",
+            es: "IA segura para <element:span>equipos</element:span>"
+          },
+          hash: "65c7f646f6a580367c7edc989a3f0a69"
+        },
+        "11/body/0/argument/3/1/openingElement/1/value/expression": {
+          content: {
+            en: "Protect your trade secrets while using AI. <element:br></element:br> No data is shared with advertisers, competitors, or third parties. Period.",
+            es: "Protege tus secretos comerciales mientras usas IA. <element:br></element:br> Ningún dato se comparte con anunciantes, competidores o terceros. Punto."
+          },
+          hash: "1d3b885b46e2b854802852277a659ced"
+        },
+        "11/body/0/argument/3/13/1/1/1": {
+          content: {
+            en: "Powerful AI models. <element:span>No data sharing.</element:span>",
+            es: "Potentes modelos de IA. <element:span>Sin compartir datos.</element:span>"
+          },
+          hash: "de36e16e3e51717542914de6fa0ea707"
+        },
+        "11/body/0/argument/3/13/1/1/3": {
+          content: {
+            en: "We use open-source models from the biggest providers.",
+            es: "Utilizamos modelos de código abierto de los mayores proveedores."
+          },
+          hash: "5908ced334a2be5e46c2987b4b618854"
+        },
+        "11/body/0/argument/3/13/1/5/1": {
+          content: {
+            en: "<element:br></element:br> None of your data is transmitted to these companies.<element:br></element:br> Get the best without the mess.",
+            es: "<element:br></element:br> Ninguno de tus datos se transmite a estas empresas.<element:br></element:br> Obtén lo mejor sin complicaciones."
+          },
+          hash: "d42a3955bdf73dd76e1724618c20ee5c"
+        },
+        "11/body/0/argument/3/17/1/1/1": {
+          content: {
+            en: "Security by <element:span>Design</element:span>",
+            es: "Seguridad por <element:span>diseño</element:span>"
+          },
+          hash: "78a1df8f1891860e7583302a16842318"
+        },
+        "11/body/0/argument/3/17/1/1/3": {
+          content: {
+            en: "You don't share company secrets with competitors, so why should your AI? Whether you're designing products in a highly competitive market or dealing with sensitive client information at a firm or non-profit, Teams protects it all.",
+            es: "No compartes secretos empresariales con competidores, ¿por qué debería hacerlo tu IA? Ya sea que estés diseñando productos en un mercado altamente competitivo o manejando información sensible de clientes en una empresa u organización sin fines de lucro, Teams lo protege todo."
+          },
+          hash: "4390eef454da01345b0f42c48b9461b9"
+        },
+        "11/body/0/argument/3/17/1/5/1-alt": {
+          content: {
+            en: "Two audio hardware engineers collaborating at work using secure Maple AI",
+            es: "Dos ingenieros de hardware de audio colaborando en el trabajo usando Maple AI seguro"
+          },
+          hash: "abc648f18bf51d5aac43d2ff971f88cc"
+        },
+        "11/body/0/argument/3/17/1/7/1-description": {
+          content: {
+            en: "All conversations and files are encrypted on your device and only decrypted inside secure enclaves. No one—not even Maple—can access your plaintext data.",
+            es: "Todas las conversaciones y archivos se cifran en tu dispositivo y solo se descifran dentro de enclaves seguros. Nadie, ni siquiera Maple, puede acceder a tus datos en texto plano."
+          },
+          hash: "c75075364216ed24d964629e01a00159"
+        },
+        "11/body/0/argument/3/17/1/7/1-title": {
+          content: {
+            en: "End-to-End Encryption",
+            es: "Cifrado de extremo a extremo"
+          },
+          hash: "824ad790255699bf6eac309327454f10"
+        },
+        "11/body/0/argument/3/17/1/7/3-description": {
+          content: {
+            en: "Maple runs inside hardware-secured enclaves (AWS Nitro, Nvidia TEE) with cryptographic proof. Your organization’s data is protected at every step.",
+            es: "Maple funciona dentro de enclaves protegidos por hardware (AWS Nitro, Nvidia TEE) con prueba criptográfica. Los datos de tu organización están protegidos en cada paso."
+          },
+          hash: "d4d3a45667edb5c45279231016917cec"
+        },
+        "11/body/0/argument/3/17/1/7/3-title": {
+          content: {
+            en: "Confidential Computing",
+            es: "Computación confidencial"
+          },
+          hash: "1dfe6f9331567b9d9e10c61e5fc47208"
+        },
+        "11/body/0/argument/3/17/1/7/5-description": {
+          content: {
+            en: "Teams users get access to the best models Maple offers, including advanced open source LLMs. Your data is never sent to model creators—it always stays within secure enclaves.",
+            es: "Los usuarios de Teams obtienen acceso a los mejores modelos que ofrece Maple, incluidos avanzados LLM de código abierto. Tus datos nunca se envían a los creadores del modelo; siempre permanecen dentro de enclaves seguros."
+          },
+          hash: "dd9c59e6bd47ba3c58ed2e9296f36a8b"
+        },
+        "11/body/0/argument/3/17/1/7/5-title": {
+          content: {
+            en: "Open Source Models",
+            es: "Modelos de código abierto"
+          },
+          hash: "c3b1835da96ed6d8d912eca1a0233bae"
+        },
+        "11/body/0/argument/3/21/1/1/1": {
+          content: {
+            en: "How Maple Teams Works",
+            es: "Cómo funciona Maple Teams"
+          },
+          hash: "4a0df92db6a10c2ccf3697c95c192513"
+        },
+        "11/body/0/argument/3/21/1/1/3/1/1": {
+          content: {
+            en: "Purchase seats for your team",
+            es: "Compra asientos para tu equipo"
+          },
+          hash: "23e3824abc5db6f13fd0b1b6a8909e9a"
+        },
+        "11/body/0/argument/3/21/1/1/3/1/3": {
+          content: {
+            en: "Invite members by email",
+            es: "Invita a miembros por correo electrónico"
+          },
+          hash: "343d2deab04272a473e54f043ade9ef4"
+        },
+        "11/body/0/argument/3/21/1/1/3/1/5": {
+          content: {
+            en: "Use AI securely with your data, encrypted",
+            es: "Usa IA de forma segura con tus datos, cifrados"
+          },
+          hash: "3b4d15f88021f1ac3eadf5ce3fe8e5bb"
+        },
+        "11/body/0/argument/3/21/1/1/5/1": {
+          content: {
+            en: "Learn More",
+            es: "Saber más"
+          },
+          hash: "1740bf7aba10e661fbd46e442d8fa6cc"
+        },
+        "11/body/0/argument/3/21/1/3/1/1/3": {
+          content: {
+            en: "For Businesses",
+            es: "Para empresas"
+          },
+          hash: "76617aaf95540d17973cab4752b0ff65"
+        },
+        "11/body/0/argument/3/21/1/3/1/3": {
+          content: {
+            en: "Maple Teams is trusted by organizations in big tech, legal, higher education, healthcare, finance, consulting, and more. Draft contracts, analyze client data, and collaborate on sensitive projects with full privacy and compliance.",
+            es: "Maple Teams es de confianza para organizaciones en grandes tecnológicas, legales, educación superior, salud, finanzas, consultoría y más. Redacta contratos, analiza datos de clientes y colabora en proyectos sensibles con total privacidad y cumplimiento."
+          },
+          hash: "1c6312803f0880b21a2f730e3e2a19d5"
+        },
+        "11/body/0/argument/3/21/1/3/1/5/1-alt": {
+          content: {
+            en: "Legal professionals working in a modern law office with secure AI assistance",
+            es: "Profesionales legales trabajando en una oficina jurídica moderna con asistencia de IA segura"
+          },
+          hash: "941e632ffa88f70696bcebdd2f17d9f4"
+        },
+        "11/body/0/argument/3/21/1/3/3/1/3": {
+          content: {
+            en: "For Non-Profits",
+            es: "Para organizaciones sin fines de lucro"
+          },
+          hash: "066166e15df5403a64ab1716226e1bd9"
+        },
+        "11/body/0/argument/3/21/1/3/3/3": {
+          content: {
+            en: "Non-profits and advocacy groups use Maple to securely manage sensitive information, collaborate on grant writing, and protect the privacy of those they serve—no IT headaches, just secure, private AI for your mission.",
+            es: "Las organizaciones sin fines de lucro y grupos de defensa utilizan Maple para gestionar de forma segura información sensible, colaborar en la redacción de subvenciones y proteger la privacidad de aquellos a quienes sirven—sin dolores de cabeza de TI, solo IA segura y privada para tu misión."
+          },
+          hash: "7d0f9f5b01561d41b6e33fd2d044a2bc"
+        },
+        "11/body/0/argument/3/21/1/3/3/5/1-alt": {
+          content: {
+            en: "Social workers collaborating in a non-profit office using secure AI tools",
+            es: "Trabajadores sociales colaborando en una oficina sin fines de lucro usando herramientas de IA seguras"
+          },
+          hash: "ab64ed2e4d9a8132cc64eb99e867a833"
+        },
+        "11/body/0/argument/3/25/1/1": {
+          content: {
+            en: "Simple, Transparent Pricing",
+            es: "Precios simples y transparentes"
+          },
+          hash: "680c1228bc4b023acee47a10a944b718"
+        },
+        "11/body/0/argument/3/25/1/3": {
+          content: {
+            en: "$30/month per seat. All features included. No hidden fees. Cancel anytime.",
+            es: "$30/mes por asiento. Todas las funciones incluidas. Sin cargos ocultos. Cancela cuando quieras."
+          },
+          hash: "168638043771f10fccafd62c0365a765"
+        },
+        "11/body/0/argument/3/25/1/7": {
+          content: {
+            en: "Need a larger deployment or have compliance questions? <element:a>Contact us</element:a> for enterprise options.",
+            es: "¿Necesitas una implementación más grande o tienes preguntas sobre cumplimiento? <element:a>Contáctanos</element:a> para opciones empresariales."
+          },
+          hash: "787d922e3f29310f6a869ae627332002"
+        },
+        "11/body/0/argument/3/5/1": {
+          content: {
+            en: "Get Started with Teams <element:ArrowRight></element:ArrowRight>",
+            es: "Comienza con Teams <element:ArrowRight></element:ArrowRight>"
+          },
+          hash: "defef6417f0a0b471aae4932fb757341"
+        },
+        "11/body/0/argument/3/5/3": {
+          content: {
+            en: "Request a Demo",
+            es: "Solicitar una demo"
+          },
+          hash: "2df6b22385bade18c77f7e8433a6b87c"
+        },
+        "11/body/0/argument/3/9/1/1/1": {
+          content: {
+            en: "Why Choose <element:span>Maple Teams?</element:span>",
+            es: "¿Por qué elegir <element:span>Maple Teams?</element:span>"
+          },
+          hash: "e8ea53ea380822523292d6e318c9cc9e"
+        },
+        "11/body/0/argument/3/9/1/1/3": {
+          content: {
+            en: "Experience the productivity gains of AI without the data tracking.<element:br></element:br> Maple Teams scales AI across your entire organization to meet your needs.",
+            es: "Experimenta los aumentos de productividad de la IA sin el seguimiento de datos.<element:br></element:br> Maple Teams escala la IA en toda tu organización para satisfacer tus necesidades."
+          },
+          hash: "f7de301ababe5dfdb303b319b096a5a6"
+        },
+        "11/body/0/argument/3/9/1/5/1-alt": {
+          content: {
+            en: "A company office with different departments of Accounting, Finance, Marketing, Engineering, and Sales",
+            es: "Una oficina de empresa con diferentes departamentos de Contabilidad, Finanzas, Marketing, Ingeniería y Ventas"
+          },
+          hash: "320dd60fd6c41b802e356f426bf9a6c9"
+        },
+        "11/body/0/argument/3/9/1/7/1-description": {
+          content: {
+            en: "Share AI credits across your team and control access from a central dashboard. Add or remove users anytime.",
+            es: "Comparte créditos de IA entre tu equipo y controla el acceso desde un panel central. Añade o elimina usuarios en cualquier momento."
+          },
+          hash: "76a6e3c1e449b981edc6c5fe681a9a77"
+        },
+        "11/body/0/argument/3/9/1/7/1-title": {
+          content: {
+            en: "Pooled Usage",
+            es: "Uso compartido"
+          },
+          hash: "18ae4bc63e988b4d31795c2755d7d944"
+        },
+        "11/body/0/argument/3/9/1/7/3-description": {
+          content: {
+            en: "Upload documents and images for AI analysis—summarize PDFs, extract insights from text files, or analyze images securely as a team. Supports PDF, TXT, MD, JPG, PNG, and more.",
+            es: "Sube documentos e imágenes para análisis de IA—resume PDFs, extrae información de archivos de texto o analiza imágenes de forma segura como equipo. Compatible con PDF, TXT, MD, JPG, PNG y más."
+          },
+          hash: "ed0b68d91d69fc18ffcd9b9f5289f6b5"
+        },
+        "11/body/0/argument/3/9/1/7/3-title": {
+          content: {
+            en: "Document & Image Upload",
+            es: "Carga de documentos e imágenes"
+          },
+          hash: "15f89ded6f4ea104133c78d804ae212e"
+        },
+        "11/body/0/argument/3/9/1/7/5-description": {
+          content: {
+            en: "Use Maple to redact or anonymize sensitive client information before sharing with other cloud tools or AI. Protect privacy and stay compliant.",
+            es: "Usa Maple para redactar o anonimizar información sensible de clientes antes de compartirla con otras herramientas en la nube o IA. Protege la privacidad y mantén el cumplimiento."
+          },
+          hash: "f9c03c4c81a7ac99f19efc38c15b4a62"
+        },
+        "11/body/0/argument/3/9/1/7/5-title": {
+          content: {
+            en: "Sanitize Client Data",
+            es: "Sanitizar datos de clientes"
+          },
+          hash: "c9ea3c50396f7f4dad99cba0d465b7e4"
+        }
+      }
+    },
+    "routes/verify.$code.tsx": {
+      entries: {
+        "7/body/6/consequent/0/argument/1/1": {
+          content: {
+            en: "Verifying Email",
+            es: "Verificando correo electrónico"
+          },
+          hash: "d922e15048d8cb909d5c0d2a107c08a6"
+        },
+        "7/body/7/consequent/0/argument/1/1": {
+          content: {
+            en: "Verification Failed",
+            es: "Verificación fallida"
+          },
+          hash: "7157733f774f9bc07f1202eb2b0156d8"
+        },
+        "7/body/7/consequent/0/argument/3/1-title": {
+          content: {
+            en: "Error",
+            es: "Error"
+          },
+          hash: "3c95bcb32c2104b99a46f5b3dd015248"
+        },
+        "7/body/8/argument/1/1": {
+          content: {
+            en: "Email Verified",
+            es: "Correo electrónico verificado"
+          },
+          hash: "1198a84576c526d433d566f764117f2e"
+        },
+        "7/body/8/argument/3": {
+          content: {
+            en: "Your email has been successfully verified. Redirecting...",
+            es: "Tu correo electrónico ha sido verificado con éxito. Redirigiendo..."
+          },
+          hash: "c74f91f5944b5500c5c64045b564e324"
+        }
+      }
+    }
+  }
+};

--- a/frontend/src/lingo/meta.json
+++ b/frontend/src/lingo/meta.json
@@ -1,0 +1,5848 @@
+{
+  "version": 0.1,
+  "files": {
+    "components/AccountDialog.tsx": {
+      "scopes": {
+        "12/declaration/body/9/argument/1/1/1": {
+          "type": "element",
+          "hash": "5158811ccd3dc7f34c43104ec752117e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Update Your Account"
+        },
+        "12/declaration/body/9/argument/1/1/3": {
+          "type": "element",
+          "hash": "ba3fdcbebb09316395aaca9a69a15af3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Change your email or upgrade your plan."
+        },
+        "12/declaration/body/9/argument/1/3/1/expression/right/1": {
+          "type": "element",
+          "hash": "e7f34943a0c2fb849db1839ff6ef5cb5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email"
+        },
+        "12/declaration/body/9/argument/1/3/1/expression/right/5/expression/right/1/expression/consequent": {
+          "type": "element",
+          "hash": "b9ed21d5af83c3edcc2ccdee1c0d8b93",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Unverified - <element:button>Resend verification email</element:button>"
+        },
+        "12/declaration/body/9/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "c6a08c771f97d86b02cf10d8f5f2d788",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Plan"
+        },
+        "12/declaration/body/9/argument/1/3/3/3/3/1/1": {
+          "type": "element",
+          "hash": "c6a08c771f97d86b02cf10d8f5f2d788",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Plan"
+        },
+        "12/declaration/body/9/argument/1/3/5/1": {
+          "type": "element",
+          "hash": "165daa4cf8fb29b9ade6d953afca2954",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "User Preferences"
+        },
+        "12/declaration/body/9/argument/1/3/5/3/expression/right/1": {
+          "type": "element",
+          "hash": "78a4bf8cad46e6b1bcc1f3958be55aa3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Change Password"
+        },
+        "12/declaration/body/9/argument/1/3/5/5": {
+          "type": "element",
+          "hash": "d977430f34258d84d78cc5bfed6758a7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Trash></element:Trash> Delete Account"
+        },
+        "12/declaration/body/9/argument/1/5/1": {
+          "type": "element",
+          "hash": "e0e373a41634205df41b708880165e43",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Save Changes"
+        }
+      }
+    },
+    "components/AccountMenu.tsx": {
+      "scopes": {
+        "19/body/4/argument/1/1": {
+          "type": "element",
+          "hash": "6d5cd13628a7887711fd0c29f1123652",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure?"
+        },
+        "19/body/4/argument/1/3": {
+          "type": "element",
+          "hash": "a3d5a7d87030107b0cfa5b59041b4a2b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This will delete your entire chat history."
+        },
+        "19/body/4/argument/3/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "19/body/4/argument/3/3": {
+          "type": "element",
+          "hash": "8bcf303dd10a645b5baacb02b47d72c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Delete"
+        },
+        "20/declaration/body/20/argument/1/1/1/5/1": {
+          "type": "element",
+          "hash": "b853b058e40dd9b194a9e1eb327f1019",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:User></element:User> Account<expression/>"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/13/3": {
+          "type": "element",
+          "hash": "9a236bb8f8bec867ec0d0950d38bcc71",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log out"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/1/1/3": {
+          "type": "element",
+          "hash": "d7878693f91303a438852d617f6d35df",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Profile"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/11/1/3": {
+          "type": "element",
+          "hash": "94887d927b8010412f4cfd70c816f54d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Delete History"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/3/expression/right/1/3": {
+          "type": "element",
+          "hash": "555f4914d0f19b9566c5ca7678339e29",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Upgrade your plan"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/7/expression/right/1/1/3": {
+          "type": "element",
+          "hash": "02d78d6b589015b06bd06a6d34ce2dcb",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Manage Team"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/7/expression/right/1/3/expression/right": {
+          "type": "element",
+          "hash": "f3241d4072ebea7dcd02878ba025c5f7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Setup Required"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/5/9/expression/right/3": {
+          "type": "element",
+          "hash": "b3d76fe5a47de22d9a422c902b3ae82d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Management"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/1/9/1/3": {
+          "type": "element",
+          "hash": "8f89131a66d4659be07cd5af2c7ea898",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "About Us"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/1/1/3": {
+          "type": "element",
+          "hash": "f541015a827e37cb3b1234e56bc2aa3c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Back"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/1/1/3": {
+          "type": "element",
+          "hash": "253c5a54e1e11e54a05f00c4afccad8b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "About Maple"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/3/3": {
+          "type": "element",
+          "hash": "7459744a63ef8af4e517a09024bd7c08",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Privacy Policy"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/5/3": {
+          "type": "element",
+          "hash": "5add91f519e39025708e54a7eb7a9fc5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Terms of Service"
+        },
+        "20/declaration/body/20/argument/1/1/3/1/5/5/7/1/3": {
+          "type": "element",
+          "hash": "2a75337dc9603915c4ec1d1905afb7b9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Contact Us"
+        }
+      }
+    },
+    "components/AppleAuthProvider.tsx": {
+      "scopes": {
+        "14/declaration/body/9/argument/alternate": {
+          "type": "element",
+          "hash": "19ad2aed2e69c9abe9fefe8071a6829a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Apple></element:Apple> Log in with Apple"
+        }
+      }
+    },
+    "components/AuthMain.tsx": {
+      "scopes": {
+        "4/declaration/body/0/argument/1/1/1-alt": {
+          "type": "attribute",
+          "hash": "b5b1f436ba922b2e4a0eb1615efb346a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple AI logo"
+        },
+        "4/declaration/body/0/argument/1/1/3-alt": {
+          "type": "attribute",
+          "hash": "b5b1f436ba922b2e4a0eb1615efb346a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple AI logo"
+        }
+      }
+    },
+    "components/ChangePasswordDialog.tsx": {
+      "scopes": {
+        "8/declaration/body/10/argument/1/1/1": {
+          "type": "element",
+          "hash": "a552fc5c4189ebc3e2e6018edda7d18f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Change Password"
+        },
+        "8/declaration/body/10/argument/1/1/3": {
+          "type": "element",
+          "hash": "36291f0d0974db90a0173f145c47dd35",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter your current password and a new password to update your account."
+        },
+        "8/declaration/body/10/argument/1/3/3/expression/right/1": {
+          "type": "element",
+          "hash": "01af737e898cfe4e3c50dd062170dcba",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Password changed successfully. This dialog will close shortly."
+        },
+        "8/declaration/body/10/argument/1/3/5/1": {
+          "type": "element",
+          "hash": "2e186f3990c3fcacb1f892c94f7ecae1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Current Password"
+        },
+        "8/declaration/body/10/argument/1/3/7/1": {
+          "type": "element",
+          "hash": "80d809edd5d1b66123b18faaac10537b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "New Password"
+        },
+        "8/declaration/body/10/argument/1/3/9/1": {
+          "type": "element",
+          "hash": "d3194bdcb74c9a912c67d7e1b030b88a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Confirm New Password"
+        }
+      }
+    },
+    "components/ChatHistoryList.tsx": {
+      "scopes": {
+        "13/declaration/body/32/consequent/0/argument": {
+          "type": "element",
+          "hash": "4601c8eb6d6e81c91ef4f0fe43141918",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Loading chat history..."
+        },
+        "13/declaration/body/34/consequent/0/argument/1": {
+          "type": "element",
+          "hash": "4236da1be65d3240cfe260c42910ef18",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "No chats found matching \"{trimmedQuery}\""
+        },
+        "13/declaration/body/34/consequent/0/argument/3": {
+          "type": "element",
+          "hash": "87132887ef8f4ebb921b7ca2378423e8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Try a different search term"
+        },
+        "13/declaration/body/35/argument/1/expression/0/body/4/argument/3/3/1/3": {
+          "type": "element",
+          "hash": "bb846c81ebb761285702bf2eb9315d9e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Rename Chat"
+        },
+        "13/declaration/body/35/argument/1/expression/0/body/4/argument/3/3/3/3": {
+          "type": "element",
+          "hash": "38f623dc2fe274087d6dfbcae8700202",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Delete Chat"
+        },
+        "13/declaration/body/35/argument/9/expression/right/1/3": {
+          "type": "element",
+          "hash": "36a012d3a66004474d6fcc6d6731dc60",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Archived ({filteredArchivedChats.length})"
+        },
+        "13/declaration/body/35/argument/9/expression/right/3/expression/right/1/expression/0/body/1/argument/3/3/1/3": {
+          "type": "element",
+          "hash": "bb846c81ebb761285702bf2eb9315d9e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Rename Chat"
+        },
+        "13/declaration/body/35/argument/9/expression/right/3/expression/right/1/expression/0/body/1/argument/3/3/3/3": {
+          "type": "element",
+          "hash": "38f623dc2fe274087d6dfbcae8700202",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Delete Chat"
+        }
+      }
+    },
+    "components/ComparisonChart.tsx": {
+      "scopes": {
+        "3/0/init/body/0/0/0/argument/1-aria-label": {
+          "type": "attribute",
+          "hash": "216de63cd5d8bf0bc1cfb470cb2d924b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Available"
+        },
+        "3/0/init/body/0/1/0/argument/1-aria-label": {
+          "type": "attribute",
+          "hash": "c84536a39463bb93f07245a2aa00ccae",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Not Available"
+        },
+        "3/0/init/body/0/2/0/argument/1-aria-label": {
+          "type": "attribute",
+          "hash": "6392f5a447b526482b68fa3127f548f2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Unknown or Unclear"
+        },
+        "3/0/init/body/0/3/0/argument/1-aria-label": {
+          "type": "attribute",
+          "hash": "aa985c4cdc283d220057e9f5678333fc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Paid Feature"
+        },
+        "3/0/init/body/0/4/0/argument/1-aria-label": {
+          "type": "attribute",
+          "hash": "beb971200802fc1b7a61bd3245e38a23",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Partially Available"
+        },
+        "4/declaration/body/1/argument/1/1/1": {
+          "type": "element",
+          "hash": "586672042bd9ce2cd832651246444f5d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How We <element:span>Compare</element:span>"
+        },
+        "4/declaration/body/1/argument/1/1/3": {
+          "type": "element",
+          "hash": "3dcc0cdb851d5f26930e5830249b5d78",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "See how Maple stacks up against other AI chat platforms when it comes to privacy, security, and developer features."
+        },
+        "4/declaration/body/1/argument/1/7/1/3": {
+          "type": "element",
+          "hash": "216de63cd5d8bf0bc1cfb470cb2d924b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Available"
+        },
+        "4/declaration/body/1/argument/1/7/3/3": {
+          "type": "element",
+          "hash": "c84536a39463bb93f07245a2aa00ccae",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Not Available"
+        },
+        "4/declaration/body/1/argument/1/7/5/3": {
+          "type": "element",
+          "hash": "beb971200802fc1b7a61bd3245e38a23",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Partially Available"
+        },
+        "4/declaration/body/1/argument/1/7/7/3": {
+          "type": "element",
+          "hash": "43325b1dfe49cf3939d1780bb9fef887",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Claim Unverifiable"
+        },
+        "4/declaration/body/1/argument/1/7/9/3": {
+          "type": "element",
+          "hash": "bfadf2181f393a8fa8a30393f91f573e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Expensive Paid Feature"
+        }
+      }
+    },
+    "components/ContextLimitDialog.tsx": {
+      "scopes": {
+        "4/declaration/body/1/argument/1/1/1/3": {
+          "type": "element",
+          "hash": "1257a62fcf3670013efe6e58ab2d9fbf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Message Too Large"
+        },
+        "4/declaration/body/1/argument/1/1/3": {
+          "type": "element",
+          "hash": "c5e95058e718b8c72ef8e390576c3804",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your message exceeds the context limit for the current model."
+        },
+        "4/declaration/body/1/argument/1/3/1/1": {
+          "type": "element",
+          "hash": "5789340d0946ed2b791b8dd5dbc7984e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Here's what you can try:"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/1/3": {
+          "type": "element",
+          "hash": "b0b4bf6746e8e920355f040e21ef118f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:strong>Shorten your message</element:strong> - Try reducing the amount of text or content"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/3/expression/right/3": {
+          "type": "element",
+          "hash": "3248aabeb54185e4f79d553f9196273a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:strong>Use a smaller document</element:strong> - Try uploading a shorter document or extracting only the relevant sections"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/5/expression/right/3": {
+          "type": "element",
+          "hash": "d22f01c5837e7b6e3a08a5a36449d2cb",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:strong>Switch to a model with more context</element:strong> - Try DeepSeek R1, Mistral, or other models that support 128k tokens"
+        },
+        "4/declaration/body/1/argument/1/5/1": {
+          "type": "element",
+          "hash": "6359071421abf7a7dbf4181c22bd79d2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Got it"
+        }
+      }
+    },
+    "components/CreditUsage.tsx": {
+      "scopes": {
+        "2/declaration/body/7/argument/1/1": {
+          "type": "element",
+          "hash": "1abaf86d3e77f16e115dbfadbb08b94f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Credit Usage"
+        },
+        "2/declaration/body/7/argument/1/3": {
+          "type": "element",
+          "hash": "5ffe4a4526d680df3dc6d6e7880cbc9a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "{roundedPercent}%"
+        }
+      }
+    },
+    "components/DeleteAccountDialog.tsx": {
+      "scopes": {
+        "10/declaration/body/10/argument/1/3/1/expression/right/1/1": {
+          "type": "element",
+          "hash": "b06a326a6e8f7938805479896126d5a0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Warning: This will permanently delete your account and all associated data. You will lose access to any paid features, chat history, and settings."
+        },
+        "10/declaration/body/10/argument/1/3/1/expression/right/3/1": {
+          "type": "element",
+          "hash": "e3b109c0649f38e2126d482cf60bf745",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Type DELETE to confirm"
+        },
+        "10/declaration/body/10/argument/1/3/3/expression/right/1": {
+          "type": "element",
+          "hash": "d20561439ce7a3b3b5795b28a22c6572",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Confirmation Code"
+        },
+        "10/declaration/body/10/argument/1/3/3/expression/right/3-placeholder": {
+          "type": "attribute",
+          "hash": "a90fc584939036afdd5520f814131f77",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter code from email"
+        },
+        "10/declaration/body/10/argument/1/3/5/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "10/declaration/body/10/argument/1/5/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "10/declaration/body/10/argument/1/5/3/expression/alternate/1/expression/consequent": {
+          "type": "element",
+          "hash": "f16934ef4750ea88a7e6eb8fd365d46a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Processing..."
+        },
+        "10/declaration/body/10/argument/1/5/3/expression/consequent/1/expression/consequent": {
+          "type": "element",
+          "hash": "f16934ef4750ea88a7e6eb8fd365d46a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Processing..."
+        }
+      }
+    },
+    "components/DeleteChatDialog.tsx": {
+      "scopes": {
+        "2/declaration/body/1/argument/1/1/1": {
+          "type": "element",
+          "hash": "f24abe5f3cfad07d6038f038e24681a6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure you want to delete this chat?"
+        },
+        "2/declaration/body/1/argument/1/1/3": {
+          "type": "element",
+          "hash": "30c51b10fa2a66d01aac589d405655b6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This will permanently delete \"{chatTitle}\". This action cannot be undone."
+        },
+        "2/declaration/body/1/argument/1/3/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "2/declaration/body/1/argument/1/3/3": {
+          "type": "element",
+          "hash": "1ba028f51d433fd043e2e7b404264ce2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Delete"
+        }
+      }
+    },
+    "components/DocumentPlatformDialog.tsx": {
+      "scopes": {
+        "6/declaration/body/3/argument/1/1/1/3": {
+          "type": "element",
+          "hash": "911006c3eba8d21ab5ea49e5469ee9dc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Document Upload on Mobile & Desktop"
+        },
+        "6/declaration/body/3/argument/1/3/1/1/3": {
+          "type": "element",
+          "hash": "0a43dae170adffd6e82fc484440a2af7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Desktop"
+        },
+        "6/declaration/body/3/argument/1/3/1/1/5": {
+          "type": "element",
+          "hash": "55d55dc21190360046e0486aefa6602e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "macOS • Linux"
+        },
+        "6/declaration/body/3/argument/1/3/1/3/3": {
+          "type": "element",
+          "hash": "7d34c49cdc321c9359a418d3dac87619",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mobile"
+        },
+        "6/declaration/body/3/argument/1/3/1/3/5": {
+          "type": "element",
+          "hash": "d5cc1e2c14302ea774b7a726aa82f770",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "iOS • Android (beta)"
+        },
+        "6/declaration/body/3/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "6b1b3632e6da94f635e80cecf7e3c984",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Features include:"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/1/3": {
+          "type": "element",
+          "hash": "bbe04736536b65551a2fd22502170b89",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Local PDF processing - files are processed on your device"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/3/3": {
+          "type": "element",
+          "hash": "8f7be8c59e1fcad93911a58a2355fdab",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Support for PDF, TXT, and Markdown files"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/5/3": {
+          "type": "element",
+          "hash": "4e6efe3c389848d9c434a393947350c3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Extracted text is secured with end-to-end encryption"
+        },
+        "6/declaration/body/3/argument/1/3/3/3/7/3": {
+          "type": "element",
+          "hash": "7fb3cf94226180eb202d4d9dccecbb9d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Files up to 10MB supported"
+        },
+        "6/declaration/body/3/argument/1/3/5/expression/right/1": {
+          "type": "element",
+          "hash": "d85055cf0d255e584b819059421f1d80",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Upgrade to Pro to unlock document upload along with voice recording, powerful models, and more."
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/alternate/1": {
+          "type": "element",
+          "hash": "a2610146668da9773f12281ef291a303",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maybe Later"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/alternate/3": {
+          "type": "element",
+          "hash": "d9a9529c70b4ffa005261f06e0498e8e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Sparkles></element:Sparkles> View Plans"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/consequent/1": {
+          "type": "element",
+          "hash": "1a97bc2b1ad01b81b070928d056cc66b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Close"
+        },
+        "6/declaration/body/3/argument/1/5/1/expression/consequent/3": {
+          "type": "element",
+          "hash": "60f04515d4630472820c495e5df0d2e2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Smartphone></element:Smartphone> Get Apps"
+        }
+      }
+    },
+    "components/ErrorFallback.tsx": {
+      "scopes": {
+        "2/declaration/body/1/argument/1/5/1/1": {
+          "type": "element",
+          "hash": "3236b297d477ec810e1ebb9603328949",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Go home"
+        }
+      }
+    },
+    "components/ExternalUrlConfirmDialog.tsx": {
+      "scopes": {
+        "3/declaration/body/1/argument/1/1/1": {
+          "type": "element",
+          "hash": "5c03291ff80a229d23714c1c54e53f81",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Open External Link?"
+        },
+        "3/declaration/body/1/argument/1/1/3": {
+          "type": "element",
+          "hash": "5f8d92bec36df568707cad661083f78f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You are about to open an external URL in your browser:<element:div>{url}</element:div>"
+        },
+        "3/declaration/body/1/argument/1/3/1": {
+          "type": "element",
+          "hash": "806df1c96f83121893c2a72a5ca8e443",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "3/declaration/body/1/argument/1/3/3": {
+          "type": "element",
+          "hash": "9a8c3b16091ea6cef3f771fc6715ab67",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Open"
+        }
+      }
+    },
+    "components/Footer.tsx": {
+      "scopes": {
+        "4/declaration/body/1/argument/1/1/1/1-alt": {
+          "type": "attribute",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "4/declaration/body/1/argument/1/1/1/3-alt": {
+          "type": "attribute",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "4/declaration/body/1/argument/1/1/1/5": {
+          "type": "element",
+          "hash": "aa239d8e7f65539c3d533d319b052293",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Private AI chat with end-to-end encryption. Your conversations stay yours."
+        },
+        "4/declaration/body/1/argument/1/1/1/7/1-aria-label": {
+          "type": "attribute",
+          "hash": "ba3d4aed69a50759b53a0b7c319a3ad9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Twitter"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/3-aria-label": {
+          "type": "attribute",
+          "hash": "6e1cf3c00fa6fbe24afcc78ea3b5f3e4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "GitHub"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/5-aria-label": {
+          "type": "attribute",
+          "hash": "06ec7d95ab44931ed9d1925e4063d703",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Discord"
+        },
+        "4/declaration/body/1/argument/1/1/1/7/7-aria-label": {
+          "type": "attribute",
+          "hash": "e7f34943a0c2fb849db1839ff6ef5cb5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email"
+        },
+        "4/declaration/body/1/argument/1/1/3/1": {
+          "type": "element",
+          "hash": "4e5f845a09d417dde0a1310bc9ca4bfe",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Product"
+        },
+        "4/declaration/body/1/argument/1/1/3/3": {
+          "type": "element",
+          "hash": "d54416fc69270a57577dd7f00c55323b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pricing"
+        },
+        "4/declaration/body/1/argument/1/1/3/5": {
+          "type": "element",
+          "hash": "97d42bd141f1505f7855cb42919a15ef",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Downloads"
+        },
+        "4/declaration/body/1/argument/1/1/3/7": {
+          "type": "element",
+          "hash": "17881c043d1ebce370c29ebcc1c0c8e3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Security Proof"
+        },
+        "4/declaration/body/1/argument/1/1/3/9": {
+          "type": "element",
+          "hash": "85ff3e7bf1a7b54b75f61c70150da851",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Teams"
+        },
+        "4/declaration/body/1/argument/1/1/5/1": {
+          "type": "element",
+          "hash": "ec7fb05ed963bb6781a35782b3475502",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Resources"
+        },
+        "4/declaration/body/1/argument/1/1/5/3": {
+          "type": "element",
+          "hash": "2b852f205e105696fd4d0a687e1bb0a4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Blog"
+        },
+        "4/declaration/body/1/argument/1/1/5/5": {
+          "type": "element",
+          "hash": "b3aa3b29fc2852e8d8f47b6f6a47c8a2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "OpenSecret"
+        },
+        "4/declaration/body/1/argument/1/1/5/7": {
+          "type": "element",
+          "hash": "5c2225c0ed64a283433f87be1f617b30",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Community"
+        },
+        "4/declaration/body/1/argument/1/1/5/9": {
+          "type": "element",
+          "hash": "2498a5a49400c3b1161d65b52b5b047c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "About"
+        },
+        "4/declaration/body/1/argument/1/3/1/3/expression/right-title": {
+          "type": "attribute",
+          "hash": "e2e7d7b3cb2e6ab077252abbfa7ea3e6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "BetterStack Status"
+        },
+        "4/declaration/body/1/argument/1/3/1/5": {
+          "type": "element",
+          "hash": "3e76d6a6e751214cce2ab2d8273293da",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "© <function:Date.getFullYear/> Maple AI. All rights reserved. Powered by <element:a>OpenSecret</element:a>"
+        }
+      }
+    },
+    "components/GlobalNotification.tsx": {
+      "scopes": {
+        "5/declaration/body/8/argument/1/5/3": {
+          "type": "element",
+          "hash": "2c2e22f8424a1031de89063bd0022e16",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Close"
+        }
+      }
+    },
+    "components/GuestCredentialsDialog.tsx": {
+      "scopes": {
+        "8/declaration/body/4/argument/1/1/1": {
+          "type": "element",
+          "hash": "4480128866595353d58e20d1bc8f1f36",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:AlertTriangle></element:AlertTriangle> Save Your Anonymous Account ID"
+        },
+        "8/declaration/body/4/argument/1/1/3": {
+          "type": "element",
+          "hash": "992d93d9b64a760bf6c26fbed29bc9ad",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This is your ONLY chance to see your Account ID. Save it now!"
+        },
+        "8/declaration/body/4/argument/1/3/11/1": {
+          "type": "element",
+          "hash": "2c60a8e8957f3a02e0fb30b961d6044e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How to save your Account ID:"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/1": {
+          "type": "element",
+          "hash": "ddd56cd88ecbe2b6a55cf6f93951e761",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Copy it to a password manager (recommended)"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/3": {
+          "type": "element",
+          "hash": "6ff7aca1e65f7829e729c64497eff70b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Write it down on paper and store it safely"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/5": {
+          "type": "element",
+          "hash": "4b6b69ea7915c60ef37d690f5a765968",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Save it in a secure note or encrypted file"
+        },
+        "8/declaration/body/4/argument/1/3/11/3/7": {
+          "type": "element",
+          "hash": "76fc5fd919aa8da74dfc218cd04c85f6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Take a screenshot and store it securely"
+        },
+        "8/declaration/body/4/argument/1/3/15/3": {
+          "type": "element",
+          "hash": "131c442fca6288e1cc87954586227240",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "I have securely saved my Account ID and understand I cannot recover my account without it"
+        },
+        "8/declaration/body/4/argument/1/3/3/1/3/1": {
+          "type": "element",
+          "hash": "b4890dcde40b01dcc59d50d7f2d5a034",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Critical: Save your Account ID immediately!"
+        },
+        "8/declaration/body/4/argument/1/3/3/1/3/3": {
+          "type": "element",
+          "hash": "9a33cb496faaf80a81cbab72f6f842ba",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your Account ID will <element:strong>never be shown again</element:strong> after you close this dialog. If you lose it, you will <element:strong>permanently lose access</element:strong> to your account. We cannot recover it for you."
+        },
+        "8/declaration/body/4/argument/1/3/7/1": {
+          "type": "element",
+          "hash": "3231cf1b9ea54c7349cd88382e499bde",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your Account ID"
+        },
+        "8/declaration/body/4/argument/1/3/7/5": {
+          "type": "element",
+          "hash": "5851e6b64b7758189e8a0c9a64a67159",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You will need this Account ID along with your password to sign in."
+        },
+        "8/declaration/body/4/argument/1/5/1": {
+          "type": "element",
+          "hash": "0e12dcc9cacb6ccf8e3b52efdff222f6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Continue to Payment"
+        }
+      }
+    },
+    "components/GuestPaymentWarningDialog.tsx": {
+      "scopes": {
+        "6/declaration/body/4/argument/1/1/1": {
+          "type": "element",
+          "hash": "b5f579815fa3651b67befff52227e0ef",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:AlertTriangle></element:AlertTriangle> Subscription Required"
+        },
+        "6/declaration/body/4/argument/1/1/3": {
+          "type": "element",
+          "hash": "9ee35c8f6671ad8cdb5a28e40911d7f4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anonymous accounts require a paid subscription to use Maple AI."
+        },
+        "6/declaration/body/4/argument/1/3/1/1": {
+          "type": "element",
+          "hash": "607bcb4dc06ca138364f1fb4619fe10f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your anonymous account is not activated yet and cannot use the chat feature."
+        },
+        "6/declaration/body/4/argument/1/3/1/3": {
+          "type": "element",
+          "hash": "5010fa12dc9b96d9441c58dab548482f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "To start chatting with Maple AI, you need to subscribe to a paid plan. Anonymous accounts must pay for a full year using Bitcoin."
+        },
+        "6/declaration/body/4/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "488de6b75c456f753b49b70f41b22707",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:CreditCard></element:CreditCard> View Pricing & Subscribe"
+        },
+        "6/declaration/body/4/argument/1/3/3/3": {
+          "type": "element",
+          "hash": "70c2a4ef60d2e77e06c421cbdc48fc2e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:LogOut></element:LogOut> Log Out"
+        }
+      }
+    },
+    "components/GuestSignupWarningDialog.tsx": {
+      "scopes": {
+        "7/declaration/body/5/argument/1/1/1": {
+          "type": "element",
+          "hash": "89d08d8d099f665762446e156ea5af60",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:AlertTriangle></element:AlertTriangle> Anonymous Account - Important Warnings"
+        },
+        "7/declaration/body/5/argument/1/1/3": {
+          "type": "element",
+          "hash": "ba969596dd56228ae85d6b340a657c3b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Please read and acknowledge all warnings before creating an anonymous account."
+        },
+        "7/declaration/body/5/argument/1/3/1/11/3/1": {
+          "type": "element",
+          "hash": "f9692bba773da91ede90a65f479930d1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "I understand I <element:strong>MUST backup my Account ID</element:strong> after signup. My Account ID will only be shown once, and if I lose it, I will permanently lose access to my account. We cannot recover it."
+        },
+        "7/declaration/body/5/argument/1/3/1/3/3/1": {
+          "type": "element",
+          "hash": "892d98e9cf82c589896b2e13c0dc8317",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "I understand I <element:strong>MUST pay for a full year in Bitcoin only</element:strong>. Nocredit card, no Stripe, no monthly payment options, and <element:strong>no free trial</element:strong> are available for anonymous accounts."
+        },
+        "7/declaration/body/5/argument/1/3/1/7/3/1": {
+          "type": "element",
+          "hash": "b6cc435b17005665a3228d6ca91668dd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "I understand there is <element:strong>absolutely no support</element:strong> available for anonymous accounts. If I have issues, I cannot contact support for help."
+        },
+        "7/declaration/body/5/argument/1/3/3/1/1": {
+          "type": "element",
+          "hash": "79d470dbf318f9311710151df3b2d93a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Why these restrictions?"
+        },
+        "7/declaration/body/5/argument/1/3/3/3": {
+          "type": "element",
+          "hash": "48ae4e3516e2cffdaa0e6f068248ec8b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anonymous accounts are designed for users who prioritize privacy and don't want to provide an email address. This comes with trade-offs in support and payment options."
+        },
+        "7/declaration/body/5/argument/1/5/1": {
+          "type": "element",
+          "hash": "806df1c96f83121893c2a72a5ca8e443",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "7/declaration/body/5/argument/1/5/3": {
+          "type": "element",
+          "hash": "b8554aa4e3fdbc8ceae9607272e1408c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "I Understand and Accept"
+        }
+      }
+    },
+    "components/Marketing.tsx": {
+      "scopes": {
+        "11/body/0/argument/1": {
+          "type": "element",
+          "hash": "ffd37b87597a079be4eef1216a8dd023",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "“{quote}”"
+        },
+        "12/body/1/argument/1/expression/right": {
+          "type": "element",
+          "hash": "058119799e4ef10eac64f18f79603517",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Most Popular"
+        },
+        "12/body/1/argument/13/expression/consequent": {
+          "type": "element",
+          "hash": "f6ec66a15a0a03cbb1dfe9822f9f80b4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Coming Soon"
+        },
+        "12/body/1/argument/5/3/expression/alternate/right": {
+          "type": "element",
+          "hash": "ed85f2a8ca60f479ded99b66261a808a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "/mo"
+        },
+        "12/body/1/argument/5/3/expression/consequent": {
+          "type": "element",
+          "hash": "e8d71d1cad8164af9b5b0f8bfceb695c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "/user /mo"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/1": {
+          "type": "element",
+          "hash": "8bd03ed27440eb1b9bd458d9f53fb12f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "We <element:span>Prove</element:span> Our Security"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/3": {
+          "type": "element",
+          "hash": "d33e8138684fb8aa55bb1495f36db785",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Unlike other services that merely claim to be secure, we provide cryptographic proof. Our commitment to transparency means you don't have to trust us - you can verify it yourself."
+        },
+        "14/declaration/body/3/argument/11/1/1/1/5": {
+          "type": "element",
+          "hash": "cac8ea5ae40e9daad5ab474a936ff231",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Live Secure Enclave Verification"
+        },
+        "14/declaration/body/3/argument/11/1/1/1/9": {
+          "type": "element",
+          "hash": "94143f2b142256bf6a2603cf94c9acfc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Learn more about our verification system <element:ArrowRight></element:ArrowRight>"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/3/1": {
+          "type": "element",
+          "hash": "6ca41cc4aacdfa241463fe4f5f83d958",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Secure Server"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/1/3/7/5": {
+          "type": "element",
+          "hash": "498be7db34d3644b9d665a4df261304e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Encrypted Connection"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/1/7/7/1/5": {
+          "type": "element",
+          "hash": "f6589cdb5c6f59ba06edcf5980e36468",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Encrypted Connection"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/5/1": {
+          "type": "element",
+          "hash": "40b475ba8e7b4f3b8cb6929617e954d6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "0x7B4..."
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/5/3": {
+          "type": "element",
+          "hash": "908901f4bc6cf504a237e9de70cf99b6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "ECDSA P-384"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/1/7/5/5": {
+          "type": "element",
+          "hash": "830a750cf52d1108d470e32e7187a86f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "SHA-384"
+        },
+        "14/declaration/body/3/argument/11/1/1/3/5": {
+          "type": "element",
+          "hash": "e24ac133bb6f207574c038f8e72220e7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Shield></element:Shield> Secure Enclave Verified"
+        },
+        "14/declaration/body/3/argument/19/1/1/1": {
+          "type": "element",
+          "hash": "cbdee2295a42b712352a162f9d23b9d2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "What Our <element:span>Users Say</element:span>"
+        },
+        "14/declaration/body/3/argument/19/1/1/3": {
+          "type": "element",
+          "hash": "888002d03da7727aa8b42b67017036a8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Hear from those who've made privacy a priority with Maple AI.<element:br></element:br> (Quotes are real, names are changed for privacy)"
+        },
+        "14/declaration/body/3/argument/23/1/1/1": {
+          "type": "element",
+          "hash": "cd68e507b8a594a215505890d6c138dd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Simple, <element:span>Transparent</element:span> Pricing"
+        },
+        "14/declaration/body/3/argument/23/1/1/3": {
+          "type": "element",
+          "hash": "69a895cda00e495b187af19ac5fe5a80",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "No hidden fees. Choose the plan that works for your needs."
+        },
+        "14/declaration/body/3/argument/27/1/1/1/1": {
+          "type": "element",
+          "hash": "b733d787de3768e898a8737bb51e1071",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Ready to Chat <element:span>Securely?</element:span>"
+        },
+        "14/declaration/body/3/argument/27/1/1/1/3": {
+          "type": "element",
+          "hash": "85a0d74d645110beaf69051ab9c6f371",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Join privacy-conscious users who've made the switch to truly secure AI chat."
+        },
+        "14/declaration/body/3/argument/27/1/1/1/5/1": {
+          "type": "element",
+          "hash": "b711c2e2e8b0d4d515018607d8cbe033",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:MessageSquareMore></element:MessageSquareMore> Start Chatting Securely"
+        },
+        "14/declaration/body/3/argument/27/1/1/1/5/3": {
+          "type": "element",
+          "hash": "0029e5a35676c0051e761fcd046ef9ee",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In"
+        },
+        "14/declaration/body/3/argument/3/1/1/1/1/1": {
+          "type": "element",
+          "hash": "0fd89b999b090fb17fc5d64d4b361a9c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Private AI Chat"
+        },
+        "14/declaration/body/3/argument/3/1/1/1/1/6": {
+          "type": "element",
+          "hash": "49134c881a5902c45476fafa2287dc8c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "that's truly secure"
+        },
+        "14/declaration/body/3/argument/3/1/1/1/3": {
+          "type": "element",
+          "hash": "ccff3b59fd2645cb388145c88313352a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "End-to-end encryption means your conversations are confidential and protected at every step. Only you can access your data — not even we can read your chats."
+        },
+        "14/declaration/body/3/argument/3/1/1/3/1": {
+          "type": "element",
+          "hash": "d2611b1015de5a7aee791d6e479b5161",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Sparkles></element:Sparkles> Start Secure Chat"
+        },
+        "14/declaration/body/3/argument/3/1/1/3/3": {
+          "type": "element",
+          "hash": "0029e5a35676c0051e761fcd046ef9ee",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/1/1-alt": {
+          "type": "attribute",
+          "hash": "f59c849b0b69ee500101491d571959a3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "User avatar"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/1/3-alt": {
+          "type": "attribute",
+          "hash": "f59c849b0b69ee500101491d571959a3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "User avatar"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/1/5-alt": {
+          "type": "attribute",
+          "hash": "f59c849b0b69ee500101491d571959a3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "User avatar"
+        },
+        "14/declaration/body/3/argument/3/1/1/5/1/3": {
+          "type": "element",
+          "hash": "b60a993295b36690cb4917563ba92bba",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Trusted by professionals who handle sensitive client information"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/1/3": {
+          "type": "element",
+          "hash": "a858b6d5a63448ea48c527e612fd22fc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Encrypted Chat"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/1/1": {
+          "type": "element",
+          "hash": "18e72ed3f198250caaf6c7fbf52b7d48",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "AI"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/1/3": {
+          "type": "element",
+          "hash": "b6c56029811f28a46ba0dcb9c337804e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How can I help you today? Your conversation is fully encrypted."
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/3/1": {
+          "type": "element",
+          "hash": "361dfcd0482fd50063cdb2a186d7a7b4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "I need to discuss some sensitive information. Is this really secure?"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/3/3": {
+          "type": "element",
+          "hash": "390c9785562c73825f5108c07c4f5e8e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "U"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/5/1": {
+          "type": "element",
+          "hash": "18e72ed3f198250caaf6c7fbf52b7d48",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "AI"
+        },
+        "14/declaration/body/3/argument/3/1/3/1/3/5/3": {
+          "type": "element",
+          "hash": "e36e8b543a5d58988b61ace0f169092a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Yes, absolutely. Your messages are end-to-end encrypted. Even the server admins can't read your conversations. We use secure enclaves and open-source code to verify this."
+        },
+        "14/declaration/body/3/argument/3/1/3/3": {
+          "type": "element",
+          "hash": "276c817e4b79fa65d11cf52f91789286",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Lock></element:Lock> End-to-End Encrypted"
+        },
+        "14/declaration/body/3/argument/3/3/1/3": {
+          "type": "element",
+          "hash": "0a43dae170adffd6e82fc484440a2af7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Desktop"
+        },
+        "14/declaration/body/3/argument/3/3/3/1-alt": {
+          "type": "attribute",
+          "hash": "aa7eb35109f6069021d46c7b6b793fdf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download on the App Store"
+        },
+        "14/declaration/body/3/argument/7/1/1/1": {
+          "type": "element",
+          "hash": "950602d813af95fafda77147353c356d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Privacy at <element:span>Every Layer</element:span>"
+        },
+        "14/declaration/body/3/argument/7/1/1/3": {
+          "type": "element",
+          "hash": "6df81a7b90812ad496558f372810d9ef",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your security is our primary concern. We've engineered Maple to ensure your data remains yours alone, protected by cutting-edge encryption."
+        },
+        "14/declaration/body/3/argument/7/1/3/1-description": {
+          "type": "attribute",
+          "hash": "5cc8acb1b78cf7470cb3c3f051fea534",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "All communications are encrypted locally on your device before being transmitted, ensuring your data is secured from the start."
+        },
+        "14/declaration/body/3/argument/7/1/3/1-title": {
+          "type": "attribute",
+          "hash": "7b28181f4c28b245635dfa4339181440",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your Device"
+        },
+        "14/declaration/body/3/argument/7/1/3/3-description": {
+          "type": "attribute",
+          "hash": "75e57ba7948939d97bf2f00c6c06d84a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Our servers can't read your data. We use secure enclaves in confidential computing environments to verify our infrastructure integrity."
+        },
+        "14/declaration/body/3/argument/7/1/3/3-title": {
+          "type": "attribute",
+          "hash": "d6943523162f401109159d9c42148f5d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Secure Server"
+        },
+        "14/declaration/body/3/argument/7/1/3/5-description": {
+          "type": "attribute",
+          "hash": "03d97086e0b5cfc8b0e1048f05a0ec57",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Even during AI processing, your data remains encrypted. The entire pipeline through to the GPU is designed with privacy as the priority."
+        },
+        "14/declaration/body/3/argument/7/1/3/5-title": {
+          "type": "attribute",
+          "hash": "c16b63ed0fd0b69a3f642fa467572ceb",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "AI Processing"
+        }
+      }
+    },
+    "components/ModelSelector.tsx": {
+      "scopes": {
+        "15/declaration/body/17/0/init/body/2/alternate/2/expression/0": {
+          "type": "element",
+          "hash": "f6ec66a15a0a03cbb1dfe9822f9f80b4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Coming Soon"
+        },
+        "15/declaration/body/19/argument/1/3/1/expression/alternate/3/3": {
+          "type": "element",
+          "hash": "f541015a827e37cb3b1234e56bc2aa3c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Back"
+        },
+        "15/declaration/body/19/argument/1/3/1/expression/consequent/9/3/1": {
+          "type": "element",
+          "hash": "16e9b03eda6f6c1324cce54b96bbccd6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Advanced"
+        },
+        "15/declaration/body/19/argument/1/3/1/expression/consequent/9/3/3": {
+          "type": "element",
+          "hash": "e521e05d8850aec6cc82ac111210fdb4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "All models"
+        }
+      }
+    },
+    "components/NotFoundFallback.tsx": {
+      "scopes": {
+        "2/declaration/body/1/argument/1/1/1": {
+          "type": "element",
+          "hash": "b7218679a87e1426b5daa91922d59d31",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "404"
+        },
+        "2/declaration/body/1/argument/1/3/1": {
+          "type": "element",
+          "hash": "d635cc289be6d47da702ca8fac007e6f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Route not found."
+        },
+        "2/declaration/body/1/argument/1/5/1/1": {
+          "type": "element",
+          "hash": "3236b297d477ec810e1ebb9603328949",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Go home"
+        }
+      }
+    },
+    "components/PasswordResetConfirmForm.tsx": {
+      "scopes": {
+        "10/declaration/body/11/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "82f2c74808b046d94d7ea5b700362cac",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Password Reset Successful"
+        },
+        "10/declaration/body/11/consequent/0/argument/1/3": {
+          "type": "element",
+          "hash": "347247837ae94a9b9a1aafadcdadb780",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You can now log in with your new password."
+        },
+        "10/declaration/body/11/consequent/0/argument/3/1/expression/alternate": {
+          "type": "element",
+          "hash": "a9fb89ed2101fe8d998fa7f2fd02af98",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You will be redirected to the login page in a few seconds."
+        },
+        "10/declaration/body/11/consequent/0/argument/3/1/expression/consequent/3": {
+          "type": "element",
+          "hash": "f22b35c946fe8671defd7e647d15e43c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Redirecting to login page..."
+        },
+        "10/declaration/body/12/argument/1/1": {
+          "type": "element",
+          "hash": "e01d21b5ec434f705960fea531175644",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Confirm Password Reset"
+        },
+        "10/declaration/body/12/argument/1/3": {
+          "type": "element",
+          "hash": "0fb8c4762a50206435d6853bb2644e80",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter the reset code and your new password."
+        },
+        "10/declaration/body/12/argument/3/1/1/1/1": {
+          "type": "element",
+          "hash": "ef6e2491a89b9b212bfa1906d2536371",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Reset Code"
+        },
+        "10/declaration/body/12/argument/3/1/1/1/3-title": {
+          "type": "attribute",
+          "hash": "a71611c0c7a9756b915ec7bee3a9e0ee",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "8-character alphanumeric code"
+        },
+        "10/declaration/body/12/argument/3/1/1/3/1": {
+          "type": "element",
+          "hash": "80d809edd5d1b66123b18faaac10537b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "New Password"
+        },
+        "10/declaration/body/12/argument/3/1/1/5/1": {
+          "type": "element",
+          "hash": "d3194bdcb74c9a912c67d7e1b030b88a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Confirm New Password"
+        },
+        "10/declaration/body/12/argument/3/1/1/7/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        }
+      }
+    },
+    "components/PasswordResetRequestForm.tsx": {
+      "scopes": {
+        "8/declaration/body/8/argument/1/1": {
+          "type": "element",
+          "hash": "52ec990b25991808a4f49db84986eefc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Reset Password"
+        },
+        "8/declaration/body/8/argument/1/3": {
+          "type": "element",
+          "hash": "29635d6aea111b1904b187cdcd8c198f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter your email address to request a password reset."
+        },
+        "8/declaration/body/8/argument/3/1/1/1/1": {
+          "type": "element",
+          "hash": "e7f34943a0c2fb849db1839ff6ef5cb5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email"
+        },
+        "8/declaration/body/8/argument/3/1/1/3/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        }
+      }
+    },
+    "components/PreferencesDialog.tsx": {
+      "scopes": {
+        "8/declaration/body/10/argument/1/1/1": {
+          "type": "element",
+          "hash": "c79439f008cdfeba5e04c2aae2985ff5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "User Preferences"
+        },
+        "8/declaration/body/10/argument/1/1/3": {
+          "type": "element",
+          "hash": "307cf549b42cc59c30bc2d800bc502f7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Customize your default system prompt for AI conversations."
+        },
+        "8/declaration/body/10/argument/1/3/3/expression/right/1": {
+          "type": "element",
+          "hash": "10b9639fd181767f5f4cc358f4de1e84",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Preferences saved successfully."
+        },
+        "8/declaration/body/10/argument/1/3/5/1": {
+          "type": "element",
+          "hash": "3980ee4b3313840de80cdbeeb510a573",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "System Prompt"
+        },
+        "8/declaration/body/10/argument/1/3/5/3-placeholder": {
+          "type": "attribute",
+          "hash": "062025304977bae52d0d54fd0169400f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter your custom system prompt here..."
+        },
+        "8/declaration/body/10/argument/1/3/5/5": {
+          "type": "element",
+          "hash": "8c9ca93efd5f7ff0bcbbc60d954b7d79",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This prompt will be used as the default instruction for your AI conversations."
+        }
+      }
+    },
+    "components/RecordingOverlay.tsx": {
+      "scopes": {
+        "5/declaration/body/8/argument/3/3/1-aria-label": {
+          "type": "attribute",
+          "hash": "0d537afc558e02c6e6bb3b0bc9c69762",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel recording"
+        },
+        "5/declaration/body/8/argument/3/3/3-aria-label": {
+          "type": "attribute",
+          "hash": "e7f5837f04e4a5c74c2ede29e7141546",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Send recording"
+        },
+        "5/declaration/body/8/argument/3/3/3/1/expression/alternate/alternate": {
+          "type": "element",
+          "hash": "34cdf390ae616d6f28789d6336ed3627",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:CornerRightUp></element:CornerRightUp> Send"
+        },
+        "5/declaration/body/8/argument/3/5/11/expression/right/1/expression/alternate": {
+          "type": "element",
+          "hash": "f3ae80da32830222cb596ab56a5049ba",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:div></element:div> Recording"
+        },
+        "5/declaration/body/8/argument/3/5/11/expression/right/1/expression/consequent": {
+          "type": "element",
+          "hash": "f16934ef4750ea88a7e6eb8fd365d46a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Processing..."
+        }
+      }
+    },
+    "components/RenameChatDialog.tsx": {
+      "scopes": {
+        "7/declaration/body/6/argument/1/1/1": {
+          "type": "element",
+          "hash": "bb846c81ebb761285702bf2eb9315d9e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Rename Chat"
+        },
+        "7/declaration/body/6/argument/1/1/3": {
+          "type": "element",
+          "hash": "a5e18b57251f5f58b378349fd9084c89",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter a new name for this chat conversation."
+        },
+        "7/declaration/body/6/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "f1adc643cdbddc678471eeffcb417c20",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Chat Title"
+        },
+        "7/declaration/body/6/argument/1/3/5/1": {
+          "type": "element",
+          "hash": "07296eb8d91ad98e1b60cd7ab0def914",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        }
+      }
+    },
+    "components/Sidebar.tsx": {
+      "scopes": {
+        "9/declaration/body/15/argument/1/3/1/3/3": {
+          "type": "element",
+          "hash": "3d7b701878aca8e2dbb7c6732f7f3bee",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "New Chat"
+        },
+        "9/declaration/body/15/argument/1/5/1": {
+          "type": "element",
+          "hash": "b0578d6d225f512e42f823fbca2e3c32",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "History"
+        },
+        "9/declaration/body/15/argument/1/7/expression/right/1-aria-label": {
+          "type": "attribute",
+          "hash": "cf48ea476325fcd15eb8ae6956a2a161",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Search chat titles"
+        },
+        "9/declaration/body/15/argument/1/7/expression/right/1-placeholder": {
+          "type": "attribute",
+          "hash": "c3604cf8b46d55603fe18f6f0c56b245",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Search chat titles..."
+        },
+        "9/declaration/body/15/argument/1/7/expression/right/3/expression/right-aria-label": {
+          "type": "attribute",
+          "hash": "0ee4a80abe134b7edd90c74f03638877",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Clear search"
+        }
+      }
+    },
+    "components/TeamSeatDialog.tsx": {
+      "scopes": {
+        "8/declaration/body/5/argument/1/1/1": {
+          "type": "element",
+          "hash": "da3fe1295c0a26ae3b9c737e4bdbe88d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Select Team Seats"
+        },
+        "8/declaration/body/5/argument/1/1/3": {
+          "type": "element",
+          "hash": "44f6e205ab0bea3ffdc2fa731bb15031",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How many seats would you like to purchase? You can change this at any time."
+        },
+        "8/declaration/body/5/argument/1/3/1/1/1": {
+          "type": "element",
+          "hash": "6f7555af8847258d6a56e563487e18ca",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Number of Seats"
+        },
+        "8/declaration/body/5/argument/1/3/1/1/5": {
+          "type": "element",
+          "hash": "951876786ca2a50e913363f021718aec",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Minimum 2 seats, maximum 100 seats"
+        },
+        "8/declaration/body/5/argument/1/3/1/3/3": {
+          "type": "element",
+          "hash": "a18e5de0f9831ee2039e8768b664aefe",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Each seat is billed per user per month. You can adjust the number of seats anytime in your billing settings."
+        },
+        "8/declaration/body/5/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "07296eb8d91ad98e1b60cd7ab0def914",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "8/declaration/body/5/argument/1/3/3/3": {
+          "type": "element",
+          "hash": "812e650be774be4279912fa52e376574",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Continue to Checkout"
+        }
+      }
+    },
+    "components/TopNav.tsx": {
+      "scopes": {
+        "6/declaration/body/5/argument/1/1/1/1/1/1-alt": {},
+        "6/declaration/body/5/argument/1/1/1/1/1/3-alt": {
+          "type": "attribute",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/1": {
+          "type": "element",
+          "hash": "ce27f1aeacccc542a174c4b2bce022b0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pricing"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/3": {
+          "type": "element",
+          "hash": "b5e978c348a23f69c4d203e00d34c127",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Proof"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/5": {
+          "type": "element",
+          "hash": "b63448c05270497973ac4407047dae02",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Teams"
+        },
+        "6/declaration/body/5/argument/1/1/1/5/1/7": {
+          "type": "element",
+          "hash": "8fd61954275895ccb460f566e481aade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Guides"
+        },
+        "6/declaration/body/5/argument/1/1/1/7/3/expression/alternate": {
+          "type": "element",
+          "hash": "0f30c64101c63fde988467e4c0150879",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In"
+        },
+        "6/declaration/body/5/argument/1/1/1/7/3/expression/consequent": {
+          "type": "element",
+          "hash": "387d7e99f5c2d20bd17b5d80e199df51",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Chat"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/1": {
+          "type": "element",
+          "hash": "7bffd0574da45aadff376937c9b445b5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pricing"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/3": {
+          "type": "element",
+          "hash": "32a7fe96bf21354cf52291beea73f14d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Proof"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/5": {
+          "type": "element",
+          "hash": "4f2f1815ec7aeb09fd90299038888f8a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Teams"
+        },
+        "6/declaration/body/5/argument/1/5/expression/right/1/7": {
+          "type": "element",
+          "hash": "7b4680f0ea350e4797d66a8c555780d4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Guides"
+        },
+        "7/declaration/body/5/argument/1/1/1/1/1/1-alt": {},
+        "7/declaration/body/5/argument/1/1/1/1/1/3-alt": {
+          "type": "attribute",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "7/declaration/body/5/argument/1/1/1/5/1/1": {
+          "type": "element",
+          "hash": "ce27f1aeacccc542a174c4b2bce022b0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pricing"
+        },
+        "7/declaration/body/5/argument/1/1/1/5/1/3": {
+          "type": "element",
+          "hash": "b5e978c348a23f69c4d203e00d34c127",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Proof"
+        },
+        "7/declaration/body/5/argument/1/1/1/5/1/5": {
+          "type": "element",
+          "hash": "b63448c05270497973ac4407047dae02",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Teams"
+        },
+        "7/declaration/body/5/argument/1/1/1/5/1/7": {
+          "type": "element",
+          "hash": "8fd61954275895ccb460f566e481aade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Guides"
+        },
+        "7/declaration/body/5/argument/1/1/1/7/3/expression/alternate": {
+          "type": "element",
+          "hash": "0f30c64101c63fde988467e4c0150879",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In"
+        },
+        "7/declaration/body/5/argument/1/1/1/7/3/expression/consequent": {
+          "type": "element",
+          "hash": "387d7e99f5c2d20bd17b5d80e199df51",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Chat"
+        },
+        "7/declaration/body/5/argument/1/1/1/7/7/expression/alternate": {
+          "type": "element",
+          "hash": "0f30c64101c63fde988467e4c0150879",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In"
+        },
+        "7/declaration/body/5/argument/1/1/1/7/7/expression/consequent": {
+          "type": "element",
+          "hash": "387d7e99f5c2d20bd17b5d80e199df51",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Chat"
+        },
+        "7/declaration/body/5/argument/1/5/expression/right/1/1": {
+          "type": "element",
+          "hash": "7bffd0574da45aadff376937c9b445b5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pricing"
+        },
+        "7/declaration/body/5/argument/1/5/expression/right/1/3": {
+          "type": "element",
+          "hash": "32a7fe96bf21354cf52291beea73f14d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Proof"
+        },
+        "7/declaration/body/5/argument/1/5/expression/right/1/5": {
+          "type": "element",
+          "hash": "4f2f1815ec7aeb09fd90299038888f8a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Teams"
+        },
+        "7/declaration/body/5/argument/1/5/expression/right/1/7": {
+          "type": "element",
+          "hash": "7b4680f0ea350e4797d66a8c555780d4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Guides"
+        }
+      }
+    },
+    "components/UnifiedChat.tsx": {
+      "scopes": {
+        "35/body/3/consequent/4/argument/1/3": {
+          "type": "element",
+          "hash": "d8626fd27af08620fba41e528e93b13f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Tool Result"
+        },
+        "36/0/init/0/body/1/argument/5/expression/0/body/4/consequent/3/argument/1/3/1/9/expression/right/3": {
+          "type": "element",
+          "hash": "20a72b66179eec4f226e20f1e131cc15",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Chat Canceled"
+        },
+        "36/0/init/0/body/1/argument/9/expression/right/1/3/1": {
+          "type": "element",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "38/declaration/body/91/argument/7/11/expression/right/1/5-aria-label": {
+          "type": "attribute",
+          "hash": "3137bd8485c6f0fee4b0bbcce4eecdad",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "New chat"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/1/1/11/1-placeholder": {
+          "type": "attribute",
+          "hash": "d1b963159f49a60a54d13ca56a47ea6b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Message Maple..."
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/1/1/11/5/1/9/3/1/3": {
+          "type": "element",
+          "hash": "9f2b8d6e3a50342a3f569f4704ad4f83",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Add Images"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/1/1/11/5/1/9/3/3/3": {
+          "type": "element",
+          "hash": "5463aa69d668b45549bc7943b1bc9cc6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Add Document"
+        },
+        "38/declaration/body/91/argument/7/19/expression/alternate/1/3": {
+          "type": "element",
+          "hash": "3f9bcc7f3dbc4af3aaf3ae196abb77d2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "AI can make mistakes. Check important info."
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/3/3/1-alt": {
+          "type": "attribute",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/3/3/3-alt": {
+          "type": "attribute",
+          "hash": "d5b65a7ddef623ff7b488cbf15a4b4c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/3/7": {
+          "type": "element",
+          "hash": "80ad8600613bf3c538923374f6b21091",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Private AI Chat"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/1": {
+          "type": "element",
+          "hash": "4baa45b6e6d953ea40b802910f235026",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How can I help you today?"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/5/1/11/1-placeholder": {
+          "type": "attribute",
+          "hash": "d1b963159f49a60a54d13ca56a47ea6b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Message Maple..."
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/5/1/11/5/1/9/3/1/3": {
+          "type": "element",
+          "hash": "9f2b8d6e3a50342a3f569f4704ad4f83",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Add Images"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/5/1/11/5/1/9/3/3/3": {
+          "type": "element",
+          "hash": "5463aa69d668b45549bc7943b1bc9cc6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Add Document"
+        },
+        "38/declaration/body/91/argument/7/19/expression/consequent/1/7/9": {
+          "type": "element",
+          "hash": "f7ebad57a99c0dad1e797bcab3c291b4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Encrypted at every step"
+        }
+      }
+    },
+    "components/UpgradePromptDialog.tsx": {
+      "scopes": {
+        "6/declaration/body/11/argument/1/5/3/expression/alternate": {
+          "type": "element",
+          "hash": "71f6a4cd0395ee97f578382f13e410f7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maybe Later"
+        },
+        "6/declaration/body/11/argument/1/5/3/expression/consequent": {
+          "type": "element",
+          "hash": "15cf7d809d21324fdebb32ac25ef9d3a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Start New Chat"
+        }
+      }
+    },
+    "components/VerificationModal.tsx": {
+      "scopes": {
+        "8/declaration/body/12/argument/1/1/1": {
+          "type": "element",
+          "hash": "1682e88a6eb7c961ae918fefc7325e2f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verify Your Email"
+        },
+        "8/declaration/body/12/argument/1/1/3": {
+          "type": "element",
+          "hash": "3625c767230ae20dfb0743b6b9429617",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Please check your email (<expression/>) to verify your account. You'll need to verify your email to continue using Maple AI."
+        },
+        "8/declaration/body/12/argument/1/3/1/1": {
+          "type": "element",
+          "hash": "4cebef0f16689fbb49d5f1eee10618d2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verification Code"
+        },
+        "8/declaration/body/12/argument/1/3/1/3/1-placeholder": {
+          "type": "attribute",
+          "hash": "4a787736e92ea6fcffc8c294c5382d35",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter verification code"
+        },
+        "8/declaration/body/12/argument/1/3/1/3/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "29e1824a993ee98fcbe31246e694b8e8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Verifying..."
+        },
+        "8/declaration/body/12/argument/1/3/1/5/expression/right-title": {
+          "type": "attribute",
+          "hash": "7157733f774f9bc07f1202eb2b0156d8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verification Failed"
+        },
+        "8/declaration/body/12/argument/1/3/3/1/expression/alternate/1/expression/consequent": {
+          "type": "element",
+          "hash": "54fbbcae8a2b258c9ad68aa8e88c2d98",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Sending..."
+        },
+        "8/declaration/body/12/argument/1/3/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "53d2274d9952831dfce3f8c486a7e7ab",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:CheckCircle></element:CheckCircle> Verification email sent! Please check your inbox."
+        },
+        "8/declaration/body/12/argument/1/3/3/3": {
+          "type": "element",
+          "hash": "70c2a4ef60d2e77e06c421cbdc48fc2e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:LogOut></element:LogOut> Log Out"
+        }
+      }
+    },
+    "components/VerificationStatus.tsx": {
+      "scopes": {
+        "4/declaration/body/3/argument/1/expression/right/3": {
+          "type": "element",
+          "hash": "421ed451e3e4b14dc2dcf25956fca011",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verifying..."
+        },
+        "4/declaration/body/3/argument/3/expression/right/3": {
+          "type": "element",
+          "hash": "9566bd61c1f754dd5082eea5101f15a8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verified"
+        },
+        "4/declaration/body/3/argument/5/expression/right/3": {
+          "type": "element",
+          "hash": "e8cc2a0c12f97985b404320423cd927b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verification failed"
+        }
+      }
+    },
+    "components/apikeys/ApiCreditsSection.tsx": {
+      "scopes": {
+        "14/declaration/body/16/consequent/0/argument/1": {
+          "type": "element",
+          "hash": "8f7737b74c5f8dbd535011192f8c4feb",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Failed to load credit balance"
+        },
+        "14/declaration/body/17/argument/11/1/1/1": {
+          "type": "element",
+          "hash": "d62938e4e89008963a3536b9a37609ce",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Credit Balance"
+        },
+        "14/declaration/body/17/argument/11/1/1/5": {
+          "type": "element",
+          "hash": "90611563496f13d602bca63f5270dd1a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "$1 per 1,000 credits • Use for API requests"
+        },
+        "14/declaration/body/17/argument/15/1": {
+          "type": "element",
+          "hash": "b1e12db2744789a7ef83c7ef4e148d7d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Purchase Credits"
+        },
+        "14/declaration/body/17/argument/15/13/1": {
+          "type": "element",
+          "hash": "3a5f4da319a3cde3bfc3b674345b5c11",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<expression/> Pay with Card"
+        },
+        "14/declaration/body/17/argument/15/13/3": {
+          "type": "element",
+          "hash": "ce41dbff4e60c7d138cdf0a0c803247c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<expression/> Pay with Bitcoin"
+        },
+        "14/declaration/body/17/argument/15/15": {
+          "type": "element",
+          "hash": "aed82ddf982a63072c0c990f0830e8c5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Minimum purchase: <function:MIN_PURCHASE_CREDITS.toLocaleString/> credits (${MIN_PURCHASE_AMOUNT})"
+        },
+        "14/declaration/body/17/argument/15/5/1/expression/0/body/3": {
+          "type": "element",
+          "hash": "ce3025799d70859c869af0b2fea2ad8a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "${pkg.price}"
+        },
+        "14/declaration/body/17/argument/15/9/1/1/1": {
+          "type": "element",
+          "hash": "1e687d79d9cf32433a264d8237c4dbc5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Custom Amount"
+        },
+        "14/declaration/body/17/argument/15/9/1/1/3": {
+          "type": "element",
+          "hash": "90485af5b6db9ac425c475d6a0378795",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "$10 - $1,000"
+        },
+        "14/declaration/body/17/argument/15/9/3/expression/right/1-placeholder": {
+          "type": "attribute",
+          "hash": "d8f463730f6320d9eb03df8f2d250d06",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter amount ($10-$1000)"
+        },
+        "14/declaration/body/17/argument/3/expression/right/3": {
+          "type": "element",
+          "hash": "41c33f9916e21be33cee7b689bcc57c0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Payment successful! Your credits have been added to your account."
+        }
+      }
+    },
+    "components/apikeys/ApiKeyDashboard.tsx": {
+      "scopes": {
+        "17/declaration/body/15/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "b3d76fe5a47de22d9a422c902b3ae82d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Management"
+        },
+        "17/declaration/body/15/consequent/0/argument/1/3": {
+          "type": "element",
+          "hash": "82b4ea7ed1439094d7c4be13aaba9a66",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Loading..."
+        },
+        "17/declaration/body/16/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "b3d76fe5a47de22d9a422c902b3ae82d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Management"
+        },
+        "17/declaration/body/16/consequent/0/argument/1/3": {
+          "type": "element",
+          "hash": "8322eea00959820ef842faeefe7b8f4c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Failed to load API keys. Please try again."
+        },
+        "17/declaration/body/17/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "0274bf067d1e310de1545372646d82df",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Sparkles></element:Sparkles> Unlock API Access"
+        },
+        "17/declaration/body/17/consequent/0/argument/1/3": {
+          "type": "element",
+          "hash": "698e00ba75464005be84670b54998c44",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Upgrade to a paid plan to access powerful API features"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/1/3/1": {
+          "type": "element",
+          "hash": "1df98067396fd9e97cb41e70f1a31c61",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Programmatic Access"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/1/3/3": {
+          "type": "element",
+          "hash": "d1101c6783a160e6c8b7f2f95903e12e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Integrate Maple directly into your applications and workflows"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/3/3/1": {
+          "type": "element",
+          "hash": "dbda0a8b4ff81e045e096a86e6351156",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Secure API Keys"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/3/3/3": {
+          "type": "element",
+          "hash": "30b1956cae67146fa288f3850bc15a3f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Create and manage multiple API keys with granular control"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/5/3/1": {
+          "type": "element",
+          "hash": "e1f3fc567c914b7e8bf6819538eb18c8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pay-As-You-Go Credits"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/1/1/5/3/3": {
+          "type": "element",
+          "hash": "9ef5e9e01d766e99f0e29b8723c71ff9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Purchase credits for API usage at just $1 per 1,000 credits"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/3/1": {
+          "type": "element",
+          "hash": "1b713c5c3b91d5a63ee8681b02ea324b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Starting at just <element:span>$20/month</element:span> with the Pro plan"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/3/3": {
+          "type": "element",
+          "hash": "f78620789ac574033cc70301bd966211",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Sparkles></element:Sparkles> View Pricing Plans"
+        },
+        "17/declaration/body/17/consequent/0/argument/3/3/5": {
+          "type": "element",
+          "hash": "77d863f605e0b8ca081def71b01fdc33",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Unlock API access, increased limits, and premium features"
+        },
+        "17/declaration/body/18/argument/1/1": {
+          "type": "element",
+          "hash": "8c6d03728c3d9470616eb5cee5f9f65d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Access"
+        },
+        "17/declaration/body/18/argument/1/3": {
+          "type": "element",
+          "hash": "7d485d8d77ddd89a88186933317b4f0c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Manage API keys and configure access to Maple services. <element:a>Read more</element:a>"
+        },
+        "17/declaration/body/18/argument/3/1/1": {
+          "type": "element",
+          "hash": "a6b8c01787a844905f87b723efa0f352",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:CreditCard></element:CreditCard> Credits"
+        },
+        "17/declaration/body/18/argument/3/1/3": {
+          "type": "element",
+          "hash": "22d9e6c4357e815f7c5f9ffbc471d960",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Key></element:Key> API Keys"
+        },
+        "17/declaration/body/18/argument/3/1/5/expression/right": {
+          "type": "element",
+          "hash": "52ae547330d1d64f8c6260b6b206dad6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Server></element:Server> Local Proxy"
+        },
+        "17/declaration/body/18/argument/3/5/1/1/1": {
+          "type": "element",
+          "hash": "f961b547cd312cc8b9b79f0c9e0b2cc3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Keys"
+        },
+        "17/declaration/body/18/argument/3/5/1/1/13/1": {
+          "type": "element",
+          "hash": "532fd72f4ed64b693d834f6d175f3a7c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API keys allow you to integrate Maple into your applications and workflows."
+        },
+        "17/declaration/body/18/argument/3/5/1/1/13/3": {
+          "type": "element",
+          "hash": "9915de285ab7eb3f3419cfcbb134b77b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Keep your API keys secure and never share them publicly. Treat them like passwords."
+        },
+        "17/declaration/body/18/argument/3/5/1/1/5": {
+          "type": "element",
+          "hash": "93282b8bbb4336a1b63b21a727b9bf2e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Plus></element:Plus> Create New API Key"
+        }
+      }
+    },
+    "components/apikeys/ApiKeysList.tsx": {
+      "scopes": {
+        "7/declaration/body/5/argument/1/1/1/expression/0/body/1/3": {
+          "type": "element",
+          "hash": "15ff43c6dbc1a99a067c0b1cb18bd932",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Calendar></element:Calendar> Created <function:formatDate/>"
+        },
+        "7/declaration/body/5/argument/5/1/1/1": {
+          "type": "element",
+          "hash": "ec13e8592107ad09f8c9bf0c1ac57628",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Delete API Key"
+        },
+        "7/declaration/body/5/argument/5/1/1/3": {
+          "type": "element",
+          "hash": "372f67f2e6e46e1cf67415e20682f09c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure you want to delete the API key \"{deleteKeyName}\"? This action cannot be undone and any applications using this key will stop working immediately."
+        },
+        "7/declaration/body/5/argument/5/1/3/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "7/declaration/body/5/argument/5/1/3/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "b24acf9993cbd2c3fede3b9b2757749b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Deleting..."
+        }
+      }
+    },
+    "components/apikeys/CreateApiKeyDialog.tsx": {
+      "scopes": {
+        "9/declaration/body/9/argument/1/1/1": {
+          "type": "element",
+          "hash": "dd7204449746f211b13a10cef9902021",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Create API Key"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/1/1/3": {
+          "type": "element",
+          "hash": "8face93349f3f03405daf6f86cbc5e82",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Make sure to copy your API key now. You won't be able to see it again!"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/1/3/1": {
+          "type": "element",
+          "hash": "7d4b6ffc6c77197385ddab84128c80ff",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your API Key"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/1/5/1": {
+          "type": "element",
+          "hash": "f464ef680f7541fae3abe08066f15b9a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Use this key to authenticate with the Maple API. <element:a>Read here</element:a>"
+        },
+        "9/declaration/body/9/argument/1/3/expression/alternate/3/1": {
+          "type": "element",
+          "hash": "dfdcfd01b8af0544912bccd21af26744",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Done"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/3/1/1": {
+          "type": "element",
+          "hash": "6601f961f0f2a40a93880a1c22259eb7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Key Name"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/3/1/3-placeholder": {
+          "type": "attribute",
+          "hash": "62fad45f1891a921bb1425997260ac29",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "e.g., Production App, Development"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/3/1/5": {
+          "type": "element",
+          "hash": "2a218fefd5437ebbfa65edb06b881982",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "/100 characters"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/5/1": {
+          "type": "element",
+          "hash": "5936f87dccc089542c7871a72ed1dacf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "9/declaration/body/9/argument/1/3/expression/consequent/5/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "64477295ccbee49bfde20cc48d97bd1f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Creating..."
+        }
+      }
+    },
+    "components/apikeys/ProxyConfigSection.tsx": {
+      "scopes": {
+        "10/declaration/body/14/argument/11/expression/right/1/1/1": {
+          "type": "element",
+          "hash": "69fee08b294c5d8bb988c55e41902bca",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Python Example:"
+        },
+        "10/declaration/body/14/argument/11/expression/right/3/1/1": {
+          "type": "element",
+          "hash": "6dc5e73a33fe46607cb313d870aa5b9c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "cURL Example:"
+        },
+        "10/declaration/body/14/argument/5/1": {
+          "type": "element",
+          "hash": "d9ee93931bc82d8dfd287f4cc658d748",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Server></element:Server> Local OpenAI Proxy"
+        },
+        "10/declaration/body/14/argument/7/11/expression/right/1": {
+          "type": "element",
+          "hash": "15fb7768aefd0ad72c62381c1b339a96",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Proxy URL"
+        },
+        "10/declaration/body/14/argument/7/11/expression/right/5": {
+          "type": "element",
+          "hash": "609e5108827a7ce2bffaef48e21002dd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Use this URL as your OpenAI base URL in any client"
+        },
+        "10/declaration/body/14/argument/7/15/1/expression/alternate": {
+          "type": "element",
+          "hash": "90cd77da69ec989176c0d0cc035ac3f9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<expression/> Stop Proxy"
+        },
+        "10/declaration/body/14/argument/7/15/1/expression/consequent": {
+          "type": "element",
+          "hash": "721beefcc63d28812dc288e3bc105413",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<expression/> Start Proxy"
+        },
+        "10/declaration/body/14/argument/7/19/1": {
+          "type": "element",
+          "hash": "2a8ce094e96da3b682ebdc40e1d70001",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enable CORS (for web clients)"
+        },
+        "10/declaration/body/14/argument/7/23/1/1": {
+          "type": "element",
+          "hash": "6f56604c2f4ab3576686e457fffef071",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Auto-start proxy when app launches"
+        },
+        "10/declaration/body/14/argument/7/23/1/3": {
+          "type": "element",
+          "hash": "f6f186c388c64a30b7bd6733ae6e15a4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Proxy will start automatically on app launch if configured"
+        },
+        "10/declaration/body/14/argument/7/3/1/1": {
+          "type": "element",
+          "hash": "b8e35955c05907867a731a19f6023d51",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Host"
+        },
+        "10/declaration/body/14/argument/7/3/1/3-placeholder": {
+          "type": "attribute",
+          "hash": "0a1db25f677dd312e232eff2549e3645",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "127.0.0.1"
+        },
+        "10/declaration/body/14/argument/7/3/3/1": {
+          "type": "element",
+          "hash": "29b1e7e48599145af6b06eebc1fb42d9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Port"
+        },
+        "10/declaration/body/14/argument/7/3/3/3/1-placeholder": {
+          "type": "attribute",
+          "hash": "c72f517d783f817b070589a8ccb21429",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "8080"
+        },
+        "10/declaration/body/14/argument/7/7/expression/right/1": {
+          "type": "element",
+          "hash": "3ca677efa954ec7a8640f1b3a297abd5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API Key Status"
+        },
+        "10/declaration/body/14/argument/7/7/expression/right/3": {
+          "type": "element",
+          "hash": "f19737501d9d6c458bfa64c01bb731b4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "API key configured"
+        }
+      }
+    },
+    "components/icons/LinkedIn.tsx": {
+      "scopes": {
+        "1/declaration/body/0/argument/1": {
+          "type": "element",
+          "hash": "f29b78f253094277c2e9ef79d10b5e4f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "LinkedIn"
+        }
+      }
+    },
+    "components/icons/X.tsx": {
+      "scopes": {
+        "1/declaration/body/0/argument/1": {
+          "type": "element",
+          "hash": "dc96f9cb0985d77c30f55927723f0175",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "X"
+        }
+      }
+    },
+    "components/markdown.tsx": {
+      "scopes": {
+        "16/body/6/argument/1/5/1/expression/consequent": {
+          "type": "element",
+          "hash": "798fa677e8609fdb7fe9bb4c9f92f0a9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Thinking for {durationText} seconds<element:span><element:span>.</element:span><element:span>.</element:span><element:span>.</element:span></element:span>"
+        },
+        "20/declaration/body/3/argument/1/1/1/expression/alternate/3": {
+          "type": "element",
+          "hash": "1722a0fe065d4c44df3d5e4a887dd1ae",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Copy Code"
+        },
+        "20/declaration/body/3/argument/1/1/1/expression/consequent/3": {
+          "type": "element",
+          "hash": "29208e06d704c4fc4b8b534dc7acc4ef",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Copied"
+        }
+      }
+    },
+    "components/team/TeamDashboard.tsx": {
+      "scopes": {
+        "12/declaration/body/14/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "02941905c52e6d720733451585944ea4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team Information"
+        },
+        "12/declaration/body/14/consequent/0/argument/3/3/1/1/3/expression/right": {
+          "type": "element",
+          "hash": "c843b25e81c85c4e51defa26dc1e790f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Member since <function:Date.toLocaleDateString/>"
+        },
+        "12/declaration/body/14/consequent/0/argument/3/3/1/3": {
+          "type": "element",
+          "hash": "65e65f05f4f820ff2628514b06072b88",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:User></element:User> Member"
+        },
+        "12/declaration/body/14/consequent/0/argument/3/7/1": {
+          "type": "element",
+          "hash": "cb76f477232b58641fe386756839a7ed",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Need to leave this team? You'll need an invitation to rejoin."
+        },
+        "12/declaration/body/15/argument/1/1": {
+          "type": "element",
+          "hash": "08561a2cc60760729b969123d1fa8f7e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team Dashboard"
+        },
+        "12/declaration/body/15/argument/3/11/expression/right": {
+          "type": "element",
+          "hash": "a06154b89dec35d511851352dc81713b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:UserPlus></element:UserPlus> Invite Members"
+        },
+        "12/declaration/body/15/argument/3/3/expression/right/3": {
+          "type": "element",
+          "hash": "364db56307cbda1fd54389e1e26eaf35",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Seat limit exceeded. Remove members or purchase additional seats."
+        },
+        "12/declaration/body/15/argument/3/7/1/1/1/expression/consequent/3/1": {
+          "type": "element",
+          "hash": "82567f89a5f47eb61c1e23b328177c33",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "/100 characters"
+        },
+        "12/declaration/body/15/argument/3/7/1/1/3/expression/right": {
+          "type": "element",
+          "hash": "f0afb30d4012e5f5472883fded055b35",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Created <function:Date.toLocaleDateString/>"
+        },
+        "12/declaration/body/15/argument/3/7/1/3/expression/right": {
+          "type": "element",
+          "hash": "37b4ce10351c75274ef4979a30619be4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Crown></element:Crown> Admin"
+        },
+        "12/declaration/body/15/argument/3/7/5/1/1": {
+          "type": "element",
+          "hash": "96f4f25d117c3c298a63ef05ce4d6ea7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Seat Usage"
+        },
+        "12/declaration/body/15/argument/3/7/5/1/3": {
+          "type": "element",
+          "hash": "ca14f0b8b7164d2cf3cf9d9ecd061de7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "{seatsUsed}/{seatsPurchased} (<function:Math.round/>%)"
+        },
+        "12/declaration/body/6/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "08561a2cc60760729b969123d1fa8f7e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team Dashboard"
+        },
+        "12/declaration/body/6/consequent/0/argument/1/3": {
+          "type": "element",
+          "hash": "a5171c2d12afb3e5c1c39663dcc63bf9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Loading team information..."
+        }
+      }
+    },
+    "components/team/TeamInviteDialog.tsx": {
+      "scopes": {
+        "13/declaration/body/12/argument/1/1/1": {
+          "type": "element",
+          "hash": "2485e3adb99027f9615976fd070f5649",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Invite Team Members"
+        },
+        "13/declaration/body/12/argument/1/1/3": {
+          "type": "element",
+          "hash": "f5e929e728458af70f8e8360ca2e9f3b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Send invitations to new team members. They'll receive an email to join your team."
+        },
+        "13/declaration/body/12/argument/1/3/1/1/1": {
+          "type": "element",
+          "hash": "934acb216360e4613727994fc77a78ac",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email Addresses"
+        },
+        "13/declaration/body/12/argument/1/3/1/1/5": {
+          "type": "element",
+          "hash": "0d59ab1a19d27ab7c18a534899228a9c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter one email per line or separate with commas"
+        },
+        "13/declaration/body/12/argument/1/3/1/3/expression/right/3": {
+          "type": "element",
+          "hash": "7ce71fabc5d578cc1ece560c7dabe52e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You have <element:strong>{seatsAvailable}</element:strong> <expression/> available for new members."
+        },
+        "13/declaration/body/12/argument/1/3/1/5/expression/right/1/3": {
+          "type": "element",
+          "hash": "93972c2cfa65cdc875436afad603e59b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "No seats available. Please purchase additional seats or remove existing members before inviting new ones."
+        },
+        "13/declaration/body/12/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "07296eb8d91ad98e1b60cd7ab0def914",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "13/declaration/body/12/argument/1/3/3/3/1/expression/alternate": {
+          "type": "element",
+          "hash": "24e414e6202f5b671de4eb7ab2a12a64",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:UserPlus></element:UserPlus> Send Invites"
+        },
+        "13/declaration/body/12/argument/1/3/3/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "6cb0b8e8fabc7bb23c8efe8f7ae88ed8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Sending Invites..."
+        }
+      }
+    },
+    "components/team/TeamMembersList.tsx": {
+      "scopes": {
+        "13/declaration/body/16/consequent/0/argument/1": {
+          "type": "element",
+          "hash": "43742ed2c0dd1e0e3038fd6843cfc240",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:LogOut></element:LogOut> Leave Team"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/1/1": {
+          "type": "element",
+          "hash": "0fdc334a0248b88ecb41d4719077a468",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Leave team?"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/1/3": {
+          "type": "element",
+          "hash": "18146b1ef72949f80fa1c261689b29c8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure you want to leave the team? You will lose access to all team resources and will need to be invited again to rejoin."
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/5/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "13/declaration/body/16/consequent/0/argument/5/1/5/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "c055fb3db095a8447539f61c77e3ee86",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Leaving..."
+        },
+        "13/declaration/body/18/argument/1/1/1": {
+          "type": "element",
+          "hash": "61333c4a765e10b2ad46774951725233",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team Members"
+        },
+        "13/declaration/body/18/argument/1/1/3": {
+          "type": "element",
+          "hash": "8263fa2d5fcde4cdc22ee6957252369d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "{members.length} active <expression/><expression/>"
+        },
+        "13/declaration/body/18/argument/1/11/expression/right": {
+          "type": "element",
+          "hash": "6e21156444f80ec54f10ebed545b59e2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "No team members yet. Start by inviting your team!"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/1/1/3/1/expression/right": {
+          "type": "element",
+          "hash": "adfc9a780b5f38c7ea2a461e392fd114",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Crown></element:Crown> Admin"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/1/1/3/3/expression/right": {
+          "type": "element",
+          "hash": "699def1aff09e50b0645fd3819977894",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/1/3": {
+          "type": "element",
+          "hash": "737d46f606174c8e494a8f1c25451a32",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Joined <function:Date.toLocaleDateString/>"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/3/expression/right/3/1": {
+          "type": "element",
+          "hash": "556c4e421b70b52fed9058be054a618d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:UserMinus></element:UserMinus> Remove from team"
+        },
+        "13/declaration/body/18/argument/1/5/1/expression/0/body/2/argument/5/expression/right": {
+          "type": "element",
+          "hash": "0f14f61d4be887244e98f14ea75d3605",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:LogOut></element:LogOut> Leave team"
+        },
+        "13/declaration/body/18/argument/1/9/expression/right/3/1": {
+          "type": "element",
+          "hash": "3f41764c00c258b3e45fa5de69bc72ad",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pending Invites"
+        },
+        "13/declaration/body/18/argument/13/1/1/1": {
+          "type": "element",
+          "hash": "0fdc334a0248b88ecb41d4719077a468",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Leave team?"
+        },
+        "13/declaration/body/18/argument/13/1/1/3": {
+          "type": "element",
+          "hash": "84563e2da39df867feeabc5c49318619",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure you want to leave the team? You will lose access to all team resources and will need to be invited again to rejoin."
+        },
+        "13/declaration/body/18/argument/13/1/5/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "13/declaration/body/18/argument/13/1/5/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "39f25a21a4b0362cb84db1fa279618d0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Leaving..."
+        },
+        "13/declaration/body/18/argument/5/1/1/1": {
+          "type": "element",
+          "hash": "d8bc4943cdf3f64faccc58bfb0a0152f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Remove team member?"
+        },
+        "13/declaration/body/18/argument/5/1/1/3": {
+          "type": "element",
+          "hash": "0dd5fe62c4ef55b2e4afa50fea036d4b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure you want to remove <expression/> from the team? They will lose access to all team resources immediately."
+        },
+        "13/declaration/body/18/argument/5/1/5/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "13/declaration/body/18/argument/5/1/5/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "c92c29b5384d872cf737a8cb44ff8642",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Removing..."
+        },
+        "13/declaration/body/18/argument/9/1/1/1": {
+          "type": "element",
+          "hash": "1ad8c66405cdda7976471af92ea6b5dd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Revoke invitation?"
+        },
+        "13/declaration/body/18/argument/9/1/1/3": {
+          "type": "element",
+          "hash": "4fd62b650a257da33c32686f6d98dc6a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Are you sure you want to revoke the invitation for <expression/>? They will no longer be able to join the team using this invitation."
+        },
+        "13/declaration/body/18/argument/9/1/5/1": {
+          "type": "element",
+          "hash": "2e2a849c2223911717de8caa2c71bade",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "13/declaration/body/18/argument/9/1/5/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "35cb1de4303728093747ac593ef13081",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Revoking..."
+        }
+      }
+    },
+    "components/team/TeamSetupDialog.tsx": {
+      "scopes": {
+        "11/declaration/body/7/argument/1/1/1": {
+          "type": "element",
+          "hash": "ffaab82758a0babebea452eff8868b43",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Set Up Your Team"
+        },
+        "11/declaration/body/7/argument/1/1/3": {
+          "type": "element",
+          "hash": "4e1fa4e1a3ba978789a16397024b1821",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You've purchased a team plan! Let's create your team to get started. You'll be able to invite members after setup."
+        },
+        "11/declaration/body/7/argument/1/3/1/1/1": {
+          "type": "element",
+          "hash": "d1a5f99dbf503ca53f06b3a98b511d02",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team Name"
+        },
+        "11/declaration/body/7/argument/1/3/1/1/3-placeholder": {
+          "type": "attribute",
+          "hash": "8eefccf07ab94f4e8faa6515932bc582",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "e.g., My Company Team"
+        },
+        "11/declaration/body/7/argument/1/3/1/1/5": {
+          "type": "element",
+          "hash": "d59424f541e1331a2f5f82caba47363b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This is how your team will be identified. You can change it later."
+        },
+        "11/declaration/body/7/argument/1/3/1/3/expression/right/3": {
+          "type": "element",
+          "hash": "33430cb1e8c763164b52c2b882580de8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your team plan includes <element:strong>{teamStatus.seats_purchased} seats</element:strong>.You'll be the team admin and can invite up to <expression/> additional members."
+        },
+        "11/declaration/body/7/argument/1/3/3/1": {
+          "type": "element",
+          "hash": "07296eb8d91ad98e1b60cd7ab0def914",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cancel"
+        },
+        "11/declaration/body/7/argument/1/3/3/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "7cb862aeb455529461e69b3d708d32ea",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Creating Team..."
+        }
+      }
+    },
+    "components/ui/dialog.tsx": {
+      "scopes": {
+        "10/0/init/0/body/3/3/3": {
+          "type": "element",
+          "hash": "2c2e22f8424a1031de89063bd0022e16",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Close"
+        }
+      }
+    },
+    "routes/_auth.chat.$chatId.tsx": {
+      "scopes": {
+        "13/body/1/argument/0/body/alternate-alt": {},
+        "16/body/2/argument/1/3/1/1": {
+          "type": "element",
+          "hash": "3980ee4b3313840de80cdbeeb510a573",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "System Prompt"
+        },
+        "16/body/2/argument/1/3/3/1/expression/alternate/3/expression/right/3": {
+          "type": "element",
+          "hash": "bc0fa9371ec59c3567503c5f0b833ad4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "see more"
+        },
+        "16/body/2/argument/1/3/3/1/expression/consequent/3/expression/right/3": {
+          "type": "element",
+          "hash": "12467720a8cf83354b678cedc8e2cef1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "show less"
+        },
+        "17/body/13/consequent/0/argument/3/1": {
+          "type": "element",
+          "hash": "0fa31f2b4c77c3fc5647e435c03192c0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Loading archived chat..."
+        },
+        "17/body/14/consequent/0/argument/3/1": {
+          "type": "element",
+          "hash": "6ce9c7bc91b62d499f8cf4c7b106fb75",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Archived chat not found"
+        },
+        "17/body/16/argument/3/3/1/1/expression/right-aria-label": {
+          "type": "attribute",
+          "hash": "3137bd8485c6f0fee4b0bbcce4eecdad",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "New chat"
+        },
+        "17/body/16/argument/3/3/5/expression/right-aria-label": {
+          "type": "attribute",
+          "hash": "9481586f42c7c8b1b91c220346e1e630",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Scroll to bottom"
+        },
+        "17/body/16/argument/3/7/1/3/1": {
+          "type": "element",
+          "hash": "2a32aeceb23b71b714e8f027bb65f804",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Archived Chat"
+        },
+        "17/body/16/argument/3/7/1/3/3": {
+          "type": "element",
+          "hash": "49bcc34635fa432f67b4fe41defce9c1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This is a read-only chat from your history. Start a new chat to continue the conversation."
+        },
+        "17/body/16/argument/3/7/1/5": {
+          "type": "element",
+          "hash": "24492f2089875d64592574b93dc9ac8b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "New Chat"
+        }
+      }
+    },
+    "routes/about.tsx": {
+      "scopes": {
+        "8/body/0/argument/3/1/openingElement/0/value/expression": {
+          "type": "element",
+          "hash": "b04c53944c40234296799789d8a8dc83",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:span>About</element:span> Maple AI"
+        },
+        "8/body/0/argument/3/1/openingElement/1/value/expression": {
+          "type": "element",
+          "hash": "279ba99cbdef4eabf7d95589b1de1c11",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Incredibly powerful AI that doesn't share your data with anyone"
+        },
+        "8/body/0/argument/3/3/11/1": {
+          "type": "element",
+          "hash": "e7a5d2ebfbcd6a46894316ce3b83632b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Built on OpenSecret"
+        },
+        "8/body/0/argument/3/3/11/3/1-alt": {
+          "type": "attribute",
+          "hash": "0199b7730c58b69986e670700252611b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "OpenSecret company logo"
+        },
+        "8/body/0/argument/3/3/11/3/3/1": {
+          "type": "element",
+          "hash": "2aef756e6248a98a3d051948e9ca0aed",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple AI is built on OpenSecret, pioneering the future of privacy-preserving apps. Whether artificial intelligence or traditional apps, user data is end-to-end encrypted."
+        },
+        "8/body/0/argument/3/3/11/3/3/3": {
+          "type": "element",
+          "hash": "75eba4b3b566429ef04617f18e0b093a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Learn more about OpenSecret →"
+        },
+        "8/body/0/argument/3/3/15/1": {
+          "type": "element",
+          "hash": "0cc6fdceed0e0671e851c2bb33bb8ee3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Developer Programs"
+        },
+        "8/body/0/argument/3/3/15/3/3/1-alt": {
+          "type": "attribute",
+          "hash": "5d4d5cb4e748f6def6a562f8659f0ba4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "NVIDIA Inception Program logo"
+        },
+        "8/body/0/argument/3/3/15/3/3/3": {
+          "type": "element",
+          "hash": "7a48aa62786d2c964bc13d9e8fd00184",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Inception Program"
+        },
+        "8/body/0/argument/3/3/15/3/7/1-alt": {
+          "type": "attribute",
+          "hash": "d1c8d9fc2f0b8f1f072ec05a837d7adf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Google Cloud for Startups program logo"
+        },
+        "8/body/0/argument/3/3/15/3/7/3": {
+          "type": "element",
+          "hash": "245f6fe3b3214a477c90ef37d8500406",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Google Cloud for Startups"
+        },
+        "8/body/0/argument/3/3/19/1": {
+          "type": "element",
+          "hash": "ca6faed46366280fe316192bf08781e9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Built in Austin. Living in Secure Enclaves."
+        },
+        "8/body/0/argument/3/3/3/1": {
+          "type": "element",
+          "hash": "0a9ea2ca707dbbc5f80102d81409a18e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Our Inspiration"
+        },
+        "8/body/0/argument/3/3/3/3/1/1-alt": {
+          "type": "attribute",
+          "hash": "6a66eb1a8a7a4f742e0c6e8e0a94553f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple autumn forest"
+        },
+        "8/body/0/argument/3/3/3/3/1/3": {
+          "type": "element",
+          "hash": "7dcabf6e8fa72fe68d79bc2eb5bcfb96",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Autumn Woods <element:br></element:br> by William Trost Richards"
+        },
+        "8/body/0/argument/3/3/3/3/1/5-alt": {
+          "type": "attribute",
+          "hash": "ca8a9521de245a95234bd98ba2d256f2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple App Icon"
+        },
+        "8/body/0/argument/3/3/3/3/3/1": {
+          "type": "element",
+          "hash": "67606dd7ea05fd16bb9dcc9b98c8073b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple trees form underground networks of root systems, communicating and sharing resources without the knowledge of animals above. This cooperative approach helps them thrive in challenging environments."
+        },
+        "8/body/0/argument/3/3/3/3/3/3": {
+          "type": "element",
+          "hash": "b35cefde8b5bcbfb7ad69981e710f0ae",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple AI draws inspiration from this natural model of secure, decentralized intelligence. Each account uses a personal encryption key, giving you control over the data. Whether you are handling sensitive information on behalf of clients or your own personal thoughts, communication stays between you and the AI. No data is used for training models nor shared with third parties, not even us."
+        },
+        "8/body/0/argument/3/3/3/3/3/5": {
+          "type": "element",
+          "hash": "06dacf3639928686d2b88a364943261a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "People shouldn't have to sacrifice their privacy for high-quality AI. Maple upholds the highest standards of privacy and confidentiality, preserving the fundamental human right to freedom of thought. With confidence in AI, you can work together to thrive in your own challenging environments."
+        },
+        "8/body/0/argument/3/3/3/3/3/7-alt": {
+          "type": "attribute",
+          "hash": "ca8a9521de245a95234bd98ba2d256f2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple App Icon"
+        },
+        "8/body/0/argument/3/3/7/1": {
+          "type": "element",
+          "hash": "0bfffc402dade83bd68f5c6e6f1df0b9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Founders"
+        },
+        "8/body/0/argument/3/3/7/3": {
+          "type": "element",
+          "hash": "12efccf518879a085c4f6cee4ce709ac",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Our team has combined over 30 years experience building scalable cloud and local app solutions that take privacy and security seriously. We have successfully built in the fields of data storage, defense, fintech, education, security, therapy, computer vision, and consumer technology."
+        },
+        "8/body/0/argument/3/3/7/5/3/1-aria-label": {
+          "type": "attribute",
+          "hash": "be87ed14fece9ef9ca415a7bd62c1602",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mark Suman on X"
+        },
+        "8/body/0/argument/3/3/7/5/3/1/1-alt": {
+          "type": "attribute",
+          "hash": "279163e55ed32085b27082b8cbb108e1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mark, Co-founder of Maple AI"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/1": {
+          "type": "element",
+          "hash": "9c9c55353291472794b45f113f02358b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mark Suman"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/3": {
+          "type": "element",
+          "hash": "b25e3cb3c8800107503a5ecfd499d872",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "CEO"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/5": {
+          "type": "element",
+          "hash": "c81babc3b93d9c9b6325927207693535",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Early employee in Product and Engineering at multiple startups, including Instructure Canvas. Most recently, 6 years in software engineering at Apple with a focus on AI and Privacy.<element:span><element:a><element:X></element:X></element:a><element:a><element:LinkedIn></element:LinkedIn></element:a></element:span>"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/5/1/1-aria-label": {
+          "type": "attribute",
+          "hash": "be87ed14fece9ef9ca415a7bd62c1602",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mark Suman on X"
+        },
+        "8/body/0/argument/3/3/7/5/3/3/5/1/3-aria-label": {
+          "type": "attribute",
+          "hash": "3641203d06ac071b49833f807582ab15",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mark Suman on LinkedIn"
+        },
+        "8/body/0/argument/3/3/7/5/7/1-aria-label": {
+          "type": "attribute",
+          "hash": "0777d686054b8f3aa44b59e59078cfe4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anthony Ronning on X"
+        },
+        "8/body/0/argument/3/3/7/5/7/1/1-alt": {
+          "type": "attribute",
+          "hash": "074648f41b51b019ef4fd5b38aa7fbe0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anthony, Co-founder of Maple AI"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/1": {
+          "type": "element",
+          "hash": "7edec9a2ce7195f96803012040cb9292",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anthony Ronning"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/3": {
+          "type": "element",
+          "hash": "8969cd6bb5a49670ce1e4388839c0862",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "CTO"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/5": {
+          "type": "element",
+          "hash": "06cb3e88e26c82d6cfca563197680475",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Infrastructure engineer in many startups over the last 9 years. Previous experience in defense, security, networking, and bitcoin companies.<element:span><element:a><element:X></element:X></element:a></element:span>"
+        },
+        "8/body/0/argument/3/3/7/5/7/3/5/1/1-aria-label": {
+          "type": "attribute",
+          "hash": "0777d686054b8f3aa44b59e59078cfe4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anthony Ronning on X"
+        }
+      }
+    },
+    "routes/auth.$provider.callback.tsx": {
+      "scopes": {
+        "10/body/10/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "a149592ad26c48aeb88ff5014e7f2a46",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "{formattedProvider} Authentication Successful"
+        },
+        "10/body/10/consequent/0/argument/3/1": {
+          "type": "element",
+          "hash": "6383e381db4ebc158e52b0e8e689a1e2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Authentication successful! Redirecting you back to the app..."
+        },
+        "10/body/11/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "ae9de74df4783f42d2003a4bf7a79963",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Processing {formattedProvider} Login"
+        },
+        "10/body/12/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "1281af9b80ab0d929824ba6ddb1fad06",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Authentication Failed"
+        },
+        "10/body/12/consequent/0/argument/3/1-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "10/body/12/consequent/0/argument/3/3/1/1": {
+          "type": "element",
+          "hash": "d65fad81c5f8f90405b26bf6e5d70ab9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Try Again"
+        },
+        "10/body/13/argument/1/1": {
+          "type": "element",
+          "hash": "a149592ad26c48aeb88ff5014e7f2a46",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "{formattedProvider} Authentication Successful"
+        },
+        "10/body/13/argument/3": {
+          "type": "element",
+          "hash": "e90fe5fc2441590fb14e274df5ed9903",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You have successfully authenticated with {formattedProvider}.<expression/>"
+        }
+      }
+    },
+    "routes/desktop-auth.tsx": {
+      "scopes": {
+        "8/body/5/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "61f0d0f265a96adcf9839fcca4c68a51",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Apple Sign In"
+        },
+        "8/body/5/consequent/0/argument/3/1": {
+          "type": "element",
+          "hash": "ebb2d6da482cc3045d5192f2b5708259",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Click the button below to sign in with Apple:"
+        },
+        "8/body/6/argument/1/1": {
+          "type": "element",
+          "hash": "40276f1d6fef538ede70403ff11917b1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Redirecting to {provider}"
+        },
+        "8/body/6/argument/3/1": {
+          "type": "element",
+          "hash": "ec05eb06e45feeac6c35da2ebc6c7408",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Please wait while we redirect you to complete authentication..."
+        }
+      }
+    },
+    "routes/downloads.tsx": {
+      "scopes": {
+        "15/body/5/argument/3/1/openingElement/0/value/expression": {
+          "type": "element",
+          "hash": "aa56a6de880cd6b1e7a02672cdff904b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:span>Download</element:span> Maple"
+        },
+        "15/body/5/argument/3/1/openingElement/1/value/expression/1": {
+          "type": "element",
+          "hash": "77d6473f013aab4a6cff5020af4945e9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Available for macOS and Ubuntu Linux"
+        },
+        "15/body/5/argument/3/1/openingElement/1/value/expression/3": {
+          "type": "element",
+          "hash": "a3a097fc373da5c5d97d8c9d66a00ddf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Access your private AI chat with end-to-end encryption"
+        },
+        "15/body/5/argument/3/13/1/1/1/1": {
+          "type": "element",
+          "hash": "de993e9fd764ef5fd906a6556f714a13",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Web Version"
+        },
+        "15/body/5/argument/3/13/1/1/1/3": {
+          "type": "element",
+          "hash": "1362782bd31a2fb7b41d41daa07dd979",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Don't want to download anything? Use Maple directly in your browser with the same end-to-end encryption."
+        },
+        "15/body/5/argument/3/13/1/1/1/5": {
+          "type": "element",
+          "hash": "fca480edc33c46a4440bb51d36f88fb3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Globe></element:Globe> Open Web App"
+        },
+        "15/body/5/argument/3/13/1/1/3/1/1/3": {
+          "type": "element",
+          "hash": "bf46d82177b514a7b4ead4cef5e1bd9a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "trymaple.ai"
+        },
+        "15/body/5/argument/3/5/1": {
+          "type": "element",
+          "hash": "3e7cb8b9eaaf453289115ed0d172e2a4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Monitor></element:Monitor> Desktop Apps<element:span>A faster, more focused experience for your private AI chat</element:span>"
+        },
+        "15/body/5/argument/3/5/3/1/3": {
+          "type": "element",
+          "hash": "b6e77d1eaa9437bb6714c882aa1dec23",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "macOS"
+        },
+        "15/body/5/argument/3/5/3/1/5": {
+          "type": "element",
+          "hash": "1c7e1739726f0be8dbb84029f2a959f4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "For Apple Silicon and Intel-based Macs running macOS 11.0 or later."
+        },
+        "15/body/5/argument/3/5/3/1/7/1": {
+          "type": "element",
+          "hash": "c7cc3c87e02168b962b33eb423aa9572",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download for macOS"
+        },
+        "15/body/5/argument/3/5/3/1/7/3": {
+          "type": "element",
+          "hash": "2197e2d43bda5f641801f84102b1d94e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Universal for both Apple Silicon and Intel"
+        },
+        "15/body/5/argument/3/5/3/3/3": {
+          "type": "element",
+          "hash": "76c91bba2fb7679708e9264130bfa0c1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Linux"
+        },
+        "15/body/5/argument/3/5/3/3/5": {
+          "type": "element",
+          "hash": "abb5ae20835f1cee0caf3071d49ff46d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "For Ubuntu 24.04+ only. Other Linux distributions are not officially supported."
+        },
+        "15/body/5/argument/3/5/3/3/7/1": {
+          "type": "element",
+          "hash": "c0c422410114f9e832b2f145ec8f4a70",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download AppImage"
+        },
+        "15/body/5/argument/3/5/3/3/7/3/1": {
+          "type": "element",
+          "hash": "93064dffa0b02e3ef91a2c30ebcee1a7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": ".deb"
+        },
+        "15/body/5/argument/3/5/3/3/7/3/3": {
+          "type": "element",
+          "hash": "9f944631768c6ae5617411f1ff4755ed",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": ".rpm"
+        },
+        "15/body/5/argument/3/5/5/1": {
+          "type": "element",
+          "hash": "d7f980889e9b23c891cc5b4f9f5114d2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Windows version coming soon. In the meantime, you can use the <element:a>web app</element:a> for full functionality."
+        },
+        "15/body/5/argument/3/5/5/3": {
+          "type": "element",
+          "hash": "a50040cd44dc1b7bcc0e473237f81367",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Current version: <element:span>{currentVersion}</element:span><expression/> • <element:a>Release notes</element:a>"
+        },
+        "15/body/5/argument/3/9/1/3": {
+          "type": "element",
+          "hash": "52a6962957416602ed50cd2223f29101",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Mobile Apps"
+        },
+        "15/body/5/argument/3/9/3/1/3": {
+          "type": "element",
+          "hash": "a7413e511bd963452b69286de1ebe85b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "iOS"
+        },
+        "15/body/5/argument/3/9/3/1/5": {
+          "type": "element",
+          "hash": "a4f3672b3f2dcd58524b82e60613891c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download our native iOS app for iPhones and iPads."
+        },
+        "15/body/5/argument/3/9/3/1/7/1/1-alt": {
+          "type": "attribute",
+          "hash": "aa7eb35109f6069021d46c7b6b793fdf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download on the App Store"
+        },
+        "15/body/5/argument/3/9/3/1/7/3/1": {
+          "type": "element",
+          "hash": "180c74ea190387508f08f6032e314049",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Want to test the latest features before they hit the App Store? Join our beta program."
+        },
+        "15/body/5/argument/3/9/3/1/7/3/3/1/1-alt": {
+          "type": "attribute",
+          "hash": "19034c14290546abbdeee32fd328fe35",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Available on TestFlight"
+        },
+        "15/body/5/argument/3/9/3/3/3": {
+          "type": "element",
+          "hash": "7f1144cdf1a7df38c98ff2c876ad16e0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Android"
+        },
+        "15/body/5/argument/3/9/3/3/5": {
+          "type": "element",
+          "hash": "81e141544a3b8476f7f9af5ea4ca8e0b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download our native Android app for phones and tablets."
+        },
+        "15/body/5/argument/3/9/3/3/7/1": {
+          "type": "element",
+          "hash": "625f2dd57c279873f677bd1d9aeed4fc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Join our beta program to test the latest features:"
+        },
+        "15/body/5/argument/3/9/3/3/7/3": {
+          "type": "element",
+          "hash": "59143bf44854e97d2d60861813542984",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Join Google Play Beta"
+        },
+        "15/body/5/argument/3/9/3/3/7/5/1": {
+          "type": "element",
+          "hash": "a3e74450a50201cfe3c23dae762d49e8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Or download the APK directly:"
+        },
+        "15/body/5/argument/3/9/3/3/7/5/3": {
+          "type": "element",
+          "hash": "fa46cd90131bcb7fd1385fc709d7a4e1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Download APK (Beta)"
+        },
+        "15/body/5/argument/3/9/3/3/7/7": {
+          "type": "element",
+          "hash": "d174740b742a6b013eb8a8f725fa8386",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Beta version - help us test new features before the official release"
+        }
+      }
+    },
+    "routes/login.tsx": {
+      "scopes": {
+        "22/body/14/consequent/0/argument-description": {
+          "type": "attribute",
+          "hash": "076e3f88f8adaaea274aef226bd27b02",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Choose your preferred login method"
+        },
+        "22/body/14/consequent/0/argument-title": {
+          "type": "attribute",
+          "hash": "0029e5a35676c0051e761fcd046ef9ee",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In"
+        },
+        "22/body/14/consequent/0/argument/1/expression/right-title": {
+          "type": "attribute",
+          "hash": "e0337f202c911423275f834edeffc54b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Note"
+        },
+        "22/body/14/consequent/0/argument/11": {
+          "type": "element",
+          "hash": "96532529f18a10225c3858e4ef5ae675",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:UserCircle></element:UserCircle> Log in as Anonymous"
+        },
+        "22/body/14/consequent/0/argument/13": {
+          "type": "element",
+          "hash": "490ead436d12f5f4c87f760eebef8236",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Need an account? <element:Link>Sign Up</element:Link>"
+        },
+        "22/body/14/consequent/0/argument/3": {
+          "type": "element",
+          "hash": "4b66ac66b5708eda97344d55b8e58be9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Mail></element:Mail> Log in with Email"
+        },
+        "22/body/14/consequent/0/argument/5": {
+          "type": "element",
+          "hash": "f7bc297e04db8e8a711455060ac9109b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Github></element:Github> Log in with GitHub"
+        },
+        "22/body/14/consequent/0/argument/7": {
+          "type": "element",
+          "hash": "bf44c3b5a03288a0996900bc95d0abc5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Google></element:Google> Log in with Google"
+        },
+        "22/body/14/consequent/0/argument/9/expression/consequent": {
+          "type": "element",
+          "hash": "0b48e81eae618420e5050e08e8604e46",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Apple></element:Apple> Log in with Apple"
+        },
+        "22/body/15/consequent/0/argument/1-description": {
+          "type": "attribute",
+          "hash": "ecda203536a4ee5410677cab0c4d0f51",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter your Account ID and password."
+        },
+        "22/body/15/consequent/0/argument/1-title": {
+          "type": "attribute",
+          "hash": "77da085061775e23bc233e3dfce55a57",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In as Anonymous"
+        },
+        "22/body/15/consequent/0/argument/1/1/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "22/body/15/consequent/0/argument/1/11": {
+          "type": "element",
+          "hash": "720b2dca2de6da9c0b26db8337967dc2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Need an account? <element:Link>Sign up</element:Link>"
+        },
+        "22/body/15/consequent/0/argument/1/3/1": {
+          "type": "element",
+          "hash": "e795343893c6a1e18fba01dcabfcf920",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Account ID"
+        },
+        "22/body/15/consequent/0/argument/1/3/3-placeholder": {
+          "type": "attribute",
+          "hash": "bf9f7aa2a03f6959fb118b80cabec6a7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your Account ID"
+        },
+        "22/body/15/consequent/0/argument/1/5/1": {
+          "type": "element",
+          "hash": "223a61cf906ab9c40d22612c588dff48",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Password"
+        },
+        "22/body/15/consequent/0/argument/1/7/1/expression/consequent": {
+          "type": "element",
+          "hash": "4eb8e7c015bc7925cf227ce9330bacaa",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Please wait"
+        },
+        "22/body/15/consequent/0/argument/1/9": {
+          "type": "element",
+          "hash": "cbbd1435d979ffb51400d1b07067da11",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Back"
+        },
+        "22/body/16/argument/1-description": {
+          "type": "attribute",
+          "hash": "466c611ff1151e3416ecdca61184b9cd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enter your email and password to log in."
+        },
+        "22/body/16/argument/1-title": {
+          "type": "attribute",
+          "hash": "82611ff1d55ecf05ecdf6077b3910e95",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Log In with Email"
+        },
+        "22/body/16/argument/1/1/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "22/body/16/argument/1/11/1": {
+          "type": "element",
+          "hash": "720b2dca2de6da9c0b26db8337967dc2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Need an account? <element:Link>Sign up</element:Link>"
+        },
+        "22/body/16/argument/1/11/3/1": {
+          "type": "element",
+          "hash": "99dfe43fb2d632030841e5ac8121bfd0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Forgot password?"
+        },
+        "22/body/16/argument/1/3/1": {
+          "type": "element",
+          "hash": "e7f34943a0c2fb849db1839ff6ef5cb5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email"
+        },
+        "22/body/16/argument/1/3/3-placeholder": {
+          "type": "attribute",
+          "hash": "1bae7cb01431340f48009940e779bc41",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "email@example.com"
+        },
+        "22/body/16/argument/1/5/1": {
+          "type": "element",
+          "hash": "223a61cf906ab9c40d22612c588dff48",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Password"
+        },
+        "22/body/16/argument/1/7/1/expression/consequent": {
+          "type": "element",
+          "hash": "02dc4bc19a8fd7b885b5097a9543f52d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Please wait"
+        },
+        "22/body/16/argument/1/9": {
+          "type": "element",
+          "hash": "788f9766bae87b169f3a65297bbea35e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Back"
+        }
+      }
+    },
+    "routes/password-reset.confirm.tsx": {
+      "scopes": {
+        "3/body/1/argument/1": {
+          "type": "element",
+          "hash": "e01d21b5ec434f705960fea531175644",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Confirm Password Reset"
+        }
+      }
+    },
+    "routes/pricing.tsx": {
+      "scopes": {
+        "23/body/0/argument/1": {
+          "type": "element",
+          "hash": "47e0ee2eb40b4e7e732e05e2233fc71c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "FAQ"
+        },
+        "23/body/0/argument/3/1/1": {
+          "type": "element",
+          "hash": "690888a5e3ae02209a250c7323780975",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "What is the difference between the plans?"
+        },
+        "23/body/0/argument/3/1/3/1": {
+          "type": "element",
+          "hash": "5bc4750e76d7714e538be42f0fb6f70d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "The plans are sized to grow with your needs."
+        },
+        "23/body/0/argument/3/1/3/3/1": {
+          "type": "element",
+          "hash": "3057e93f7ef497bb7403f495ae55ee5f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Free: 25 messages per week, resets Sunday 00:00 UTC. Max length on individual messages."
+        },
+        "23/body/0/argument/3/1/3/3/3": {
+          "type": "element",
+          "hash": "b62e500447fde762b2f8a56b225069cd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pro: Generous usage for power users with a high monthly cap"
+        },
+        "23/body/0/argument/3/1/3/3/5": {
+          "type": "element",
+          "hash": "5b7563f5a4057c52acbe622e7dab877c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Max: 20x more usage than Pro for maximum power users"
+        },
+        "23/body/0/argument/3/1/3/3/7": {
+          "type": "element",
+          "hash": "fe0844b1d8288f94f2fd83c7c2147f0f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team: Even more usage per team member with unified billing"
+        },
+        "23/body/0/argument/3/1/3/3/9": {
+          "type": "element",
+          "hash": "f8d67fb2fea017c7e425fe198be3207d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Enterprise: Message us at team@opensecret.cloud"
+        },
+        "23/body/0/argument/3/11/1": {
+          "type": "element",
+          "hash": "bd37dd8042faef39fa732aa2544ffd12",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Which file types are supported for document and image upload?"
+        },
+        "23/body/0/argument/3/11/3/1": {
+          "type": "element",
+          "hash": "6ca48cc8c89e7d0ee1276e27885ab8e2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "We support a range of file types for both images and documents."
+        },
+        "23/body/0/argument/3/11/3/3/1": {
+          "type": "element",
+          "hash": "386b59433323f105e835c038f3d933bc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Images:"
+        },
+        "23/body/0/argument/3/11/3/5/1": {
+          "type": "element",
+          "hash": "9570474090fe69fdacfa72960a40357f",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Documents (Desktop/Mobile apps only):"
+        },
+        "23/body/0/argument/3/11/3/7": {
+          "type": "element",
+          "hash": "aa2cd5648d35ad54ebd717a1a547e52d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "There is a 1 file limit per chat prompt with a 10MB file size limit per file."
+        },
+        "23/body/0/argument/3/13/1": {
+          "type": "element",
+          "hash": "2be7aa9963b9d38a651803639729d89c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How did you build this?"
+        },
+        "23/body/0/argument/3/13/3": {
+          "type": "element",
+          "hash": "17e90620beb6dc410d62d397c722d2fc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple is made using <element:a>OpenSecret</element:a> , an encrypted backend for developers. It handles private keys, encrypted data sync, private AI, and more automatically. We're building OpenSecret as a way to bring better privacy to users by turning on encryption by default. If you're a developer, go see how easy it is to build with."
+        },
+        "23/body/0/argument/3/3/1": {
+          "type": "element",
+          "hash": "31d65d3b348ef33832e1edf671767224",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How private is Maple?"
+        },
+        "23/body/0/argument/3/3/3": {
+          "type": "element",
+          "hash": "810b1869892465ab7f36ed9654120362",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Encrypted end to end. Maple uses confidential computing to secure the code that access user data and LLM data. Your account has its own private key that encrypts your chats and the responses from the AI model. Every user has their own personal data vault that can't be read by anyone else, not even us."
+        },
+        "23/body/0/argument/3/5/1": {
+          "type": "element",
+          "hash": "bfb4f3fca2459dcfc612914b356dfca9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How do you synchronize my chat history across devices?"
+        },
+        "23/body/0/argument/3/5/3": {
+          "type": "element",
+          "hash": "f6e764779b21bd8c3fb30c1bc4f8e323",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "We use a secure synchronization protocol that ensures your encrypted chat history is synced across all your devices. This means that you can start a conversation on one device and pick it up where you left off on another device, without compromising your security or privacy."
+        },
+        "23/body/0/argument/3/7/1": {
+          "type": "element",
+          "hash": "b02fe2b0ea143c712c49b7c92ea32297",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Is this safe to use with my company's confidential information?"
+        },
+        "23/body/0/argument/3/7/3": {
+          "type": "element",
+          "hash": "083655c895fc69383c51e98414362d92",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "The service is encrypted end-to-end, so your confidential information is private between you and the AI. Consult your company's security policy."
+        },
+        "23/body/0/argument/3/9/1": {
+          "type": "element",
+          "hash": "3ac7b8c69e74f01d02bbcee3333147b4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Can companies use my data to train their AI models?"
+        },
+        "23/body/0/argument/3/9/3": {
+          "type": "element",
+          "hash": "e48f71f71917c314491b76f526a3a121",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "No. When you chat with AI in Maple, nobody knows what is being said back and forth. Thus data is not able to be used for training new AI models by any company."
+        },
+        "24/body/20/0/init/body/0/consequent/0/argument": {
+          "type": "element",
+          "hash": "45a24665a0c932ef13f4dddebe5b4d01",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Processing..."
+        },
+        "24/body/25/consequent/0/argument/3/1/openingElement/0/value/expression": {
+          "type": "element",
+          "hash": "a968cb0e7a3fcf51afbeea3180e87935",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Simple, <element:span>Transparent</element:span> Pricing"
+        },
+        "24/body/25/consequent/0/argument/3/1/openingElement/1/value/expression/1": {
+          "type": "element",
+          "hash": "0abbc16abc0ccf38ecc1fb70f6114129",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Start with our free tier and upgrade as you grow."
+        },
+        "24/body/25/consequent/0/argument/3/1/openingElement/1/value/expression/3": {
+          "type": "element",
+          "hash": "ef4f879dfca52257db29b3ddc0be58bf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "All plans include end-to-end encrypted AI chat."
+        },
+        "24/body/26/consequent/1/argument/3/1-subtitle": {
+          "type": "attribute",
+          "hash": "3ce6bdf8b2d76ea1f6781962e40bba2d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Choose the plan that's right for you."
+        },
+        "24/body/26/consequent/1/argument/3/1-title": {
+          "type": "attribute",
+          "hash": "ce27f1aeacccc542a174c4b2bce022b0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pricing"
+        },
+        "24/body/26/consequent/1/argument/3/3/1/1/3/1": {
+          "type": "element",
+          "hash": "c37d8e01cbfd21c17ee180beee235d35",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Unable to Load Pricing"
+        },
+        "24/body/26/consequent/1/argument/3/3/1/1/5": {
+          "type": "element",
+          "hash": "afc46d3f8880aabf23a2e32a1554a327",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Retry"
+        },
+        "24/body/27/argument/3/1/openingElement/0/value/expression": {
+          "type": "element",
+          "hash": "b650afb47005a8852f3f29158c60bed1",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Simple, <element:span>Transparent</element:span> Pricing"
+        },
+        "24/body/27/argument/3/1/openingElement/1/value/expression/1": {
+          "type": "element",
+          "hash": "0abbc16abc0ccf38ecc1fb70f6114129",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Start with our free tier and upgrade as you grow."
+        },
+        "24/body/27/argument/3/1/openingElement/1/value/expression/3": {
+          "type": "element",
+          "hash": "ef4f879dfca52257db29b3ddc0be58bf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "All plans include end-to-end encrypted AI chat."
+        },
+        "24/body/27/argument/3/11/1/1/3": {
+          "type": "element",
+          "hash": "e1ef3146b26ac2d2dfc0ff66d8226ff3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pay with Bitcoin"
+        },
+        "24/body/27/argument/3/11/3/expression/right": {
+          "type": "element",
+          "hash": "a16c8fdfe0e0c5d7b24aa4b8b3da13c4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Anonymous accounts must pay with Bitcoin (yearly only)"
+        },
+        "24/body/27/argument/3/5/expression/right/1/3": {
+          "type": "element",
+          "hash": "efb377c3d3475eda0d4bbd0c3b949dcf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Payment successful! Your subscription has been updated."
+        },
+        "24/body/27/argument/3/7/expression/right/1/3": {
+          "type": "element",
+          "hash": "af60d8a3bc8ccb197192645b5cfa7208",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Payment canceled. Your subscription remains unchanged."
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/1/expression/right": {
+          "type": "element",
+          "hash": "8057f5b558ba4b395fd0347a9fcca7f7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Most Popular"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/3/expression/right": {
+          "type": "element",
+          "hash": "9ea74e58354048829980b11a5f73cf02",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Current Plan"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/5/expression/right": {
+          "type": "element",
+          "hash": "55bf31448c446153aebfc3216e602e17",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "10% OFF"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/alternate/1": {
+          "type": "element",
+          "hash": "ce3025799d70859c869af0b2fea2ad8a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "${monthlyPrice}"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/alternate/3": {
+          "type": "element",
+          "hash": "b9b2c98b7b857080492d527d94146680",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "per month"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/1/1": {
+          "type": "element",
+          "hash": "923b9a59e22156813b18cd62a5e11010",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "${displayPrice}"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/1/3/expression/right": {
+          "type": "element",
+          "hash": "ac772210d192da47ab363e149102d8b2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "${monthlyOriginalPrice}"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/1/5/3": {
+          "type": "element",
+          "hash": "ee6c6783c9ecfaba3a709a27abbe0a47",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "per month"
+        },
+        "24/body/27/argument/3/9/expression/callee/body/2/argument/1/expression/0/body/11/argument/7/9/1/expression/consequent/3/1/expression/right/3": {
+          "type": "element",
+          "hash": "4434cc8dd93afff614ffc6bcfea793f7",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Save 10% with annual billing"
+        }
+      }
+    },
+    "routes/proof.tsx": {
+      "scopes": {
+        "10/body/0/argument/1/1": {
+          "type": "element",
+          "hash": "304bd3aefcc6c8c9f1a4061d584de0c2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Server PCR0 Fingerprint"
+        },
+        "10/body/0/argument/1/5": {
+          "type": "element",
+          "hash": "d70578f45d341ec502116c18898020c0",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "For technical details, check out the <element:a>AWS Nitro Enclaves documentation</element:a> ."
+        },
+        "10/body/0/argument/3/1/1": {
+          "type": "element",
+          "hash": "16dfe5dc481240cd2819a6394f90df92",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Show"
+        },
+        "10/body/0/argument/3/1/3": {
+          "type": "element",
+          "hash": "a6088b934651055bb27314d111be510b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Hide"
+        },
+        "10/body/0/argument/3/3/1/1": {
+          "type": "element",
+          "hash": "0cc723580d3f75394b85b4e6f95a03aa",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Module ID: <element:span>{parsedDocument.moduleId}</element:span>"
+        },
+        "10/body/0/argument/3/3/1/11/1/1": {
+          "type": "element",
+          "hash": "8c7df8617340d14adfb8a8c2c45a5753",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Additional PCR Values"
+        },
+        "10/body/0/argument/3/3/1/11/1/3/1/expression/0/body/right/1": {
+          "type": "element",
+          "hash": "861f9de3ccfd942eb8874184a304318d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "PCR{pcr.id}: <element:span>{pcr.value}</element:span>"
+        },
+        "10/body/0/argument/3/3/1/13/1": {
+          "type": "element",
+          "hash": "0a46369f39c666923943e1306329de46",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Certificate Chain:"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/1/expression/alternate": {
+          "type": "element",
+          "hash": "ea012704234ab561b99a1113792f6f92",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Certificate <expression/>"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/1/expression/consequent": {
+          "type": "element",
+          "hash": "ca4a9a05f476c783653654476ef3666a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Root Certificate"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/11/1": {
+          "type": "element",
+          "hash": "1bf7534cb3a00d9da3963cc5a589ca0a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Show PEM Certificate"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/3": {
+          "type": "element",
+          "hash": "0d1fa4317c860bbb9a5a59a4a09b0185",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Subject: {cert.subject}"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/5": {
+          "type": "element",
+          "hash": "dc8eab5f9e6c8db6d696465ab0d55b12",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Valid From: {cert.notBefore}"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/7": {
+          "type": "element",
+          "hash": "da4e653a99588b9804a5f15badd199e9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Valid Until: {cert.notAfter}"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/9/expression/consequent/1": {
+          "type": "element",
+          "hash": "6b46af3eb4e274ed18db8760334fb721",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Calculated SHA-256: <element:span>{parsedDocument.cert0hash}</element:span>"
+        },
+        "10/body/0/argument/3/3/1/13/3/expression/0/body/9/expression/consequent/3": {
+          "type": "element",
+          "hash": "3e3708740ca25957ccfb9490ab5e52c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Expected root cert hash: <element:span>{os.expectedRootCertHash}</element:span>"
+        },
+        "10/body/0/argument/3/3/1/3": {
+          "type": "element",
+          "hash": "01b34b270c0965f7b558c15682c56c16",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Timestamp: {parsedDocument.timestamp}"
+        },
+        "10/body/0/argument/3/3/1/5/expression/right": {
+          "type": "element",
+          "hash": "5d97449dcad95da03cd0301b0d6ab330",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Nonce: <element:span>{parsedDocument.nonce}</element:span>"
+        },
+        "10/body/0/argument/3/3/1/7": {
+          "type": "element",
+          "hash": "000d7c3292f8c6a34222ced9efdc8bcd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Digest: {parsedDocument.digest}"
+        },
+        "10/body/0/argument/3/3/1/9/expression/right/1": {
+          "type": "element",
+          "hash": "abf609e52225b325d268b5d05a8332c2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Public Key: <element:span>{parsedDocument.publicKey}</element:span>"
+        },
+        "11/body/3/argument/3/1/openingElement/0/value/expression": {
+          "type": "element",
+          "hash": "23994e4cefc88b66b192d69a202273e5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:span>Proof</element:span> of Security"
+        },
+        "11/body/3/argument/3/1/openingElement/1/value/expression": {
+          "type": "element",
+          "hash": "99b1e7ea2872ae5e2e2871a37f50b185",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Cryptographic proof that you're talking with a secure server."
+        },
+        "11/body/3/argument/3/5/expression/right": {
+          "type": "element",
+          "hash": "70fd2e278d4a6ec10be06fc567832e6d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Failed to validate attestation document: <expression/>"
+        }
+      }
+    },
+    "routes/signup.tsx": {
+      "scopes": {
+        "25/body/19/consequent/0/argument-description": {
+          "type": "attribute",
+          "hash": "149bc652066463bd0fb34bf55c1fe7af",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Choose your preferred sign-up method"
+        },
+        "25/body/19/consequent/0/argument-title": {
+          "type": "attribute",
+          "hash": "0dd2ae69be4618c1f9e615774a4509ca",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Sign Up"
+        },
+        "25/body/19/consequent/0/argument/1/expression/right-title": {
+          "type": "attribute",
+          "hash": "e0337f202c911423275f834edeffc54b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Note"
+        },
+        "25/body/19/consequent/0/argument/11": {
+          "type": "element",
+          "hash": "7782764d4ec63db5a80deddb692aa371",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:UserCircle></element:UserCircle> Sign up as Anonymous"
+        },
+        "25/body/19/consequent/0/argument/13": {
+          "type": "element",
+          "hash": "da0de41cf67b1c8e8c457da9b8222d61",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Already have an account? <element:Link>Log In</element:Link>"
+        },
+        "25/body/19/consequent/0/argument/3": {
+          "type": "element",
+          "hash": "2fa98d1f1ac3c33385e7876dd4e83680",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Mail></element:Mail> Sign up with Email"
+        },
+        "25/body/19/consequent/0/argument/5": {
+          "type": "element",
+          "hash": "df8e8ac46a44f5b7810c3dc7cb0b42e4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Github></element:Github> Sign up with GitHub"
+        },
+        "25/body/19/consequent/0/argument/7": {
+          "type": "element",
+          "hash": "c3210fcf52ba8180ff588a9bfd66535b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Google></element:Google> Sign up with Google"
+        },
+        "25/body/19/consequent/0/argument/9/expression/consequent": {
+          "type": "element",
+          "hash": "c67e6f6969f68e77ec82454c1cf0f369",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Apple></element:Apple> Sign up with Apple"
+        },
+        "25/body/20/consequent/0/argument/1/1-title": {
+          "type": "attribute",
+          "hash": "7e9c05b47d6cb54b9f926fc72b331844",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Sign Up as Anonymous"
+        },
+        "25/body/20/consequent/0/argument/1/1/1/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "25/body/20/consequent/0/argument/1/1/3/1": {
+          "type": "element",
+          "hash": "daf1472309d84128a40ae5ad26b5f2cb",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Create Password"
+        },
+        "25/body/20/consequent/0/argument/1/1/3/3-placeholder": {
+          "type": "attribute",
+          "hash": "0d61743541fa5e1758c89d8207d1a8e9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Create a strong password"
+        },
+        "25/body/20/consequent/0/argument/1/1/3/5": {
+          "type": "element",
+          "hash": "375d79edd7469e3103190fb321df8ddf",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You'll need this password along with your Account ID to sign in. Your Account ID will be shown in the next step."
+        },
+        "25/body/20/consequent/0/argument/1/1/5/1/expression/consequent": {
+          "type": "element",
+          "hash": "048170dcb220a55dd4880cad8dbb7689",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Creating Account..."
+        },
+        "25/body/20/consequent/0/argument/1/1/7": {
+          "type": "element",
+          "hash": "9e5482679a6b6962fd38c8e6c7ec0aa8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Back"
+        },
+        "25/body/21/argument/1-title": {
+          "type": "attribute",
+          "hash": "ef07169abfa69578905cce031f771006",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Sign Up with Email"
+        },
+        "25/body/21/argument/1/1/expression/right-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "25/body/21/argument/1/11": {
+          "type": "element",
+          "hash": "da0de41cf67b1c8e8c457da9b8222d61",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Already have an account? <element:Link>Log In</element:Link>"
+        },
+        "25/body/21/argument/1/3/1": {
+          "type": "element",
+          "hash": "e7f34943a0c2fb849db1839ff6ef5cb5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email"
+        },
+        "25/body/21/argument/1/3/3-placeholder": {
+          "type": "attribute",
+          "hash": "1bae7cb01431340f48009940e779bc41",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "email@example.com"
+        },
+        "25/body/21/argument/1/5/1": {
+          "type": "element",
+          "hash": "223a61cf906ab9c40d22612c588dff48",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Password"
+        },
+        "25/body/21/argument/1/7/1/expression/consequent": {
+          "type": "element",
+          "hash": "02dc4bc19a8fd7b885b5097a9543f52d",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Please wait"
+        },
+        "25/body/21/argument/1/9": {
+          "type": "element",
+          "hash": "788f9766bae87b169f3a65297bbea35e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Back"
+        }
+      }
+    },
+    "routes/team.invite.$inviteId.tsx": {
+      "scopes": {
+        "13/body/14/consequent/0/argument/3/1/1/1/3": {
+          "type": "element",
+          "hash": "a17348f53399042e26f40b68a0fff563",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Invalid or Expired Invitation"
+        },
+        "13/body/14/consequent/0/argument/3/1/1/1/5": {
+          "type": "element",
+          "hash": "eddbaee9a8a9be96bb3437bc37af35c3",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "This invitation link is no longer valid. It may have expired or already been used."
+        },
+        "13/body/14/consequent/0/argument/3/1/1/3/1": {
+          "type": "element",
+          "hash": "2151c2e15e2e854cdb22cce1fb4ab7b5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Go to Dashboard"
+        },
+        "13/body/15/consequent/0/argument/3/1/1/1/3": {
+          "type": "element",
+          "hash": "3f2495dbb3a5b746fcc91f722f0df759",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Welcome to the Team!"
+        },
+        "13/body/15/consequent/0/argument/3/1/1/1/5": {
+          "type": "element",
+          "hash": "e358a597f6351b37cd77f030c3e9fbfc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You've successfully joined <expression/>. Redirecting you to the dashboard..."
+        },
+        "13/body/16/argument/3/1/1/1/3": {
+          "type": "element",
+          "hash": "173c38114e2e81e1b98514de9e155ab6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team Invitation"
+        },
+        "13/body/16/argument/3/1/1/1/5": {
+          "type": "element",
+          "hash": "d8a39823b8aa8bbe6fabc55a4f9ea88c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You've been invited to join a team on Maple AI"
+        },
+        "13/body/16/argument/3/1/1/3/1/1/1": {
+          "type": "element",
+          "hash": "c621ea9404a37af289def443b309bf1b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Team"
+        },
+        "13/body/16/argument/3/1/1/3/1/3/expression/right/1": {
+          "type": "element",
+          "hash": "8a42306eb202461322b4a13968502e32",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Invited by"
+        },
+        "13/body/16/argument/3/1/1/3/1/5/1": {
+          "type": "element",
+          "hash": "ed269a50d6b679a692b68608e66b64ab",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your email"
+        },
+        "13/body/16/argument/3/1/1/3/5/1": {
+          "type": "element",
+          "hash": "e6ca61edb1c5580b604d32e0818b8260",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Decline"
+        },
+        "13/body/16/argument/3/1/1/3/5/3/1/expression/alternate": {
+          "type": "element",
+          "hash": "211b263dbe1fd94fd25bf31c4a760aa2",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:CheckCircle></element:CheckCircle> Accept Invitation"
+        },
+        "13/body/16/argument/3/1/1/3/5/3/1/expression/consequent": {
+          "type": "element",
+          "hash": "a2a4b0af9ca2bd126ccac96a803752dd",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:Loader2></element:Loader2> Joining..."
+        },
+        "13/body/16/argument/3/1/1/3/7": {
+          "type": "element",
+          "hash": "39e0f88f2a982d8a455d4ad5088f54ea",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "By accepting this invitation, you'll join the team and gain access to shared resources."
+        }
+      }
+    },
+    "routes/teams.tsx": {
+      "scopes": {
+        "11/body/0/argument/3/1/openingElement/0/value/expression": {
+          "type": "element",
+          "hash": "65c7f646f6a580367c7edc989a3f0a69",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Secure AI for <element:span>Teams</element:span>"
+        },
+        "11/body/0/argument/3/1/openingElement/1/value/expression": {
+          "type": "element",
+          "hash": "1d3b885b46e2b854802852277a659ced",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Protect your trade secrets while using AI. <element:br></element:br> No data is shared with advertisers, competitors, or third parties. Period."
+        },
+        "11/body/0/argument/3/13/1/1/1": {
+          "type": "element",
+          "hash": "de36e16e3e51717542914de6fa0ea707",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Powerful AI models. <element:span>No data sharing.</element:span>"
+        },
+        "11/body/0/argument/3/13/1/1/3": {
+          "type": "element",
+          "hash": "5908ced334a2be5e46c2987b4b618854",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "We use open-source models from the biggest providers."
+        },
+        "11/body/0/argument/3/13/1/5/1": {
+          "type": "element",
+          "hash": "d42a3955bdf73dd76e1724618c20ee5c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "<element:br></element:br> None of your data is transmitted to these companies.<element:br></element:br> Get the best without the mess."
+        },
+        "11/body/0/argument/3/17/1/1/1": {
+          "type": "element",
+          "hash": "78a1df8f1891860e7583302a16842318",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Security by <element:span>Design</element:span>"
+        },
+        "11/body/0/argument/3/17/1/1/3": {
+          "type": "element",
+          "hash": "4390eef454da01345b0f42c48b9461b9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "You don't share company secrets with competitors, so why should your AI? Whether you're designing products in a highly competitive market or dealing with sensitive client information at a firm or non-profit, Teams protects it all."
+        },
+        "11/body/0/argument/3/17/1/5/1-alt": {
+          "type": "attribute",
+          "hash": "abc648f18bf51d5aac43d2ff971f88cc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Two audio hardware engineers collaborating at work using secure Maple AI"
+        },
+        "11/body/0/argument/3/17/1/7/1-description": {
+          "type": "attribute",
+          "hash": "c75075364216ed24d964629e01a00159",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "All conversations and files are encrypted on your device and only decrypted inside secure enclaves. No one—not even Maple—can access your plaintext data."
+        },
+        "11/body/0/argument/3/17/1/7/1-title": {
+          "type": "attribute",
+          "hash": "824ad790255699bf6eac309327454f10",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "End-to-End Encryption"
+        },
+        "11/body/0/argument/3/17/1/7/3-description": {
+          "type": "attribute",
+          "hash": "d4d3a45667edb5c45279231016917cec",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple runs inside hardware-secured enclaves (AWS Nitro, Nvidia TEE) with cryptographic proof. Your organization’s data is protected at every step."
+        },
+        "11/body/0/argument/3/17/1/7/3-title": {
+          "type": "attribute",
+          "hash": "1dfe6f9331567b9d9e10c61e5fc47208",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Confidential Computing"
+        },
+        "11/body/0/argument/3/17/1/7/5-description": {
+          "type": "attribute",
+          "hash": "dd9c59e6bd47ba3c58ed2e9296f36a8b",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Teams users get access to the best models Maple offers, including advanced open source LLMs. Your data is never sent to model creators—it always stays within secure enclaves."
+        },
+        "11/body/0/argument/3/17/1/7/5-title": {
+          "type": "attribute",
+          "hash": "c3b1835da96ed6d8d912eca1a0233bae",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Open Source Models"
+        },
+        "11/body/0/argument/3/21/1/1/1": {
+          "type": "element",
+          "hash": "4a0df92db6a10c2ccf3697c95c192513",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "How Maple Teams Works"
+        },
+        "11/body/0/argument/3/21/1/1/3/1/1": {
+          "type": "element",
+          "hash": "23e3824abc5db6f13fd0b1b6a8909e9a",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Purchase seats for your team"
+        },
+        "11/body/0/argument/3/21/1/1/3/1/3": {
+          "type": "element",
+          "hash": "343d2deab04272a473e54f043ade9ef4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Invite members by email"
+        },
+        "11/body/0/argument/3/21/1/1/3/1/5": {
+          "type": "element",
+          "hash": "3b4d15f88021f1ac3eadf5ce3fe8e5bb",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Use AI securely with your data, encrypted"
+        },
+        "11/body/0/argument/3/21/1/1/5/1": {
+          "type": "element",
+          "hash": "1740bf7aba10e661fbd46e442d8fa6cc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Learn More"
+        },
+        "11/body/0/argument/3/21/1/3/1/1/3": {
+          "type": "element",
+          "hash": "76617aaf95540d17973cab4752b0ff65",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "For Businesses"
+        },
+        "11/body/0/argument/3/21/1/3/1/3": {
+          "type": "element",
+          "hash": "1c6312803f0880b21a2f730e3e2a19d5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Maple Teams is trusted by organizations in big tech, legal, higher education, healthcare, finance, consulting, and more. Draft contracts, analyze client data, and collaborate on sensitive projects with full privacy and compliance."
+        },
+        "11/body/0/argument/3/21/1/3/1/5/1-alt": {
+          "type": "attribute",
+          "hash": "941e632ffa88f70696bcebdd2f17d9f4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Legal professionals working in a modern law office with secure AI assistance"
+        },
+        "11/body/0/argument/3/21/1/3/3/1/3": {
+          "type": "element",
+          "hash": "066166e15df5403a64ab1716226e1bd9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "For Non-Profits"
+        },
+        "11/body/0/argument/3/21/1/3/3/3": {
+          "type": "element",
+          "hash": "7d0f9f5b01561d41b6e33fd2d044a2bc",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Non-profits and advocacy groups use Maple to securely manage sensitive information, collaborate on grant writing, and protect the privacy of those they serve—no IT headaches, just secure, private AI for your mission."
+        },
+        "11/body/0/argument/3/21/1/3/3/5/1-alt": {
+          "type": "attribute",
+          "hash": "ab64ed2e4d9a8132cc64eb99e867a833",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Social workers collaborating in a non-profit office using secure AI tools"
+        },
+        "11/body/0/argument/3/25/1/1": {
+          "type": "element",
+          "hash": "680c1228bc4b023acee47a10a944b718",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Simple, Transparent Pricing"
+        },
+        "11/body/0/argument/3/25/1/3": {
+          "type": "element",
+          "hash": "168638043771f10fccafd62c0365a765",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "$30/month per seat. All features included. No hidden fees. Cancel anytime."
+        },
+        "11/body/0/argument/3/25/1/7": {
+          "type": "element",
+          "hash": "787d922e3f29310f6a869ae627332002",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Need a larger deployment or have compliance questions? <element:a>Contact us</element:a> for enterprise options."
+        },
+        "11/body/0/argument/3/5/1": {
+          "type": "element",
+          "hash": "defef6417f0a0b471aae4932fb757341",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Get Started with Teams <element:ArrowRight></element:ArrowRight>"
+        },
+        "11/body/0/argument/3/5/3": {
+          "type": "element",
+          "hash": "2df6b22385bade18c77f7e8433a6b87c",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Request a Demo"
+        },
+        "11/body/0/argument/3/9/1/1/1": {
+          "type": "element",
+          "hash": "e8ea53ea380822523292d6e318c9cc9e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Why Choose <element:span>Maple Teams?</element:span>"
+        },
+        "11/body/0/argument/3/9/1/1/3": {
+          "type": "element",
+          "hash": "f7de301ababe5dfdb303b319b096a5a6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Experience the productivity gains of AI without the data tracking.<element:br></element:br> Maple Teams scales AI across your entire organization to meet your needs."
+        },
+        "11/body/0/argument/3/9/1/5/1-alt": {
+          "type": "attribute",
+          "hash": "320dd60fd6c41b802e356f426bf9a6c9",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "A company office with different departments of Accounting, Finance, Marketing, Engineering, and Sales"
+        },
+        "11/body/0/argument/3/9/1/7/1-description": {
+          "type": "attribute",
+          "hash": "76a6e3c1e449b981edc6c5fe681a9a77",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Share AI credits across your team and control access from a central dashboard. Add or remove users anytime."
+        },
+        "11/body/0/argument/3/9/1/7/1-title": {
+          "type": "attribute",
+          "hash": "18ae4bc63e988b4d31795c2755d7d944",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Pooled Usage"
+        },
+        "11/body/0/argument/3/9/1/7/3-description": {
+          "type": "attribute",
+          "hash": "ed0b68d91d69fc18ffcd9b9f5289f6b5",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Upload documents and images for AI analysis—summarize PDFs, extract insights from text files, or analyze images securely as a team. Supports PDF, TXT, MD, JPG, PNG, and more."
+        },
+        "11/body/0/argument/3/9/1/7/3-title": {
+          "type": "attribute",
+          "hash": "15f89ded6f4ea104133c78d804ae212e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Document & Image Upload"
+        },
+        "11/body/0/argument/3/9/1/7/5-description": {
+          "type": "attribute",
+          "hash": "f9c03c4c81a7ac99f19efc38c15b4a62",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Use Maple to redact or anonymize sensitive client information before sharing with other cloud tools or AI. Protect privacy and stay compliant."
+        },
+        "11/body/0/argument/3/9/1/7/5-title": {
+          "type": "attribute",
+          "hash": "c9ea3c50396f7f4dad99cba0d465b7e4",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Sanitize Client Data"
+        }
+      }
+    },
+    "routes/verify.$code.tsx": {
+      "scopes": {
+        "7/body/6/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "d922e15048d8cb909d5c0d2a107c08a6",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verifying Email"
+        },
+        "7/body/7/consequent/0/argument/1/1": {
+          "type": "element",
+          "hash": "7157733f774f9bc07f1202eb2b0156d8",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Verification Failed"
+        },
+        "7/body/7/consequent/0/argument/3/1-title": {
+          "type": "attribute",
+          "hash": "3c95bcb32c2104b99a46f5b3dd015248",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Error"
+        },
+        "7/body/8/argument/1/1": {
+          "type": "element",
+          "hash": "1198a84576c526d433d566f764117f2e",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Email Verified"
+        },
+        "7/body/8/argument/3": {
+          "type": "element",
+          "hash": "c74f91f5944b5500c5c64045b564e324",
+          "context": "",
+          "skip": false,
+          "overrides": {},
+          "content": "Your email has been successfully verified. Redirecting..."
+        }
+      }
+    }
+  }
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -2,6 +2,7 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./app";
 import { waitForPlatform } from "@/utils/platform";
+import { LingoProviderWrapper, loadDictionary } from "lingo.dev/react/client";
 
 // Initialize platform detection before rendering
 async function initializeApp() {
@@ -15,7 +16,9 @@ async function initializeApp() {
     const root = createRoot(rootElement);
     root.render(
       <StrictMode>
-        <App />
+        <LingoProviderWrapper loadDictionary={(locale) => loadDictionary(locale)}>
+          <App />
+        </LingoProviderWrapper>
       </StrictMode>
     );
   }

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -3,13 +3,20 @@ import react from "@vitejs/plugin-react";
 import path from "path";
 import { TanStackRouterVite } from "@tanstack/router-plugin/vite";
 import derPlugin from "./vite-der-plugin";
+import lingoCompiler from "lingo.dev/compiler";
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [TanStackRouterVite(), react(), derPlugin()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src")
+export default defineConfig(() =>
+  lingoCompiler.vite({
+    sourceRoot: "src",
+    targetLocales: ["es"],
+    models: "lingo.dev"
+  })({
+    plugins: [TanStackRouterVite(), react(), derPlugin()],
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src")
+      }
     }
-  }
-});
+  })
+);


### PR DESCRIPTION
## Overview
Added lingo.dev for multilingual support with Spanish translation.

## Changes
- Installed lingo.dev compiler and React provider
- Configured Vite build to compile translations  
- Added LingoProviderWrapper to main.tsx
- Added LocaleSwitcher to TopNav (desktop + mobile)

## ⚠️ CRITICAL ISSUE - DO NOT MERGE

**Lingo breaks Radix UI components!** The text wrapping causes ref forwarding to fail in:
- Dialog components (Profile dialog won't open)
- DropdownMenu components  
- AlertDialog components
- Any component that uses refs internally

This makes critical UI features unusable.

## Possible Solutions

1. **Find exclusion mechanism** - Need way to exclude Radix components from translation
2. **Switch to different i18n** - Use react-i18next or similar that doesn't wrap text
3. **Accept limitations** - Manually mark problem components with `data-lingo-skip`

## Testing

Run `bun run dev` and try to:
- ❌ Open profile dialog from sidebar (fails)
- ❌ Use dropdown menus (may fail)
- ✅ Language switcher works (visible in top nav)

This PR is for documentation purposes to show the Lingo integration attempt and its issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added language switcher to top navigation for selecting between English and Spanish locales. Language switcher appears on desktop and mobile navigation menus.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->