### PR TITLE
Set default OpenSecret client id

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,10 @@ bun run dev
 bun tauri dev
 ```
 
-Expects a `VITE_OPEN_SECRET_API_URL` environment variable to be set. (See `.env.example`)
+Expects a `VITE_OPEN_SECRET_API_URL` environment variable to be set. The public
+OpenSecret client id defaults to Maple's project id
+`ba5a14b5-d915-47b1-b7b1-afda52bc5fc6`, so `VITE_CLIENT_ID` is only needed to
+override the default. (See `.env.example`)
 
 ## Building
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,5 @@
 VITE_OPEN_SECRET_API_URL=http://0.0.0.0:3000
+# Public OpenSecret project id. Optional; the app uses this value by default.
+VITE_CLIENT_ID=ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 #VITE_MAPLE_BILLING_API_URL=http://0.0.0.0:3001
 #VITE_DEV_MODEL_OVERRIDE=gpt-4o

--- a/frontend/.env.test
+++ b/frontend/.env.test
@@ -1,2 +1,3 @@
 # VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
 VITE_OPEN_SECRET_API_URL=https://enclave.secretgpt.ai
+VITE_CLIENT_ID=ba5a14b5-d915-47b1-b7b1-afda52bc5fc6

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -17,6 +17,8 @@ import { ProxyEventListener } from "./components/ProxyEventListener";
 import { UpdateEventListener } from "./components/UpdateEventListener";
 import { TTSProvider } from "./services/tts/TTSContext";
 
+const DEFAULT_OPEN_SECRET_CLIENT_ID = "ba5a14b5-d915-47b1-b7b1-afda52bc5fc6";
+
 // Create a new router instance
 const router = createRouter({
   routeTree,
@@ -56,7 +58,7 @@ export default function App() {
       <NotificationProvider>
         <OpenSecretProvider
           apiUrl={import.meta.env.VITE_OPEN_SECRET_API_URL}
-          clientId={import.meta.env.VITE_CLIENT_ID}
+          clientId={import.meta.env.VITE_CLIENT_ID || DEFAULT_OPEN_SECRET_CLIENT_ID}
           pcrConfig={{
             pcr0Values: [
               "ed9109c16f30a470cf0ea2251816789b4ffa510c990118323ce94a2364b9bf05bdb8777959cbac86f5cabc4852e0da71",

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,1 +1,12 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_OPEN_SECRET_API_URL: string;
+  readonly VITE_CLIENT_ID?: string;
+  readonly VITE_MAPLE_BILLING_API_URL?: string;
+  readonly VITE_DEV_MODEL_OVERRIDE?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add Maple's public OpenSecret client id as the app fallback
- document and expose the client id in tracked env templates
- add Vite env typings for the frontend env vars

## Verification
- bun run typecheck
- bun run lint
- pre-commit: prettier check, bun run build, bun test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/500" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment setup guidance with clarified configuration for OpenSecret client ID, indicating it is optional with a default value.

* **New Features**
  * OpenSecret client ID is now configurable via environment variable, allowing users to override the default project ID when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->