### PR TITLE
fix(android): add 16KB page size support for Android 15+

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -159,6 +159,25 @@ jobs:
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> $GITHUB_ENV
           echo "SCCACHE_CACHE_SIZE=2G" >> $GITHUB_ENV
 
+      - name: Create cargo config for 16KB page size support
+        run: |
+          # Android 15+ requires 16KB page size alignment for native libraries
+          # https://developer.android.com/guide/practices/page-sizes
+          mkdir -p frontend/src-tauri/.cargo
+          cat > frontend/src-tauri/.cargo/config.toml << 'EOF'
+          [target.aarch64-linux-android]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+          [target.armv7-linux-androideabi]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+          [target.i686-linux-android]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+          [target.x86_64-linux-android]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+          EOF
+
       - name: Build Rust library (${{ matrix.rust_target }})
         run: |
           export NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,25 @@ jobs:
           echo "SCCACHE_DIR=$HOME/.cache/sccache" >> $GITHUB_ENV
           echo "SCCACHE_CACHE_SIZE=2G" >> $GITHUB_ENV
 
+      - name: Create cargo config for 16KB page size support
+        run: |
+          # Android 15+ requires 16KB page size alignment for native libraries
+          # https://developer.android.com/guide/practices/page-sizes
+          mkdir -p frontend/src-tauri/.cargo
+          cat > frontend/src-tauri/.cargo/config.toml << 'EOF'
+          [target.aarch64-linux-android]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+          [target.armv7-linux-androideabi]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+          [target.i686-linux-android]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+
+          [target.x86_64-linux-android]
+          rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
+          EOF
+
       - name: Build Rust library (${{ matrix.rust_target }})
         run: |
           export NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}


### PR DESCRIPTION
Google Play now requires apps to support 16KB memory page sizes for Android 15+ devices. This adds the required linker flags (`-Wl,-z,max-page-size=16384`) to align native libraries to 16KB page boundaries.

Fixes the error:
> Your app does not support 16 KB memory page sizes

Reference: https://developer.android.com/guide/practices/page-sizes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Android build configuration to enhance memory page size alignment during the build process across all supported Android architectures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->