### PR TITLE
Redirect Kimi K2.5 to Kimi K2.6

### DIFF
--- a/docs/support-faq.md
+++ b/docs/support-faq.md
@@ -215,7 +215,7 @@ We keep it open so anyone can review and verify our security claims.
 **Answer:**
 - **Free tier:** GPT-OSS 120B, Llama 3.3 70B
 - **Legacy Starter+ tier:** Gemma 4 31B (reasoning, vision), Qwen3-VL 30B (vision)
-- **Pro+ tier:** Kimi K2.5 (reasoning, vision)
+- **Pro+ tier:** Kimi K2.6 (reasoning, vision)
 
 None of your data is transmitted to model providers - everything stays within secure enclaves.
 

--- a/frontend/public/llms-full.txt
+++ b/frontend/public/llms-full.txt
@@ -53,7 +53,7 @@ Compared to ChatGPT, Claude, Gemini, Grok, and other AI services:
 All plans include end-to-end encrypted AI chat. Bitcoin payments accepted with a 10% annual discount.
 
 - **Free** ($0/month): end-to-end encryption, core AI features, search chat history, rename chats, GPT-OSS 120B and Meta Llama 3.3 70B
-- **Pro** ($20/month, most popular): All Free features plus generous usage, image upload, document upload (PDF/TXT/MD), voice recording (Whisper Large v3), powerful models including Gemma 4 31B and Kimi K2.5, live web search, API access
+- **Pro** ($20/month, most popular): All Free features plus generous usage, image upload, document upload (PDF/TXT/MD), voice recording (Whisper Large v3), powerful models including Gemma 4 31B and Kimi K2.6, live web search, API access
 - **Max** ($100/month): All Pro features plus 20x more usage, priority support, early access to new features and models, API access
 - **Team** ($30/month per seat): All Pro features plus 2x more usage per member, pooled chat credits across the team, priority support, unified billing, early access, API access. Minimum 2 seats.
 
@@ -61,7 +61,7 @@ All plans include end-to-end encrypted AI chat. Bitcoin payments accepted with a
 
 All models run inside secure enclaves with zero data retention. None of your data is transmitted to the companies that created these models.
 
-**Kimi K2.5** (by Moonshot AI)
+**Kimi K2.6** (by Moonshot AI)
 - 1 trillion total parameters, 32 billion active per query (Mixture of Experts architecture)
 - 256K context window
 - Best for: Advanced reasoning, coding, research, multi-step agentic tasks, image analysis
@@ -104,7 +104,7 @@ Chats sync automatically between web, desktop, and mobile devices using an encry
 Upload files for AI analysis, summarization, or explanation. Supported formats: PDF, TXT, MD. Max file size: 10MB. One file per reply. Files are encrypted before upload and processed inside secure enclaves.
 
 **Image Upload**
-Upload images (JPG, PNG, WEBP) for analysis, text extraction, translation, and visual understanding. Available with Gemma 4, Qwen3-VL, and Kimi K2.5.
+Upload images (JPG, PNG, WEBP) for analysis, text extraction, translation, and visual understanding. Available with Gemma 4, Qwen3-VL, and Kimi K2.6.
 
 **Voice Input and Output**
 Tap the microphone icon to speak naturally. Audio is encrypted before leaving your device. Speech-to-text uses Whisper (OpenAI's open-source model) running in a secure enclave. Maple responds with both text and natural speech. The natural speech is generated locally on-device. Zero audio retention.
@@ -163,7 +163,7 @@ All pricing is pay-as-you-go. Purchase credits in $10 increments.
 |---|---|
 | llama3-3-70b | $4 input / $4 output |
 | gpt-oss-120b | $4 input / $4 output |
-| kimi-k2-5 | $4 input / $4 output |
+| kimi-k2-6 | $4 input / $4 output |
 | qwen3-vl-30b | $4 input / $4 output |
 
 ### Getting Started

--- a/frontend/public/llms.txt
+++ b/frontend/public/llms.txt
@@ -26,7 +26,7 @@ Key differentiators from ChatGPT, Claude, Gemini, and Grok:
 - [Model Guide](https://blog.trymaple.ai/maple-ai-model-guide-with-example-prompts/): Detailed guide to all available models with example prompts and use cases.
 
 Available models (all running inside secure enclaves with zero data retention):
-- Kimi K2.5 (1T params, 32B active per query, MoE architecture, 256K context) — advanced reasoning, coding, research, image analysis
+- Kimi K2.6 (1T params, 32B active per query, MoE architecture, 256K context) — advanced reasoning, coding, research, image analysis
 - Gemma 4 31B (256K context) — reasoning, long-context work, image analysis
 - OpenAI GPT-OSS 120B (128K context) — creative chat, structured data
 - Meta Llama 3.3 70B (128K context) — general reasoning, daily tasks (available on Free plan)
@@ -74,7 +74,7 @@ Security architecture: AWS Nitro Enclaves for backend processing, NVIDIA GPU TEE
 
 - [One Year of Private AI](https://blog.trymaple.ai/one-year-of-private-ai-how-maple-ai-made-encryption-easy/): Retrospective on Maple's first year — 5x user growth, 90%+ paying customer retention, and the mission ahead.
 - [Maple 2.0 - Now with Live Data](https://blog.trymaple.ai/maple-2-0-now-with-live-data/): Live web search, anonymous accounts, custom AI personality, and background processing.
-- [Kimi K2.5 in Maple AI](https://blog.trymaple.ai/kimi-k2-in-maple-ai-open-reasoning-that-competes-with-chatgpt-and-claude/): Open reasoning model that competes with GPT-5 and Claude Sonnet 4.5.
+- [Kimi K2.6 in Maple AI](https://blog.trymaple.ai/kimi-k2-in-maple-ai-open-reasoning-that-competes-with-chatgpt-and-claude/): Open reasoning model that competes with GPT-5 and Claude Sonnet 4.5.
 - [Encrypted Voice in Maple](https://blog.trymaple.ai/speak-freely-encrypted-voice-arrives-in-maple/): Voice input and output with end-to-end encryption.
 - [Document and Image Upload](https://blog.trymaple.ai/introducing-confidential-document-and-image-upload-in-maple-ai/): Confidential document and image analysis.
 - [Introducing Maple Proxy](https://blog.trymaple.ai/introducing-maple-proxy-the-maple-ai-api-that-brings-encrypted-llms-to-your-openai-apps/): OpenAI-compatible encrypted API for developers.

--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -25,7 +25,7 @@ const AI_MODELS = [
   {
     src: "/badge-kimi-logo.png",
     alt: "Moonshot",
-    labels: ["Kimi K2.5"]
+    labels: ["Kimi K2.6"]
   },
   { src: "/badge-zai-logo.png", alt: "Z.ai", labels: ["GLM 5.1"] },
   { src: "/badge-qwen-logo.png", alt: "Qwen", labels: ["Qwen3-VL"] },

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -54,14 +54,6 @@ export const MODEL_CONFIG: Record<string, ModelCfg> = {
     requiresPro: true,
     tokenLimit: 256000
   },
-  "kimi-k2-5": {
-    displayName: "Kimi K2.5",
-    shortName: "Kimi K2.5",
-    badges: ["Pro", "Reasoning"],
-    requiresPro: true,
-    supportsVision: true,
-    tokenLimit: 256000
-  },
   "kimi-k2-6": {
     displayName: "Kimi K2.6",
     shortName: "Kimi K2.6",

--- a/frontend/src/components/PromoDialog.tsx
+++ b/frontend/src/components/PromoDialog.tsx
@@ -29,7 +29,7 @@ export function PromoDialog({ open, onOpenChange, discount }: PromoDialogProps) 
   const benefits = [
     {
       icon: <Cpu className="h-4 w-4" />,
-      text: "Powerful AI models including Gemma 4 31B, GLM 5.1, and Kimi K2.5"
+      text: "Powerful AI models including Gemma 4 31B, GLM 5.1, and Kimi K2.6"
     },
     {
       icon: <Image className="h-4 w-4" />,

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -96,7 +96,7 @@ export function UpgradePromptDialog({
         benefits: [
           "Images stay private with end-to-end encryption",
           "Upload JPEG, PNG, and WebP formats securely",
-          "Use Gemma 4 31B and Qwen3-VL on Starter, plus Kimi K2.5 on Pro and above",
+          "Use Gemma 4 31B and Qwen3-VL on Starter, plus Kimi K2.6 on Pro and above",
           "Analyze diagrams, screenshots, and photos privately",
           "Extract text from images without exposing data"
         ]
@@ -152,7 +152,7 @@ export function UpgradePromptDialog({
           : isPro
             ? [
                 "10x more monthly messages with Max plan",
-                "Access to all AI models including GLM 5.1 and Kimi K2.5",
+                "Access to all AI models including GLM 5.1 and Kimi K2.6",
                 "Highest priority during peak times",
                 "Maximum rate limits for power users",
                 "Or purchase extra credits to keep chatting now"
@@ -186,7 +186,7 @@ export function UpgradePromptDialog({
         requiredPlan: "Pro",
         benefits: [
           "All models run in secure, encrypted environments",
-          "Access to GLM 5.1, Kimi K2.5, and the full model lineup",
+          "Access to GLM 5.1, Kimi K2.6, and the full model lineup",
           "OpenAI GPT-OSS, Qwen, and other advanced models",
           "Higher token limits for longer conversations",
           "Priority access to new models as they launch"
@@ -231,7 +231,7 @@ export function UpgradePromptDialog({
                 {isFreeTier
                   ? "Plus access to powerful models, image & document processing, and more"
                   : isPro
-                    ? "Plus access to GLM 5.1, Kimi K2.5, 10x more usage, API access, and priority support"
+                    ? "Plus access to GLM 5.1, Kimi K2.6, 10x more usage, API access, and priority support"
                     : "Explore our pricing options for the best plan for your needs"}
               </p>
             </div>

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -54,7 +54,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-red-500" />
       },
       {
-        text: "Paid AI models including Gemma 4 31B, GLM 5.1, and Kimi K2.5",
+        text: "Paid AI models including Gemma 4 31B, GLM 5.1, and Kimi K2.6",
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
       },
@@ -99,7 +99,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-red-500" />
       },
       {
-        text: "GLM 5.1 + Kimi K2.5",
+        text: "GLM 5.1 + Kimi K2.6",
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
       },
@@ -134,7 +134,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "All AI models including GLM 5.1 and Kimi K2.5",
+        text: "All AI models including GLM 5.1 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -184,7 +184,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "All AI models including GLM 5.1 and Kimi K2.5",
+        text: "All AI models including GLM 5.1 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -243,7 +243,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "All AI models including GLM 5.1 and Kimi K2.5",
+        text: "All AI models including GLM 5.1 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },

--- a/frontend/src/routes/teams.tsx
+++ b/frontend/src/routes/teams.tsx
@@ -126,7 +126,7 @@ function TeamsPage() {
               const models = [
                 { src: "/badge-openai-logo.png", alt: "OpenAI", label: "OpenAI GPT-OSS" },
                 { src: "/badge-google-logo.png", alt: "Google", label: "Gemma 4" },
-                { src: "/badge-kimi-logo.png", alt: "Moonshot", label: "Kimi K2.5" },
+                { src: "/badge-kimi-logo.png", alt: "Moonshot", label: "Kimi K2.6" },
                 { src: "/badge-zai-logo.png", alt: "Z.ai", label: "GLM 5.1" },
                 { src: "/badge-meta-logo.png", alt: "Meta", label: "Meta Llama" }
               ];

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -79,9 +79,10 @@ export const LLAMA_MODEL_ID = "llama3-3-70b";
 const MODEL_NAME_ALIASES: Record<string, string> = {
   "llama-3.3-70b": LLAMA_MODEL_ID,
   "gemma-3-27b": "gemma4-31b",
-  "deepseek-r1-0528": "kimi-k2-5",
-  "kimi-k2": "kimi-k2-5",
-  "kimi-k2-thinking": "kimi-k2-5"
+  "deepseek-r1-0528": "kimi-k2-6",
+  "kimi-k2": "kimi-k2-6",
+  "kimi-k2-thinking": "kimi-k2-6",
+  "kimi-k2-5": "kimi-k2-6"
 };
 
 export function aliasModelName(modelName: string | undefined): string {


### PR DESCRIPTION
## Summary
- Redirect deprecated Kimi model IDs, including kimi-k2-5, to kimi-k2-6
- Remove Kimi K2.5 from the frontend model selector config
- Update Kimi K2.5 UI copy and public docs references to Kimi K2.6

## Validation
- just format
- just lint
- just build
- pre-commit hook: prettier check, build, bun test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/491" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated the available Kimi AI model from version 2.5 to 2.6 across the platform, including pricing information, feature descriptions, model selection, documentation, and promotional messaging. Version 2.5 is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->