### PR TITLE
fix(android): add explicit OAuth URLs to opener plugin permissions

### DIFF
--- a/frontend/src-tauri/capabilities/mobile-android.json
+++ b/frontend/src-tauri/capabilities/mobile-android.json
@@ -77,6 +77,15 @@
           "url": "https://*.google.com/*"
         },
         {
+          "url": "https://accounts.google.com/*"
+        },
+        {
+          "url": "https://oauth.github.com/*"
+        },
+        {
+          "url": "https://appleid.apple.com/*"
+        },
+        {
           "url": "https://*"
         }
       ]


### PR DESCRIPTION
Android release builds don't reliably respect wildcard https://* permissions in the opener plugin. This causes OAuth flows to fail on physical devices because the external browser won't open.

Added explicit URL permissions for:
- https://accounts.google.com/* (Google OAuth)
- https://oauth.github.com/* (GitHub OAuth)
- https://appleid.apple.com/* (Apple Sign In)

These explicit permissions ensure OAuth works on both debug builds (emulator) and release builds (physical devices/production).

Tested on:
- Emulator: OAuth flows work ✓
- Physical device: OAuth flows work after fix ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Google, GitHub, and Apple authentication methods on mobile Android devices, enabling users to sign in using their existing accounts with these providers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->