### PR TITLE
Fix misleading Voice Mode label in comparison chart

### DIFF
--- a/frontend/src/components/ComparisonChart.tsx
+++ b/frontend/src/components/ComparisonChart.tsx
@@ -66,7 +66,7 @@ const comparisonData: ComparisonData[] = [
     chatGPT: "Yes"
   },
   {
-    feature: "Voice Mode",
+    feature: "Voice Input",
     maple: "Yes",
     lumo: "No",
     duckAI: "No",


### PR DESCRIPTION
Change 'Voice Mode' to 'Voice Input' in the comparison chart to accurately reflect that Maple currently only supports voice input (speech-to-text), not voice output (text-to-speech).

This was causing user confusion as 'Voice Mode' implied full two-way voice chat like ChatGPT offers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the feature label in the comparison chart for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->