### PR TITLE
Add fullscreen mode for chat input

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -669,11 +669,20 @@ export function UnifiedChat() {
   const [isFullscreen, setIsFullscreen] = useState(() => {
     return localStorage.getItem("chatFullscreen") === "true";
   });
+  const [isFullscreenAnimating, setIsFullscreenAnimating] = useState(false);
 
   // Save fullscreen preference to localStorage when it changes
   useEffect(() => {
     localStorage.setItem("chatFullscreen", isFullscreen.toString());
   }, [isFullscreen]);
+
+  // Toggle fullscreen with animation
+  const toggleFullscreen = useCallback(() => {
+    setIsFullscreenAnimating(true);
+    setIsFullscreen((prev) => !prev);
+    // Reset animation state after transition completes
+    setTimeout(() => setIsFullscreenAnimating(false), 300);
+  }, []);
 
   // Easter egg state (for future features)
   const [logoTapCount, setLogoTapCount] = useState(0);
@@ -2368,14 +2377,14 @@ export function UnifiedChat() {
         {messages.length === 0 && !chatId ? (
           // Centered input for new chat
           <div
-            className={`absolute inset-0 flex flex-col px-4 transition-all duration-300 ${
-              isFullscreen ? "justify-start pt-8" : "justify-center"
-            }`}
+            className={`absolute inset-0 flex flex-col px-4 ${
+              isFullscreenAnimating ? "transition-all duration-300" : ""
+            } ${isFullscreen ? "justify-start pt-8" : "justify-center"}`}
           >
             <div
-              className={`w-full mx-auto transition-all duration-300 ${
-                isFullscreen ? "max-w-6xl h-full flex flex-col" : "max-w-4xl"
-              }`}
+              className={`w-full mx-auto ${
+                isFullscreenAnimating ? "transition-all duration-300" : ""
+              } ${isFullscreen ? "max-w-6xl h-full flex flex-col" : "max-w-4xl"}`}
             >
               {/* Logo section - hidden in fullscreen */}
               {!isFullscreen && (
@@ -2468,14 +2477,14 @@ export function UnifiedChat() {
 
                     {/* Main input container with purple focus border */}
                     <div
-                      className={`relative rounded-xl border-2 border-border focus-within:border-purple-500 transition-all bg-background overflow-hidden ${
-                        isFullscreen ? "flex flex-col h-[70vh] max-h-[800px]" : ""
-                      }`}
+                      className={`relative rounded-xl border-2 border-border focus-within:border-purple-500 bg-background overflow-hidden ${
+                        isFullscreenAnimating ? "transition-all duration-300" : "transition-colors"
+                      } ${isFullscreen ? "flex flex-col h-[70vh] max-h-[800px]" : ""}`}
                     >
                       {/* Fullscreen toggle button - top right corner */}
                       <button
                         type="button"
-                        onClick={() => setIsFullscreen(!isFullscreen)}
+                        onClick={toggleFullscreen}
                         className="absolute right-2 top-2 z-10 p-1.5 rounded-md text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors"
                         aria-label={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
                       >


### PR DESCRIPTION
## Summary
Adds a fullscreen mode for power users who want a distraction-free chat experience.

## Changes
- Added Maximize2/Minimize2 toggle button in the top-right inside corner of the chat input box
- When fullscreen is enabled:
  - Hides the Maple logo and "Private AI Chat" subtitle
  - Hides "How can I help you today?"
  - Hides "Encrypted at every step"
  - Expands input container width from max-w-4xl to max-w-6xl
  - Expands textarea to 70vh height (max 800px) for longer prompts
- Preference is persisted in localStorage (key: `chatFullscreen`)
- Works well on mobile with viewport-relative sizing

## Testing
1. Open a new chat (no messages)
2. Click the maximize icon in the top-right corner of the input box
3. Verify the UI elements hide and the input expands
4. Refresh the page - preference should be remembered
5. Click minimize to return to normal mode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fullscreen mode for an immersive, distraction‑free chat with maximize/minimize controls (top‑right toggle and in-input control).
  * Layout adapts in fullscreen: expanded input area, hidden nonessential headers/footers, and repositioned branding.
  * Text input dynamically resizes to use available vertical space; footer messaging is suppressed in fullscreen.
  * Fullscreen state persists across sessions and includes smooth animated transitions for open/close.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->