### PR TITLE
Show subscription expiration/renewal date in account profile

### DIFF
--- a/frontend/src/components/AccountDialog.tsx
+++ b/frontend/src/components/AccountDialog.tsx
@@ -117,11 +117,14 @@ export function AccountDialog() {
                 billingStatus.payment_provider === "zaprite"
                   ? "Expires on "
                   : "Renews on "}
-                {new Date(billingStatus.current_period_end).toLocaleDateString(undefined, {
-                  year: "numeric",
-                  month: "long",
-                  day: "numeric"
-                })}
+                {new Date(Number(billingStatus.current_period_end) * 1000).toLocaleDateString(
+                  undefined,
+                  {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric"
+                  }
+                )}
               </div>
             )}
           </div>


### PR DESCRIPTION
This PR updates the Account Dialog to display the subscription renewal date for Stripe users and expiration date for Zaprite/Subscription Pass users. This replaces the need for a 'Manage Plan' button for non-Stripe users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Account settings now show billing period details beneath the plan selector, displaying a formatted date and context-sensitive prefix: "Expires on" for certain payment providers and "Renews on" for others, so you can quickly see when your billing period ends or renews.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->