### PR TITLE
fix(signup): blur input on submit to prevent password manager conflicts

### DIFF
--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -207,6 +207,14 @@ function SignupPage() {
 
   const handleGuestSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
+
+    // Blur the active element (password input) to prevent conflicts with password managers
+    // (like Bitwarden) that might try to show a popup/overlay when Enter is pressed,
+    // which can conflict with the GuestCredentialsDialog.
+    if (document.activeElement instanceof HTMLElement) {
+      document.activeElement.blur();
+    }
+
     setIsLoading(true);
     setError(null);
     const formData = new FormData(e.currentTarget);


### PR DESCRIPTION
This PR fixes a bug where password managers (like Bitwarden) would show an overlay/popup when the user presses Enter to submit the anonymous signup form, conflicting with the subsequent Account ID dialog.

The fix is to blur the active element (password input) immediately upon form submission, which dismisses any potential password manager overlays before the modal appears.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved a compatibility issue where password-manager UI overlays would interfere with guest signup when submitting the form via the Enter key. This fix ensures the signup workflow completes smoothly and reliably without interruptions from third-party password management tools, delivering a more seamless user experience.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->