### PR TITLE
Use backend model catalog in selector

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "3.0.2",
+        "@opensecret/react": "3.1.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -239,7 +239,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opensecret/react": ["@opensecret/react@3.0.2", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" } }, "sha512-cSg6/JiNEW4QWZlhLpAY9OtsBwXpuhafAY/okyQUhz40S6gPk9l8+u0KecGF/4/8imGdhPqsqGHfoOiqZZ0oWg=="],
+    "@opensecret/react": ["@opensecret/react@3.1.1", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-KYKC/jMhbwvXfS8eUTSb5qgSuIAIfqjB1FA/xponberLia61wWt/PnvZxmlEIcXJ0DnvbhfStjcfNfD7YpVlOw=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,7 +28,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@opensecret/react": "3.0.2",
+    "@opensecret/react": "3.1.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -9,100 +9,70 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { useLocalState } from "@/state/useLocalState";
 import { useOpenSecret } from "@opensecret/react";
-import { useEffect, useRef, useState } from "react";
-import type { Model } from "openai/resources/models.js";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
-import { aliasModelName, LLAMA_MODEL_ID } from "@/utils/utils";
+import { POWERFUL_MODEL_ALIAS, QUICK_MODEL_ALIAS } from "@/utils/utils";
+import type {
+  ModelAccessTier,
+  OpenSecretModel,
+  OpenSecretModelAlias,
+  OpenSecretModelCatalog
+} from "@/state/LocalStateContextDef";
 
-// Model configuration for display names, badges, and token limits
-type ModelCfg = {
-  displayName: string;
-  shortName: string;
-  badges?: string[];
-  disabled?: boolean;
-  requiresPro?: boolean;
-  requiresStarter?: boolean;
-  supportsVision?: boolean;
-  tokenLimit: number;
-};
-
-export const MODEL_CONFIG: Record<string, ModelCfg> = {
-  [LLAMA_MODEL_ID]: {
-    displayName: "Llama 3.3 70B",
-    shortName: "Llama 3.3",
-    tokenLimit: 70000
-  },
-  "gemma4-31b": {
-    displayName: "Gemma 4 31B",
-    shortName: "Gemma 4",
-    badges: ["New", "Reasoning"],
-    requiresStarter: true,
-    supportsVision: true,
-    tokenLimit: 256000
-  },
-  "glm-5-1": {
-    displayName: "GLM 5.1",
-    shortName: "GLM 5.1",
-    badges: ["Pro", "New", "Reasoning"],
-    requiresPro: true,
-    tokenLimit: 202000
-  },
-  "deepseek-v4-pro": {
-    displayName: "DeepSeek V4 Pro",
-    shortName: "DeepSeek V4 Pro",
-    badges: ["Pro", "New", "Reasoning"],
-    requiresPro: true,
-    tokenLimit: 256000
-  },
-  "kimi-k2-6": {
-    displayName: "Kimi K2.6",
-    shortName: "Kimi K2.6",
-    badges: ["Pro", "New", "Reasoning"],
-    requiresPro: true,
-    supportsVision: true,
-    tokenLimit: 256000
-  },
-  "gpt-oss-120b": {
-    displayName: "OpenAI GPT-OSS 120B",
-    shortName: "GPT-OSS",
-    badges: ["Reasoning"],
-    tokenLimit: 128000
-  },
-  "qwen3-vl-30b": {
-    displayName: "Qwen3-VL 30B",
-    shortName: "Qwen3-VL",
-    requiresStarter: true,
-    supportsVision: true,
-    tokenLimit: 256000
-  }
-};
-
-// Default token limit for unknown models
-export const DEFAULT_TOKEN_LIMIT = 64000;
-
-// Get token limit for a specific model
-export function getModelTokenLimit(modelId: string): number {
-  return MODEL_CONFIG[aliasModelName(modelId)]?.tokenLimit || DEFAULT_TOKEN_LIMIT;
-}
-
-// Primary model options
-const PRIMARY_MODELS = {
-  quick: "gpt-oss-120b",
-  powerful: "kimi-k2-6"
-};
-
-const PRIMARY_INFO = {
-  quick: {
+const PRIMARY_MODELS = [
+  {
+    id: QUICK_MODEL_ALIAS,
     label: "Quick",
     icon: Zap,
-    description: "Fast, everyday responses"
+    description: "Fast, everyday responses",
+    access: "free" as ModelAccessTier,
+    capabilities: { vision: false, reasoning: true }
   },
-  powerful: {
+  {
+    id: POWERFUL_MODEL_ALIAS,
     label: "Powerful",
     icon: Brain,
-    description: "Deeper thinking & analysis"
+    description: "Deeper thinking & analysis",
+    access: "pro" as ModelAccessTier,
+    capabilities: { vision: true, reasoning: true }
   }
+] as const;
+
+type ModelCatalogClient = {
+  fetchModelCatalog?: () => Promise<OpenSecretModelCatalog>;
+  fetchModels?: () => Promise<OpenSecretModel[]>;
 };
+
+function isAutoModelAlias(modelId: string): boolean {
+  return modelId === QUICK_MODEL_ALIAS || modelId === POWERFUL_MODEL_ALIAS;
+}
+
+function isSelectableChatModel(model: OpenSecretModel): boolean {
+  return model.enabled !== false && model.deprecated !== true && model.capabilities?.chat !== false;
+}
+
+const FALLBACK_ALIAS_TARGETS = {
+  [QUICK_MODEL_ALIAS]: "gpt-oss-120b",
+  [POWERFUL_MODEL_ALIAS]: "kimi-k2-6"
+} as const;
+
+function buildFallbackModelAliases(models: OpenSecretModel[]): OpenSecretModelAlias[] {
+  const modelById = new Map(models.map((availableModel) => [availableModel.id, availableModel]));
+
+  return PRIMARY_MODELS.map((primaryModel) => {
+    const targetModel = modelById.get(FALLBACK_ALIAS_TARGETS[primaryModel.id]);
+
+    return {
+      id: primaryModel.id,
+      label: primaryModel.label,
+      short_name: primaryModel.label,
+      description: primaryModel.description,
+      target_model: targetModel?.id || "",
+      access: targetModel?.access || primaryModel.access,
+      capabilities: targetModel?.capabilities || primaryModel.capabilities
+    };
+  });
+}
 
 export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
   const {
@@ -110,167 +80,245 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
     setModel,
     availableModels,
     setAvailableModels,
+    modelAliases,
+    setModelAliases,
     billingStatus,
     setHasWhisperModel
   } = useLocalState();
   const os = useOpenSecret();
   const isFetching = useRef(false);
   const hasFetched = useRef(false);
-  const availableModelsRef = useRef(availableModels);
+  const currentModelRef = useRef(model);
   const [upgradeDialogOpen, setUpgradeDialogOpen] = useState(false);
   const [selectedModelName, setSelectedModelName] = useState<string>("");
   const [showAdvanced, setShowAdvanced] = useState(false);
 
+  useEffect(() => {
+    currentModelRef.current = model;
+  }, [model]);
+
   // Use the passed hasImages prop directly
   const chatHasImages = hasImages;
 
-  // Keep ref updated
-  useEffect(() => {
-    availableModelsRef.current = availableModels;
+  const modelById = useMemo(() => {
+    return new Map(availableModels.map((availableModel) => [availableModel.id, availableModel]));
   }, [availableModels]);
 
-  useEffect(() => {
-    // Always fetch once at startup
-    if (!hasFetched.current && os.fetchModels && !isFetching.current) {
-      hasFetched.current = true;
-      isFetching.current = true;
-      os.fetchModels()
-        .then((models) => {
-          // Check if whisper-large-v3 is available before filtering
-          const hasWhisper = models.some((model) => model.id === "whisper-large-v3");
-          setHasWhisperModel(hasWhisper);
+  const aliasById = useMemo(() => {
+    return new Map(modelAliases.map((alias) => [alias.id, alias]));
+  }, [modelAliases]);
 
-          // Filter out embedding models and "latest"
-          interface ModelWithTasks extends Model {
-            tasks?: string[];
-          }
-          const filteredModels = models.filter((model) => {
-            if (model.id === "latest") return false;
+  const reconcileSelectedConcreteModel = useCallback(
+    (models: OpenSecretModel[]) => {
+      const currentModel = currentModelRef.current;
+      if (!currentModel || isAutoModelAlias(currentModel)) return;
 
-            // Filter out whisper models (transcription)
-            if (model.id.toLowerCase().includes("whisper")) {
-              return false;
-            }
+      const selectedModel = models.find((availableModel) => availableModel.id === currentModel);
+      if (selectedModel) {
+        setModel(currentModel, selectedModel);
+      } else {
+        setModel(QUICK_MODEL_ALIAS);
+      }
+    },
+    [setModel]
+  );
 
-            // Filter out qwen3-coder-30b-a3b
-            if (model.id === "qwen3-coder-30b-a3b") {
-              return false;
-            }
+  const fetchCatalog = useCallback(async () => {
+    if (hasFetched.current || isFetching.current) return;
 
-            // Filter out models with lowercase 'instruct' or 'embed' in their ID
-            if (model.id.includes("instruct") || model.id.includes("embed")) {
-              return false;
-            }
+    isFetching.current = true;
 
-            const modelWithTasks = model as ModelWithTasks;
-            // If no tasks property, include the model
-            if (!modelWithTasks.tasks) return true;
+    try {
+      const modelClient = os as unknown as ModelCatalogClient;
 
-            // If tasks exists, exclude only if it has "embed" but not "generate"
-            if (
-              modelWithTasks.tasks.includes("embed") &&
-              !modelWithTasks.tasks.includes("generate")
-            ) {
-              return false;
-            }
-
-            return true;
-          });
-
-          // Get current models for merging from ref
-          const currentModels = availableModelsRef.current || [];
-          const existingModelIds = new Set(currentModels.map((m) => aliasModelName(m.id)));
-          const newModels = filteredModels.filter(
-            (m) => !existingModelIds.has(aliasModelName(m.id))
+      if (modelClient.fetchModelCatalog) {
+        try {
+          const catalog = await modelClient.fetchModelCatalog();
+          const selectableModels = catalog.data.filter(isSelectableChatModel);
+          const hasCatalogWhisperModel = catalog.data.some(
+            (catalogModel) => catalogModel.id === "whisper-large-v3"
           );
+          hasFetched.current = true;
+          setAvailableModels(selectableModels);
+          setModelAliases(catalog.aliases);
+          setHasWhisperModel(catalog.audio?.transcription?.available ?? hasCatalogWhisperModel);
+          reconcileSelectedConcreteModel(selectableModels);
 
-          // Merge with existing models (keeping the hardcoded one)
-          setAvailableModels([...currentModels, ...newModels]);
-        })
-        .catch((error) => {
-          console.error("Failed to fetch models from endpoint:", error);
-          // Silently handle error - will continue with hardcoded model
+          return;
+        } catch (error) {
           if (import.meta.env.DEV) {
-            console.warn("Failed to fetch available models:", error);
+            console.warn("Failed to fetch model catalog, falling back to fetchModels:", error);
           }
-        })
-        .finally(() => {
-          isFetching.current = false;
+        }
+      }
+
+      if (modelClient.fetchModels) {
+        const models = await modelClient.fetchModels();
+        const availableGenerateModels = models.filter((availableModel) => {
+          const tasks = availableModel.tasks || [];
+          if (tasks.length > 0) return tasks.includes("generate");
+          const id = availableModel.id.toLowerCase();
+          return !id.includes("whisper") && !id.includes("embed");
         });
+        hasFetched.current = true;
+        setHasWhisperModel(
+          models.some((availableModel) => availableModel.id === "whisper-large-v3")
+        );
+        setAvailableModels(availableGenerateModels);
+        setModelAliases(buildFallbackModelAliases(availableGenerateModels));
+        reconcileSelectedConcreteModel(availableGenerateModels);
+      }
+    } catch (error) {
+      if (import.meta.env.DEV) {
+        console.warn("Failed to fetch model metadata:", error);
+      }
+    } finally {
+      isFetching.current = false;
     }
-  }, [os, setAvailableModels, setHasWhisperModel]);
+  }, [os, reconcileSelectedConcreteModel, setAvailableModels, setHasWhisperModel, setModelAliases]);
+
+  useEffect(() => {
+    void fetchCatalog();
+  }, [fetchCatalog]);
+
+  const getAlias = useCallback(
+    (modelId: string): OpenSecretModelAlias | undefined => {
+      const alias = aliasById.get(modelId as OpenSecretModelAlias["id"]);
+      if (alias) return alias;
+
+      const fallback = PRIMARY_MODELS.find((primaryModel) => primaryModel.id === modelId);
+      if (!fallback) return undefined;
+
+      return {
+        id: fallback.id,
+        label: fallback.label,
+        short_name: fallback.label,
+        description: fallback.description,
+        target_model: "",
+        access: fallback.access,
+        capabilities: fallback.capabilities
+      };
+    },
+    [aliasById]
+  );
+
+  const getTargetModel = useCallback(
+    (alias: OpenSecretModelAlias | undefined) => {
+      if (!alias?.target_model) return undefined;
+      return modelById.get(alias.target_model);
+    },
+    [modelById]
+  );
+
+  const getAccess = useCallback(
+    (modelId: string): ModelAccessTier => {
+      const alias = getAlias(modelId);
+      if (alias) {
+        return getTargetModel(alias)?.access || alias.access || "free";
+      }
+      return modelById.get(modelId)?.access || "free";
+    },
+    [getAlias, getTargetModel, modelById]
+  );
+
+  const supportsVision = useCallback(
+    (modelId: string): boolean => {
+      const alias = getAlias(modelId);
+      if (alias) {
+        return Boolean(getTargetModel(alias)?.capabilities?.vision ?? alias.capabilities?.vision);
+      }
+      return Boolean(modelById.get(modelId)?.capabilities?.vision);
+    },
+    [getAlias, getTargetModel, modelById]
+  );
+
+  const hasAccessToModel = useCallback(
+    (modelId: string) => {
+      const access = getAccess(modelId);
+      if (access === "free") return true;
+
+      const planName = billingStatus?.product_name?.toLowerCase() || "";
+
+      if (access === "pro") {
+        return planName.includes("pro") || planName.includes("max") || planName.includes("team");
+      }
+
+      if (access === "starter") {
+        return (
+          planName.includes("starter") ||
+          planName.includes("pro") ||
+          planName.includes("max") ||
+          planName.includes("team")
+        );
+      }
+
+      return true;
+    },
+    [billingStatus?.product_name, getAccess]
+  );
+
+  const getDisplayLabel = (modelId: string): string => {
+    const alias = getAlias(modelId);
+    if (alias) return alias.short_name || alias.label;
+
+    const selectedModel = modelById.get(modelId);
+    return selectedModel?.short_name || selectedModel?.display_name || modelId;
+  };
+
+  const getDisplayNameText = (modelId: string): string => {
+    const alias = getAlias(modelId);
+    if (alias) return alias.label;
+
+    const selectedModel = modelById.get(modelId);
+    return selectedModel?.display_name || selectedModel?.short_name || modelId;
+  };
 
   // Auto-switch to a vision-capable model when images are uploaded
   useEffect(() => {
     if (!chatHasImages) return;
-    const currentModelConfig = MODEL_CONFIG[model];
-    if (currentModelConfig?.supportsVision) return; // Already on a vision model
+    if (supportsVision(model)) return;
 
     const planName = billingStatus?.product_name?.toLowerCase() || "";
     const isProMaxOrTeam =
       planName.includes("pro") || planName.includes("max") || planName.includes("team");
-    const isStarter = planName.includes("starter");
 
-    if (isProMaxOrTeam) {
-      // Pro/Max/Team: switch to Powerful (Kimi K2.6 has vision)
-      setModel(PRIMARY_MODELS.powerful);
-    } else if (isStarter) {
-      // Starter: switch to Gemma 4
-      setModel("gemma4-31b");
-    }
-    // Free: no auto-switch (existing upgrade prompt handles it)
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [chatHasImages]);
-
-  // Get dropdown button label based on selected model
-  const getDropdownLabel = (): string => {
-    if (model === PRIMARY_MODELS.quick) return "Quick";
-    if (model === PRIMARY_MODELS.powerful) return "Powerful";
-    const config = MODEL_CONFIG[model];
-    return config?.shortName || config?.displayName || model;
-  };
-
-  // Check if user has access to a model based on their plan
-  const hasAccessToModel = (modelId: string) => {
-    const config = MODEL_CONFIG[modelId];
-
-    // If no restrictions, allow access
-    if (!config?.requiresPro && !config?.requiresStarter) return true;
-
-    const planName = billingStatus?.product_name?.toLowerCase() || "";
-
-    // Check if user is on Pro, Max, or Team plan (for requiresPro models)
-    if (config?.requiresPro) {
-      return planName.includes("pro") || planName.includes("max") || planName.includes("team");
-    }
-
-    // Check if user is on Starter, Pro, Max, or Team plan (for requiresStarter models)
-    if (config?.requiresStarter) {
-      return (
-        planName.includes("starter") ||
-        planName.includes("pro") ||
-        planName.includes("max") ||
-        planName.includes("team")
-      );
-    }
-
-    return true;
-  };
-
-  // Handle primary option selection
-  const handlePrimarySelect = (key: "quick" | "powerful") => {
-    const targetModel = PRIMARY_MODELS[key];
-
-    // Prevent switching to non-vision models if chat has images
-    const targetModelConfig = MODEL_CONFIG[targetModel];
-    if (chatHasImages && !targetModelConfig?.supportsVision) {
+    if (
+      isProMaxOrTeam &&
+      hasAccessToModel(POWERFUL_MODEL_ALIAS) &&
+      supportsVision(POWERFUL_MODEL_ALIAS)
+    ) {
+      setModel(POWERFUL_MODEL_ALIAS);
       return;
     }
 
-    // Check access
+    const visionModel = availableModels.find(
+      (availableModel) =>
+        isSelectableChatModel(availableModel) &&
+        availableModel.capabilities?.vision &&
+        hasAccessToModel(availableModel.id)
+    );
+
+    if (visionModel) {
+      setModel(visionModel.id, visionModel);
+    }
+  }, [
+    availableModels,
+    billingStatus?.product_name,
+    chatHasImages,
+    hasAccessToModel,
+    model,
+    setModel,
+    supportsVision
+  ]);
+
+  // Handle primary option selection
+  const handlePrimarySelect = (targetModel: string) => {
+    if (chatHasImages && !supportsVision(targetModel)) {
+      return;
+    }
+
     if (!hasAccessToModel(targetModel)) {
-      const modelConfig = MODEL_CONFIG[targetModel];
-      setSelectedModelName(modelConfig?.displayName || targetModel);
+      setSelectedModelName(getDisplayNameText(targetModel));
       setUpgradeDialogOpen(true);
       return;
     }
@@ -280,19 +328,16 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
 
   // Get dynamic badges for a model based on billing status
   const getModelBadges = (modelId: string): string[] => {
-    const config = MODEL_CONFIG[modelId];
-
-    // Filter out Pro and Starter badges
-    const badges = config?.badges || [];
+    const badges = modelById.get(modelId)?.badges || [];
     return badges.filter((badge) => badge !== "Pro" && badge !== "Starter");
   };
 
   const getDisplayName = (modelId: string, showLock = false) => {
-    const config = MODEL_CONFIG[modelId];
+    const selectedModel = modelById.get(modelId);
     const elements: React.ReactNode[] = [];
 
-    if (config) {
-      elements.push(config.displayName);
+    if (selectedModel) {
+      elements.push(selectedModel.display_name || selectedModel.short_name || modelId);
 
       const badges = getModelBadges(modelId);
       if (badges && badges.length > 0) {
@@ -324,29 +369,15 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
         });
       }
 
-      if (
-        showLock &&
-        (config.requiresPro || config.requiresStarter) &&
-        !hasAccessToModel(modelId)
-      ) {
+      if (showLock && !hasAccessToModel(modelId)) {
         elements.push(<Lock key="lock" className="h-3 w-3 opacity-50" />);
       }
 
-      if (config.supportsVision) {
+      if (selectedModel.capabilities?.vision) {
         elements.push(<Camera key="cam" className="h-3 w-3 opacity-50" />);
       }
     } else {
-      // Unknown models: show model ID with "Coming Soon" badge
-      const model = availableModels.find((m) => m.id === modelId);
-      elements.push(model?.id || modelId);
-      elements.push(
-        <span
-          key="badge"
-          className="rounded-md bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground"
-        >
-          Coming Soon
-        </span>
-      );
+      elements.push(getDisplayNameText(modelId));
     }
 
     return <span className="flex items-center gap-1">{elements}</span>;
@@ -355,7 +386,7 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
   // Show current category or model name in the collapsed view
   const modelDisplay = (
     <div className="flex items-center gap-1">
-      <div className="text-xs font-medium">{getDropdownLabel()}</div>
+      <div className="text-xs font-medium">{getDisplayLabel(model)}</div>
     </div>
   );
 
@@ -370,7 +401,7 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
             size="sm"
             className="h-8 gap-1 px-2 text-[hsl(var(--maple-secondary-700))] hover:bg-[hsl(var(--maple-primary-container))] hover:text-[hsl(var(--maple-secondary-700))]"
             data-testid="model-selector-button"
-            aria-label={`Current model: ${MODEL_CONFIG[model]?.displayName || model}. Click to change model.`}
+            aria-label={`Current model: ${getDisplayNameText(model)}. Click to change model.`}
           >
             {modelDisplay}
             <ChevronDown className="h-3 w-3" />
@@ -380,23 +411,21 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
           {!showAdvanced ? (
             <div className="p-1 flex flex-col">
               {/* Primary options */}
-              {(["quick", "powerful"] as const).map((key) => {
-                const info = PRIMARY_INFO[key];
-                const Icon = info.icon;
-                const targetModel = PRIMARY_MODELS[key];
+              {PRIMARY_MODELS.map((primaryModel) => {
+                const alias = getAlias(primaryModel.id);
+                const Icon = primaryModel.icon;
+                const targetModel = primaryModel.id;
                 const isActive = model === targetModel;
                 const hasAccess = hasAccessToModel(targetModel);
-                const targetModelConfig = MODEL_CONFIG[targetModel];
                 const requiresUpgrade = !hasAccess;
 
                 // Disable non-vision options if chat has images
-                const isDisabledDueToImages = chatHasImages && !targetModelConfig?.supportsVision;
-                const isDisabled = isDisabledDueToImages || targetModelConfig?.disabled;
+                const isDisabled = chatHasImages && !supportsVision(targetModel);
 
                 return (
                   <DropdownMenuItem
-                    key={key}
-                    onClick={() => handlePrimarySelect(key)}
+                    key={targetModel}
+                    onClick={() => handlePrimarySelect(targetModel)}
                     className={`flex items-center gap-2 px-3 py-1.5 cursor-pointer ${
                       isDisabled ? "opacity-50 cursor-not-allowed" : ""
                     } ${
@@ -409,10 +438,14 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
                     <Icon className="h-4 w-4 opacity-70" />
                     <div className="flex-1">
                       <div className="flex items-center gap-1.5">
-                        <span className="text-sm font-medium">{info.label}</span>
+                        <span className="text-sm font-medium">
+                          {alias?.label || primaryModel.label}
+                        </span>
                         {requiresUpgrade && <Lock className="h-3 w-3 opacity-50" />}
                       </div>
-                      <div className="text-xs text-muted-foreground">{info.description}</div>
+                      <div className="text-xs text-muted-foreground">
+                        {alias?.description || primaryModel.description}
+                      </div>
                     </div>
                     {isActive && <Check className="h-4 w-4" />}
                   </DropdownMenuItem>
@@ -425,6 +458,7 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
               <DropdownMenuItem
                 onSelect={(e) => {
                   e.preventDefault();
+                  void fetchCatalog();
                   setShowAdvanced(true);
                 }}
                 className="flex items-center gap-2 px-3 py-1.5 cursor-pointer"
@@ -454,36 +488,30 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
 
               {/* Scrollable model list */}
               <div className="overflow-y-auto flex-1">
-                {availableModels &&
-                  Array.isArray(availableModels) &&
+                {availableModels.length === 0 ? (
+                  <DropdownMenuItem disabled className="px-3 py-2 text-sm text-muted-foreground">
+                    Loading models...
+                  </DropdownMenuItem>
+                ) : (
                   [...availableModels]
-                    .filter((m) => MODEL_CONFIG[m.id] !== undefined)
+                    .filter(isSelectableChatModel)
                     // Remove duplicates by id
                     .filter(
-                      (m, index, self) =>
-                        MODEL_CONFIG[m.id] !== undefined &&
-                        self.findIndex((model) => model.id === m.id) === index
+                      (m, index, self) => self.findIndex((model) => model.id === m.id) === index
                     )
                     .sort((a, b) => {
-                      const aConfig = MODEL_CONFIG[a.id];
-                      const bConfig = MODEL_CONFIG[b.id];
-
                       // If chat has images, prioritize vision models
                       if (chatHasImages) {
-                        const aHasVision = aConfig?.supportsVision || false;
-                        const bHasVision = bConfig?.supportsVision || false;
+                        const aHasVision = Boolean(a.capabilities?.vision);
+                        const bHasVision = Boolean(b.capabilities?.vision);
                         if (aHasVision && !bHasVision) return -1;
                         if (!aHasVision && bHasVision) return 1;
                       }
 
-                      const aDisabled = aConfig?.disabled || false;
-                      const bDisabled = bConfig?.disabled || false;
-                      const aRestricted =
-                        (aConfig?.requiresPro || aConfig?.requiresStarter || false) &&
-                        !hasAccessToModel(a.id);
-                      const bRestricted =
-                        (bConfig?.requiresPro || bConfig?.requiresStarter || false) &&
-                        !hasAccessToModel(b.id);
+                      const aDisabled = a.enabled === false;
+                      const bDisabled = b.enabled === false;
+                      const aRestricted = !hasAccessToModel(a.id);
+                      const bRestricted = !hasAccessToModel(b.id);
 
                       // Disabled models go last
                       if (aDisabled && !bDisabled) return 1;
@@ -493,19 +521,20 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
                       if (aRestricted && !bRestricted) return 1;
                       if (!aRestricted && bRestricted) return -1;
 
-                      return 0;
+                      return (a.sort_order ?? 999) - (b.sort_order ?? 999);
                     })
                     .map((availableModel) => {
-                      const config = MODEL_CONFIG[availableModel.id];
-                      const isDisabled = config?.disabled || false;
-                      const requiresPro = config?.requiresPro || false;
-                      const requiresStarter = config?.requiresStarter || false;
+                      const isDisabled = availableModel.enabled === false;
                       const hasAccess = hasAccessToModel(availableModel.id);
-                      const isRestricted = (requiresPro || requiresStarter) && !hasAccess;
+                      const isRestricted = !hasAccess;
 
                       // Disable non-vision models if chat has images
-                      const isDisabledDueToImages = chatHasImages && !config?.supportsVision;
+                      const isDisabledDueToImages =
+                        chatHasImages && !availableModel.capabilities?.vision;
                       const effectivelyDisabled = isDisabled || isDisabledDueToImages;
+                      const selectedAliasTarget = getAlias(model)?.target_model;
+                      const isActive =
+                        model === availableModel.id || selectedAliasTarget === availableModel.id;
 
                       return (
                         <DropdownMenuItem
@@ -513,11 +542,12 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
                           onClick={() => {
                             if (effectivelyDisabled) return;
                             if (isRestricted) {
-                              const modelConfig = MODEL_CONFIG[availableModel.id];
-                              setSelectedModelName(modelConfig?.displayName || availableModel.id);
+                              setSelectedModelName(
+                                availableModel.display_name || availableModel.id
+                              );
                               setUpgradeDialogOpen(true);
                             } else {
-                              setModel(availableModel.id);
+                              setModel(availableModel.id, availableModel);
                               setShowAdvanced(false);
                             }
                           }}
@@ -533,10 +563,11 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
                           <div className="flex items-center gap-2 flex-1">
                             <div className="text-sm">{getDisplayName(availableModel.id, true)}</div>
                           </div>
-                          {model === availableModel.id && <Check className="h-4 w-4" />}
+                          {isActive && <Check className="h-4 w-4" />}
                         </DropdownMenuItem>
                       );
-                    })}
+                    })
+                )}
               </div>
             </div>
           )}

--- a/frontend/src/components/apikeys/ProxyConfigSection.tsx
+++ b/frontend/src/components/apikeys/ProxyConfigSection.tsx
@@ -7,7 +7,7 @@ import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Play, Square, Loader2, AlertCircle, CheckCircle, Server, Copy, Check } from "lucide-react";
 import { proxyService, ProxyConfig, ProxyStatus } from "@/services/proxyService";
 import { isTauriDesktop } from "@/utils/platform";
-import { LLAMA_MODEL_ID } from "@/utils/utils";
+import { QUICK_MODEL_ALIAS } from "@/utils/utils";
 
 interface ProxyConfigSectionProps {
   apiKeys: Array<{ name: string; created_at: string }>;
@@ -342,7 +342,7 @@ client = OpenAI(
 )
 
 response = client.chat.completions.create(
-  model="${LLAMA_MODEL_ID}",
+  model="${QUICK_MODEL_ALIAS}",
   messages=[{"role": "user", "content": "Hello!"}],
   stream=True
 )
@@ -360,7 +360,7 @@ for chunk in response:
                 <code>{`curl -N http://${config.host}:${config.port}/v1/chat/completions \\
   -H "Content-Type: application/json" \\
   -d '{
-    "model": "${LLAMA_MODEL_ID}",
+    "model": "${QUICK_MODEL_ALIAS}",
     "messages": [{"role": "user", "content": "Hello!"}],
     "stream": true
   }'`}</code>

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -1,8 +1,14 @@
 import { useOpenSecret } from "@opensecret/react";
 import { useCallback, useState } from "react";
 import { BillingStatus } from "@/billing/billingApi";
-import { LocalStateContext, Chat, HistoryItem, OpenSecretModel } from "./LocalStateContextDef";
-import { aliasModelName } from "@/utils/utils";
+import {
+  LocalStateContext,
+  Chat,
+  HistoryItem,
+  OpenSecretModel,
+  OpenSecretModelAlias
+} from "./LocalStateContextDef";
+import { aliasModelName, migrateStickyModelName } from "@/utils/utils";
 
 export {
   LocalStateContext,
@@ -11,8 +17,32 @@ export {
   type LocalState
 } from "./LocalStateContextDef";
 
-export const DEFAULT_MODEL_ID = "gpt-oss-120b";
-export const PAID_DEFAULT_MODEL_ID = "kimi-k2-6";
+export const QUICK_MODEL_ALIAS = "auto:quick";
+export const POWERFUL_MODEL_ALIAS = "auto:powerful";
+export const DEFAULT_MODEL_ID = QUICK_MODEL_ALIAS;
+export const PAID_DEFAULT_MODEL_ID = POWERFUL_MODEL_ALIAS;
+const SELECTED_MODEL_METADATA_KEY = "selectedModelMetadata";
+
+const DEFAULT_MODEL_ALIASES: OpenSecretModelAlias[] = [
+  {
+    id: QUICK_MODEL_ALIAS,
+    label: "Quick",
+    short_name: "Quick",
+    description: "Fast, everyday responses",
+    target_model: "",
+    access: "free",
+    capabilities: { chat: true, vision: false, reasoning: true, tool_use: true }
+  },
+  {
+    id: POWERFUL_MODEL_ALIAS,
+    label: "Powerful",
+    short_name: "Powerful",
+    description: "Deeper thinking & analysis",
+    target_model: "",
+    access: "pro",
+    capabilities: { chat: true, vision: true, reasoning: true, tool_use: true }
+  }
+];
 
 // Check if a plan name corresponds to a pro/max/team plan
 function isProMaxOrTeamPlan(planName: string): boolean {
@@ -65,7 +95,11 @@ function getInitialModel(): string {
     // Priority 1: Check local storage for user's explicit model choice
     const selectedModel = localStorage.getItem("selectedModel");
     if (selectedModel) {
-      return aliasModelName(selectedModel);
+      if (getCachedSelectedModelMetadata(selectedModel)) {
+        return selectedModel;
+      }
+
+      return migrateStickyModelName(selectedModel);
     }
 
     // Priority 2: Check if paid defaults were already applied
@@ -98,34 +132,73 @@ function normalizeAvailableModels(models: OpenSecretModel[]): OpenSecretModel[] 
   const normalizedModels = new Map<string, OpenSecretModel>();
 
   for (const model of models) {
-    const normalizedId = aliasModelName(model.id);
-    const normalizedModel = normalizedId === model.id ? model : { ...model, id: normalizedId };
-
-    if (!normalizedModels.has(normalizedId) || model.id === normalizedId) {
-      normalizedModels.set(normalizedId, normalizedModel);
+    if (!normalizedModels.has(model.id)) {
+      normalizedModels.set(model.id, model);
     }
   }
 
   return Array.from(normalizedModels.values());
 }
 
+function isAutoModelAlias(modelId: string): boolean {
+  return modelId === QUICK_MODEL_ALIAS || modelId === POWERFUL_MODEL_ALIAS;
+}
+
+function getCachedSelectedModelMetadata(modelId: string): OpenSecretModel | null {
+  if (!modelId || isAutoModelAlias(modelId)) return null;
+
+  try {
+    const cachedMetadata = localStorage.getItem(SELECTED_MODEL_METADATA_KEY);
+    if (!cachedMetadata) return null;
+
+    const parsedMetadata = JSON.parse(cachedMetadata) as OpenSecretModel;
+    if (parsedMetadata.id !== modelId) return null;
+
+    return {
+      ...parsedMetadata,
+      object: "model",
+      created: parsedMetadata.created || Date.now(),
+      owned_by: parsedMetadata.owned_by || "opensecret"
+    };
+  } catch (error) {
+    console.error("Failed to load selected model metadata:", error);
+    return null;
+  }
+}
+
+function cacheSelectedModelMetadata(modelId: string, modelMetadata?: OpenSecretModel | null) {
+  try {
+    if (!modelMetadata || isAutoModelAlias(modelId)) {
+      localStorage.removeItem(SELECTED_MODEL_METADATA_KEY);
+      return;
+    }
+
+    const cacheableMetadata: OpenSecretModel = {
+      ...modelMetadata,
+      id: modelId,
+      object: "model",
+      created: modelMetadata.created || Date.now(),
+      owned_by: modelMetadata.owned_by || "opensecret"
+    };
+
+    localStorage.setItem(SELECTED_MODEL_METADATA_KEY, JSON.stringify(cacheableMetadata));
+  } catch (error) {
+    console.error("Failed to cache selected model metadata:", error);
+  }
+}
+
 export const LocalStateProvider = ({ children }: { children: React.ReactNode }) => {
-  /** The model that should be assumed when a chat doesn't yet have one */
-  const defaultModel: OpenSecretModel = {
-    id: DEFAULT_MODEL_ID,
-    object: "model",
-    created: Date.now(),
-    owned_by: "openai",
-    tasks: ["generate"]
-  };
+  const initialModel = getInitialModel();
+  const cachedSelectedModel = getCachedSelectedModelMetadata(initialModel);
 
   const [localState, setLocalState] = useState({
     userPrompt: "",
     systemPrompt: null as string | null,
     userImages: [] as File[],
     sentViaVoice: false,
-    model: getInitialModel(),
-    availableModels: normalizeAvailableModels([defaultModel]),
+    model: initialModel,
+    availableModels: cachedSelectedModel ? [cachedSelectedModel] : ([] as OpenSecretModel[]),
+    modelAliases: DEFAULT_MODEL_ALIASES,
     hasWhisperModel: true, // Default to true to avoid hiding button during loading
     billingStatus: null as BillingStatus | null,
     searchQuery: "",
@@ -243,7 +316,7 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
     try {
       if (isProMaxOrTeam && !hasPaidDefaultsBeenApplied()) {
         // Apply paid defaults — set model to Powerful reasoning model
-        setModelInternal(PAID_DEFAULT_MODEL_ID);
+        setModelInternal(PAID_DEFAULT_MODEL_ID, true);
 
         // Enable web search
         localStorage.setItem("webSearchEnabled", "true");
@@ -266,7 +339,7 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
           // hasn't manually chosen one (selectedModel not in localStorage)
           const selectedModel = localStorage.getItem("selectedModel");
           if (!selectedModel) {
-            setModelInternal(PAID_DEFAULT_MODEL_ID);
+            setModelInternal(PAID_DEFAULT_MODEL_ID, true);
           }
         } else {
           // User downgraded to free/starter — switch back to free model
@@ -450,34 +523,43 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
 
   // Internal model setter — updates state and localStorage but does NOT mark as
   // a user's explicit choice. Used by billing/system logic.
-  function setModelInternal(modelId: string) {
+  function setModelInternal(modelId: string, persist = false) {
     const aliasedModel = aliasModelName(modelId);
     setLocalState((prev) => {
       if (prev.model === aliasedModel) return prev;
       return { ...prev, model: aliasedModel };
     });
-    try {
-      localStorage.setItem("selectedModel", aliasedModel);
-    } catch (error) {
-      console.error("Failed to save model to localStorage:", error);
+    if (persist) {
+      try {
+        localStorage.setItem("selectedModel", aliasedModel);
+        cacheSelectedModelMetadata(aliasedModel);
+      } catch (error) {
+        console.error("Failed to save model to localStorage:", error);
+      }
     }
   }
 
   // Public model setter — records the choice as a user-initiated selection.
   // After this, we won't auto-override their model choice.
-  function setModel(model: string) {
-    const aliasedModel = aliasModelName(model);
+  function setModel(model: string, modelMetadata?: OpenSecretModel | null) {
+    const nextModel = modelMetadata ? model : aliasModelName(model);
     setLocalState((prev) => {
-      if (prev.model === aliasedModel) return prev;
+      if (prev.model === nextModel && !modelMetadata) return prev;
 
       // Save to localStorage as user's explicit choice
       try {
-        localStorage.setItem("selectedModel", aliasedModel);
+        localStorage.setItem("selectedModel", nextModel);
+        cacheSelectedModelMetadata(nextModel, modelMetadata);
       } catch (error) {
         console.error("Failed to save model to localStorage:", error);
       }
 
-      return { ...prev, model: aliasedModel };
+      const availableModels =
+        modelMetadata && !isAutoModelAlias(nextModel)
+          ? normalizeAvailableModels([modelMetadata, ...prev.availableModels])
+          : prev.availableModels;
+
+      return { ...prev, model: nextModel, availableModels };
     });
   }
 
@@ -485,6 +567,13 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
     setLocalState((prev) => ({
       ...prev,
       availableModels: normalizeAvailableModels(models)
+    }));
+  }
+
+  function setModelAliases(aliases: OpenSecretModelAlias[]) {
+    setLocalState((prev) => ({
+      ...prev,
+      modelAliases: aliases.length > 0 ? aliases : DEFAULT_MODEL_ALIASES
     }));
   }
 
@@ -497,8 +586,10 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
       value={{
         model: localState.model,
         availableModels: localState.availableModels,
+        modelAliases: localState.modelAliases,
         setModel,
         setAvailableModels,
+        setModelAliases,
         hasWhisperModel: localState.hasWhisperModel,
         setHasWhisperModel,
         userPrompt: localState.userPrompt,

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -5,9 +5,63 @@ import type { Responses } from "openai/resources/responses.js";
 type ResponseItem = Responses.ResponseItem;
 
 // Extended Model type for OpenSecret API which includes additional properties
+export type ModelAccessTier = "free" | "starter" | "pro";
+
+export type ModelCapabilities = {
+  chat?: boolean;
+  vision?: boolean;
+  reasoning?: boolean;
+  tool_use?: boolean;
+};
+
 export interface OpenSecretModel extends Model {
   tasks?: string[];
+  provider?: string;
+  provider_id?: string;
+  display_name?: string;
+  short_name?: string;
+  description?: string;
+  context_window?: number;
+  max_context_tokens?: number;
+  access?: ModelAccessTier;
+  capabilities?: ModelCapabilities;
+  badges?: string[];
+  enabled?: boolean;
+  deprecated?: boolean;
+  sort_order?: number;
 }
+
+export type OpenSecretModelAlias = {
+  id: "auto:quick" | "auto:powerful";
+  label: string;
+  short_name: string;
+  description: string;
+  target_model: string;
+  access?: ModelAccessTier;
+  capabilities?: ModelCapabilities;
+};
+
+export type OpenSecretModelCatalog = {
+  object: "list";
+  data: OpenSecretModel[];
+  aliases: OpenSecretModelAlias[];
+  defaults?: {
+    quick: "auto:quick";
+    powerful: "auto:powerful";
+  };
+  audio?: {
+    transcription?: {
+      available: boolean;
+      model: string;
+      display_name?: string;
+    };
+    speech?: {
+      available: boolean;
+      model: string;
+      display_name?: string;
+    };
+  };
+};
 
 export type Chat = {
   id: string;
@@ -26,8 +80,10 @@ export type HistoryItem = {
 export type LocalState = {
   model: string;
   availableModels: OpenSecretModel[];
-  setModel: (model: string) => void;
+  modelAliases: OpenSecretModelAlias[];
+  setModel: (model: string, modelMetadata?: OpenSecretModel | null) => void;
   setAvailableModels: (models: OpenSecretModel[]) => void;
+  setModelAliases: (aliases: OpenSecretModelAlias[]) => void;
   /** Whether the whisper transcription model is available */
   hasWhisperModel: boolean;
   setHasWhisperModel: (hasWhisper: boolean) => void;
@@ -71,8 +127,10 @@ export type LocalState = {
 export const LocalStateContext = createContext<LocalState>({
   model: "",
   availableModels: [],
+  modelAliases: [],
   setModel: () => void 0,
   setAvailableModels: () => void 0,
+  setModelAliases: () => void 0,
   hasWhisperModel: true,
   setHasWhisperModel: () => void 0,
   userPrompt: "",

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -75,18 +75,22 @@ export function useClickOutside(
 }
 
 export const LLAMA_MODEL_ID = "llama3-3-70b";
+export const QUICK_MODEL_ALIAS = "auto:quick";
+export const POWERFUL_MODEL_ALIAS = "auto:powerful";
 
 const MODEL_NAME_ALIASES: Record<string, string> = {
-  "llama-3.3-70b": LLAMA_MODEL_ID,
-  "gemma-3-27b": "gemma4-31b",
-  "deepseek-r1-0528": "kimi-k2-6",
-  "kimi-k2": "kimi-k2-6",
-  "kimi-k2-thinking": "kimi-k2-6",
-  "kimi-k2-5": "kimi-k2-6"
+  quick: QUICK_MODEL_ALIAS,
+  powerful: POWERFUL_MODEL_ALIAS
 };
 
 export function aliasModelName(modelName: string | undefined): string {
   if (!modelName) return "";
 
   return MODEL_NAME_ALIASES[modelName] ?? modelName;
+}
+
+export function migrateStickyModelName(modelName: string | undefined): string {
+  if (!modelName) return "";
+
+  return aliasModelName(modelName);
 }


### PR DESCRIPTION
## Summary
- Store Quick/Powerful as stable auto aliases instead of concrete model IDs.
- Fetch backend-owned model metadata for selector rendering and advanced models, with legacy fallback support.
- Migrate sticky cached model choices while keeping explicit advanced model selections concrete.

## Validation
- npm --prefix /Users/tony/Dev/OpenSecret/maple/frontend run typecheck
- npm --prefix /Users/tony/Dev/OpenSecret/maple/frontend run lint
- npm --prefix /Users/tony/Dev/OpenSecret/maple/frontend run build
- nix develop /Users/tony/Dev/OpenSecret/maple -c git commit hook ran bun format/build/test

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Models now load from a remote catalog with alias-driven "Quick" and "Powerful" defaults and alias-aware selection.

* **Updates**
  * Model selector displays richer metadata (badges, access, capabilities), improved filtering/sorting, disabled/restricted states, and vision icons.
  * Image-upload auto-switch now picks a vision-capable accessible model from the catalog.
  * Usage examples updated to alias-based defaults; selected-model persistence and metadata caching improved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->