### PR TITLE
Upgrade vision model to Qwen3-VL 30B

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -116,7 +116,7 @@ export const CATEGORY_MODELS = {
   reasoning_on: "deepseek-r1-0528", // R1 with thinking
   reasoning_off: "deepseek-v31-terminus", // V3.1 without thinking
   math: "qwen3-coder-480b",
-  image: "gemma-3-27b" // Gemma for image analysis
+  image: "qwen3-vl-30b" // Qwen3-VL for image analysis
 };
 
 const CATEGORY_INFO = {


### PR DESCRIPTION
## Changes

- Allow starter plan users (any paid user) to access Qwen3-VL 30B
- Change the Image Analysis category to use Qwen3-VL 30B instead of Gemma 3 27B
- Gemma 3 27B remains available in the Advanced menu

This upgrades the default vision model for paid users while keeping Gemma accessible for those who prefer it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Qwen3-VL 30B model now accessible to Starter tier users (previously Pro-only)
  * Image analysis category now powered by Qwen3-VL model

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->