### PR TITLE
Remove DeepSeek v3.1 terminus model

### DIFF
--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -25,7 +25,7 @@ const AI_MODELS = [
   {
     src: "/badge-deepseek-logo.png",
     alt: "DeepSeek",
-    labels: ["DeepSeek R1", "DeepSeek V3.1 Terminus"]
+    labels: ["DeepSeek R1"]
   },
   { src: "/badge-qwen-logo.png", alt: "Qwen", labels: ["Qwen3 Coder", "Qwen3-VL"] },
   { src: "/badge-meta-logo.png", alt: "Meta", labels: ["Meta Llama"] }

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -68,13 +68,6 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     requiresPro: true,
     tokenLimit: 130000
   },
-  "deepseek-v31-terminus": {
-    displayName: "DeepSeek V3.1 Terminus",
-    shortName: "DeepSeek V3.1",
-    badges: ["Pro", "New"],
-    requiresPro: true,
-    tokenLimit: 130000
-  },
   "gpt-oss-120b": {
     displayName: "OpenAI GPT-OSS 120B",
     shortName: "GPT-OSS",
@@ -114,7 +107,7 @@ export const CATEGORY_MODELS = {
   free: "llama-3.3-70b",
   quick: "gpt-oss-120b",
   reasoning_on: "deepseek-r1-0528", // R1 with thinking
-  reasoning_off: "deepseek-v31-terminus", // V3.1 without thinking
+  reasoning_off: "deepseek-r1-0528", // R1 without thinking (brain toggle temporarily disabled)
   math: "qwen3-coder-480b",
   image: "qwen3-vl-30b" // Qwen3-VL for image analysis
 };

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -2525,39 +2525,41 @@ export function UnifiedChat() {
                             }
                           />
 
-                          {/* Thinking toggle button - only visible when reasoning model is selected */}
-                          {(localState.model === CATEGORY_MODELS.reasoning_on ||
-                            localState.model === CATEGORY_MODELS.reasoning_off) && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 w-8 p-0"
-                              onClick={() => {
-                                const newThinkingEnabled = !localState.thinkingEnabled;
-                                localState.setThinkingEnabled(newThinkingEnabled);
-                                // Switch between R1 (with thinking) and V3.1 (without)
-                                localState.setModel(
-                                  newThinkingEnabled
-                                    ? CATEGORY_MODELS.reasoning_on
-                                    : CATEGORY_MODELS.reasoning_off
-                                );
-                              }}
-                              aria-label={
-                                localState.thinkingEnabled
-                                  ? "Disable thinking mode"
-                                  : "Enable thinking mode"
-                              }
-                            >
-                              <Brain
-                                className={`h-4 w-4 ${
+                          {/* Thinking toggle button - temporarily disabled while we remove V3.1 */}
+                          {/* eslint-disable-next-line no-constant-binary-expression */}
+                          {false &&
+                            (localState.model === CATEGORY_MODELS.reasoning_on ||
+                              localState.model === CATEGORY_MODELS.reasoning_off) && (
+                              <Button
+                                type="button"
+                                variant="ghost"
+                                size="sm"
+                                className="h-8 w-8 p-0"
+                                onClick={() => {
+                                  const newThinkingEnabled = !localState.thinkingEnabled;
+                                  localState.setThinkingEnabled(newThinkingEnabled);
+                                  // Switch between R1 (with thinking) and V3.1 (without)
+                                  localState.setModel(
+                                    newThinkingEnabled
+                                      ? CATEGORY_MODELS.reasoning_on
+                                      : CATEGORY_MODELS.reasoning_off
+                                  );
+                                }}
+                                aria-label={
                                   localState.thinkingEnabled
-                                    ? "text-purple-500"
-                                    : "text-muted-foreground"
-                                }`}
-                              />
-                            </Button>
-                          )}
+                                    ? "Disable thinking mode"
+                                    : "Enable thinking mode"
+                                }
+                              >
+                                <Brain
+                                  className={`h-4 w-4 ${
+                                    localState.thinkingEnabled
+                                      ? "text-purple-500"
+                                      : "text-muted-foreground"
+                                  }`}
+                                />
+                              </Button>
+                            )}
 
                           {/* Web search toggle button - always visible */}
                           <Button
@@ -2802,39 +2804,41 @@ export function UnifiedChat() {
                           }
                         />
 
-                        {/* Thinking toggle button - only visible when reasoning model is selected */}
-                        {(localState.model === CATEGORY_MODELS.reasoning_on ||
-                          localState.model === CATEGORY_MODELS.reasoning_off) && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0"
-                            onClick={() => {
-                              const newThinkingEnabled = !localState.thinkingEnabled;
-                              localState.setThinkingEnabled(newThinkingEnabled);
-                              // Switch between R1 (with thinking) and V3.1 (without)
-                              localState.setModel(
-                                newThinkingEnabled
-                                  ? CATEGORY_MODELS.reasoning_on
-                                  : CATEGORY_MODELS.reasoning_off
-                              );
-                            }}
-                            aria-label={
-                              localState.thinkingEnabled
-                                ? "Disable thinking mode"
-                                : "Enable thinking mode"
-                            }
-                          >
-                            <Brain
-                              className={`h-4 w-4 ${
+                        {/* Thinking toggle button - temporarily disabled while we remove V3.1 */}
+                        {/* eslint-disable-next-line no-constant-binary-expression */}
+                        {false &&
+                          (localState.model === CATEGORY_MODELS.reasoning_on ||
+                            localState.model === CATEGORY_MODELS.reasoning_off) && (
+                            <Button
+                              type="button"
+                              variant="ghost"
+                              size="sm"
+                              className="h-8 w-8 p-0"
+                              onClick={() => {
+                                const newThinkingEnabled = !localState.thinkingEnabled;
+                                localState.setThinkingEnabled(newThinkingEnabled);
+                                // Switch between R1 (with thinking) and V3.1 (without)
+                                localState.setModel(
+                                  newThinkingEnabled
+                                    ? CATEGORY_MODELS.reasoning_on
+                                    : CATEGORY_MODELS.reasoning_off
+                                );
+                              }}
+                              aria-label={
                                 localState.thinkingEnabled
-                                  ? "text-purple-500"
-                                  : "text-muted-foreground"
-                              }`}
-                            />
-                          </Button>
-                        )}
+                                  ? "Disable thinking mode"
+                                  : "Enable thinking mode"
+                              }
+                            >
+                              <Brain
+                                className={`h-4 w-4 ${
+                                  localState.thinkingEnabled
+                                    ? "text-purple-500"
+                                    : "text-muted-foreground"
+                                }`}
+                              />
+                            </Button>
+                          )}
 
                         {/* Web search toggle button - always visible */}
                         <Button


### PR DESCRIPTION
## Summary
- Removed DeepSeek v3.1 terminus from model configuration and selection logic
- Updated "Reasoning" mode to always use DeepSeek R1
- Temporarily disabled brain toggle UI (can be re-enabled later)
- Removed v3.1 from marketing materials

Resolves #343

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporarily disabled the thinking (brain) toggle UI while improvements are made.
  * Adjusted available reasoning model selection to reflect current model availability.
  * Simplified model badge display to show fewer labels for the DeepSeek entry.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->