### PR TITLE
ci: publish Android releases to Zapstore

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,6 +328,43 @@ jobs:
           VITE_MAPLE_BILLING_API_URL: https://billing.opensecret.cloud
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 
+      - name: Setup Go (zsp)
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.22.x"
+          cache: true
+
+      - name: Install zsp
+        shell: bash
+        run: |
+          set -euo pipefail
+          go install "github.com/zapstore/zsp@v0.3.3"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
+      - name: Prepare APK for Zapstore
+        shell: bash
+        run: |
+          set -euo pipefail
+          cp frontend/src-tauri/gen/android/app/build/outputs/apk/universal/release/app-universal-release.apk ./app-universal-release.apk
+
+      - name: Publish to Zapstore
+        env:
+          SIGN_WITH: ${{ secrets.ZAPSTORE_SIGN_WITH }}
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${SIGN_WITH}" ]; then
+            echo "Missing required secret: ZAPSTORE_SIGN_WITH" >&2
+            exit 1
+          fi
+
+          zsp publish \
+            -y \
+            --skip-preview \
+            --commit "${{ github.sha }}" \
+            zapstore.yaml
+
       - name: Upload Android APK to Release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/zapstore.yaml
+++ b/zapstore.yaml
@@ -1,0 +1,26 @@
+repository: https://github.com/OpenSecretCloud/Maple
+
+# The Release workflow copies the signed APK to this path before publishing.
+release_source: ./app-universal-release.apk
+
+name: Maple
+summary: Private AI Chat
+description: |
+  Maple is a private AI chat app by OpenSecret.
+
+  Learn more at https://trymaple.ai
+
+website: https://trymaple.ai
+license: MIT
+
+tags:
+  - ai
+  - chat
+  - privacy
+
+# Use a stable icon from the repo (otherwise zsp will extract from the APK).
+icon: ./frontend/src-tauri/icons/icon.png
+
+metadata_sources:
+  - github
+  - playstore


### PR DESCRIPTION
Adds Zapstore (zsp) publishing for Android release builds.

- New workflow runs after the `Release` workflow succeeds
- Downloads `app-universal-release.apk` from the GitHub release
- Publishes via `zsp publish` with `--commit ${{ github.event.workflow_run.head_sha }}` for reproducible builds (pinned commit)
- Adds `zapstore.yaml` for minimal app metadata

Secrets:
- `ZAPSTORE_SIGN_WITH` (required; set to your `nsec1...` or bunker URL)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Integrated Zapstore marketplace into the release pipeline, enabling app distribution through an additional platform with automated publishing and security verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->