### PR TITLE
Restore custom URL scheme in mobile deep-link config

### DIFF
--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -24,6 +24,10 @@
       },
       "mobile": [
         {
+          "scheme": ["cloud.opensecret.maple"],
+          "appLink": false
+        },
+        {
           "scheme": ["https"],
           "host": "trymaple.ai",
           "pathPrefix": ["/payment-success"],


### PR DESCRIPTION
Adds back the `cloud.opensecret.maple` custom scheme entry to the mobile deep-link config. This was accidentally removed in 9e6a5a2 (Dec 2, 2025) when fixing Android pathPrefix restrictions.

Without this entry, the Tauri deep-link plugin's `build.rs` sees no non-app-link mobile domains and strips `CFBundleURLTypes` from Info.plist, removing the custom URL scheme registration needed for iOS OAuth redirect.

The previous PR (build.rs workaround) is a safety net; this is the proper config-level fix. Does not affect Android -- custom schemes without a host don't generate intent filters.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/449" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open with Devin">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added mobile deep-linking support with a custom scheme integration, enabling users to launch the app directly from mobile links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->