### PR TITLE
feat: replace native update dialog with toast notification

### DIFF
--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -24,7 +24,6 @@ log = "0.4"
 tauri = { version = "2.9.2", features = [] }
 tauri-plugin-log = "2.7.1"
 tauri-plugin-updater = "2.9.0"
-tauri-plugin-dialog = "2.4.2"
 tauri-plugin = "2.1.1"
 tauri-plugin-deep-link = "2.4.5"
 tauri-plugin-single-instance = { version = "2.3.6", features = ["deep-link"] }

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -8,7 +8,6 @@
   "permissions": [
     "core:default",
     "updater:default",
-    "dialog:default",
     "fs:default",
     {
       "identifier": "fs:allow-read-file",

--- a/frontend/src-tauri/capabilities/mobile-android.json
+++ b/frontend/src-tauri/capabilities/mobile-android.json
@@ -9,7 +9,6 @@
   "permissions": [
     "core:default",
     "core:event:default",
-    "dialog:default",
     "deep-link:default",
     "fs:default",
     {

--- a/frontend/src-tauri/capabilities/mobile-ios.json
+++ b/frontend/src-tauri/capabilities/mobile-ios.json
@@ -10,7 +10,6 @@
     "core:default",
     "core:event:default",
     "updater:default",
-    "dialog:default",
     "deep-link:default",
     {
       "identifier": "opener:allow-open-url",

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -13,6 +13,7 @@ import { BillingServiceProvider } from "./components/BillingServiceProvider";
 import { DeepLinkHandler } from "./components/DeepLinkHandler";
 import { NotificationProvider } from "./contexts/NotificationContext";
 import { ProxyEventListener } from "./components/ProxyEventListener";
+import { UpdateEventListener } from "./components/UpdateEventListener";
 
 // Create a new router instance
 const router = createRouter({
@@ -99,6 +100,7 @@ export default function App() {
               <TooltipProvider>
                 <BillingServiceProvider>
                   <ProxyEventListener />
+                  <UpdateEventListener />
                   <DeepLinkHandler />
                   <InnerApp />
                 </BillingServiceProvider>

--- a/frontend/src/components/UpdateEventListener.tsx
+++ b/frontend/src/components/UpdateEventListener.tsx
@@ -1,0 +1,65 @@
+import { useEffect } from "react";
+import { listen } from "@tauri-apps/api/event";
+import { invoke } from "@tauri-apps/api/core";
+import { useNotification } from "@/contexts/NotificationContext";
+import { isTauri } from "@/utils/platform";
+
+interface UpdateReadyPayload {
+  version: string;
+}
+
+export function UpdateEventListener() {
+  const { showNotification } = useNotification();
+
+  useEffect(() => {
+    if (!isTauri()) {
+      return;
+    }
+
+    let unlistenUpdateReady: (() => void) | null = null;
+
+    const setupListeners = async () => {
+      try {
+        unlistenUpdateReady = await listen<UpdateReadyPayload>("update-ready", (event) => {
+          const { version } = event.payload;
+          showNotification({
+            type: "update",
+            title: "Update Ready",
+            message: `Version ${version} has been downloaded and is ready to install.`,
+            duration: 0,
+            actions: [
+              {
+                label: "Later",
+                variant: "secondary",
+                onClick: () => {
+                  // Just dismiss - the notification will close automatically
+                }
+              },
+              {
+                label: "Restart Now",
+                variant: "primary",
+                onClick: async () => {
+                  try {
+                    await invoke("restart_for_update");
+                  } catch (error) {
+                    console.error("Failed to restart for update:", error);
+                  }
+                }
+              }
+            ]
+          });
+        });
+      } catch (error) {
+        console.error("Failed to setup update event listeners:", error);
+      }
+    };
+
+    setupListeners();
+
+    return () => {
+      if (unlistenUpdateReady) unlistenUpdateReady();
+    };
+  }, [showNotification]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
Replace the intrusive native dialog popup with a subtle toast notification when an update is ready to install.

## Changes
- Extended `GlobalNotification.tsx` with action button support and persistent mode (duration=0)
- Created `UpdateEventListener.tsx` to handle `update-ready` events from the Rust backend
- Modified `lib.rs` to emit events instead of showing native dialog
- Added `restart_for_update` command for frontend-triggered restart

## User Experience
- Toast notification appears in top-right corner when update is downloaded
- Shows version number and two buttons: "Later" (dismiss) and "Restart Now" (apply update)
- Notification persists until user interacts with it
- Non-intrusive - doesn't block the UI like the native dialog did

## Testing
Tested locally by temporarily lowering version to trigger update detection. Toast appeared correctly with both buttons functioning as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Update notifications now show the downloaded version and offer "Later" and "Restart Now" actions.
  * Notifications support actionable buttons with primary/secondary styling.

* **Refactor**
  * Switched to an event-driven update flow where the frontend handles restart prompts and actions.

* **Chores**
  * Removed native dialog-based prompt and cleaned up related platform permissions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->