### PR TITLE
Bump proxy to 0.1.7

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2756,9 +2756,9 @@ dependencies = [
 
 [[package]]
 name = "maple-proxy"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1daaae1f5857dfb29e76d93e1431d8a665d6c908d034b0ea724c808d8f0a14b"
+checksum = "16d8742f3781717253b81504ed859f299cee38fcf23b8083d26c95b9afa709b4"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3417,9 +3417,9 @@ dependencies = [
 
 [[package]]
 name = "opensecret"
-version = "0.2.8"
+version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc8e627441c9960de937e2444fd42fc6389fab51e68927bbb2d4e4840020c53"
+checksum = "3660a0cf8ac26d42287873fec60ac5086cf1fb138bf0357417f4db723d593e80"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -32,7 +32,7 @@ tauri-plugin-os = "2.3.2"
 tauri-plugin-sign-in-with-apple = "1.0.2"
 tokio = { version = "1.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
 once_cell = "1.18.0"
-maple-proxy = "0.1.6"
+maple-proxy = "0.1.7"
 tauri-plugin-fs = "2.4.4"
 anyhow = "1.0"
 axum = "0.8"


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/429" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated supporting dependency version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->