### PR TITLE
fix: remove project build dirs from Android Gradle cache

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -54,9 +54,6 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-            frontend/src-tauri/gen/android/.gradle
-            frontend/src-tauri/gen/android/build
-            frontend/src-tauri/gen/android/app/build
           key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,9 +178,6 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-            frontend/src-tauri/gen/android/.gradle
-            frontend/src-tauri/gen/android/build
-            frontend/src-tauri/gen/android/app/build
           key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-


### PR DESCRIPTION
## Problem
The Android build CI was failing with:
```
zstd: error 70 : Write error : cannot write block : No space left on device
```

## Cause
The Gradle cache was including project-level build outputs:
- `frontend/src-tauri/gen/android/.gradle`
- `frontend/src-tauri/gen/android/build`
- `frontend/src-tauri/gen/android/app/build`

These directories contain APKs, AABs, and native `.so` files for 4 Android architectures, which are very large and caused the runner to run out of disk space during cache save.

## Fix
Keep only the global Gradle caches:
- `~/.gradle/caches` - Downloaded dependencies (the valuable part)
- `~/.gradle/wrapper` - Gradle wrapper

The Rust compilation is already cached via sccache, so the native library build time is preserved.

## Files Changed
- `.github/workflows/android-build.yml`
- `.github/workflows/release.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Android build caching configuration by excluding generated build directories, reducing cache footprint in CI/CD workflows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->