### PR TITLE
Remove kimi-k2 model and brain toggle, keep kimi-k2.5

### DIFF
--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -30,7 +30,7 @@ const AI_MODELS = [
   {
     src: "/badge-kimi-logo.png",
     alt: "Moonshot",
-    labels: ["Kimi K2", "Kimi K2.5"]
+    labels: ["Kimi K2.5"]
   },
   { src: "/badge-qwen-logo.png", alt: "Qwen", labels: ["Qwen3-VL"] },
   { src: "/badge-meta-logo.png", alt: "Meta", labels: ["Meta Llama"] }

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -36,7 +36,6 @@ import {
   Search,
   Loader2,
   Globe,
-  Brain,
   Maximize2,
   Minimize2,
   Volume2,
@@ -54,7 +53,7 @@ import { truncateMarkdownPreservingLinks } from "@/utils/markdown";
 import { useOpenAI } from "@/ai/useOpenAi";
 import { DEFAULT_MODEL_ID } from "@/state/LocalStateContext";
 import { Markdown, ThinkingBlock } from "@/components/markdown";
-import { ModelSelector, CATEGORY_MODELS } from "@/components/ModelSelector";
+import { ModelSelector } from "@/components/ModelSelector";
 import { useLocalState } from "@/state/useLocalState";
 import { useOpenSecret } from "@opensecret/react";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
@@ -2919,40 +2918,6 @@ export function UnifiedChat() {
                             }
                           />
 
-                          {/* Thinking toggle button - visible when reasoning model is selected */}
-                          {(localState.model === CATEGORY_MODELS.reasoning_on ||
-                            localState.model === CATEGORY_MODELS.reasoning_off) && (
-                            <Button
-                              type="button"
-                              variant="ghost"
-                              size="sm"
-                              className="h-8 w-8 p-0"
-                              onClick={() => {
-                                const newThinkingEnabled = !localState.thinkingEnabled;
-                                localState.setThinkingEnabled(newThinkingEnabled);
-                                // Switch between Kimi K2 (with thinking) and DeepSeek R1 (without)
-                                localState.setModel(
-                                  newThinkingEnabled
-                                    ? CATEGORY_MODELS.reasoning_on
-                                    : CATEGORY_MODELS.reasoning_off
-                                );
-                              }}
-                              aria-label={
-                                localState.thinkingEnabled
-                                  ? "Disable thinking mode"
-                                  : "Enable thinking mode"
-                              }
-                            >
-                              <Brain
-                                className={`h-4 w-4 ${
-                                  localState.thinkingEnabled
-                                    ? "text-purple-500"
-                                    : "text-muted-foreground"
-                                }`}
-                              />
-                            </Button>
-                          )}
-
                           {/* Web search toggle button - always visible */}
                           <Button
                             type="button"
@@ -3195,40 +3160,6 @@ export function UnifiedChat() {
                             )
                           }
                         />
-
-                        {/* Thinking toggle button - visible when reasoning model is selected */}
-                        {(localState.model === CATEGORY_MODELS.reasoning_on ||
-                          localState.model === CATEGORY_MODELS.reasoning_off) && (
-                          <Button
-                            type="button"
-                            variant="ghost"
-                            size="sm"
-                            className="h-8 w-8 p-0"
-                            onClick={() => {
-                              const newThinkingEnabled = !localState.thinkingEnabled;
-                              localState.setThinkingEnabled(newThinkingEnabled);
-                              // Switch between Kimi K2 (with thinking) and DeepSeek R1 (without)
-                              localState.setModel(
-                                newThinkingEnabled
-                                  ? CATEGORY_MODELS.reasoning_on
-                                  : CATEGORY_MODELS.reasoning_off
-                              );
-                            }}
-                            aria-label={
-                              localState.thinkingEnabled
-                                ? "Disable thinking mode"
-                                : "Enable thinking mode"
-                            }
-                          >
-                            <Brain
-                              className={`h-4 w-4 ${
-                                localState.thinkingEnabled
-                                  ? "text-purple-500"
-                                  : "text-muted-foreground"
-                              }`}
-                            />
-                          </Button>
-                        )}
 
                         {/* Web search toggle button - always visible */}
                         <Button

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -65,7 +65,6 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
     model: getInitialModel(),
     availableModels: [llamaModel] as OpenSecretModel[],
     hasWhisperModel: true, // Default to true to avoid hiding button during loading
-    thinkingEnabled: false, // Default to reasoning without thinking (V3.1)
     billingStatus: null as BillingStatus | null,
     searchQuery: "",
     isSearchVisible: false,
@@ -381,10 +380,6 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
     setLocalState((prev) => ({ ...prev, hasWhisperModel: hasWhisper }));
   }
 
-  function setThinkingEnabled(enabled: boolean) {
-    setLocalState((prev) => ({ ...prev, thinkingEnabled: enabled }));
-  }
-
   return (
     <LocalStateContext.Provider
       value={{
@@ -394,8 +389,6 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
         setAvailableModels,
         hasWhisperModel: localState.hasWhisperModel,
         setHasWhisperModel,
-        thinkingEnabled: localState.thinkingEnabled,
-        setThinkingEnabled,
         userPrompt: localState.userPrompt,
         systemPrompt: localState.systemPrompt,
         userImages: localState.userImages,

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -31,9 +31,6 @@ export type LocalState = {
   /** Whether the whisper transcription model is available */
   hasWhisperModel: boolean;
   setHasWhisperModel: (hasWhisper: boolean) => void;
-  /** Whether thinking mode is enabled for reasoning models */
-  thinkingEnabled: boolean;
-  setThinkingEnabled: (enabled: boolean) => void;
   userPrompt: string;
   systemPrompt: string | null;
   userImages: File[];
@@ -74,8 +71,6 @@ export const LocalStateContext = createContext<LocalState>({
   setAvailableModels: () => void 0,
   hasWhisperModel: true,
   setHasWhisperModel: () => void 0,
-  thinkingEnabled: false,
-  setThinkingEnabled: () => void 0,
   userPrompt: "",
   systemPrompt: null,
   userImages: [],

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -93,5 +93,10 @@ export function aliasModelName(modelName: string | undefined): string {
     return "kimi-k2-5";
   }
 
+  // Alias kimi-k2 (old thinking model) to kimi-k2-5
+  if (modelName === "kimi-k2" || modelName === "kimi-k2-thinking") {
+    return "kimi-k2-5";
+  }
+
   return modelName;
 }


### PR DESCRIPTION
## Summary
- Remove `kimi-k2-thinking` from MODEL_CONFIG (keeping `kimi-k2-5`)
- Simplify `CATEGORY_MODELS.reasoning` to point directly to `deepseek-r1-0528`
- Remove `thinkingEnabled` state and brain icon toggle from UnifiedChat
- Add alias for `kimi-k2`/`kimi-k2-thinking` -> `kimi-k2-5` for backward compatibility
- Update Marketing.tsx to show only "Kimi K2.5"

## Changes
- **ModelSelector.tsx**: Removed kimi-k2-thinking config, simplified reasoning category
- **UnifiedChat.tsx**: Removed brain toggle button (both mobile and desktop views)
- **LocalStateContext.tsx / LocalStateContextDef.ts**: Removed thinkingEnabled state
- **utils.ts**: Added alias mapping old model names to kimi-k2-5
- **Marketing.tsx**: Updated AI models list to show only Kimi K2.5
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/414">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Removed the thinking/reasoning toggle from the chat interface.
  * Consolidated model reasoning options into a single selection.
  * Updated Kimi model labeling for consistency.

* **Bug Fixes**
  * Added backward compatibility support for legacy model references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->