### PR TITLE
Update anon account warnings to mention subscription passes

### DIFF
--- a/frontend/src/components/GuestPaymentWarningDialog.tsx
+++ b/frontend/src/components/GuestPaymentWarningDialog.tsx
@@ -51,7 +51,7 @@ export function GuestPaymentWarningDialog({ open, onOpenChange }: GuestPaymentWa
             </p>
             <p className="text-sm text-muted-foreground">
               To start chatting with Maple AI, you need to subscribe to a paid plan. Anonymous
-              accounts must pay for a full year using Bitcoin.
+              accounts must pay for a full year using Bitcoin or redeem a subscription pass.
             </p>
           </div>
 

--- a/frontend/src/components/GuestSignupWarningDialog.tsx
+++ b/frontend/src/components/GuestSignupWarningDialog.tsx
@@ -68,8 +68,9 @@ export function GuestSignupWarningDialog({
                   htmlFor="bitcoin-payment"
                   className="text-sm font-medium leading-relaxed cursor-pointer break-words"
                 >
-                  I understand I <strong>MUST pay for a full year in Bitcoin only</strong>. No
-                  credit card, no Stripe, no monthly payment options, and{" "}
+                  I understand I{" "}
+                  <strong>MUST pay for a full year in Bitcoin or redeem a subscription pass</strong>
+                  . No credit card, no Stripe, no monthly payment options, and{" "}
                   <strong>no free trial</strong> are available for anonymous accounts.
                 </Label>
               </div>


### PR DESCRIPTION
Updated GuestSignupWarningDialog and GuestPaymentWarningDialog to inform users that they can redeem subscription passes as an alternative to Bitcoin payment for anonymous accounts.

Fixes #317

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated payment messaging for guest account signups to clarify that annual subscriptions can be paid via Bitcoin or by redeeming a subscription pass.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->