### PR TITLE
Bump to 2.0.26

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "2.0.25",
+  "version": "2.0.26",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2717,7 +2717,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maple"
-version = "2.0.25"
+version = "2.0.26"
 dependencies = [
  "anyhow",
  "axum",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "2.0.25"
+version = "2.0.26"
 description = "Maple AI"
 authors = ["tony@opensecret.cloud"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.25</string>
+	<string>2.0.26</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.25</string>
+	<string>2.0.26</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 2.0.25
-        CFBundleVersion: 2.0.25
+        CFBundleShortVersionString: 2.0.26
+        CFBundleVersion: 2.0.26
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "2.0.25",
+  "version": "2.0.26",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -89,7 +89,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000025000
+      "versionCode": 2000026000
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- Bump Maple version from 2.0.25 to 2.0.26 across package, Tauri, Cargo, iOS project, and lockfile metadata
- Update Android versionCode to 2000026000

## Validation
- just bump-patch
- just rust-lint
- pre-commit hook: Prettier check, bun build, bun test, Rust unit tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/492" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 2.0.26 released with package configuration updates across all deployment targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->