### PR TITLE
fix: skip proxy notification listeners on web

### DIFF
--- a/frontend/src/components/ProxyEventListener.tsx
+++ b/frontend/src/components/ProxyEventListener.tsx
@@ -2,11 +2,17 @@ import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { useNotification } from "@/contexts/NotificationContext";
 import { Server } from "lucide-react";
+import { isTauri } from "@/utils/platform";
 
 export function ProxyEventListener() {
   const { showNotification } = useNotification();
 
   useEffect(() => {
+    // Only setup listeners if running on Tauri (not web)
+    if (!isTauri()) {
+      return;
+    }
+
     let unlistenAutoStarted: (() => void) | null = null;
     let unlistenAutoStartFailed: (() => void) | null = null;
 


### PR DESCRIPTION
Fixes #326

Added isTauri() check to ProxyEventListener component to prevent console errors when running on web platform. The component now only sets up Tauri event listeners on desktop/mobile Tauri environments.

## Changes
- Modified `frontend/src/components/ProxyEventListener.tsx`
- Added platform detection to skip listener setup on web

----
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed event listener initialization to properly detect and run only within the Tauri environment, preventing potential errors when running the application in other contexts.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->