### PR TITLE
Fix iOS URL scheme registration in project.yml

### DIFF
--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -52,6 +52,10 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
+        CFBundleURLTypes:
+          - CFBundleURLSchemes:
+              - cloud.opensecret.maple
+            CFBundleURLName: cloud.opensecret.maple
         CFBundleShortVersionString: 2.0.18
         CFBundleVersion: 2.0.18
     entitlements:


### PR DESCRIPTION
The `cloud.opensecret.maple` custom URL scheme was defined in `Info.plist` but missing from `project.yml`. When XcodeGen regenerates the Xcode project (e.g. during the Xcode 26 update), the URL scheme gets dropped from the actual build, breaking OAuth deep link redirects on iOS.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/445" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->
