### PR TITLE
Fix truncated URLs in web search results opening broken links

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -50,6 +50,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { useIsMobile } from "@/utils/utils";
 import { fileToDataURL } from "@/utils/file";
+import { truncateMarkdownPreservingLinks } from "@/utils/markdown";
 import { useOpenAI } from "@/ai/useOpenAi";
 import { DEFAULT_MODEL_ID } from "@/state/LocalStateContext";
 import { Markdown, ThinkingBlock } from "@/components/markdown";
@@ -337,7 +338,7 @@ function ToolCallRenderer({
     // If we have a toolOutput, render them grouped together
     if (toolOutput) {
       const output = toolOutput.output || "";
-      const preview = output.length > 150 ? output.substring(0, 150) + "..." : output;
+      const preview = truncateMarkdownPreservingLinks(output, 150);
       const hasMore = output.length > 150;
       const isWebSearch = functionCall.name === "web_search";
 
@@ -426,7 +427,7 @@ function ToolCallRenderer({
     const output = toolOutput.output || "";
 
     // Show preview (first 150 chars to match grouped rendering)
-    const preview = output.length > 150 ? output.substring(0, 150) + "..." : output;
+    const preview = truncateMarkdownPreservingLinks(output, 150);
     const hasMore = output.length > 150;
 
     return (

--- a/frontend/src/utils/markdown.ts
+++ b/frontend/src/utils/markdown.ts
@@ -1,0 +1,56 @@
+/**
+ * Truncates text while preserving clickable links.
+ * Converts plain URLs that would be truncated into markdown links with full href but truncated display.
+ */
+export function truncateMarkdownPreservingLinks(text: string, maxLength: number): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  // Precompute all markdown link ranges first
+  const mdLinkRegex = /\[([^\]]*)\]\(([^)]+)\)/g;
+  const mdLinkRanges: { start: number; end: number }[] = [];
+  let match;
+
+  while ((match = mdLinkRegex.exec(text)) !== null) {
+    mdLinkRanges.push({ start: match.index, end: match.index + match[0].length });
+  }
+
+  // Helper to check if an index falls inside any markdown link range
+  const isInsideMdLink = (index: number): boolean => {
+    return mdLinkRanges.some((range) => index >= range.start && index < range.end);
+  };
+
+  // Find all plain URLs that are not inside markdown links
+  const urlRegex = /(https?:\/\/[^\s\]<>]+)/g;
+  const plainUrls: { start: number; end: number; url: string }[] = [];
+
+  while ((match = urlRegex.exec(text)) !== null) {
+    if (!isInsideMdLink(match.index)) {
+      plainUrls.push({ start: match.index, end: match.index + match[0].length, url: match[0] });
+    }
+  }
+
+  // Check if truncation point falls within a plain URL
+  for (const urlInfo of plainUrls) {
+    if (maxLength > urlInfo.start && maxLength < urlInfo.end) {
+      // Truncation would cut this URL - convert to markdown link with truncated display
+      const beforeUrl = text.substring(0, urlInfo.start);
+      const truncatedDisplay = urlInfo.url.substring(0, maxLength - urlInfo.start) + "...";
+      // Create markdown link: [truncated-display](full-url)
+      return beforeUrl + `[${truncatedDisplay}](${urlInfo.url})`;
+    }
+  }
+
+  // Check if truncation point falls within a markdown link (reuse precomputed ranges)
+  for (const range of mdLinkRanges) {
+    if (maxLength > range.start && maxLength < range.end) {
+      // Truncation would break this markdown link - truncate before it
+      const truncated = text.substring(0, range.start).trimEnd();
+      return truncated + "...";
+    }
+  }
+
+  // Safe to truncate at maxLength
+  return text.substring(0, maxLength) + "...";
+}


### PR DESCRIPTION
When web search results are collapsed, URLs were being truncated for display but the truncated text was also used as the href. Now URLs that would be cut by truncation are converted to markdown links that preserve the full URL in the href while showing truncated display text.

Fixes #387 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tool and function-call output previews now use smarter truncation that preserves plain URLs and Markdown links, keeping them clickable and improving readability.
  * Previews use cleaner ellipses and avoid cutting through links or link text.

* **Notes**
  * No changes to public API behavior or external integrations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->