### PR TITLE
feat: refresh credit usage after chat completion

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -963,6 +963,7 @@ export function UnifiedChat() {
   const assistantStreamingRef = useRef(false);
 
   const abortControllerRef = useRef<AbortController | null>(null);
+  const billingRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const documentInputRef = useRef<HTMLInputElement>(null);
 
@@ -991,6 +992,15 @@ export function UnifiedChat() {
       textareaRef.current.style.height = `${Math.min(scrollHeight, 200)}px`;
     }
   }, [input]);
+
+  // Cleanup billing refresh timeout on unmount
+  useEffect(() => {
+    return () => {
+      if (billingRefreshTimeoutRef.current) {
+        clearTimeout(billingRefreshTimeoutRef.current);
+      }
+    };
+  }, []);
 
   // Auto-focus textbox on desktop (not mobile to avoid keyboard popup interrupting reading)
   // Focus when: app launches, new chat, conversation loads, or assistant finishes streaming
@@ -2367,8 +2377,9 @@ export function UnifiedChat() {
           setCurrentResponseId(undefined);
 
           // Invalidate billing status after a delay to allow backend processing
-          setTimeout(() => {
+          billingRefreshTimeoutRef.current = setTimeout(() => {
             queryClient.invalidateQueries({ queryKey: ["billingStatus"] });
+            billingRefreshTimeoutRef.current = null;
           }, 3000);
         }
       } catch (error) {


### PR DESCRIPTION
Fixes #373

Invalidates billing status query 3 seconds after chat streaming completes to allow backend billing events to process. This ensures the sidepanel credit usage indicator stays up-to-date during long chat sessions.

## Changes
- Added TanStack Query invalidation in `UnifiedChat.tsx` after streaming completes
- Uses a 3-second delay to allow backend processing

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved billing-status refresh after chat interactions by delaying the refresh briefly to ensure accurate display.
  * Ensures any pending refresh is canceled if the chat view is closed to avoid stale or duplicate updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->