### PR TITLE
Prepare DeepSeek V4 Pro for rollout

### DIFF
--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -47,6 +47,13 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     requiresPro: true,
     tokenLimit: 202000
   },
+  "deepseek-v4-pro": {
+    displayName: "DeepSeek V4 Pro",
+    shortName: "DeepSeek V4 Pro",
+    badges: ["Pro", "New", "Reasoning"],
+    requiresPro: true,
+    tokenLimit: 256000
+  },
   "kimi-k2-5": {
     displayName: "Kimi K2.5",
     shortName: "Kimi K2.5",


### PR DESCRIPTION
## Summary
- add DeepSeek V4 Pro to the model selector configuration
- mark it as a Pro reasoning model with a New badge
- leave the current Powerful model/default unchanged and keep DeepSeek V4 Pro non-vision

## Testing
- just format
- just lint
- bun test
- just build
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/489" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Deepseek V4 Pro model to the model selector, available exclusively to Pro users with specified token limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->