### PR TITLE
Hide Google Play downloads on iOS Tauri builds

### DIFF
--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -327,7 +327,7 @@ export function Marketing() {
         <div className="flex flex-col sm:flex-row justify-center items-center gap-4 mt-8">
           <Link
             to="/downloads"
-            className="inline-flex items-center gap-2 h-10 px-6 rounded-lg text-center font-medium transition-all duration-300 
+            className="inline-flex items-center gap-2 h-10 px-6 rounded-lg text-center font-medium transition-all duration-300
               dark:bg-white/90 dark:text-black dark:hover:bg-white dark:active:bg-white/80
               bg-black text-white hover:bg-black/90 active:bg-black/80
               border border-[hsl(var(--marketing-card-border))]"
@@ -347,14 +347,20 @@ export function Marketing() {
               className="h-10 w-auto"
             />
           </a>
-          <a
-            href="https://play.google.com/store/apps/details?id=cloud.opensecret.maple"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block"
-          >
-            <img src="/google-play-badge.png" alt="Get it on Google Play" className="h-10 w-auto" />
-          </a>
+          {!isIOSPlatform && (
+            <a
+              href="https://play.google.com/store/apps/details?id=cloud.opensecret.maple"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-block"
+            >
+              <img
+                src="/google-play-badge.png"
+                alt="Get it on Google Play"
+                className="h-10 w-auto"
+              />
+            </a>
+          )}
         </div>
       </section>
 

--- a/frontend/src/routes/downloads.tsx
+++ b/frontend/src/routes/downloads.tsx
@@ -7,6 +7,7 @@ import { Apple } from "@/components/icons/Apple";
 import { Android } from "@/components/icons/Android";
 import { useState, useEffect } from "react";
 import { getLatestDownloadInfo } from "@/utils/githubRelease";
+import { isIOS } from "@/utils/platform";
 import packageJson from "../../package.json";
 
 interface DownloadUrls {
@@ -30,6 +31,7 @@ const FALLBACK_URLS: DownloadUrls = {
 };
 
 function DownloadPage() {
+  const isIOSPlatform = isIOS();
   const [downloadUrls, setDownloadUrls] = useState<DownloadUrls>(FALLBACK_URLS);
   const [currentVersion, setCurrentVersion] = useState<string>(FALLBACK_VERSION);
   const [releaseUrl, setReleaseUrl] = useState<string>(
@@ -228,52 +230,58 @@ function DownloadPage() {
                 </div>
               </div>
             </div>
-            <div className="flex flex-col border border-[hsl(var(--marketing-card-border))] bg-[hsl(var(--marketing-card))]/75 text-foreground p-6 rounded-lg hover:border-foreground/30 transition-all duration-300">
-              <div className="p-3 rounded-full bg-[hsl(var(--marketing-card))]/50 border border-[hsl(var(--purple))]/30 w-fit mb-4">
-                <Android className="w-6 h-6 text-[hsl(var(--purple))]" />
-              </div>
-              <h3 className="text-xl font-medium mb-2">Android</h3>
-              <p className="text-[hsl(var(--marketing-text-muted))] mb-6 flex-grow">
-                Download our native Android app for phones and tablets.
-              </p>
-              <div className="flex flex-col items-center gap-4">
-                <a
-                  href="https://play.google.com/store/apps/details?id=cloud.opensecret.maple"
-                  className="inline-block"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                >
-                  <img src="/google-play-badge.png" alt="Get it on Google Play" className="h-12" />
-                </a>
-                <div className="w-full border-t border-[hsl(var(--marketing-card-border))] pt-4">
-                  <p className="text-[hsl(var(--marketing-text-muted))] text-sm mb-3 text-center">
-                    Want to test the latest features before they hit the Play Store? Join our beta
-                    program.
-                  </p>
-                  <div className="flex flex-col items-center gap-2">
-                    <a
-                      href="https://play.google.com/apps/testing/cloud.opensecret.maple"
-                      className="py-2 px-4 rounded-lg text-center text-sm font-medium transition-all duration-300
-                      dark:bg-white/90 dark:text-black dark:hover:bg-[hsl(var(--purple))]/80 dark:hover:text-[hsl(var(--foreground))] dark:active:bg-white/80
-                      bg-background text-foreground hover:bg-[hsl(var(--purple))] hover:text-[hsl(var(--foreground))] active:bg-background/80
-                      border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Join Google Play Beta
-                    </a>
-                    <a
-                      href={downloadUrls.androidApk}
-                      className="text-xs text-[hsl(var(--marketing-text-muted))] hover:text-foreground hover:underline"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      or download APK directly
-                    </a>
+            {!isIOSPlatform && (
+              <div className="flex flex-col border border-[hsl(var(--marketing-card-border))] bg-[hsl(var(--marketing-card))]/75 text-foreground p-6 rounded-lg hover:border-foreground/30 transition-all duration-300">
+                <div className="p-3 rounded-full bg-[hsl(var(--marketing-card))]/50 border border-[hsl(var(--purple))]/30 w-fit mb-4">
+                  <Android className="w-6 h-6 text-[hsl(var(--purple))]" />
+                </div>
+                <h3 className="text-xl font-medium mb-2">Android</h3>
+                <p className="text-[hsl(var(--marketing-text-muted))] mb-6 flex-grow">
+                  Download our native Android app for phones and tablets.
+                </p>
+                <div className="flex flex-col items-center gap-4">
+                  <a
+                    href="https://play.google.com/store/apps/details?id=cloud.opensecret.maple"
+                    className="inline-block"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    <img
+                      src="/google-play-badge.png"
+                      alt="Get it on Google Play"
+                      className="h-12"
+                    />
+                  </a>
+                  <div className="w-full border-t border-[hsl(var(--marketing-card-border))] pt-4">
+                    <p className="text-[hsl(var(--marketing-text-muted))] text-sm mb-3 text-center">
+                      Want to test the latest features before they hit the Play Store? Join our beta
+                      program.
+                    </p>
+                    <div className="flex flex-col items-center gap-2">
+                      <a
+                        href="https://play.google.com/apps/testing/cloud.opensecret.maple"
+                        className="py-2 px-4 rounded-lg text-center text-sm font-medium transition-all duration-300
+                        dark:bg-white/90 dark:text-black dark:hover:bg-[hsl(var(--purple))]/80 dark:hover:text-[hsl(var(--foreground))] dark:active:bg-white/80
+                        bg-background text-foreground hover:bg-[hsl(var(--purple))] hover:text-[hsl(var(--foreground))] active:bg-background/80
+                        border border-[hsl(var(--purple))]/30 hover:border-[hsl(var(--purple))]"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        Join Google Play Beta
+                      </a>
+                      <a
+                        href={downloadUrls.androidApk}
+                        className="text-xs text-[hsl(var(--marketing-text-muted))] hover:text-foreground hover:underline"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        or download APK directly
+                      </a>
+                    </div>
                   </div>
                 </div>
               </div>
-            </div>
+            )}
           </div>
         </section>
 


### PR DESCRIPTION
Fixes #314

Apple App Store policies prohibit showing alternative app stores. This change conditionally hides Google Play content when running on iOS devices:

- **Homepage**: Hide Google Play badge when running on iOS
- **Downloads page**: Hide entire Android section when running on iOS

Uses existing `isIOS()` platform detection utility.

---

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Added platform-aware content display: Android and Google Play download options are now hidden when using the app on iOS.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->