### PR TITLE
fix(android): process proguard template placeholder before copying

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -373,6 +373,14 @@ jobs:
             echo "Tauri proguard file not found (skipping): $TAURI_PROGUARD"
           fi
 
+          # Wry proguard rules (process {{package-unescaped}} placeholder)
+          WRY_PROGUARD="$WRY_DIR/src/android/kotlin/proguard-wry.pro"
+          if [ -f "$WRY_PROGUARD" ]; then
+            sed "s/{{package-unescaped}}/$PACKAGE/g" "$WRY_PROGUARD" > "$GEN_KOTLIN_DIR/proguard-wry.pro"
+          else
+            echo "Wry proguard file not found (skipping): $WRY_PROGUARD"
+          fi
+
       - name: Setup Android signing
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -365,10 +365,10 @@ jobs:
           mkdir -p frontend/src-tauri/gen/android/app/src/main/assets
           cp frontend/src-tauri/tauri.conf.json frontend/src-tauri/gen/android/app/src/main/assets/tauri.conf.json
 
-          # Tauri proguard rules
+          # Tauri proguard rules (process $PACKAGE placeholder)
           TAURI_PROGUARD="$TAURI_DIR/mobile/proguard-tauri.pro"
           if [ -f "$TAURI_PROGUARD" ]; then
-            cp "$TAURI_PROGUARD" frontend/src-tauri/gen/android/app/proguard-tauri.pro
+            sed "s/\\\$PACKAGE/$PACKAGE/g" "$TAURI_PROGUARD" > frontend/src-tauri/gen/android/app/proguard-tauri.pro
           else
             echo "Tauri proguard file not found (skipping): $TAURI_PROGUARD"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -490,10 +490,10 @@ jobs:
           mkdir -p frontend/src-tauri/gen/android/app/src/main/assets
           cp frontend/src-tauri/tauri.conf.json frontend/src-tauri/gen/android/app/src/main/assets/tauri.conf.json
 
-          # Tauri proguard rules
+          # Tauri proguard rules (process $PACKAGE placeholder)
           TAURI_PROGUARD="$TAURI_DIR/mobile/proguard-tauri.pro"
           if [ -f "$TAURI_PROGUARD" ]; then
-            cp "$TAURI_PROGUARD" frontend/src-tauri/gen/android/app/proguard-tauri.pro
+            sed "s/\\\$PACKAGE/$PACKAGE/g" "$TAURI_PROGUARD" > frontend/src-tauri/gen/android/app/proguard-tauri.pro
           else
             echo "Tauri proguard file not found (skipping): $TAURI_PROGUARD"
           fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,6 +498,14 @@ jobs:
             echo "Tauri proguard file not found (skipping): $TAURI_PROGUARD"
           fi
 
+          # Wry proguard rules (process {{package-unescaped}} placeholder)
+          WRY_PROGUARD="$WRY_DIR/src/android/kotlin/proguard-wry.pro"
+          if [ -f "$WRY_PROGUARD" ]; then
+            sed "s/{{package-unescaped}}/$PACKAGE/g" "$WRY_PROGUARD" > "$GEN_KOTLIN_DIR/proguard-wry.pro"
+          else
+            echo "Wry proguard file not found (skipping): $WRY_PROGUARD"
+          fi
+
       - name: Setup Android signing
         env:
           ANDROID_KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE_BASE64 }}


### PR DESCRIPTION
## Summary
- Fixed Android CI pipeline to properly process the `$PACKAGE` placeholder in the Tauri proguard template
- The previous code was copying the raw template, causing R8/ProGuard rules to be invalid
- This resulted in critical Kotlin classes being stripped from the APK

## Root Cause
When the Android build pipeline was refactored to parallelize builds (PR #386), the step that copies `proguard-tauri.pro` was doing a direct copy without processing the `$PACKAGE` placeholder:

```bash
# Before (broken)
cp "$TAURI_PROGUARD" frontend/src-tauri/gen/android/app/proguard-tauri.pro
```

The Tauri template contains:
```
-keep class $PACKAGE.TauriActivity {
```

This was being copied as-is, so R8 couldn't match the rule and stripped `TauriActivity` and all other generated Kotlin classes.

## Fix
Process the placeholder before copying:
```bash
sed "s/\$PACKAGE/$PACKAGE/g" "$TAURI_PROGUARD" > frontend/src-tauri/gen/android/app/proguard-tauri.pro
```

## Test plan
- [ ] Android build workflow completes successfully
- [ ] APK contains all required classes (TauriActivity, Ipc, RustWebView, etc.)
- [ ] App launches and functions correctly on Android device

Fixes #394

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved Android build tooling to perform package-name substitution in generated proguard rules instead of direct copying.
  * Added handling for additional proguard rules (Wry) with the same substitution behavior.
  * Preserved previous skip behavior and added explicit logging when proguard source files are absent.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/395">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
