### PR TITLE
Make Kimi K2.6 the default powerful model

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -89,7 +89,7 @@ export function getModelTokenLimit(modelId: string): number {
 // Primary model options
 const PRIMARY_MODELS = {
   quick: "gpt-oss-120b",
-  powerful: "kimi-k2-5"
+  powerful: "kimi-k2-6"
 };
 
 const PRIMARY_INFO = {
@@ -213,7 +213,7 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
     const isStarter = planName.includes("starter");
 
     if (isProMaxOrTeam) {
-      // Pro/Max/Team: switch to Powerful (kimi-k2-5 has vision)
+      // Pro/Max/Team: switch to Powerful (Kimi K2.6 has vision)
       setModel(PRIMARY_MODELS.powerful);
     } else if (isStarter) {
       // Starter: switch to Gemma 4

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -12,7 +12,7 @@ export {
 } from "./LocalStateContextDef";
 
 export const DEFAULT_MODEL_ID = "gpt-oss-120b";
-export const PAID_DEFAULT_MODEL_ID = "kimi-k2-5";
+export const PAID_DEFAULT_MODEL_ID = "kimi-k2-6";
 
 // Check if a plan name corresponds to a pro/max/team plan
 function isProMaxOrTeamPlan(planName: string): boolean {


### PR DESCRIPTION
## Summary\n- switch the main "Powerful" selector option to Kimi K2.6\n- update the paid default model to Kimi K2.6\n- keep Kimi K2.5 available as a separate selectable model without alias redirection\n\n## Validation\n- just format\n- just lint\n- just build\n- bun test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/486" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Upgraded the default AI model for Pro, Max, and Team users to the latest version, enhancing performance and capabilities across the platform. Automatic model selection for image uploads has also been updated to use the new model version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->