### PR TITLE
Fix: Workaround macOS hashFiles runner bug

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -32,7 +32,8 @@ jobs:
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/sccache
             /opt/homebrew/Cellar/openssl@3
-          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/desktop-build.yml') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: ${{ runner.os }}-brew-v1
           restore-keys: |
             ${{ runner.os }}-brew-
 
@@ -46,7 +47,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Caches/Mozilla.sccache
-          key: ${{ runner.os }}-sccache-macos-${{ hashFiles('**/Cargo.lock') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: ${{ runner.os }}-sccache-macos-v1
           restore-keys: |
             ${{ runner.os }}-sccache-macos-
             ${{ runner.os }}-sccache-

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -28,14 +28,16 @@ jobs:
           path: |
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/openssl@3
-          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/mobile-build.yml') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: ${{ runner.os }}-brew-v1
           restore-keys: |
             ${{ runner.os }}-brew-
 
       - name: Cache Xcode DerivedData and SourcePackages
         uses: irgaly/xcode-cache@v1
         with:
-          key: xcode-cache-ios-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: xcode-cache-ios-${{ github.workflow }}-v1
           restore-keys: |
             xcode-cache-ios-${{ github.workflow }}-
             xcode-cache-ios-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,8 @@ jobs:
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/sccache
             /opt/homebrew/Cellar/openssl@3
-          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/release.yml') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: ${{ runner.os }}-brew-v1
           restore-keys: |
             ${{ runner.os }}-brew-
 
@@ -82,7 +83,8 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ matrix.platform == 'macos-latest' && '~/Library/Caches/Mozilla.sccache' || '~/.cache/sccache' }}
-          key: ${{ runner.os }}-sccache-release-${{ hashFiles('**/Cargo.lock') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: ${{ runner.os }}-sccache-release-${{ matrix.platform == 'macos-latest' && 'v1' || hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-sccache-release-
             ${{ runner.os }}-sccache-

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -86,14 +86,16 @@ jobs:
           path: |
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/openssl@3
-          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/testflight-on-comment.yml') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: ${{ runner.os }}-brew-v1
           restore-keys: |
             ${{ runner.os }}-brew-
 
       - name: Cache Xcode DerivedData and SourcePackages
         uses: irgaly/xcode-cache@v1
         with:
-          key: xcode-cache-testflight-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
+          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
+          key: xcode-cache-testflight-${{ github.workflow }}-v1
           restore-keys: |
             xcode-cache-testflight-${{ github.workflow }}-
             xcode-cache-testflight-


### PR DESCRIPTION
This PR implements a temporary workaround for a critical GitHub Actions runner bug affecting macOS environments.

The `hashFiles` function is currently throwing 'The template is not valid' errors on macOS runners. To unblock builds, this PR replaces dynamic hash-based cache keys with static keys (`v1`) for macOS jobs in the following workflows:

- `mobile-build.yml`
- `desktop-build.yml`
- `testflight-on-comment.yml`
- `release.yml`

Reference: https://github.com/actions/runner-images/issues/13341

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardized CI cache keys across desktop, mobile, release and TestFlight workflows to work around a macOS hashing issue, improving build consistency, reducing cache-related failures, and speeding CI runs. Added explanatory notes in the workflows to aid future maintenance.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->