### PR TITLE
Prepare Kimi K2.6 selector metadata for rollout

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -55,6 +55,14 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     supportsVision: true,
     tokenLimit: 256000
   },
+  "kimi-k2-6": {
+    displayName: "Kimi K2.6",
+    shortName: "Kimi K2.6",
+    badges: ["Pro", "New", "Reasoning"],
+    requiresPro: true,
+    supportsVision: true,
+    tokenLimit: 256000
+  },
   "gpt-oss-120b": {
     displayName: "OpenAI GPT-OSS 120B",
     shortName: "GPT-OSS",


### PR DESCRIPTION
## Summary
- add a Kimi K2.6 selector config entry with the same current metadata as Kimi K2.5
- tag it as Pro, New, and Reasoning
- keep Kimi K2.5 as the current powerful/default reasoning model until K2.6 is ready

## Testing
- just format
- just lint
- just build
- bun test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/482" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Kimi K2.6 model with advanced reasoning capabilities and vision support (Pro subscription required, 256K token limit).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->