### PR TITLE
ci: use actions/cache for Android NDK instead of broken local-cache

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -127,13 +127,18 @@ jobs:
             ${{ runner.os }}-cargo-${{ matrix.rust_target }}-
             ${{ runner.os }}-cargo-
 
+      - name: Cache Android NDK
+        uses: actions/cache@v4
+        id: ndk-cache
+        with:
+          path: /home/runner/.setup-ndk/r27c
+          key: ${{ runner.os }}-ndk-r27c
+
       - name: Setup Android NDK
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
         uses: nttld/setup-ndk@v1
-        id: setup-ndk
         with:
           ndk-version: r27c
-          add-to-path: true
-          local-cache: true
 
       - name: Install sccache
         run: |
@@ -181,7 +186,7 @@ jobs:
 
       - name: Build Rust library (${{ matrix.rust_target }})
         run: |
-          export NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+          export NDK_HOME=/home/runner/.setup-ndk/r27c
           export PATH=$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
 
           # C toolchain env for build scripts (e.g. openssl-sys)

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -139,6 +139,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27c
+          local-cache: true
 
       - name: Install sccache
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -252,13 +252,18 @@ jobs:
             ${{ runner.os }}-cargo-release-${{ matrix.rust_target }}-
             ${{ runner.os }}-cargo-
 
+      - name: Cache Android NDK
+        uses: actions/cache@v4
+        id: ndk-cache
+        with:
+          path: /home/runner/.setup-ndk/r27c
+          key: ${{ runner.os }}-ndk-r27c
+
       - name: Setup Android NDK
+        if: steps.ndk-cache.outputs.cache-hit != 'true'
         uses: nttld/setup-ndk@v1
-        id: setup-ndk
         with:
           ndk-version: r27c
-          add-to-path: true
-          local-cache: true
 
       - name: Install sccache
         run: |
@@ -306,7 +311,7 @@ jobs:
 
       - name: Build Rust library (${{ matrix.rust_target }})
         run: |
-          export NDK_HOME=${{ steps.setup-ndk.outputs.ndk-path }}
+          export NDK_HOME=/home/runner/.setup-ndk/r27c
           export PATH=$NDK_HOME/toolchains/llvm/prebuilt/linux-x86_64/bin:$PATH
 
           # C toolchain env for build scripts (e.g. openssl-sys)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -264,6 +264,7 @@ jobs:
         uses: nttld/setup-ndk@v1
         with:
           ndk-version: r27c
+          local-cache: true
 
       - name: Install sccache
         run: |


### PR DESCRIPTION
The `nttld/setup-ndk` `local-cache` option has a known bug where symlinks break after cache restore (see [nttld/setup-ndk#547](https://github.com/nttld/setup-ndk/issues/547)). This causes the NDK to be re-downloaded on every run despite caching attempts.

**Changes:**
- Switch to manual caching with `actions/cache` which properly handles the NDK directory
- Cache key is simple (`Linux-ndk-r27c`) since NDK content is static for a given version
- Skip `setup-ndk` action entirely when cache hits

**Expected behavior:**
- First run: Downloads NDK (~1.5GB), saves to cache
- Subsequent runs: Restores from cache in seconds, skips download entirely

This should eliminate the 5-15 minute waits you've been seeing when Google's CDN is slow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added Android NDK caching and a cache-hit check in CI to reduce build times and improve release pipeline reliability.
  * Made NDK setup conditional on cache misses and standardized environment usage for the NDK to simplify CI behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->