### PR TITLE
Revert "Workaround macOS hashFiles runner bug"

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -32,8 +32,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/sccache
             /opt/homebrew/Cellar/openssl@3
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: ${{ runner.os }}-brew-v1
+          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/desktop-build.yml') }}
           restore-keys: |
             ${{ runner.os }}-brew-
 
@@ -47,8 +46,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/Library/Caches/Mozilla.sccache
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: ${{ runner.os }}-sccache-macos-v1
+          key: ${{ runner.os }}-sccache-macos-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-sccache-macos-
             ${{ runner.os }}-sccache-

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -28,16 +28,14 @@ jobs:
           path: |
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/openssl@3
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: ${{ runner.os }}-brew-v1
+          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/mobile-build.yml') }}
           restore-keys: |
             ${{ runner.os }}-brew-
 
       - name: Cache Xcode DerivedData and SourcePackages
         uses: irgaly/xcode-cache@v1
         with:
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: xcode-cache-ios-${{ github.workflow }}-v1
+          key: xcode-cache-ios-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             xcode-cache-ios-${{ github.workflow }}-
             xcode-cache-ios-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,8 +57,7 @@ jobs:
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/sccache
             /opt/homebrew/Cellar/openssl@3
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: ${{ runner.os }}-brew-v1
+          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/release.yml') }}
           restore-keys: |
             ${{ runner.os }}-brew-
 
@@ -83,8 +82,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ matrix.platform == 'macos-latest' && '~/Library/Caches/Mozilla.sccache' || '~/.cache/sccache' }}
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: ${{ runner.os }}-sccache-release-${{ matrix.platform == 'macos-latest' && 'v1' || hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-sccache-release-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-sccache-release-
             ${{ runner.os }}-sccache-

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -86,16 +86,14 @@ jobs:
           path: |
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/openssl@3
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: ${{ runner.os }}-brew-v1
+          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/testflight-on-comment.yml') }}
           restore-keys: |
             ${{ runner.os }}-brew-
 
       - name: Cache Xcode DerivedData and SourcePackages
         uses: irgaly/xcode-cache@v1
         with:
-          # Workaround for hashFiles bug on macOS runners: https://github.com/actions/runner-images/issues/13341
-          key: xcode-cache-testflight-${{ github.workflow }}-v1
+          key: xcode-cache-testflight-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             xcode-cache-testflight-${{ github.workflow }}-
             xcode-cache-testflight-


### PR DESCRIPTION
Reverts the workaround for the macOS hashFiles runner bug as the upstream issue has been resolved/mitigated. Restores dynamic caching keys.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline caching to ensure dependencies and workflow changes trigger appropriate cache refreshes, resulting in more efficient and reliable builds across desktop, mobile, and release workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->