### PR TITLE
Fix iOS build by linking libc++ for ONNX Runtime

### DIFF
--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,10 +1,14 @@
 fn main() {
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "ios" {
+        println!("cargo:rustc-link-lib=c++");
+    }
+
     tauri_build::build();
 
     // The deep-link plugin's build.rs overwrites CFBundleURLTypes in Info.plist
     // based on the mobile config, stripping our custom URL scheme.
     // Re-add it after all plugin build scripts have run.
-    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if target_os == "ios" {
         ensure_ios_custom_url_scheme();
     }


### PR DESCRIPTION
The ort-sys build script emits `cargo:rustc-link-lib=c++` but it wasn't taking effect during Xcode-driven builds. Explicitly linking libc++ in our `build.rs` resolves the missing C++ symbols (`__gxx_personality_v0`, `__cxa_throw`, etc.) when statically linking ONNX Runtime on iOS.

**Change:** Added a conditional `println!("cargo:rustc-link-lib=c++")` for iOS targets in `frontend/src-tauri/build.rs`.

**Tested:** Successfully built and deployed to iPhone 16 Pro iOS 26 simulator.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/447" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved iOS build configuration to ensure C++ linking and more reliable handling of the iOS URL scheme, enhancing build stability and platform compatibility for iOS.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->