### PR TITLE
copy changes - rename API credits to extra credits

### DIFF
--- a/frontend/src/components/BillingStatus.tsx
+++ b/frontend/src/components/BillingStatus.tsx
@@ -63,11 +63,11 @@ export function BillingStatus() {
     if (!billingStatus.can_chat) {
       if (isMax) {
         return hasApiAccess
-          ? "Purchase API credits or contact us to increase limits"
+          ? "Purchase extra credits or contact us to increase limits"
           : "Contact us to increase your limits";
       }
       return hasApiAccess
-        ? "Upgrade your plan or purchase API credits to keep chatting!"
+        ? "Upgrade your plan or purchase extra credits to keep chatting!"
         : "You've run out of messages, upgrade to keep chatting!";
     }
 

--- a/frontend/src/components/CreditUsage.tsx
+++ b/frontend/src/components/CreditUsage.tsx
@@ -54,7 +54,7 @@ export function CreditUsage() {
       </div>
       <div className="mt-1 flex justify-between text-xs">
         {hasApiCredits && (
-          <span>+ {formatCredits(billingStatus.api_credit_balance ?? 0)} API credits</span>
+          <span>+ {formatCredits(billingStatus.api_credit_balance ?? 0)} extra credits</span>
         )}
         <span className={hasApiCredits ? "" : "ml-auto"}>
           {formatResetDate(billingStatus.usage_reset_date)}

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -137,8 +137,8 @@ export function UpgradePromptDialog({
         description: isFreeTier
           ? "You've reached your daily free tier limit. Upgrade to Pro for unlimited daily usage."
           : isPro
-            ? "You've reached your Pro plan's monthly limit. Upgrade to Max for 10x more usage, or purchase API credits to continue chatting."
-            : "You've reached your monthly usage limit. Purchase API credits to continue chatting, or wait for the next billing cycle.",
+            ? "You've reached your Pro plan's monthly limit. Upgrade to Max for 10x more usage, or purchase extra credits to continue chatting."
+            : "You've reached your monthly usage limit. Purchase extra credits to continue chatting, or wait for the next billing cycle.",
         requiredPlan: nextPlan,
         benefits: isFreeTier
           ? [
@@ -155,11 +155,11 @@ export function UpgradePromptDialog({
                 "Access to all premium models including DeepSeek R1",
                 "Highest priority during peak times",
                 "Maximum rate limits for power users",
-                "Or purchase API credits to keep chatting now"
+                "Or purchase extra credits to keep chatting now"
               ]
             : [
                 "You're already on our highest individual plan",
-                "Purchase API credits to extend your usage",
+                "Purchase extra credits to extend your usage",
                 "Monthly usage automatically refreshes",
                 "Contact support for custom enterprise plans"
               ]
@@ -249,7 +249,7 @@ export function UpgradePromptDialog({
           {feature === "usage" && hasApiAccess && (
             <Button variant="outline" onClick={handleBuyCredits} className="w-full gap-2">
               <Coins className="h-4 w-4" />
-              Buy API Credits
+              Buy Extra Credits
             </Button>
           )}
           {/* Show "Start New Chat" for free tier conversation limit, "Maybe Later" for others */}

--- a/frontend/src/components/apikeys/ApiCreditsSection.tsx
+++ b/frontend/src/components/apikeys/ApiCreditsSection.tsx
@@ -187,7 +187,7 @@ export function ApiCreditsSection({ showSuccessMessage = false }: ApiCreditsSect
       <Card className="p-4">
         <div className="flex items-center justify-between">
           <div>
-            <p className="text-sm text-muted-foreground">API Credit Balance</p>
+            <p className="text-sm text-muted-foreground">Extra Credit Balance</p>
             <p className="text-2xl font-bold flex items-center gap-2">
               <Coins className="h-5 w-5" />
               {formatCredits(creditBalance?.balance || 0)}

--- a/frontend/src/components/apikeys/ApiKeyDashboard.tsx
+++ b/frontend/src/components/apikeys/ApiKeyDashboard.tsx
@@ -164,7 +164,7 @@ export function ApiKeyDashboard({ showCreditSuccessMessage = false }: ApiKeyDash
                 <div>
                   <h3 className="font-semibold">Extend Your Subscription</h3>
                   <p className="text-sm text-muted-foreground">
-                    Purchase API credits to extend your usage when plan credits run out
+                    Purchase extra credits to extend your usage when plan credits run out
                   </p>
                 </div>
               </div>

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -167,8 +167,8 @@ function PricingFAQ() {
             </p>
             <ul className="list-disc list-inside space-y-1 ml-4">
               <li>Use your plan credits via the API</li>
-              <li>When plan credits run out, API credits kick in automatically</li>
-              <li>Purchase additional API credits to extend your usage anytime</li>
+              <li>When plan credits run out, extra credits kick in automatically</li>
+              <li>Purchase extra credits to extend your usage anytime</li>
             </ul>
           </div>
         </details>


### PR DESCRIPTION
Summary

  Renames "API credits" to "extra credits" throughout the UI to better communicate their
  purpose.

  Problem

  The term "API credits" may be confusing, especially for developers who use both the Maple
  chat interface and the Maple API:

  - Mental model mismatch: "API credits" suggests they're consumed when making API calls, but
   they're actually consumed last—plan credits are used first for both chat AND API usage
  - Unclear purpose: The name doesn't communicate that these credits are overflow/backup
  credits that kick in when plan credits run out
  - Potential confusion: When hitting the API from a dev tool, plan credits decrease while
  "API credits" remain unchanged—the opposite of what the name suggests

  Solution

  Rename to "extra credits" which more accurately describes their behavior:
  - They extend your usage when plan credits run out
  - They work for both chat and API (not API-specific)
  - The name "extra" implies overflow/bonus, matching the actual behavior

  This aligns with how Claude handles a similar concept with "Extra usage" in their billing
  UI—neutral terminology that communicates "this kicks in when you exceed your plan."

  Changes

  - CreditUsage.tsx - sidebar display
  - UpgradePromptDialog.tsx - upgrade prompts
  - BillingStatus.tsx - billing status messages
  - ApiCreditsSection.tsx - credits balance label
  - ApiKeyDashboard.tsx - API settings description
  - pricing.tsx - FAQ section
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/409">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated terminology across the billing and pricing interface, replacing "API credits" with "extra credits" in upgrade dialogs, purchase prompts, credit balance displays, and FAQ content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->