### PR TITLE
refactor: add Settings page

### DIFF
--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -1,123 +1,20 @@
-import {
-  LogOut,
-  Trash,
-  User,
-  CreditCard,
-  ArrowUpCircle,
-  Mail,
-  Users,
-  AlertCircle,
-  Key,
-  Info,
-  Shield,
-  FileText,
-  ChevronLeft
-} from "lucide-react";
-import { isMobile, isTauri } from "@/utils/platform";
-
-import { Button } from "@/components/ui/button";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuGroup,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from "@/components/ui/dropdown-menu";
+import { AlertCircle, Settings } from "lucide-react";
 import { useOpenSecret } from "@opensecret/react";
-import { useNavigate, useRouter } from "@tanstack/react-router";
-import { Dialog, DialogTrigger } from "./ui/dialog";
-import { AccountDialog } from "./AccountDialog";
-import { CreditUsage } from "./CreditUsage";
-import { Badge } from "./ui/badge";
-
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-  AlertDialogTrigger
-} from "@/components/ui/alert-dialog";
-import { useLocalState } from "@/state/useLocalState";
-import { useQueryClient, useQuery } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
+
 import { getBillingService } from "@/billing/billingService";
-import { useState } from "react";
+import { CreditUsage } from "@/components/CreditUsage";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { useLocalState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
-import { TeamManagementDialog } from "@/components/team/TeamManagementDialog";
-import { ApiKeyManagementDialog } from "@/components/apikeys/ApiKeyManagementDialog";
-
-function ConfirmDeleteDialog() {
-  const { clearHistory } = useLocalState();
-  const os = useOpenSecret();
-  const queryClient = useQueryClient();
-  const navigate = useNavigate();
-
-  async function handleDeleteHistory() {
-    // 1. Delete archived chats (KV)
-    try {
-      await clearHistory();
-      console.log("History (KV) cleared");
-    } catch (error) {
-      console.error("Error clearing history:", error);
-      // Continue to delete server conversations even if this fails
-    }
-
-    // 2. Delete server conversations (API) if any exist
-    try {
-      // Check if we have any conversations to delete
-      const conversations = await os.listConversations({ limit: 1 });
-      if (conversations.data && conversations.data.length > 0) {
-        await os.deleteConversations();
-        console.log("Server conversations deleted");
-      }
-    } catch (e) {
-      console.error("Error deleting conversations:", e);
-    }
-
-    // Always refresh UI and navigate home
-    queryClient.invalidateQueries({ queryKey: ["chatHistory"] });
-    queryClient.invalidateQueries({ queryKey: ["conversations"] });
-    queryClient.invalidateQueries({ queryKey: ["archivedChats"] });
-    navigate({ to: "/" });
-  }
-
-  return (
-    <AlertDialogContent>
-      <AlertDialogHeader>
-        <AlertDialogTitle>Are you sure?</AlertDialogTitle>
-        <AlertDialogDescription>This will delete your entire chat history.</AlertDialogDescription>
-      </AlertDialogHeader>
-      <AlertDialogFooter>
-        <AlertDialogCancel>Cancel</AlertDialogCancel>
-        <AlertDialogAction onClick={handleDeleteHistory}>Delete</AlertDialogAction>
-      </AlertDialogFooter>
-    </AlertDialogContent>
-  );
-}
 
 export function AccountMenu() {
   const os = useOpenSecret();
-  const router = useRouter();
   const { billingStatus } = useLocalState();
-  const [isPortalLoading, setIsPortalLoading] = useState(false);
-  const [isTeamDialogOpen, setIsTeamDialogOpen] = useState(false);
-  const [isApiKeyDialogOpen, setIsApiKeyDialogOpen] = useState(false);
-  const [showAboutMenu, setShowAboutMenu] = useState(false);
-
-  const hasStripeAccount = billingStatus?.stripe_customer_id !== null;
   const productName = billingStatus?.product_name || "";
-  const isPro = productName.toLowerCase().includes("pro");
-  const isMax = productName.toLowerCase().includes("max");
-  const isStarter = productName.toLowerCase().includes("starter");
   const isTeamPlan = productName.toLowerCase().includes("team");
-  const showUpgrade = !isMax && !isTeamPlan;
-  const showManage = (isPro || isMax || isStarter || isTeamPlan) && hasStripeAccount;
 
   // Fetch team status if user has team plan
   const { data: teamStatus } = useQuery<TeamStatus>({
@@ -133,286 +30,30 @@ export function AccountMenu() {
   const showTeamSetupAlert =
     isTeamPlan && teamStatus?.has_team_subscription && !teamStatus?.team_created;
 
-  const handleManageSubscription = async () => {
-    if (!hasStripeAccount) return;
-
-    try {
-      setIsPortalLoading(true);
-      const billingService = getBillingService();
-      const url = await billingService.getPortalUrl();
-
-      // Check if we're on a mobile platform
-      if (isMobile()) {
-        console.log(
-          "[Billing] Mobile platform detected, using opener plugin to launch external browser for portal"
-        );
-
-        const { invoke } = await import("@tauri-apps/api/core");
-
-        // Use the opener plugin directly - with NO fallback for mobile platforms
-        await invoke("plugin:opener|open_url", { url })
-          .then(() => {
-            console.log("[Billing] Successfully opened portal URL in external browser");
-          })
-          .catch((err: Error) => {
-            console.error("[Billing] Failed to open external browser:", err);
-            alert("Failed to open browser. Please try again.");
-          });
-
-        // Add a small delay to ensure the browser has time to open
-        await new Promise((resolve) => setTimeout(resolve, 300));
-        return;
-      }
-
-      // Default browser opening for non-mobile platforms
-      window.open(url, "_blank");
-    } catch (error) {
-      console.error("Error fetching portal URL:", error);
-    } finally {
-      setIsPortalLoading(false);
-    }
-  };
-
-  const handleOpenExternalUrl = async (url: string) => {
-    try {
-      // Check if we're on any Tauri platform (mobile or desktop)
-      const isInTauri = isTauri();
-
-      if (isInTauri) {
-        const { invoke } = await import("@tauri-apps/api/core");
-        await invoke("plugin:opener|open_url", { url })
-          .then(() => {
-            console.log("[External Link] Successfully opened URL with Tauri opener");
-          })
-          .catch((err: Error) => {
-            console.error("[External Link] Failed to open with Tauri opener:", err);
-            // Fallback to window.open on desktop (may work), alert on mobile
-            if (isMobile()) {
-              alert("Failed to open link. Please try again.");
-            } else {
-              window.open(url, "_blank", "noopener,noreferrer");
-            }
-          });
-      } else {
-        // Default browser opening for web platform
-        window.open(url, "_blank", "noopener,noreferrer");
-      }
-    } catch (error) {
-      console.error("Error opening external URL:", error);
-      // Fallback to window.open
-      window.open(url, "_blank", "noopener,noreferrer");
-    }
-  };
-
-  async function signOut() {
-    try {
-      // Try to clear billing token first
-      try {
-        getBillingService().clearToken();
-      } catch (error) {
-        console.error("Error clearing billing token:", error);
-        // Fallback to direct session storage removal if billing service fails
-        sessionStorage.removeItem("maple_billing_token");
-      }
-
-      // Sign out from OpenSecret
-      await os.signOut();
-
-      // Navigate after everything is done
-      await router.invalidate();
-      await router.navigate({ to: "/" });
-    } catch (error) {
-      console.error("Error during sign out:", error);
-      // Force reload as last resort
-      window.location.href = "/";
-    }
-  }
+  const settingsSearch = showTeamSetupAlert
+    ? ({ tab: "team", team_setup: true } as const)
+    : ({ tab: "account" } as const);
 
   return (
-    <AlertDialog>
-      <Dialog>
-        <DropdownMenu onOpenChange={(open) => !open && setShowAboutMenu(false)}>
-          <div className="flex flex-col gap-2">
-            <Link to="/pricing" className="self-end">
-              <Badge
-                variant="secondary"
-                className="bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] hover:bg-[hsl(var(--primary))]/80 dark:bg-white dark:text-[hsl(var(--background))] dark:hover:bg-white/80 transition-colors cursor-pointer uppercase"
-              >
-                {billingStatus ? `${billingStatus.product_name} Plan` : "Loading..."}
-              </Badge>
-            </Link>
-            <CreditUsage />
-            <DropdownMenuTrigger asChild>
-              <Button variant="outline" className="gap-2 relative">
-                <User className="w-4 h-4" />
-                Account
-                {showTeamSetupAlert && (
-                  <AlertCircle className="absolute -top-1 -right-1 h-4 w-4 text-amber-500 bg-background rounded-full" />
-                )}
-              </Button>
-            </DropdownMenuTrigger>
-          </div>
-          <DropdownMenuContent className="w-[calc(280px-2rem)] overflow-hidden">
-            <div className="relative">
-              <div
-                className={`transition-transform duration-300 ease-in-out ${
-                  showAboutMenu ? "-translate-x-full" : "translate-x-0"
-                }`}
-              >
-                <DropdownMenuLabel>{teamStatus?.team_name || "Maple AI"}</DropdownMenuLabel>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DialogTrigger asChild>
-                    <DropdownMenuItem>
-                      <User className="mr-2 h-4 w-4" />
-                      <span>Profile</span>
-                    </DropdownMenuItem>
-                  </DialogTrigger>
-                  {showUpgrade && (
-                    <DropdownMenuItem asChild>
-                      <Link to="/pricing">
-                        <ArrowUpCircle className="mr-2 h-4 w-4" />
-                        <span>Upgrade your plan</span>
-                      </Link>
-                    </DropdownMenuItem>
-                  )}
-                  {showManage && (
-                    <DropdownMenuItem onClick={handleManageSubscription} disabled={isPortalLoading}>
-                      <CreditCard className="mr-2 h-4 w-4" />
-                      <span>{isPortalLoading ? "Loading..." : "Manage Subscription"}</span>
-                    </DropdownMenuItem>
-                  )}
-                  {isTeamPlan && (
-                    <DropdownMenuItem onClick={() => setIsTeamDialogOpen(true)}>
-                      <div className="flex items-center justify-between w-full">
-                        <div className="flex items-center">
-                          <Users className="mr-2 h-4 w-4" />
-                          <span>Manage Team</span>
-                        </div>
-                        {showTeamSetupAlert && (
-                          <Badge
-                            variant="secondary"
-                            className="py-0 px-1.5 text-xs bg-amber-500 text-white"
-                          >
-                            Setup Required
-                          </Badge>
-                        )}
-                      </div>
-                    </DropdownMenuItem>
-                  )}
-                  {!isMobile() && (
-                    <DropdownMenuItem onClick={() => setIsApiKeyDialogOpen(true)}>
-                      <Key className="mr-2 h-4 w-4" />
-                      <span>API Management</span>
-                    </DropdownMenuItem>
-                  )}
-                  <AlertDialogTrigger asChild>
-                    <DropdownMenuItem>
-                      <Trash className="mr-2 h-4 w-4" />
-                      <span>Delete History</span>
-                    </DropdownMenuItem>
-                  </AlertDialogTrigger>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setShowAboutMenu(true);
-                    }}
-                    onSelect={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    <Info className="mr-2 h-4 w-4" />
-                    <span>About Us</span>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuItem onClick={signOut}>
-                  <LogOut className="mr-2 h-4 w-4" />
-                  <span>Log out</span>
-                </DropdownMenuItem>
-              </div>
-
-              {/* About Us Submenu */}
-              <div
-                className={`absolute top-0 left-0 w-full transition-transform duration-300 ease-in-out ${
-                  showAboutMenu ? "translate-x-0" : "translate-x-full"
-                }`}
-              >
-                <DropdownMenuGroup>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      setShowAboutMenu(false);
-                    }}
-                    onSelect={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    <ChevronLeft className="mr-2 h-4 w-4" />
-                    <span>Back</span>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-                <DropdownMenuSeparator />
-                <DropdownMenuGroup>
-                  <DropdownMenuItem asChild>
-                    <Link to="/about">
-                      <Info className="mr-2 h-4 w-4" />
-                      <span>About Maple</span>
-                    </Link>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleOpenExternalUrl("https://opensecret.cloud/privacy");
-                    }}
-                    onSelect={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    <Shield className="mr-2 h-4 w-4" />
-                    <span>Privacy Policy</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleOpenExternalUrl("https://opensecret.cloud/terms");
-                    }}
-                    onSelect={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    <FileText className="mr-2 h-4 w-4" />
-                    <span>Terms of Service</span>
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={(e) => {
-                      e.preventDefault();
-                      handleOpenExternalUrl("mailto:support@opensecret.cloud");
-                    }}
-                    onSelect={(e) => {
-                      e.preventDefault();
-                    }}
-                  >
-                    <Mail className="mr-2 h-4 w-4" />
-                    <span>Contact Us</span>
-                  </DropdownMenuItem>
-                </DropdownMenuGroup>
-              </div>
-            </div>
-          </DropdownMenuContent>
-          <AccountDialog />
-          <ConfirmDeleteDialog />
-          <TeamManagementDialog
-            open={isTeamDialogOpen}
-            onOpenChange={setIsTeamDialogOpen}
-            teamStatus={teamStatus}
-          />
-          <ApiKeyManagementDialog open={isApiKeyDialogOpen} onOpenChange={setIsApiKeyDialogOpen} />
-        </DropdownMenu>
-      </Dialog>
-    </AlertDialog>
+    <div className="flex flex-col gap-2">
+      <Link to="/pricing" className="self-end">
+        <Badge
+          variant="secondary"
+          className="bg-[hsl(var(--primary))] text-[hsl(var(--primary-foreground))] hover:bg-[hsl(var(--primary))]/80 dark:bg-white dark:text-[hsl(var(--background))] dark:hover:bg-white/80 transition-colors cursor-pointer uppercase"
+        >
+          {billingStatus ? `${billingStatus.product_name} Plan` : "Loading..."}
+        </Badge>
+      </Link>
+      <CreditUsage />
+      <Button variant="outline" className="gap-2 relative" asChild>
+        <Link to="/settings" search={settingsSearch}>
+          <Settings className="w-4 h-4" />
+          Settings
+          {showTeamSetupAlert && (
+            <AlertCircle className="absolute -top-1 -right-1 h-4 w-4 text-amber-500 bg-background rounded-full" />
+          )}
+        </Link>
+      </Button>
+    </div>
   );
 }

--- a/frontend/src/components/apikeys/ApiCreditsSection.tsx
+++ b/frontend/src/components/apikeys/ApiCreditsSection.tsx
@@ -108,8 +108,8 @@ export function ApiCreditsSection({ showSuccessMessage = false }: ApiCreditsSect
       } else {
         // For web or desktop, use regular URLs with query params
         const baseUrl = window.location.origin;
-        successUrl = `${baseUrl}/?credits_success=true`;
-        cancelUrl = method === "stripe" ? `${baseUrl}/` : undefined;
+        successUrl = `${baseUrl}/settings?tab=api&credits_success=true`;
+        cancelUrl = method === "stripe" ? `${baseUrl}/settings?tab=api` : undefined;
       }
 
       if (method === "stripe") {

--- a/frontend/src/components/apikeys/ApiKeyDashboard.tsx
+++ b/frontend/src/components/apikeys/ApiKeyDashboard.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import {
@@ -31,6 +30,21 @@ interface ApiKey {
 
 interface ApiKeyDashboardProps {
   showCreditSuccessMessage?: boolean;
+}
+
+function DashboardHeader({
+  title,
+  description
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <h2 className="text-base font-semibold leading-none tracking-tight">{title}</h2>
+      {description ? <div className="text-sm text-muted-foreground">{description}</div> : null}
+    </div>
+  );
 }
 
 export function ApiKeyDashboard({ showCreditSuccessMessage = false }: ApiKeyDashboardProps) {
@@ -91,46 +105,41 @@ export function ApiKeyDashboard({ showCreditSuccessMessage = false }: ApiKeyDash
   // Show loading state if billing status or API keys are loading
   if (isBillingLoading || isLoading) {
     return (
-      <>
-        <DialogHeader>
-          <DialogTitle className="text-base">API Management</DialogTitle>
-          <DialogDescription>Loading...</DialogDescription>
-        </DialogHeader>
+      <div className="space-y-4">
+        <DashboardHeader title="API Management" description="Loading..." />
         <div className="flex items-center justify-center py-8">
           <Loader2 className="h-6 w-6 animate-spin" />
         </div>
-      </>
+      </div>
     );
   }
 
   if (error) {
     return (
-      <>
-        <DialogHeader>
-          <DialogTitle className="text-base">API Management</DialogTitle>
-          <DialogDescription className="text-destructive">
-            Failed to load API keys. Please try again.
-          </DialogDescription>
-        </DialogHeader>
-      </>
+      <DashboardHeader
+        title="API Management"
+        description={
+          <span className="text-destructive">Failed to load API keys. Please try again.</span>
+        }
+      />
     );
   }
 
   // Show upgrade prompt for users without API access (Free and Starter plans)
   if (!hasApiAccess) {
     return (
-      <>
-        <DialogHeader>
-          <DialogTitle className="text-base flex items-center gap-2">
-            <Sparkles className="h-5 w-5 text-amber-500" />
-            Unlock API Access
-          </DialogTitle>
-          <DialogDescription>
-            Upgrade to a paid plan to access powerful API features
-          </DialogDescription>
-        </DialogHeader>
+      <div className="space-y-6">
+        <DashboardHeader
+          title={
+            <span className="flex items-center gap-2">
+              <Sparkles className="h-5 w-5 text-amber-500" />
+              Unlock API Access
+            </span>
+          }
+          description="Upgrade to a paid plan to access powerful API features"
+        />
 
-        <div className="mt-6 space-y-4">
+        <div className="space-y-4">
           <Card className="p-6 bg-gradient-to-br from-amber-500/10 to-orange-500/10 border-amber-500/20">
             <div className="space-y-4">
               <div className="flex items-center gap-3">
@@ -187,28 +196,30 @@ export function ApiKeyDashboard({ showCreditSuccessMessage = false }: ApiKeyDash
             </p>
           </div>
         </div>
-      </>
+      </div>
     );
   }
 
   return (
-    <>
-      <DialogHeader>
-        <DialogTitle className="text-base">API Access</DialogTitle>
-        <DialogDescription>
-          Manage API keys and configure access to Maple services.{" "}
-          <a
-            href="https://blog.trymaple.ai/maple-proxy-documentation/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-primary underline hover:no-underline"
-          >
-            Read more
-          </a>
-        </DialogDescription>
-      </DialogHeader>
+    <div className="space-y-4">
+      <DashboardHeader
+        title="API Access"
+        description={
+          <span>
+            Manage API keys and configure access to Maple services.{" "}
+            <a
+              href="https://blog.trymaple.ai/maple-proxy-documentation/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
+              Read more
+            </a>
+          </span>
+        }
+      />
 
-      <Tabs defaultValue="credits" className="mt-4">
+      <Tabs defaultValue="credits">
         <TabsList
           className={`grid w-full ${isTauriDesktopPlatform ? "grid-cols-3" : "grid-cols-2"}`}
         >
@@ -280,6 +291,6 @@ export function ApiKeyDashboard({ showCreditSuccessMessage = false }: ApiKeyDash
         onOpenChange={setIsCreateDialogOpen}
         onKeyCreated={handleKeyCreated}
       />
-    </>
+    </div>
   );
 }

--- a/frontend/src/components/team/TeamDashboard.tsx
+++ b/frontend/src/components/team/TeamDashboard.tsx
@@ -1,5 +1,4 @@
 import { useState } from "react";
-import { DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
@@ -14,6 +13,21 @@ interface TeamDashboardProps {
   teamStatus?: TeamStatus;
 }
 
+function DashboardHeader({
+  title,
+  description
+}: {
+  title: React.ReactNode;
+  description?: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-1">
+      <h2 className="text-base font-semibold leading-none tracking-tight">{title}</h2>
+      {description ? <div className="text-sm text-muted-foreground">{description}</div> : null}
+    </div>
+  );
+}
+
 export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
   const [isInviteDialogOpen, setIsInviteDialogOpen] = useState(false);
   const [isEditingName, setIsEditingName] = useState(false);
@@ -23,14 +37,7 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
   const queryClient = useQueryClient();
 
   if (!teamStatus) {
-    return (
-      <>
-        <DialogHeader>
-          <DialogTitle>Team Dashboard</DialogTitle>
-          <DialogDescription>Loading team information...</DialogDescription>
-        </DialogHeader>
-      </>
-    );
+    return <DashboardHeader title="Team Dashboard" description="Loading team information..." />;
   }
 
   const seatsUsed = teamStatus.seats_used || 0;
@@ -94,9 +101,7 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
   if (!isAdmin) {
     return (
       <>
-        <DialogHeader>
-          <DialogTitle className="text-base">Team Information</DialogTitle>
-        </DialogHeader>
+        <DashboardHeader title="Team Information" />
 
         <div className="mt-3 space-y-3 overflow-hidden">
           {/* Compact team info */}
@@ -132,9 +137,7 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
   // Full admin view
   return (
     <>
-      <DialogHeader>
-        <DialogTitle className="text-base">Team Dashboard</DialogTitle>
-      </DialogHeader>
+      <DashboardHeader title="Team Dashboard" />
 
       <div className="mt-3 space-y-3 overflow-hidden">
         {/* Seat limit exceeded warning */}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -27,6 +27,7 @@ import { Route as AuthImport } from './routes/_auth'
 import { Route as IndexImport } from './routes/index'
 import { Route as VerifyCodeImport } from './routes/verify.$code'
 import { Route as PasswordResetConfirmImport } from './routes/password-reset.confirm'
+import { Route as AuthSettingsImport } from './routes/_auth.settings'
 import { Route as TeamInviteInviteIdImport } from './routes/team.invite.$inviteId'
 import { Route as AuthProviderCallbackImport } from './routes/auth.$provider.callback'
 import { Route as AuthChatChatIdImport } from './routes/_auth.chat.$chatId'
@@ -126,6 +127,12 @@ const PasswordResetConfirmRoute = PasswordResetConfirmImport.update({
   id: '/confirm',
   path: '/confirm',
   getParentRoute: () => PasswordResetRoute,
+} as any)
+
+const AuthSettingsRoute = AuthSettingsImport.update({
+  id: '/settings',
+  path: '/settings',
+  getParentRoute: () => AuthRoute,
 } as any)
 
 const TeamInviteInviteIdRoute = TeamInviteInviteIdImport.update({
@@ -248,6 +255,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof TeamsImport
       parentRoute: typeof rootRoute
     }
+    '/_auth/settings': {
+      id: '/_auth/settings'
+      path: '/settings'
+      fullPath: '/settings'
+      preLoaderRoute: typeof AuthSettingsImport
+      parentRoute: typeof AuthImport
+    }
     '/password-reset/confirm': {
       id: '/password-reset/confirm'
       path: '/confirm'
@@ -289,10 +303,12 @@ declare module '@tanstack/react-router' {
 // Create and export the route tree
 
 interface AuthRouteChildren {
+  AuthSettingsRoute: typeof AuthSettingsRoute
   AuthChatChatIdRoute: typeof AuthChatChatIdRoute
 }
 
 const AuthRouteChildren: AuthRouteChildren = {
+  AuthSettingsRoute: AuthSettingsRoute,
   AuthChatChatIdRoute: AuthChatChatIdRoute,
 }
 
@@ -325,6 +341,7 @@ export interface FileRoutesByFullPath {
   '/redeem': typeof RedeemRoute
   '/signup': typeof SignupRoute
   '/teams': typeof TeamsRoute
+  '/settings': typeof AuthSettingsRoute
   '/password-reset/confirm': typeof PasswordResetConfirmRoute
   '/verify/$code': typeof VerifyCodeRoute
   '/chat/$chatId': typeof AuthChatChatIdRoute
@@ -347,6 +364,7 @@ export interface FileRoutesByTo {
   '/redeem': typeof RedeemRoute
   '/signup': typeof SignupRoute
   '/teams': typeof TeamsRoute
+  '/settings': typeof AuthSettingsRoute
   '/password-reset/confirm': typeof PasswordResetConfirmRoute
   '/verify/$code': typeof VerifyCodeRoute
   '/chat/$chatId': typeof AuthChatChatIdRoute
@@ -370,6 +388,7 @@ export interface FileRoutesById {
   '/redeem': typeof RedeemRoute
   '/signup': typeof SignupRoute
   '/teams': typeof TeamsRoute
+  '/_auth/settings': typeof AuthSettingsRoute
   '/password-reset/confirm': typeof PasswordResetConfirmRoute
   '/verify/$code': typeof VerifyCodeRoute
   '/_auth/chat/$chatId': typeof AuthChatChatIdRoute
@@ -394,6 +413,7 @@ export interface FileRouteTypes {
     | '/redeem'
     | '/signup'
     | '/teams'
+    | '/settings'
     | '/password-reset/confirm'
     | '/verify/$code'
     | '/chat/$chatId'
@@ -415,6 +435,7 @@ export interface FileRouteTypes {
     | '/redeem'
     | '/signup'
     | '/teams'
+    | '/settings'
     | '/password-reset/confirm'
     | '/verify/$code'
     | '/chat/$chatId'
@@ -436,6 +457,7 @@ export interface FileRouteTypes {
     | '/redeem'
     | '/signup'
     | '/teams'
+    | '/_auth/settings'
     | '/password-reset/confirm'
     | '/verify/$code'
     | '/_auth/chat/$chatId'
@@ -519,6 +541,7 @@ export const routeTree = rootRoute
     "/_auth": {
       "filePath": "_auth.tsx",
       "children": [
+        "/_auth/settings",
         "/_auth/chat/$chatId"
       ]
     },
@@ -560,6 +583,10 @@ export const routeTree = rootRoute
     },
     "/teams": {
       "filePath": "teams.tsx"
+    },
+    "/_auth/settings": {
+      "filePath": "_auth.settings.tsx",
+      "parent": "/_auth"
     },
     "/password-reset/confirm": {
       "filePath": "password-reset.confirm.tsx",

--- a/frontend/src/routes/_auth.settings.tsx
+++ b/frontend/src/routes/_auth.settings.tsx
@@ -1,0 +1,711 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-router";
+import { useOpenSecret } from "@opensecret/react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  ArrowLeft,
+  CheckCircle,
+  CreditCard,
+  FileText,
+  Info,
+  Key,
+  LogOut,
+  Mail,
+  Shield,
+  Trash,
+  User,
+  Users
+} from "lucide-react";
+
+import { Sidebar, SidebarToggle } from "@/components/Sidebar";
+import { ApiKeyDashboard } from "@/components/apikeys/ApiKeyDashboard";
+import { ChangePasswordDialog } from "@/components/ChangePasswordDialog";
+import { DeleteAccountDialog } from "@/components/DeleteAccountDialog";
+import { PreferencesDialog } from "@/components/PreferencesDialog";
+import { TeamDashboard } from "@/components/team/TeamDashboard";
+import { TeamSetupDialog } from "@/components/team/TeamSetupDialog";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Separator } from "@/components/ui/separator";
+import { getBillingService } from "@/billing/billingService";
+import { useLocalState } from "@/state/useLocalState";
+import type { TeamStatus } from "@/types/team";
+import { cn, useIsMobile } from "@/utils/utils";
+import { isMobile, isTauri } from "@/utils/platform";
+import { openExternalUrlWithConfirmation } from "@/utils/openUrl";
+
+const SETTINGS_TABS = ["account", "billing", "team", "api", "history", "about"] as const;
+type SettingsTab = (typeof SETTINGS_TABS)[number];
+
+type SettingsSearchParams = {
+  tab?: SettingsTab;
+  team_setup?: boolean;
+  credits_success?: boolean;
+};
+
+function parseSettingsTab(value: unknown): SettingsTab | undefined {
+  if (typeof value !== "string") return undefined;
+  return (SETTINGS_TABS as readonly string[]).includes(value) ? (value as SettingsTab) : undefined;
+}
+
+function validateSearch(search: Record<string, unknown>): SettingsSearchParams {
+  return {
+    tab: parseSettingsTab(search.tab),
+    team_setup: search?.team_setup === true || search?.team_setup === "true" ? true : undefined,
+    credits_success:
+      search?.credits_success === true || search?.credits_success === "true" ? true : undefined
+  };
+}
+
+export const Route = createFileRoute("/_auth/settings")({
+  component: SettingsPage,
+  validateSearch
+});
+
+function SettingsPage() {
+  const os = useOpenSecret();
+  const router = useRouter();
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const isMobileViewport = useIsMobile();
+  const { setBillingStatus, billingStatus } = useLocalState();
+
+  const { tab, team_setup, credits_success } = Route.useSearch();
+  const [isSidebarOpen, setIsSidebarOpen] = useState(!isMobileViewport);
+  const [showApiCreditSuccessMessage, setShowApiCreditSuccessMessage] = useState(false);
+  const [autoOpenTeamSetup, setAutoOpenTeamSetup] = useState(false);
+
+  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+
+  // Proactively fetch billing status for authenticated users
+  useQuery({
+    queryKey: ["billingStatus"],
+    queryFn: async () => {
+      const billingService = getBillingService();
+      const status = await billingService.getBillingStatus();
+      setBillingStatus(status);
+      return status;
+    },
+    enabled: !!os.auth.user
+  });
+
+  const productName = billingStatus?.product_name || "";
+  const isTeamPlan = productName.toLowerCase().includes("team");
+
+  const { data: teamStatus } = useQuery<TeamStatus>({
+    queryKey: ["teamStatus"],
+    queryFn: async () => {
+      const billingService = getBillingService();
+      return await billingService.getTeamStatus();
+    },
+    enabled: isTeamPlan && !!os.auth.user && !!billingStatus
+  });
+
+  const effectiveTab: SettingsTab = useMemo(() => {
+    if (team_setup) return "team";
+    if (credits_success) return "api";
+    return tab ?? "account";
+  }, [tab, team_setup, credits_success]);
+
+  // Support legacy/team flow query params by routing into the appropriate settings section.
+  useEffect(() => {
+    if (!team_setup || !os.auth.user) return;
+    setAutoOpenTeamSetup(true);
+    navigate({ to: "/settings", search: { tab: "team" }, replace: true });
+  }, [team_setup, os.auth.user, navigate]);
+
+  useEffect(() => {
+    if (!credits_success || !os.auth.user) return;
+
+    setShowApiCreditSuccessMessage(true);
+    queryClient.invalidateQueries({ queryKey: ["apiCreditBalance"] });
+    navigate({ to: "/settings", search: { tab: "api" }, replace: true });
+
+    // Let ApiCreditsSection manage its own 5s hide timer; we just prevent re-show on remounts.
+    const timer = setTimeout(() => setShowApiCreditSuccessMessage(false), 6000);
+    return () => clearTimeout(timer);
+  }, [credits_success, os.auth.user, navigate, queryClient]);
+
+  const showTeamSetupAlert =
+    isTeamPlan && teamStatus?.has_team_subscription && teamStatus?.team_created === false;
+
+  const isMobilePlatform = isMobile();
+
+  const signOut = useCallback(async () => {
+    try {
+      try {
+        getBillingService().clearToken();
+      } catch (error) {
+        console.error("Error clearing billing token:", error);
+        sessionStorage.removeItem("maple_billing_token");
+      }
+
+      await os.signOut();
+      await router.invalidate();
+      await router.navigate({ to: "/" });
+    } catch (error) {
+      console.error("Error during sign out:", error);
+      window.location.href = "/";
+    }
+  }, [os, router]);
+
+  const navItems: Array<{
+    tab: SettingsTab;
+    label: string;
+    icon: React.ComponentType<{ className?: string }>;
+    hidden?: boolean;
+    badge?: React.ReactNode;
+  }> = [
+    { tab: "account", label: "Account", icon: User },
+    { tab: "billing", label: "Billing", icon: CreditCard },
+    {
+      tab: "team",
+      label: "Team",
+      icon: Users,
+      badge: showTeamSetupAlert ? (
+        <Badge variant="secondary" className="py-0 px-1.5 text-[10px] bg-amber-500 text-white">
+          Setup
+        </Badge>
+      ) : undefined
+    },
+    { tab: "api", label: "API", icon: Key, hidden: isMobilePlatform },
+    { tab: "history", label: "History", icon: Trash },
+    { tab: "about", label: "About", icon: Info }
+  ];
+
+  return (
+    <div
+      className={cn([
+        "grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden",
+        isSidebarOpen ? "md:grid-cols-[280px_1fr]" : ""
+      ])}
+    >
+      <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />
+
+      <div className="flex flex-col flex-1 min-w-0 min-h-0 bg-background overflow-hidden relative">
+        {!isSidebarOpen && (
+          <div className="fixed top-[9.5px] left-4 z-20">
+            <SidebarToggle onToggle={toggleSidebar} />
+          </div>
+        )}
+
+        <div className="h-14 flex items-center px-4 border-b">
+          <div className="flex items-center gap-2">
+            <Button
+              variant="ghost"
+              size="sm"
+              className="gap-2"
+              onClick={() => navigate({ to: "/" })}
+            >
+              <ArrowLeft className="h-4 w-4" />
+              Back
+            </Button>
+            <Separator orientation="vertical" className="h-6" />
+            <h1 className="text-base font-semibold">Settings</h1>
+          </div>
+
+          <div className="ml-auto flex items-center gap-2">
+            <Button variant="outline" size="sm" className="gap-2" onClick={signOut}>
+              <LogOut className="h-4 w-4" />
+              Log out
+            </Button>
+          </div>
+        </div>
+
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          <div className="mx-auto w-full max-w-5xl p-4 md:p-6">
+            <div className="grid gap-6 md:grid-cols-[220px_1fr]">
+              <nav className="space-y-1">
+                {navItems
+                  .filter((i) => !i.hidden)
+                  .map((item) => (
+                    <Button
+                      key={item.tab}
+                      variant={effectiveTab === item.tab ? "secondary" : "ghost"}
+                      className="w-full justify-start gap-2"
+                      asChild
+                    >
+                      <Link to="/settings" search={{ tab: item.tab }}>
+                        <item.icon className="h-4 w-4" />
+                        <span className="flex-1 text-left">{item.label}</span>
+                        {item.badge}
+                      </Link>
+                    </Button>
+                  ))}
+              </nav>
+
+              <div className="min-w-0">
+                {effectiveTab === "account" && <AccountSection onSignOut={signOut} />}
+                {effectiveTab === "billing" && (
+                  <BillingSection
+                    billingStatus={billingStatus}
+                    isMobilePlatform={isMobilePlatform}
+                  />
+                )}
+                {effectiveTab === "team" && (
+                  <TeamSection
+                    billingStatus={billingStatus}
+                    teamStatus={teamStatus}
+                    autoOpenSetup={autoOpenTeamSetup}
+                  />
+                )}
+                {effectiveTab === "api" && (
+                  <ApiSection
+                    isMobilePlatform={isMobilePlatform}
+                    showCreditSuccessMessage={showApiCreditSuccessMessage}
+                  />
+                )}
+                {effectiveTab === "history" && <HistorySection />}
+                {effectiveTab === "about" && <AboutSection />}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AccountSection({ onSignOut }: { onSignOut: () => Promise<void> }) {
+  const os = useOpenSecret();
+  const { billingStatus } = useLocalState();
+  const [isChangePasswordOpen, setIsChangePasswordOpen] = useState(false);
+  const [isPreferencesOpen, setIsPreferencesOpen] = useState(false);
+  const [isDeleteAccountOpen, setIsDeleteAccountOpen] = useState(false);
+  const [verificationStatus, setVerificationStatus] = useState<"unverified" | "pending">(
+    "unverified"
+  );
+
+  const isGuestUser = os.auth.user?.user.login_method?.toLowerCase() === "guest";
+  const isEmailUser = os.auth.user?.user.login_method === "email";
+  const canChangePassword = isEmailUser || isGuestUser;
+
+  const handleResendVerification = async () => {
+    try {
+      await os.requestNewVerificationEmail();
+      setVerificationStatus("pending");
+    } catch (error) {
+      console.error("Failed to resend verification email:", error);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Profile</CardTitle>
+          <CardDescription>Your account details and login status.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {!isGuestUser && (
+            <div className="space-y-2">
+              <Label>Email</Label>
+              <div className="flex items-center gap-2">
+                <Input value={os.auth.user?.user.email || ""} disabled />
+                {os.auth.user?.user.email_verified ? (
+                  <CheckCircle className="h-4 w-4 text-green-600 dark:text-green-500" />
+                ) : (
+                  <span className="text-xs text-muted-foreground">Unverified</span>
+                )}
+              </div>
+              {!os.auth.user?.user.email_verified && (
+                <div className="text-sm text-muted-foreground">
+                  {verificationStatus === "unverified" ? (
+                    <button
+                      type="button"
+                      onClick={handleResendVerification}
+                      className="text-primary hover:underline"
+                    >
+                      Resend verification email
+                    </button>
+                  ) : (
+                    "Pending — check your inbox"
+                  )}
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-2">
+            <Label>Plan</Label>
+            <div className="flex items-center gap-2">
+              <Badge variant="secondary">
+                {billingStatus ? `${billingStatus.product_name} Plan` : "Loading..."}
+              </Badge>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Security</CardTitle>
+          <CardDescription>Password and personal preferences.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2">
+          <Button variant="outline" onClick={() => setIsPreferencesOpen(true)}>
+            User Preferences
+          </Button>
+          {canChangePassword && (
+            <Button onClick={() => setIsChangePasswordOpen(true)}>Change Password</Button>
+          )}
+          <Button
+            variant="outline"
+            className="border-destructive text-destructive hover:bg-destructive/10"
+            onClick={() => setIsDeleteAccountOpen(true)}
+          >
+            Delete Account
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Session</CardTitle>
+          <CardDescription>Sign out of your account on this device.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button variant="outline" className="gap-2" onClick={onSignOut}>
+            <LogOut className="h-4 w-4" />
+            Log out
+          </Button>
+        </CardContent>
+      </Card>
+
+      {canChangePassword && (
+        <ChangePasswordDialog open={isChangePasswordOpen} onOpenChange={setIsChangePasswordOpen} />
+      )}
+      <PreferencesDialog open={isPreferencesOpen} onOpenChange={setIsPreferencesOpen} />
+      <DeleteAccountDialog open={isDeleteAccountOpen} onOpenChange={setIsDeleteAccountOpen} />
+    </div>
+  );
+}
+
+function BillingSection({
+  billingStatus,
+  isMobilePlatform
+}: {
+  billingStatus: ReturnType<typeof useLocalState>["billingStatus"];
+  isMobilePlatform: boolean;
+}) {
+  const [isPortalLoading, setIsPortalLoading] = useState(false);
+
+  const productName = billingStatus?.product_name || "";
+  const hasStripeAccount = billingStatus?.stripe_customer_id !== null;
+  const isPro = productName.toLowerCase().includes("pro");
+  const isMax = productName.toLowerCase().includes("max");
+  const isStarter = productName.toLowerCase().includes("starter");
+  const isTeamPlan = productName.toLowerCase().includes("team");
+  const showUpgrade = !isMax && !isTeamPlan;
+  const showManage = (isPro || isMax || isStarter || isTeamPlan) && hasStripeAccount;
+
+  const handleManageSubscription = async () => {
+    if (!hasStripeAccount) return;
+
+    try {
+      setIsPortalLoading(true);
+      const billingService = getBillingService();
+      const url = await billingService.getPortalUrl();
+
+      if (isMobilePlatform) {
+        const { invoke } = await import("@tauri-apps/api/core");
+        await invoke("plugin:opener|open_url", { url }).catch((err: Error) => {
+          console.error("[Billing] Failed to open external browser:", err);
+          alert("Failed to open browser. Please try again.");
+        });
+        await new Promise((resolve) => setTimeout(resolve, 300));
+        return;
+      }
+
+      window.open(url, "_blank");
+    } catch (error) {
+      console.error("Error fetching portal URL:", error);
+    } finally {
+      setIsPortalLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Plan</CardTitle>
+          <CardDescription>Manage your subscription and billing.</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between gap-2">
+            <div className="min-w-0">
+              <div className="font-medium truncate">
+                {billingStatus ? `${billingStatus.product_name} Plan` : "Loading..."}
+              </div>
+              {billingStatus?.current_period_end && (
+                <div className="text-sm text-muted-foreground">
+                  {billingStatus.payment_provider === "subscription_pass" ||
+                  billingStatus.payment_provider === "zaprite"
+                    ? "Expires on "
+                    : "Renews on "}
+                  {new Date(Number(billingStatus.current_period_end) * 1000).toLocaleDateString(
+                    undefined,
+                    {
+                      year: "numeric",
+                      month: "long",
+                      day: "numeric"
+                    }
+                  )}
+                </div>
+              )}
+            </div>
+            {billingStatus && (
+              <Badge variant="secondary" className="shrink-0">
+                {billingStatus.payment_provider}
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex flex-col sm:flex-row gap-2">
+            {showUpgrade && (
+              <Button asChild className="gap-2">
+                <Link to="/pricing">
+                  <CreditCard className="h-4 w-4" />
+                  View Pricing
+                </Link>
+              </Button>
+            )}
+            {showManage && (
+              <Button
+                variant="outline"
+                className="gap-2"
+                onClick={handleManageSubscription}
+                disabled={isPortalLoading}
+              >
+                <CreditCard className="h-4 w-4" />
+                {isPortalLoading ? "Loading..." : "Manage Subscription"}
+              </Button>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+function TeamSection({
+  billingStatus,
+  teamStatus,
+  autoOpenSetup
+}: {
+  billingStatus: ReturnType<typeof useLocalState>["billingStatus"];
+  teamStatus?: TeamStatus;
+  autoOpenSetup: boolean;
+}) {
+  const productName = billingStatus?.product_name || "";
+  const isTeamPlan = productName.toLowerCase().includes("team");
+
+  const needsSetup = teamStatus?.has_team_subscription && teamStatus?.team_created === false;
+  const [isSetupOpen, setIsSetupOpen] = useState(false);
+  const [hasAutoOpened, setHasAutoOpened] = useState(false);
+
+  useEffect(() => {
+    if (!autoOpenSetup || !needsSetup || hasAutoOpened) return;
+    setIsSetupOpen(true);
+    setHasAutoOpened(true);
+  }, [autoOpenSetup, needsSetup, hasAutoOpened]);
+
+  if (!isTeamPlan) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Teams</CardTitle>
+          <CardDescription>
+            Upgrade to a Team plan to manage members, seats, and shared usage.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button asChild>
+            <Link to="/teams">Learn about Teams</Link>
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {needsSetup && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base">Set up your team</CardTitle>
+            <CardDescription>
+              You have an active team subscription. Create your team to start inviting members.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Button onClick={() => setIsSetupOpen(true)}>Create Team</Button>
+            <TeamSetupDialog
+              open={isSetupOpen}
+              onOpenChange={setIsSetupOpen}
+              teamStatus={teamStatus}
+            />
+          </CardContent>
+        </Card>
+      )}
+
+      {!needsSetup && (
+        <Card className="p-6">
+          <TeamDashboard teamStatus={teamStatus} />
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function ApiSection({
+  isMobilePlatform,
+  showCreditSuccessMessage
+}: {
+  isMobilePlatform: boolean;
+  showCreditSuccessMessage: boolean;
+}) {
+  if (isMobilePlatform) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">API</CardTitle>
+          <CardDescription>API management is currently available on desktop/web.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-6">
+      <ApiKeyDashboard showCreditSuccessMessage={showCreditSuccessMessage} />
+    </Card>
+  );
+}
+
+function HistorySection() {
+  const { clearHistory } = useLocalState();
+  const os = useOpenSecret();
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const handleDeleteHistory = async () => {
+    try {
+      await clearHistory();
+    } catch (error) {
+      console.error("Error clearing history:", error);
+    }
+
+    try {
+      const conversations = await os.listConversations({ limit: 1 });
+      if (conversations.data && conversations.data.length > 0) {
+        await os.deleteConversations();
+      }
+    } catch (error) {
+      console.error("Error deleting conversations:", error);
+    }
+
+    queryClient.invalidateQueries({ queryKey: ["chatHistory"] });
+    queryClient.invalidateQueries({ queryKey: ["conversations"] });
+    queryClient.invalidateQueries({ queryKey: ["archivedChats"] });
+    navigate({ to: "/" });
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">History</CardTitle>
+        <CardDescription>Delete your local and server chat history.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="destructive" className="gap-2">
+              <Trash className="h-4 w-4" />
+              Delete History
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Are you sure?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will delete your entire chat history (local + server).
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleDeleteHistory}>Delete</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </CardContent>
+    </Card>
+  );
+}
+
+function AboutSection() {
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">About Maple</CardTitle>
+          <CardDescription>Product information and legal links.</CardDescription>
+        </CardHeader>
+        <CardContent className="flex flex-col gap-2">
+          <Button variant="outline" asChild className="justify-start gap-2">
+            <Link to="/about">
+              <Info className="h-4 w-4" />
+              About Maple
+            </Link>
+          </Button>
+          <Button
+            variant="outline"
+            className="justify-start gap-2"
+            onClick={() => openExternalUrlWithConfirmation("https://opensecret.cloud/privacy")}
+          >
+            <Shield className="h-4 w-4" />
+            Privacy Policy
+          </Button>
+          <Button
+            variant="outline"
+            className="justify-start gap-2"
+            onClick={() => openExternalUrlWithConfirmation("https://opensecret.cloud/terms")}
+          >
+            <FileText className="h-4 w-4" />
+            Terms of Service
+          </Button>
+          <Button
+            variant="outline"
+            className="justify-start gap-2"
+            onClick={() => openExternalUrlWithConfirmation("mailto:support@opensecret.cloud")}
+          >
+            <Mail className="h-4 w-4" />
+            Contact Support
+          </Button>
+        </CardContent>
+      </Card>
+
+      {isTauri() && (
+        <Alert>
+          <AlertDescription>External links open in your system browser.</AlertDescription>
+        </Alert>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/routes/_auth.settings.tsx
+++ b/frontend/src/routes/_auth.settings.tsx
@@ -41,7 +41,13 @@ import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Separator } from "@/components/ui/separator";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
 import { getBillingService } from "@/billing/billingService";
 import { useLocalState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
@@ -204,74 +210,104 @@ function SettingsPage() {
           </div>
         )}
 
-        <div className="h-14 flex items-center px-4 border-b">
-          <div className="flex items-center gap-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              className="gap-2"
-              onClick={() => navigate({ to: "/" })}
-            >
-              <ArrowLeft className="h-4 w-4" />
-              Back
-            </Button>
-            <Separator orientation="vertical" className="h-6" />
-            <h1 className="text-base font-semibold">Settings</h1>
-          </div>
+        <div className="h-14 flex items-center justify-between px-4 border-b">
+          <Button variant="ghost" size="sm" className="gap-2" onClick={() => navigate({ to: "/" })}>
+            <ArrowLeft className="h-4 w-4" />
+            Back
+          </Button>
 
-          <div className="ml-auto flex items-center gap-2">
-            <Button variant="outline" size="sm" className="gap-2" onClick={signOut}>
-              <LogOut className="h-4 w-4" />
-              Log out
-            </Button>
-          </div>
+          <Button variant="outline" size="sm" className="gap-2" onClick={signOut}>
+            <LogOut className="h-4 w-4" />
+            Log out
+          </Button>
         </div>
 
         <div className="flex-1 min-h-0 overflow-y-auto">
-          <div className="mx-auto w-full max-w-5xl p-4 md:p-6">
-            <div className="grid gap-6 md:grid-cols-[220px_1fr]">
-              <nav className="space-y-1">
-                {navItems
-                  .filter((i) => !i.hidden)
-                  .map((item) => (
-                    <Button
-                      key={item.tab}
-                      variant={effectiveTab === item.tab ? "secondary" : "ghost"}
-                      className="w-full justify-start gap-2"
-                      asChild
-                    >
-                      <Link to="/settings" search={{ tab: item.tab }}>
-                        <item.icon className="h-4 w-4" />
-                        <span className="flex-1 text-left">{item.label}</span>
-                        {item.badge}
-                      </Link>
-                    </Button>
-                  ))}
-              </nav>
+          <div className="w-full px-4 py-6 md:px-8">
+            <div className="w-full max-w-6xl">
+              <div className="mb-6 space-y-1">
+                <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+                <p className="text-sm text-muted-foreground">
+                  Manage your account, billing, and application preferences.
+                </p>
+              </div>
 
-              <div className="min-w-0">
-                {effectiveTab === "account" && <AccountSection onSignOut={signOut} />}
-                {effectiveTab === "billing" && (
-                  <BillingSection
-                    billingStatus={billingStatus}
-                    isMobilePlatform={isMobilePlatform}
-                  />
-                )}
-                {effectiveTab === "team" && (
-                  <TeamSection
-                    billingStatus={billingStatus}
-                    teamStatus={teamStatus}
-                    autoOpenSetup={autoOpenTeamSetup}
-                  />
-                )}
-                {effectiveTab === "api" && (
-                  <ApiSection
-                    isMobilePlatform={isMobilePlatform}
-                    showCreditSuccessMessage={showApiCreditSuccessMessage}
-                  />
-                )}
-                {effectiveTab === "history" && <HistorySection />}
-                {effectiveTab === "about" && <AboutSection />}
+              <div className="grid gap-6 lg:grid-cols-[240px_1fr]">
+                <div className="lg:hidden">
+                  <Select
+                    value={effectiveTab}
+                    onValueChange={(value) =>
+                      navigate({ to: "/settings", search: { tab: value as SettingsTab } })
+                    }
+                  >
+                    <SelectTrigger className="w-full">
+                      <SelectValue placeholder="Select a section" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {navItems
+                        .filter((i) => !i.hidden)
+                        .map((item) => (
+                          <SelectItem
+                            key={item.tab}
+                            value={item.tab}
+                          >{`${item.label}${item.tab === "team" && showTeamSetupAlert ? " (setup required)" : ""}`}</SelectItem>
+                        ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <nav className="hidden lg:block">
+                  <div className="rounded-xl border bg-card p-2">
+                    {navItems
+                      .filter((i) => !i.hidden)
+                      .map((item) => {
+                        const isActive = effectiveTab === item.tab;
+
+                        return (
+                          <Link
+                            key={item.tab}
+                            to="/settings"
+                            search={{ tab: item.tab }}
+                            className={cn(
+                              "flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+                              isActive
+                                ? "bg-muted text-foreground"
+                                : "text-muted-foreground hover:bg-muted/50 hover:text-foreground"
+                            )}
+                          >
+                            <item.icon className="h-4 w-4 shrink-0" />
+                            <span className="flex-1">{item.label}</span>
+                            {item.badge}
+                          </Link>
+                        );
+                      })}
+                  </div>
+                </nav>
+
+                <div className="min-w-0">
+                  {effectiveTab === "account" && <AccountSection onSignOut={signOut} />}
+                  {effectiveTab === "billing" && (
+                    <BillingSection
+                      billingStatus={billingStatus}
+                      isMobilePlatform={isMobilePlatform}
+                    />
+                  )}
+                  {effectiveTab === "team" && (
+                    <TeamSection
+                      billingStatus={billingStatus}
+                      teamStatus={teamStatus}
+                      autoOpenSetup={autoOpenTeamSetup}
+                    />
+                  )}
+                  {effectiveTab === "api" && (
+                    <ApiSection
+                      isMobilePlatform={isMobilePlatform}
+                      showCreditSuccessMessage={showApiCreditSuccessMessage}
+                    />
+                  )}
+                  {effectiveTab === "history" && <HistorySection />}
+                  {effectiveTab === "about" && <AboutSection />}
+                </div>
               </div>
             </div>
           </div>

--- a/frontend/src/routes/payment-success.tsx
+++ b/frontend/src/routes/payment-success.tsx
@@ -49,7 +49,7 @@ function PaymentSuccessPage() {
 
   // If team plan, redirect to home with team_setup param
   if (hasTeamPlan) {
-    return <Navigate to="/" search={{ team_setup: true }} />;
+    return <Navigate to="/settings" search={{ tab: "team", team_setup: true }} />;
   }
 
   // Otherwise, redirect to pricing page with success query parameter

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -273,8 +273,8 @@ function PricingPage() {
   // Check if team plan purchase and redirect after success
   useEffect(() => {
     if (success && freshBillingStatus?.product_name?.toLowerCase().includes("team")) {
-      // Redirect to home with team_setup param
-      navigate({ to: "/", search: { team_setup: true }, replace: true });
+      // Redirect to settings team setup
+      navigate({ to: "/settings", search: { tab: "team", team_setup: true }, replace: true });
     }
   }, [success, freshBillingStatus, navigate]);
 


### PR DESCRIPTION
Closes #380\n\n- Adds new authenticated /settings route with tabbed sections (Account, Billing, Team, API, History, About)\n- Simplifies AccountMenu to a single Settings entrypoint\n- Preserves deep-link flows for team setup + credits success

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a unified Settings page with tabs for Account, Billing, Team, API, History, and About.

* **Changes**
  * Replaced dialog-driven account flows with a compact Account panel linking into Settings.
  * Post-purchase and team-setup redirects now navigate directly to the appropriate Settings tab.
  * API credit purchase flow and API management navigation consolidated under Settings.
  * Standardized section headers across API and Team dashboards for a consistent UI.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->