### PR TITLE
Rename 'Free' model category to 'General'

### DIFF
--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -22,7 +22,11 @@ import { Badge } from "@/components/ui/badge";
 const AI_MODELS = [
   { src: "/badge-openai-logo.png", alt: "OpenAI", labels: ["OpenAI GPT-OSS"] },
   { src: "/badge-google-logo.png", alt: "Google", labels: ["Google Gemma"] },
-  { src: "/badge-deepseek-logo.png", alt: "DeepSeek", labels: ["DeepSeek R1", "DeepSeek V3.1 Terminus"] },
+  {
+    src: "/badge-deepseek-logo.png",
+    alt: "DeepSeek",
+    labels: ["DeepSeek R1", "DeepSeek V3.1 Terminus"]
+  },
   { src: "/badge-qwen-logo.png", alt: "Qwen", labels: ["Qwen3 Coder", "Qwen3-VL"] },
   { src: "/badge-meta-logo.png", alt: "Meta", labels: ["Meta Llama"] }
 ];

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -121,7 +121,7 @@ export const CATEGORY_MODELS = {
 
 const CATEGORY_INFO = {
   free: {
-    label: "Free",
+    label: "General",
     icon: Sparkles,
     description: "Balanced & capable"
   },
@@ -267,7 +267,7 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
 
   // Get current category based on selected model
   const getCurrentCategory = (): string => {
-    if (model === CATEGORY_MODELS.free) return "Free";
+    if (model === CATEGORY_MODELS.free) return "General";
     if (model === CATEGORY_MODELS.quick) return "Quick";
     if (model === CATEGORY_MODELS.reasoning_on || model === CATEGORY_MODELS.reasoning_off) {
       return "Reasoning";


### PR DESCRIPTION
Renames the 'Free' label in the model selector to 'General' for all users regardless of their subscription plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Model category label changed from "Free" to "General" for improved clarity and categorization.

* **Style**
  * Enhanced code formatting consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->