### PR TITLE
fix: restore image upload for starter plan users

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -1322,7 +1322,11 @@ export function UnifiedChat() {
       billingStatus.product_name?.toLowerCase().includes("max") ||
       billingStatus.product_name?.toLowerCase().includes("team"));
 
-  const canUseImages = hasProAccess;
+  const hasStarterAccess =
+    billingStatus &&
+    (billingStatus.product_name?.toLowerCase().includes("starter") || hasProAccess);
+
+  const canUseImages = hasStarterAccess;
   const canUseDocuments = hasProAccess;
   const canUseVoice = hasProAccess && localState.hasWhisperModel;
   const canUseWebSearch = hasProAccess;


### PR DESCRIPTION
Fixes #311

Restores image upload functionality for users on the Starter plan, which was accidentally removed in a recent refactor. Confirmed logic against pricingConfig.tsx.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated access requirements for image uploads to now require Starter-tier subscription status in addition to existing Pro-level access. Document, Voice, and WebSearch features maintain their current access requirements.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->