### PR TITLE
fix: cancel long-press timer when user scrolls

### DIFF
--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -446,6 +446,14 @@ export function ChatHistoryList({
     }
   }, []);
 
+  // Cancel long-press when user starts scrolling (touch move)
+  const handleLongPressMove = useCallback(() => {
+    if (longPressTimerRef.current) {
+      clearTimeout(longPressTimerRef.current);
+      longPressTimerRef.current = null;
+    }
+  }, []);
+
   // Cleanup long-press timer on unmount
   useEffect(() => {
     return () => {
@@ -610,6 +618,7 @@ export function ChatHistoryList({
               onMouseUp={handleLongPressEnd}
               onMouseLeave={handleLongPressEnd}
               onTouchStart={() => isMobile && handleLongPressStart(conv.id)}
+              onTouchMove={handleLongPressMove}
               onTouchEnd={handleLongPressEnd}
               onTouchCancel={handleLongPressEnd}
               className={`rounded-lg py-2 transition-all hover:text-primary cursor-pointer ${


### PR DESCRIPTION
Adds `onTouchMove` handler to cancel the long-press selection mode timer when the user starts scrolling, preventing accidental entry into multi-select mode during scroll gestures.

This complements the existing fix for pull-to-refresh (commit ace6665) by also handling regular scroll gestures anywhere in the chat list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed unintended selection mode activation when scrolling through chat history on mobile devices.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->