### PR TITLE
feat: Add multi-chat delete functionality

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -4,7 +4,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "1.5.2",
+        "@opensecret/react": "1.5.3",
         "@radix-ui/react-alert-dialog": "^1.1.1",
         "@radix-ui/react-avatar": "^1.1.0",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -223,7 +223,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opensecret/react": ["@opensecret/react@1.5.2", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-a2CU4yNIIo1vvxFqrj8/S28e/6NsG34g/DJw4wnEYoFpqqePLY8cOQTzUQbtNEqVBQfOYlkeFQ/MIiuuZkISgg=="],
+    "@opensecret/react": ["@opensecret/react@1.5.3", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-ObEm+9B9X2bzEiEWQ0B+wrbVTy2+gOFOYgjdVFD3sOEuwPmripbi9U0A1VAdjFfqmunGkhjco8RGMebKo2CrTA=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -17,7 +17,7 @@
     "mdast-util-gfm-autolink-literal": "2.0.0"
   },
   "dependencies": {
-    "@opensecret/react": "1.5.2",
+    "@opensecret/react": "1.5.3",
     "@radix-ui/react-alert-dialog": "^1.1.1",
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/src/components/BulkDeleteDialog.tsx
+++ b/frontend/src/components/BulkDeleteDialog.tsx
@@ -1,0 +1,57 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog";
+
+interface BulkDeleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+  count: number;
+  isDeleting?: boolean;
+}
+
+export function BulkDeleteDialog({
+  open,
+  onOpenChange,
+  onConfirm,
+  count,
+  isDeleting = false
+}: BulkDeleteDialogProps) {
+  const handleConfirm = (e: React.MouseEvent) => {
+    e.preventDefault();
+    onConfirm();
+  };
+
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>
+            Delete {count} chat{count !== 1 ? "s" : ""}?
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            This will permanently delete {count} selected chat{count !== 1 ? "s" : ""}. This action
+            cannot be undone.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            onClick={handleConfirm}
+            disabled={isDeleting}
+            className="bg-destructive text-white hover:bg-destructive/90"
+          >
+            {isDeleting ? "Deleting..." : "Delete"}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+}


### PR DESCRIPTION
## Summary
Add the ability to select and delete multiple chats at once.

## Changes
- Add 'Select' option to chat dropdown menu (...) to enter selection mode
- Support selecting up to 20 chats for bulk deletion
- Use batch delete API from `@opensecret/react` 1.5.3
- Long-press on mobile enters selection mode
- Selection mode shows selected count and Delete button in sidebar header
- New `BulkDeleteDialog` component for confirming bulk deletions

## How to use
1. Click the '...' menu on any chat
2. Click 'Select' to enter selection mode
3. Tap/click additional chats to select (up to 20)
4. Click 'Delete' button to bulk delete
5. Confirm in the dialog

On mobile, you can also long-press a chat to enter selection mode.

Closes #351

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Bulk deletion flow with confirmation dialog to permanently delete multiple chats.
  * Selection mode with visual checkboxes, per-item selection, header controls showing selected count, and cancel/delete actions.
  * Long-press on mobile to enter selection mode and streamlined item actions while selecting.

* **Chores**
  * Updated a frontend dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->