### PR TITLE
feat: Remember web search toggle state

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -817,8 +817,10 @@ export function UnifiedChat() {
   const [isProcessingSend, setIsProcessingSend] = useState(false);
   const [audioError, setAudioError] = useState<string | null>(null);
 
-  // Web search toggle state
-  const [isWebSearchEnabled, setIsWebSearchEnabled] = useState(false);
+  // Web search toggle state - persisted in localStorage
+  const [isWebSearchEnabled, setIsWebSearchEnabled] = useState(() => {
+    return localStorage.getItem("webSearchEnabled") === "true";
+  });
 
   // Fullscreen mode for power users - persisted in localStorage
   const [isFullscreen, setIsFullscreen] = useState(() => {
@@ -830,6 +832,11 @@ export function UnifiedChat() {
   useEffect(() => {
     localStorage.setItem("chatFullscreen", isFullscreen.toString());
   }, [isFullscreen]);
+
+  // Save web search preference to localStorage when it changes
+  useEffect(() => {
+    localStorage.setItem("webSearchEnabled", isWebSearchEnabled.toString());
+  }, [isWebSearchEnabled]);
 
   // Toggle fullscreen with animation
   const toggleFullscreen = useCallback(() => {


### PR DESCRIPTION
Implements localStorage persistence for the web search toggle following the same pattern as other user preferences (fullscreen mode, selected model).

The web search toggle state is now:
- Initialized from localStorage on component mount
- Persisted to localStorage whenever the state changes
- Uses the key "webSearchEnabled" for storage

This ensures users don't have to re-enable web search every time they start a new chat session.

Fixes #349

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Web search toggle preference now persists across browser sessions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->