### PR TITLE
Fix iOS OAuth deep link by preserving custom URL scheme in Info.plist

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "openssl",
  "ort",
  "pdf-extract",
+ "plist",
  "rand 0.8.5",
  "rand_distr",
  "regex",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -16,6 +16,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 
 [build-dependencies]
 tauri-build = { version = "2.5.1", features = [] }
+plist = "1"
 
 [dependencies]
 serde_json = "1.0"

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,3 +1,66 @@
 fn main() {
-    tauri_build::build()
+    tauri_build::build();
+
+    // The deep-link plugin's build.rs overwrites CFBundleURLTypes in Info.plist
+    // based on the mobile config, stripping our custom URL scheme.
+    // Re-add it after all plugin build scripts have run.
+    let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os == "ios" {
+        ensure_ios_custom_url_scheme();
+    }
+}
+
+#[allow(dead_code)]
+fn ensure_ios_custom_url_scheme() {
+    let plist_path = std::path::Path::new("gen/apple/maple_iOS/Info.plist");
+    if !plist_path.exists() {
+        return;
+    }
+
+    let mut plist: plist::Value = plist::from_file(plist_path).expect("failed to read Info.plist");
+    let dict = plist
+        .as_dictionary_mut()
+        .expect("Info.plist is not a dictionary");
+
+    let scheme = "cloud.opensecret.maple";
+
+    let has_scheme = dict
+        .get("CFBundleURLTypes")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter().any(|entry| {
+                entry
+                    .as_dictionary()
+                    .and_then(|d| d.get("CFBundleURLSchemes"))
+                    .and_then(|v| v.as_array())
+                    .map(|schemes| schemes.iter().any(|s| s.as_string() == Some(scheme)))
+                    .unwrap_or(false)
+            })
+        })
+        .unwrap_or(false);
+
+    if !has_scheme {
+        let mut url_type = plist::Dictionary::new();
+        url_type.insert(
+            "CFBundleURLSchemes".into(),
+            vec![plist::Value::String(scheme.to_string())].into(),
+        );
+        url_type.insert(
+            "CFBundleURLName".into(),
+            plist::Value::String(scheme.to_string()),
+        );
+
+        if !dict.contains_key("CFBundleURLTypes") {
+            dict.insert("CFBundleURLTypes".into(), plist::Value::Array(vec![]));
+        }
+
+        if let Some(arr) = dict
+            .get_mut("CFBundleURLTypes")
+            .and_then(|v| v.as_array_mut())
+        {
+            arr.push(plist::Value::Dictionary(url_type));
+        }
+
+        plist::to_file_xml(plist_path, &plist).expect("failed to write Info.plist");
+    }
 }


### PR DESCRIPTION
## Problem

iOS OAuth login (GitHub/Google) is broken. After authenticating in Safari, the redirect back to the app via `cloud.opensecret.maple://auth?...` fails with "Safari cannot open the page because the address is invalid."

## Root Cause

The `tauri-plugin-deep-link` plugin's `build.rs` overwrites `CFBundleURLTypes` in the iOS `Info.plist` during every build. Since our `tauri.conf.json` mobile config only has `https` universal link entries (for payment/pricing paths), the plugin strips the manually-added `cloud.opensecret.maple` custom URL scheme from Info.plist.

The simulator worked because it had a cached URL scheme registration from previous local builds. TestFlight/CI builds always ran the full Tauri build pipeline which triggered the stripping.

## Fix

Added a post-build step in `build.rs` that runs after `tauri_build::build()` (and after all plugin build scripts). It checks if the `cloud.opensecret.maple` scheme is present in the iOS `Info.plist` and re-adds it if missing.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/448" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS build configuration to ensure proper URL scheme setup during the build process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->