### PR TITLE
Remove Mistral and Qwen 2.5 72B model support

### DIFF
--- a/frontend/src/components/ContextLimitDialog.tsx
+++ b/frontend/src/components/ContextLimitDialog.tsx
@@ -62,8 +62,8 @@ export function ContextLimitDialog({
                 <li className="flex items-start gap-2">
                   <MessageCircle className="h-4 w-4 mt-0.5 shrink-0" />
                   <span>
-                    <strong>Switch to a model with more context</strong> - Try DeepSeek R1, Mistral,
-                    or other models that support 128k tokens
+                    <strong>Switch to a model with more context</strong> - Try DeepSeek R1 or other
+                    models that support 128k tokens
                   </span>
                 </li>
               )}

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -82,21 +82,6 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     requiresPro: true,
     tokenLimit: 128000
   },
-  "mistral-small-3-1-24b": {
-    displayName: "Mistral Small 3.1 24B",
-    shortName: "Mistral Small",
-    badges: ["Pro"],
-    requiresPro: true,
-    supportsVision: true,
-    tokenLimit: 128000
-  },
-  "qwen2-5-72b": {
-    displayName: "Qwen 2.5 72B",
-    shortName: "Qwen 2.5",
-    badges: ["Pro"],
-    requiresPro: true,
-    tokenLimit: 128000
-  },
   "qwen3-coder-480b": {
     displayName: "Qwen3 Coder 480B",
     shortName: "Qwen3 Coder",

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -193,7 +193,7 @@ export function UpgradePromptDialog({
         benefits: [
           "All models run in secure, encrypted environments",
           "Access to DeepSeek R1 for advanced reasoning",
-          "OpenAI GPT-OSS, Mistral, Qwen, and more",
+          "OpenAI GPT-OSS, Qwen, and other advanced models",
           "Higher token limits for longer conversations",
           "Priority access to new models as they launch"
         ]


### PR DESCRIPTION
Removes support for Mistral Small 3.1 24B and Qwen 2.5 72B models as they are no longer supported.

**Changes:**
- Removed  model configuration from ModelSelector
- Removed  model configuration from ModelSelector
- Updated marketing text in UpgradePromptDialog to remove Mistral reference while keeping Qwen (for Qwen3 Coder)
- Updated ContextLimitDialog to remove Mistral suggestion

**Note:** Qwen 3 Coder 480B is still supported and remains in the model list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Two models removed from the available model selection list
  * Context limit dialogs updated with revised alternative model recommendations featuring higher token capacity options
  * Marketing information about available advanced AI models revised

<!-- end of auto-generated comment: release notes by coderabbit.ai -->