### PR TITLE
Prioritize Google Play Store official launch

### DIFF
--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -327,11 +327,12 @@ export function Marketing() {
         <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-8">
           <Link
             to="/downloads"
-            className="inline-flex items-center gap-2 py-2 px-4 rounded-lg text-center font-medium transition-all duration-300 
-              border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]
-              text-[hsl(var(--marketing-text-muted))] hover:text-foreground"
+            className="inline-flex items-center gap-2 h-10 px-6 rounded-lg text-center font-medium transition-all duration-300 
+              dark:bg-white/90 dark:text-black dark:hover:bg-white dark:active:bg-white/80
+              bg-black text-white hover:bg-black/90 active:bg-black/80
+              border border-[hsl(var(--marketing-card-border))]"
           >
-            <Laptop className="h-4 w-4" />
+            <Laptop className="h-5 w-5" />
             <span>Desktop</span>
           </Link>
           <a
@@ -345,6 +346,14 @@ export function Marketing() {
               alt="Download on the App Store"
               className="h-10 w-auto"
             />
+          </a>
+          <a
+            href="https://play.google.com/store/apps/details?id=cloud.opensecret.maple"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-block"
+          >
+            <img src="/google-play-badge.png" alt="Get it on Google Play" className="h-10 w-auto" />
           </a>
         </div>
       </section>

--- a/frontend/src/routes/downloads.tsx
+++ b/frontend/src/routes/downloads.tsx
@@ -69,7 +69,6 @@ function DownloadPage() {
           }
           subtitle={
             <div className="space-y-2">
-              <p>Available for macOS and Ubuntu Linux</p>
               <p>Access your private AI chat with end-to-end encryption</p>
             </div>
           }
@@ -238,40 +237,41 @@ function DownloadPage() {
                 Download our native Android app for phones and tablets.
               </p>
               <div className="flex flex-col items-center gap-4">
-                <p className="text-[hsl(var(--marketing-text-muted))] text-sm text-center">
-                  Join our beta program to test the latest features:
-                </p>
                 <a
-                  href="https://play.google.com/apps/testing/cloud.opensecret.maple"
-                  className="py-3 px-6 rounded-lg text-center font-medium transition-all duration-300
-                  dark:bg-white/90 dark:text-black dark:hover:bg-[hsl(var(--purple))]/80 dark:hover:text-[hsl(var(--foreground))] dark:active:bg-white/80
-                  bg-background text-foreground hover:bg-[hsl(var(--purple))] hover:text-[hsl(var(--foreground))] active:bg-background/80
-                  border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]
-                  shadow-[0_0_15px_rgba(var(--purple-rgb),0.2)] hover:shadow-[0_0_25px_rgba(var(--purple-rgb),0.3)]"
+                  href="https://play.google.com/store/apps/details?id=cloud.opensecret.maple"
+                  className="inline-block"
                   target="_blank"
                   rel="noopener noreferrer"
                 >
-                  Join Google Play Beta
+                  <img src="/google-play-badge.png" alt="Get it on Google Play" className="h-12" />
                 </a>
                 <div className="w-full border-t border-[hsl(var(--marketing-card-border))] pt-4">
                   <p className="text-[hsl(var(--marketing-text-muted))] text-sm mb-3 text-center">
-                    Or download the APK directly:
+                    Want to test the latest features before they hit the Play Store? Join our beta
+                    program.
                   </p>
-                  <a
-                    href={downloadUrls.androidApk}
-                    className="py-2 px-4 rounded-lg text-center font-medium transition-all duration-300 block
-                    dark:bg-white/90 dark:text-black dark:hover:bg-[hsl(var(--purple))]/80 dark:hover:text-[hsl(var(--foreground))] dark:active:bg-white/80
-                    bg-background text-foreground hover:bg-[hsl(var(--purple))] hover:text-[hsl(var(--foreground))] active:bg-background/80
-                    border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Download APK (Beta)
-                  </a>
+                  <div className="flex flex-col items-center gap-2">
+                    <a
+                      href="https://play.google.com/apps/testing/cloud.opensecret.maple"
+                      className="py-2 px-4 rounded-lg text-center text-sm font-medium transition-all duration-300
+                      dark:bg-white/90 dark:text-black dark:hover:bg-[hsl(var(--purple))]/80 dark:hover:text-[hsl(var(--foreground))] dark:active:bg-white/80
+                      bg-background text-foreground hover:bg-[hsl(var(--purple))] hover:text-[hsl(var(--foreground))] active:bg-background/80
+                      border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Join Google Play Beta
+                    </a>
+                    <a
+                      href={downloadUrls.androidApk}
+                      className="text-xs text-[hsl(var(--marketing-text-muted))] hover:text-foreground hover:underline"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      or download APK directly
+                    </a>
+                  </div>
                 </div>
-                <p className="text-[hsl(var(--marketing-text-muted))] text-xs text-center">
-                  Beta version - help us test new features before the official release
-                </p>
               </div>
             </div>
           </div>


### PR DESCRIPTION
## Changes

This PR updates the downloads and marketing pages to feature the official Google Play Store launch prominently.

### Updates:
- ✅ Add Google Play Store badge to marketing page hero section alongside App Store
- ✅ Feature official Play Store link prominently on downloads page with store badge
- ✅ Make beta testing and APK download secondary options with smaller, minimal styling
- ✅ Update Desktop button on marketing page to match store badge styling and size
- ✅ Remove platform-specific subtitle text to reflect multi-platform availability

### Screenshots:
See mobile apps section on downloads page - Android section now leads with the official Play Store badge, with beta testing presented as an optional secondary choice similar to iOS TestFlight.

Marketing page hero now shows Desktop, App Store, and Google Play Store badges in a consistent style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Google Play badge as a download option alongside existing app store links.

* **Style**
  * Enhanced call-to-action button styling with improved dark-mode compatibility.
  * Increased icon sizes for improved visual prominence.
  * Redesigned Android download experience with badge presentation and direct APK download option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->