### PR TITLE
fix(android): generate separate intent-filters for deep links

### DIFF
--- a/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
+++ b/frontend/src-tauri/gen/android/app/src/main/AndroidManifest.xml
@@ -33,32 +33,38 @@
                 <data android:scheme="cloud.opensecret.maple" />
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
-            <!-- Payment success callbacks -->
-            <intent-filter android:autoVerify="true">
+            <intent-filter android:autoVerify="true" >
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
                 <data android:host="trymaple.ai" />
+                
+                
                 <data android:pathPrefix="/payment-success" />
+                
             </intent-filter>
-            <!-- Payment canceled callbacks -->
-            <intent-filter android:autoVerify="true">
+            <intent-filter android:autoVerify="true" >
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
                 <data android:host="trymaple.ai" />
+                
+                
                 <data android:pathPrefix="/payment-canceled" />
+                
             </intent-filter>
-            <!-- Pricing page with parameters -->
-            <intent-filter android:autoVerify="true">
+            <intent-filter android:autoVerify="true" >
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
                 <data android:scheme="https" />
                 <data android:host="trymaple.ai" />
+                
+                
                 <data android:pathPrefix="/pricing" />
+                
             </intent-filter>
             <!-- DEEP LINK PLUGIN. AUTO-GENERATED. DO NOT REMOVE. -->
         </activity>

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -24,13 +24,21 @@
       },
       "mobile": [
         {
-          "scheme": ["cloud.opensecret.maple"],
-          "appLink": false
+          "scheme": ["https"],
+          "host": "trymaple.ai",
+          "pathPrefix": ["/payment-success"],
+          "appLink": true
         },
         {
           "scheme": ["https"],
           "host": "trymaple.ai",
-          "pathPrefix": ["/payment-success", "/payment-canceled", "/pricing"],
+          "pathPrefix": ["/payment-canceled"],
+          "appLink": true
+        },
+        {
+          "scheme": ["https"],
+          "host": "trymaple.ai",
+          "pathPrefix": ["/pricing"],
           "appLink": true
         }
       ]


### PR DESCRIPTION
Split the deep-link mobile config into separate entries so the plugin generates individual intent-filters for each path. This ensures proper Android App Links verification for `/payment-success`, `/payment-canceled`, and `/pricing` paths.

**Changes:**
- Split combined `pathPrefix` array into separate mobile config entries
- Removed redundant `cloud.opensecret.maple` scheme from deep-link config (already manually maintained in AndroidManifest.xml outside the auto-generated section)

This fixes the issue where running `just android-build` would regenerate a different AndroidManifest than what was committed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Mobile & Deep Linking**
  * Improved mobile app deep linking for payment flows, ensuring proper routing when users complete or cancel payments
  * Enhanced pricing page deep link configuration for seamless mobile navigation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->