### PR TITLE
ci: cache Android NDK to speed up builds

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -133,6 +133,7 @@ jobs:
         with:
           ndk-version: r27c
           add-to-path: true
+          local-cache: true
 
       - name: Install sccache
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -258,6 +258,7 @@ jobs:
         with:
           ndk-version: r27c
           add-to-path: true
+          local-cache: true
 
       - name: Install sccache
         run: |


### PR DESCRIPTION
Enable `local-cache: true` option in `nttld/setup-ndk` action to avoid re-downloading the ~1.5GB NDK on every CI run.

This affects:
- `.github/workflows/android-build.yml` (rust-build job matrix - 4 parallel jobs)
- `.github/workflows/release.yml` (android-rust-build job matrix - 4 parallel jobs)

The NDK will be cached per runner OS and shared across all matrix jobs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD workflow performance by enabling local caching for Android NDK in build pipelines.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->