### PR TITLE
Add Reasoning tag to kimi-k2-5

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -78,7 +78,7 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
   "kimi-k2-5": {
     displayName: "Kimi K2.5",
     shortName: "Kimi K2.5",
-    badges: ["Pro", "New"],
+    badges: ["Pro", "New", "Reasoning"],
     requiresPro: true,
     supportsVision: true,
     tokenLimit: 256000


### PR DESCRIPTION
Fixes #410

Adds the "Reasoning" tag to the kimi-k2-5 model configuration while keeping the existing "New" tag, matching the pattern used by kimi-k2-thinking.

## Changes
- Updated badges array in MODEL_CONFIG for kimi-k2-5
- Badges now: `["Pro", "New", "Reasoning"]`

Generated with [Claude Code](https://claude.ai/code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/411">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Added a "Reasoning" badge to the Kimi K2.5 model in the model selector to better indicate its capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->