### PR TITLE
Avoid flaky ort downloads in Linux CI

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -167,6 +167,18 @@ jobs:
               libayatana-appindicator3-dev \
               librsvg2-dev
 
+      - name: Provide ONNX Runtime (Linux)
+        run: |
+          ORT_VERSION=1.22.0
+          ORT_ROOT="$RUNNER_TEMP/onnxruntime"
+          mkdir -p "$ORT_ROOT"
+          curl -fL --retry 5 --retry-delay 2 --retry-all-errors \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+            | tar -xz -C "$ORT_ROOT"
+          echo "ORT_LIB_LOCATION=$ORT_ROOT/onnxruntime-linux-x64-${ORT_VERSION}" >> "$GITHUB_ENV"
+          echo "ORT_SKIP_DOWNLOAD=true" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$ORT_ROOT/onnxruntime-linux-x64-${ORT_VERSION}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
       - name: Install frontend dependencies
         working-directory: ./frontend
         run: bun install
@@ -191,8 +203,10 @@ jobs:
 
       - name: Build Tauri App (Linux)
         working-directory: ./frontend
-        run: cargo tauri build
+        run: cargo tauri build --verbose
         env:
+          APPIMAGE_EXTRACT_AND_RUN: "1"
+          NO_STRIP: true
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
           VITE_OPEN_SECRET_API_URL: ${{ github.event_name == 'pull_request' && 'https://enclave.secretgpt.ai' || 'https://enclave.trymaple.ai' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
           - platform: macos-latest-xlarge
             args: --target universal-apple-darwin
           - platform: ubuntu-latest-8-cores
-            args: ""
+            args: --verbose
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -97,6 +97,19 @@ jobs:
               libayatana-appindicator3-dev \
               librsvg2-dev
 
+      - name: Provide ONNX Runtime (Linux)
+        if: matrix.platform == 'ubuntu-latest-8-cores'
+        run: |
+          ORT_VERSION=1.22.0
+          ORT_ROOT="$RUNNER_TEMP/onnxruntime"
+          mkdir -p "$ORT_ROOT"
+          curl -fL --retry 5 --retry-delay 2 --retry-all-errors \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+            | tar -xz -C "$ORT_ROOT"
+          echo "ORT_LIB_LOCATION=$ORT_ROOT/onnxruntime-linux-x64-${ORT_VERSION}" >> "$GITHUB_ENV"
+          echo "ORT_SKIP_DOWNLOAD=true" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$ORT_ROOT/onnxruntime-linux-x64-${ORT_VERSION}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
       - name: Install frontend dependencies
         working-directory: ./frontend
         run: bun install
@@ -111,6 +124,8 @@ jobs:
       - name: Build Tauri App
         uses: tauri-apps/tauri-action@v0
         env:
+          APPIMAGE_EXTRACT_AND_RUN: ${{ matrix.platform == 'ubuntu-latest-8-cores' && '1' || '' }}
+          NO_STRIP: ${{ matrix.platform == 'ubuntu-latest-8-cores' && 'true' || '' }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -47,6 +47,18 @@ jobs:
             librsvg2-dev \
             pkg-config
 
+      - name: Provide ONNX Runtime (Linux)
+        run: |
+          ORT_VERSION=1.22.0
+          ORT_ROOT="$RUNNER_TEMP/onnxruntime"
+          mkdir -p "$ORT_ROOT"
+          curl -fL --retry 5 --retry-delay 2 --retry-all-errors \
+            "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
+            | tar -xz -C "$ORT_ROOT"
+          echo "ORT_LIB_LOCATION=$ORT_ROOT/onnxruntime-linux-x64-${ORT_VERSION}" >> "$GITHUB_ENV"
+          echo "ORT_SKIP_DOWNLOAD=true" >> "$GITHUB_ENV"
+          echo "LD_LIBRARY_PATH=$ORT_ROOT/onnxruntime-linux-x64-${ORT_VERSION}/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
+
       - name: Configure sccache
         run: |
           {


### PR DESCRIPTION
## Summary
- preload official ONNX Runtime 1.22.0 in Linux desktop CI, release, and rust test workflows
- export `ORT_LIB_LOCATION` and `ORT_SKIP_DOWNLOAD` so `ort-sys` does not fall back to the flaky Pyke CDN
- cover PR, master, and release Linux build paths consistently

## Validation
- parsed edited workflow YAML successfully
- `git diff --check`
- pre-commit hook: Prettier check, frontend build, and `bun test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/490" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now provisions a pinned ONNX Runtime (v1.22.0) so builds and tests use a consistent runtime artifact.
  * CI jobs are configured to use the provided runtime and avoid redundant runtime downloads, and update the library path accordingly.
  * Linux Tauri builds run in verbose mode, force AppImage extraction/execution, and disable automatic stripping to preserve debug symbols.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->