### PR TITLE
Fix web search toggle first-time behavior

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -2507,10 +2507,12 @@ export function UnifiedChat() {
                                 return;
                               }
 
-                              // Step 2: Check if this is their first time (show info dialog)
+                              // Step 2: Check if this is their first time (enable web search, set flag, show popup)
                               const hasSeenWebSearchInfo =
                                 localStorage.getItem("hasSeenWebSearchInfo") === "true";
                               if (!hasSeenWebSearchInfo) {
+                                localStorage.setItem("hasSeenWebSearchInfo", "true");
+                                setIsWebSearchEnabled(true);
                                 setWebSearchInfoDialogOpen(true);
                                 return;
                               }
@@ -2764,10 +2766,12 @@ export function UnifiedChat() {
                               return;
                             }
 
-                            // Step 2: Check if this is their first time (show info dialog)
+                            // Step 2: Check if this is their first time (enable web search, set flag, show popup)
                             const hasSeenWebSearchInfo =
                               localStorage.getItem("hasSeenWebSearchInfo") === "true";
                             if (!hasSeenWebSearchInfo) {
+                              localStorage.setItem("hasSeenWebSearchInfo", "true");
+                              setIsWebSearchEnabled(true);
                               setWebSearchInfoDialogOpen(true);
                               return;
                             }
@@ -2927,15 +2931,11 @@ export function UnifiedChat() {
         <WebSearchInfoDialog
           open={webSearchInfoDialogOpen}
           onOpenChange={(open) => {
-            // When dialog is closed (any way), mark as seen and enable web search
-            if (!open) {
-              localStorage.setItem("hasSeenWebSearchInfo", "true");
-              setIsWebSearchEnabled(true);
-            }
+            // When dialog is closed via X or backdrop, just dismiss - web search already enabled on click
             setWebSearchInfoDialogOpen(open);
           }}
           onConfirm={() => {
-            // Just close the dialog (onOpenChange handles the rest)
+            // "Got it" button - just close (web search already enabled on click)
             setWebSearchInfoDialogOpen(false);
           }}
         />


### PR DESCRIPTION
## Problem
On the Tauri version (Android/Desktop), the web search first-time popup wasn't working correctly:
- Clicking the globe icon for the first time didn't set the flag or activate web search
- Only closing the dialog (any method) would set the flag and activate search
- This meant the popup could show multiple times and the globe wouldn't be active on first click

## Solution
- Globe icon now **enables web search immediately** on first click
- Flag is set on first click to prevent future popups
- Popup shows **after** enabling to inform the user
- Closing popup (via X, backdrop, or "Got it") only dismisses the dialog
- Subsequent clicks toggle web search on/off normally

## Testing
- Verified build passes with all pre-commit hooks
- Linting and formatting checks pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Web search is now enabled immediately when first-time users trigger the web search introduction, improving onboarding.
  * Closing the web search info dialog no longer implicitly enables web search or marks it as seen; those actions occur only at the initial trigger, reducing unexpected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->