### PR TITLE
Fix Zapstore publish workflow flag handling

### DIFF
--- a/.github/workflows/zapstore-publish.yml
+++ b/.github/workflows/zapstore-publish.yml
@@ -49,8 +49,25 @@ jobs:
             exit 1
           fi
 
-          zsp publish \
-            -y \
-            --skip-preview \
-            --commit "$COMMIT_SHA" \
-            zapstore.yaml
+          set +e
+          output="$(
+            zsp publish \
+              --quiet \
+              --commit "$COMMIT_SHA" \
+              zapstore.yaml 2>&1
+          )"
+          status=$?
+          set -e
+
+          if [ -n "$output" ]; then
+            printf '%s\n' "$output"
+          fi
+
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
+          fi
+
+          if [[ "$output" == *"flag provided but not defined"* || "$output" == *"Usage of publish:"* ]]; then
+            echo "zsp returned success but printed CLI usage, treating this as a failure." >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- replace the removed [1m-y[0m flag with [1m--quiet[0m in the Zapstore publish workflow
- fail the workflow if [1mzsp[0m prints usage text or an unknown-flag error while still exiting successfully
- preserve normal success and no-op cases for Zapstore publishes

## Validation
- git diff --check
- prettier --check .github/workflows/zapstore-publish.yml
- simulated the workflow shell logic for help-text false-success, success, no-op, and failure cases
- pre-commit hook: frontend build and tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/483" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
