### PR TITLE
Surface team seat mismatch UX

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -15,6 +15,7 @@ import { NotificationProvider } from "./contexts/NotificationContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ProxyEventListener } from "./components/ProxyEventListener";
 import { UpdateEventListener } from "./components/UpdateEventListener";
+import { TeamSeatMismatchAlert } from "./components/team/TeamSeatMismatchAlert";
 import { TTSProvider } from "./services/tts/TTSContext";
 
 const DEFAULT_OPEN_SECRET_CLIENT_ID = "ba5a14b5-d915-47b1-b7b1-afda52bc5fc6";
@@ -108,6 +109,7 @@ export default function App() {
                       <ProxyEventListener />
                       <UpdateEventListener />
                       <DeepLinkHandler />
+                      <TeamSeatMismatchAlert />
                       <InnerApp />
                     </BillingServiceProvider>
                   </TTSProvider>

--- a/frontend/src/billing/billingPortal.ts
+++ b/frontend/src/billing/billingPortal.ts
@@ -1,0 +1,8 @@
+import { getBillingService } from "@/billing/billingService";
+import { openExternalUrl } from "@/utils/openUrl";
+
+export async function openBillingPortal(): Promise<void> {
+  const billingService = getBillingService();
+  const url = await billingService.getPortalUrl();
+  await openExternalUrl(url);
+}

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -51,6 +51,7 @@ import type { TeamStatus } from "@/types/team";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { TeamManagementDialog } from "@/components/team/TeamManagementDialog";
 import { ApiKeyManagementDialog } from "@/components/apikeys/ApiKeyManagementDialog";
+import { getTeamSeatMismatch } from "@/utils/teamSeats";
 import packageJson from "../../package.json";
 import { SIDEBAR_ACCOUNT_MENU_WIDTH_CLASS, SIDEBAR_LAYOUT_STYLE } from "@/constants/layout";
 
@@ -114,7 +115,7 @@ export function AccountMenu() {
   const [showAboutMenu, setShowAboutMenu] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
 
-  const hasStripeAccount = billingStatus?.stripe_customer_id !== null;
+  const hasStripeAccount = !!billingStatus?.stripe_customer_id;
   const productName = billingStatus?.product_name || "";
   const isPro = productName.toLowerCase().includes("pro");
   const isMax = productName.toLowerCase().includes("max");
@@ -157,6 +158,8 @@ export function AccountMenu() {
   // Show alert badge if user has team plan but hasn't created team yet
   const showTeamSetupAlert =
     isTeamPlan && teamStatus?.has_team_subscription && !teamStatus?.team_created;
+  const teamSeatMismatch = getTeamSeatMismatch(teamStatus);
+  const showTeamAttentionAlert = showTeamSetupAlert || !!teamSeatMismatch;
 
   // Determine if API Management should be shown
   // On desktop/web/Android: always show
@@ -301,8 +304,12 @@ export function AccountMenu() {
                     className="relative flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[hsl(var(--sidebar-chrome))] text-[hsl(var(--on-sidebar-chrome))] shadow-none ring-0 transition-colors hover:bg-[hsl(var(--sidebar-chrome-hover))]"
                   >
                     <User className="h-4 w-4" />
-                    {showTeamSetupAlert && (
-                      <AlertCircle className="absolute -right-1 -top-1 h-4 w-4 rounded-full bg-background text-maple-warning" />
+                    {showTeamAttentionAlert && (
+                      <AlertCircle
+                        className={`absolute -right-1 -top-1 h-4 w-4 rounded-full bg-background ${
+                          teamSeatMismatch ? "text-destructive" : "text-maple-warning"
+                        }`}
+                      />
                     )}
                   </button>
                 </DropdownMenuTrigger>
@@ -362,14 +369,21 @@ export function AccountMenu() {
                             <Users className="mr-2 h-4 w-4" />
                             <span>Manage Team</span>
                           </div>
-                          {showTeamSetupAlert && (
+                          {teamSeatMismatch ? (
+                            <Badge
+                              variant="secondary"
+                              className="bg-destructive py-0 px-1.5 text-xs font-medium text-destructive-onFilled"
+                            >
+                              Paused
+                            </Badge>
+                          ) : showTeamSetupAlert ? (
                             <Badge
                               variant="secondary"
                               className="bg-maple-warning py-0 px-1.5 text-xs font-medium text-maple-onWarning"
                             >
                               Setup Required
                             </Badge>
-                          )}
+                          ) : null}
                         </div>
                       </DropdownMenuItem>
                     )}

--- a/frontend/src/components/team/TeamDashboard.tsx
+++ b/frontend/src/components/team/TeamDashboard.tsx
@@ -1,12 +1,30 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { DialogHeader, DialogTitle, DialogDescription } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Input } from "@/components/ui/input";
-import { UserPlus, AlertTriangle, Crown, User, Pencil, Check, X, Loader2 } from "lucide-react";
+import {
+  UserPlus,
+  AlertTriangle,
+  Crown,
+  User,
+  Pencil,
+  Check,
+  X,
+  Loader2,
+  CreditCard,
+  Users
+} from "lucide-react";
 import { TeamInviteDialog } from "./TeamInviteDialog";
 import { TeamMembersList } from "./TeamMembersList";
 import { getBillingService } from "@/billing/billingService";
+import { openBillingPortal } from "@/billing/billingPortal";
+import { useLocalState } from "@/state/useLocalState";
+import {
+  formatTeamSeatMismatchMessage,
+  getTeamSeatCounts,
+  getTeamSeatMismatch
+} from "@/utils/teamSeats";
 import { useQueryClient } from "@tanstack/react-query";
 import type { TeamStatus } from "@/types/team";
 
@@ -20,7 +38,11 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
   const [editedName, setEditedName] = useState("");
   const [isSavingName, setIsSavingName] = useState(false);
   const [nameError, setNameError] = useState<string | null>(null);
+  const [isPortalLoading, setIsPortalLoading] = useState(false);
+  const [portalError, setPortalError] = useState<string | null>(null);
+  const membersSectionRef = useRef<HTMLDivElement>(null);
   const queryClient = useQueryClient();
+  const { billingStatus } = useLocalState();
 
   if (!teamStatus) {
     return (
@@ -33,10 +55,15 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
     );
   }
 
-  const seatsUsed = teamStatus.seats_used || 0;
-  const seatsPurchased = teamStatus.seats_purchased || 0;
+  const seatCounts = getTeamSeatCounts(teamStatus);
+  const seatMismatch = getTeamSeatMismatch(teamStatus);
+  const seatsUsed = seatCounts.memberCount ?? 0;
+  const seatsPurchased = seatCounts.billedSeatCount ?? 0;
   const isAdmin = teamStatus.role === "admin" || teamStatus.is_team_admin === true;
   const seatUsagePercentage = seatsPurchased > 0 ? (seatsUsed / seatsPurchased) * 100 : 0;
+  const canOpenBillingPortal = billingStatus
+    ? !!billingStatus.stripe_customer_id
+    : !!teamStatus.has_team_subscription;
 
   const handleStartEdit = () => {
     setEditedName(teamStatus.team_name || "");
@@ -90,6 +117,29 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
     }
   };
 
+  const handleOpenBilling = async () => {
+    if (!canOpenBillingPortal) return;
+
+    try {
+      setPortalError(null);
+      setIsPortalLoading(true);
+      await openBillingPortal();
+      await queryClient.invalidateQueries({ queryKey: ["billingStatus"] });
+      await queryClient.invalidateQueries({ queryKey: ["teamStatus"] });
+    } catch (error) {
+      console.error("Failed to open billing portal:", error);
+      setPortalError(
+        "Unable to open subscription management. Please try again or contact support@trymaple.ai."
+      );
+    } finally {
+      setIsPortalLoading(false);
+    }
+  };
+
+  const handleReviewMembers = () => {
+    membersSectionRef.current?.scrollIntoView({ block: "nearest" });
+  };
+
   // Simplified view for non-admin members
   if (!isAdmin) {
     return (
@@ -99,6 +149,20 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
         </DialogHeader>
 
         <div className="mt-3 space-y-3 overflow-hidden">
+          {seatMismatch && (
+            <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive">
+              <div className="flex items-start gap-2">
+                <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                <div className="space-y-1">
+                  <p className="text-sm font-medium">Team usage is paused</p>
+                  <p className="text-xs leading-relaxed">
+                    {formatTeamSeatMismatchMessage(seatMismatch, "member")}
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
           {/* Compact team info */}
           <div className="bg-muted/50 rounded-lg p-3">
             <div className="flex items-center justify-between gap-2">
@@ -137,11 +201,45 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
       </DialogHeader>
 
       <div className="mt-3 space-y-3 overflow-hidden">
-        {/* Seat limit exceeded warning */}
-        {teamStatus.seat_limit_exceeded && (
-          <div className="rounded-md bg-destructive/10 p-2.5 text-destructive text-xs flex items-start gap-2">
-            <AlertTriangle className="h-3.5 w-3.5 mt-0.5 flex-shrink-0" />
-            <span>Seat limit exceeded. Remove members or purchase additional seats.</span>
+        {seatMismatch && (
+          <div className="rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <div>
+                  <p className="text-sm font-medium">Team usage is paused</p>
+                  <p className="mt-1 text-xs leading-relaxed">
+                    {formatTeamSeatMismatchMessage(seatMismatch, "admin")}
+                  </p>
+                </div>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-8 border-destructive/30 text-destructive hover:text-destructive"
+                    onClick={handleReviewMembers}
+                  >
+                    <Users className="mr-1.5 h-3.5 w-3.5" />
+                    Manage Members
+                  </Button>
+                  {canOpenBillingPortal && (
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="h-8 border-destructive/30 text-destructive hover:text-destructive"
+                      onClick={handleOpenBilling}
+                      disabled={isPortalLoading}
+                    >
+                      <CreditCard className="mr-1.5 h-3.5 w-3.5" />
+                      {isPortalLoading ? "Opening..." : "Add Seats"}
+                    </Button>
+                  )}
+                </div>
+                {portalError && <p className="text-xs leading-relaxed">{portalError}</p>}
+              </div>
+            </div>
           </div>
         )}
 
@@ -233,7 +331,11 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
             </div>
             <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
               <div
-                className="h-full transition-all bg-emerald-500"
+                className={
+                  seatMismatch
+                    ? "h-full bg-destructive transition-all"
+                    : "h-full bg-emerald-500 transition-all"
+                }
                 style={{
                   width: `${Math.min(seatUsagePercentage, 100)}%`
                 }}
@@ -246,7 +348,7 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
         {isAdmin && (
           <Button
             onClick={() => setIsInviteDialogOpen(true)}
-            disabled={teamStatus.seat_limit_exceeded}
+            disabled={!!seatMismatch}
             size="sm"
             className="w-full"
           >
@@ -256,7 +358,9 @@ export function TeamDashboard({ teamStatus }: TeamDashboardProps) {
         )}
 
         {/* Members list */}
-        <TeamMembersList teamStatus={teamStatus} />
+        <div ref={membersSectionRef}>
+          <TeamMembersList teamStatus={teamStatus} />
+        </div>
       </div>
 
       {/* Invite dialog */}

--- a/frontend/src/components/team/TeamInviteDialog.tsx
+++ b/frontend/src/components/team/TeamInviteDialog.tsx
@@ -185,13 +185,13 @@ or comma-separated: john@example.com, jane@example.com`}
                   </AlertDescription>
                 </Alert>
                 {canOpenBillingPortal && (
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="sm"
-                      className="w-full"
-                      onClick={handleManageSubscription}
-                      disabled={isPortalLoading}
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="w-full"
+                    onClick={handleManageSubscription}
+                    disabled={isPortalLoading}
                   >
                     <CreditCard className="mr-2 h-4 w-4" />
                     {isPortalLoading ? "Loading..." : "Manage Subscription"}

--- a/frontend/src/components/team/TeamInviteDialog.tsx
+++ b/frontend/src/components/team/TeamInviteDialog.tsx
@@ -185,12 +185,13 @@ or comma-separated: john@example.com, jane@example.com`}
                   </AlertDescription>
                 </Alert>
                 {canOpenBillingPortal && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="w-full"
-                    onClick={handleManageSubscription}
-                    disabled={isPortalLoading}
+                    <Button
+                      type="button"
+                      variant="outline"
+                      size="sm"
+                      className="w-full"
+                      onClick={handleManageSubscription}
+                      disabled={isPortalLoading}
                   >
                     <CreditCard className="mr-2 h-4 w-4" />
                     {isPortalLoading ? "Loading..." : "Manage Subscription"}

--- a/frontend/src/components/team/TeamInviteDialog.tsx
+++ b/frontend/src/components/team/TeamInviteDialog.tsx
@@ -14,8 +14,8 @@ import { Textarea } from "@/components/ui/textarea";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Loader2, AlertCircle, UserPlus, Info, CreditCard } from "lucide-react";
 import { getBillingService } from "@/billing/billingService";
+import { openBillingPortal } from "@/billing/billingPortal";
 import { useLocalState } from "@/state/useLocalState";
-import { isTauri } from "@/utils/platform";
 import type { TeamStatus } from "@/types/team";
 
 interface TeamInviteDialogProps {
@@ -32,43 +32,20 @@ export function TeamInviteDialog({ open, onOpenChange, teamStatus }: TeamInviteD
   const [isPortalLoading, setIsPortalLoading] = useState(false);
   const queryClient = useQueryClient();
   const { billingStatus } = useLocalState();
-  const seatsAvailable = teamStatus?.seats_available || 0;
-  const hasStripeAccount = billingStatus?.stripe_customer_id !== null;
+  const seatsAvailable = Math.max(0, teamStatus?.seats_available || 0);
+  const canOpenBillingPortal = billingStatus
+    ? !!billingStatus.stripe_customer_id
+    : !!teamStatus?.has_team_subscription;
 
   const handleManageSubscription = async () => {
-    if (!hasStripeAccount) return;
+    if (!canOpenBillingPortal) return;
 
     try {
       setError(null);
       setIsPortalLoading(true);
-      const billingService = getBillingService();
-      const url = await billingService.getPortalUrl();
-
-      // Use external browser for all Tauri platforms (mobile and desktop)
-      if (isTauri()) {
-        try {
-          // Dynamic import to avoid issues in web environments
-          const { invoke } = await import("@tauri-apps/api/core");
-          await invoke("plugin:opener|open_url", { url })
-            .then(() => {
-              console.log("[TeamInvite] Successfully opened URL in external browser");
-            })
-            .catch((error: Error) => {
-              console.error("[TeamInvite] Failed to open external browser:", error);
-              // Fall back to window.open if opener plugin fails
-              window.open(url, "_blank", "noopener,noreferrer");
-            });
-          return;
-        } catch (importError) {
-          console.error("[TeamInvite] Failed to import Tauri APIs:", importError);
-          // Fall back to web approach if dynamic import fails
-          window.open(url, "_blank", "noopener,noreferrer");
-          return;
-        }
-      }
-
-      // Web flow
-      window.open(url, "_blank", "noopener,noreferrer");
+      await openBillingPortal();
+      await queryClient.invalidateQueries({ queryKey: ["billingStatus"] });
+      await queryClient.invalidateQueries({ queryKey: ["teamStatus"] });
     } catch (error) {
       console.error("Failed to open billing portal:", error);
       setError(
@@ -207,7 +184,7 @@ or comma-separated: john@example.com, jane@example.com`}
                     before inviting new ones.
                   </AlertDescription>
                 </Alert>
-                {hasStripeAccount && (
+                {canOpenBillingPortal && (
                   <Button
                     variant="outline"
                     size="sm"

--- a/frontend/src/components/team/TeamSeatMismatchAlert.tsx
+++ b/frontend/src/components/team/TeamSeatMismatchAlert.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { useOpenSecret } from "@opensecret/react";
+import { AlertTriangle, Users } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { getBillingService } from "@/billing/billingService";
+import type { TeamStatus } from "@/types/team";
+import { formatTeamSeatMismatchMessage, getTeamSeatMismatch } from "@/utils/teamSeats";
+import { TeamManagementDialog } from "./TeamManagementDialog";
+
+export function TeamSeatMismatchAlert() {
+  const os = useOpenSecret();
+  const [isTeamDialogOpen, setIsTeamDialogOpen] = useState(false);
+
+  const { data: teamStatus } = useQuery<TeamStatus>({
+    queryKey: ["teamStatus"],
+    queryFn: async () => {
+      const billingService = getBillingService();
+      return await billingService.getTeamStatus();
+    },
+    enabled: !!os.auth.user,
+    refetchOnWindowFocus: true
+  });
+
+  const mismatch = getTeamSeatMismatch(teamStatus);
+  if (!mismatch) return null;
+
+  const isAdmin = teamStatus?.role === "admin" || teamStatus?.is_team_admin === true;
+  const summary =
+    mismatch.hasExactCounts && mismatch.memberCount !== null && mismatch.billedSeatCount !== null
+      ? `${mismatch.memberCount} ${
+          mismatch.memberCount === 1 ? "member" : "members"
+        }, ${mismatch.billedSeatCount} paid ${mismatch.billedSeatCount === 1 ? "seat" : "seats"}`
+      : "Seat count mismatch";
+
+  return (
+    <>
+      <div className="pointer-events-none fixed left-3 right-3 top-20 z-40 sm:left-auto sm:right-4 sm:w-[24rem]">
+        <div className="pointer-events-auto rounded-lg border border-destructive/50 bg-card p-4 text-card-foreground shadow-lg">
+          <div className="flex items-start gap-3">
+            <AlertTriangle className="mt-0.5 h-5 w-5 flex-shrink-0 text-destructive" />
+            <div className="min-w-0 flex-1 space-y-3">
+              <div>
+                <h4 className="text-sm font-medium leading-tight">Team usage paused</h4>
+                <p className="mt-1 text-xs font-medium text-destructive">{summary}</p>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  {formatTeamSeatMismatchMessage(mismatch, isAdmin ? "admin" : "member")}
+                </p>
+              </div>
+              <div className="flex justify-end">
+                <Button size="sm" onClick={() => setIsTeamDialogOpen(true)}>
+                  <Users className="mr-1.5 h-3.5 w-3.5" />
+                  {isAdmin ? "Manage Team" : "Team Info"}
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <TeamManagementDialog
+        open={isTeamDialogOpen}
+        onOpenChange={setIsTeamDialogOpen}
+        teamStatus={teamStatus}
+      />
+    </>
+  );
+}

--- a/frontend/src/components/team/TeamSeatMismatchAlert.tsx
+++ b/frontend/src/components/team/TeamSeatMismatchAlert.tsx
@@ -27,7 +27,10 @@ export function TeamSeatMismatchAlert() {
 
   const isAdmin = teamStatus?.role === "admin" || teamStatus?.is_team_admin === true;
   const summary =
-    mismatch.hasExactCounts && mismatch.memberCount !== null && mismatch.billedSeatCount !== null
+    mismatch.hasExactCounts &&
+    mismatch.memberCount !== null &&
+    mismatch.billedSeatCount !== null &&
+    mismatch.memberCount > mismatch.billedSeatCount
       ? `${mismatch.memberCount} ${
           mismatch.memberCount === 1 ? "member" : "members"
         }, ${mismatch.billedSeatCount} paid ${mismatch.billedSeatCount === 1 ? "seat" : "seats"}`

--- a/frontend/src/types/team.ts
+++ b/frontend/src/types/team.ts
@@ -8,6 +8,8 @@ export interface TeamStatus {
   seats_used?: number;
   seats_available?: number;
   members_count?: number;
+  billed_seat_count?: number;
+  team_member_count?: number;
   pending_invites_count?: number;
   created_at?: string;
   seat_limit_exceeded?: boolean;

--- a/frontend/src/utils/teamSeats.ts
+++ b/frontend/src/utils/teamSeats.ts
@@ -1,0 +1,78 @@
+import type { TeamStatus } from "@/types/team";
+
+export type TeamSeatCounts = {
+  memberCount: number | null;
+  billedSeatCount: number | null;
+  seatsAvailable: number | null;
+};
+
+export type TeamSeatMismatch = TeamSeatCounts & {
+  hasExactCounts: boolean;
+};
+
+function toNumber(value: number | undefined): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+export function getTeamSeatCounts(teamStatus?: TeamStatus): TeamSeatCounts {
+  const memberCount =
+    toNumber(teamStatus?.team_member_count) ??
+    toNumber(teamStatus?.members_count) ??
+    toNumber(teamStatus?.seats_used);
+
+  const billedSeatCount =
+    toNumber(teamStatus?.billed_seat_count) ?? toNumber(teamStatus?.seats_purchased);
+
+  const seatsAvailable = toNumber(teamStatus?.seats_available);
+
+  return {
+    memberCount,
+    billedSeatCount,
+    seatsAvailable: seatsAvailable === null ? null : Math.max(0, seatsAvailable)
+  };
+}
+
+export function getTeamSeatMismatch(teamStatus?: TeamStatus): TeamSeatMismatch | null {
+  if (!teamStatus?.team_created) return null;
+
+  const counts = getTeamSeatCounts(teamStatus);
+  const hasExactCounts = counts.memberCount !== null && counts.billedSeatCount !== null;
+  const countMismatch =
+    hasExactCounts && counts.memberCount !== null && counts.billedSeatCount !== null
+      ? counts.memberCount > counts.billedSeatCount
+      : false;
+
+  if (!countMismatch && teamStatus.seat_limit_exceeded !== true) return null;
+
+  return {
+    ...counts,
+    hasExactCounts
+  };
+}
+
+export function formatTeamSeatMismatchMessage(
+  mismatch: TeamSeatMismatch,
+  audience: "admin" | "member"
+): string {
+  if (
+    mismatch.hasExactCounts &&
+    mismatch.memberCount !== null &&
+    mismatch.billedSeatCount !== null
+  ) {
+    const memberLabel = mismatch.memberCount === 1 ? "member" : "members";
+    const seatLabel = mismatch.billedSeatCount === 1 ? "paid seat" : "paid seats";
+    const resolution =
+      audience === "admin"
+        ? "Team usage is paused until seats are added or members are removed."
+        : "Contact your team admin to add paid seats or remove members.";
+
+    return (
+      `This team has ${mismatch.memberCount} ${memberLabel} but only ` +
+      `${mismatch.billedSeatCount} ${seatLabel}. ${resolution}`
+    );
+  }
+
+  return audience === "admin"
+    ? "This team has more members than paid seats. Team usage is paused until seats are added or members are removed."
+    : "This team has more members than paid seats. Contact your team admin to add paid seats or remove members.";
+}

--- a/frontend/src/utils/teamSeats.ts
+++ b/frontend/src/utils/teamSeats.ts
@@ -57,7 +57,8 @@ export function formatTeamSeatMismatchMessage(
   if (
     mismatch.hasExactCounts &&
     mismatch.memberCount !== null &&
-    mismatch.billedSeatCount !== null
+    mismatch.billedSeatCount !== null &&
+    mismatch.memberCount > mismatch.billedSeatCount
   ) {
     const memberLabel = mismatch.memberCount === 1 ? "member" : "members";
     const seatLabel = mismatch.billedSeatCount === 1 ? "paid seat" : "paid seats";


### PR DESCRIPTION
## Summary

Adds persistent team seat mismatch detection and alerting across the app when team members exceed purchased seats.

**New files:**
- `utils/teamSeats.ts` — Pure helpers (`getTeamSeatCounts`, `getTeamSeatMismatch`, `formatTeamSeatMismatchMessage`) that normalize seat counts from multiple API fields and detect overage via client-side count comparison OR the server's `seat_limit_exceeded` flag.
- `billing/billingPortal.ts` — Shared `openBillingPortal()` helper (replaces duplicated platform-specific logic in `TeamInviteDialog`).
- `components/team/TeamSeatMismatchAlert.tsx` — Fixed-position toast alert rendered at app root; shows admin/member-appropriate messaging with a "Manage Team" / "Team Info" CTA.

**Modified files:**
- `AccountMenu` — Badge changes from warning (Setup Required) to destructive (Paused) when seat mismatch detected.
- `TeamDashboard` — Admin view gets mismatch banner with "Manage Members" and "Add Seats" buttons; member view gets read-only warning. Seat usage bar turns destructive on mismatch. Invite button disabled during mismatch.
- `TeamInviteDialog` — Billing portal logic replaced with shared helper; `type="button"` added to prevent form submission; `canOpenBillingPortal` check tightened.
- `types/team.ts` — `TeamStatus` extended with `billed_seat_count` and `team_member_count`.
- `app.tsx` — Renders `<TeamSeatMismatchAlert />` at app root.

**Bug fixes from review:**
- Added `memberCount > billedSeatCount` guard to both `formatTeamSeatMismatchMessage` and the alert summary to prevent contradictory display (e.g. "3 members, 5 paid seats" alongside "more members than paid seats") when `seat_limit_exceeded` is stale.
- Added `type="button"` to billing CTA in invite dialog to prevent it from also submitting the invite form.

## Review & Testing Checklist for Human

- [ ] **Verify mismatch alert with a real team account** — Requires a team where `seat_limit_exceeded` is true or `team_member_count > billed_seat_count`. Confirm the fixed-position alert appears, shows correct counts, and the "Manage Team" button opens the team dialog.
- [ ] **Verify alert does NOT appear for healthy teams** — Log in with a team account where seats are sufficient and confirm no alert renders.
- [ ] **Test billing portal from all entry points** — Dashboard "Add Seats" button, invite dialog "Manage Subscription" button. Confirm portal opens externally on desktop/mobile and that `billingStatus` + `teamStatus` queries refresh afterward.
- [ ] **Check admin vs member experience** — Admin should see "Manage Team" + "Add Seats" + "Manage Members" actions. Non-admin should see "Team Info" + read-only warning asking them to contact their admin.
- [ ] **Verify `canOpenBillingPortal` edge cases** — The check changed from `stripe_customer_id !== null` to `!!stripe_customer_id` with fallback to `has_team_subscription`. Confirm users without Stripe accounts don't see billing buttons.

**Recommended test plan:** Use a team account, temporarily set `seat_limit_exceeded: true` server-side (or add more members than seats), and walk through all surfaces: app-level alert, account menu badge, team dashboard, and invite dialog.

### Notes
- The mismatch detection is dual-path: triggers on client-side count comparison (`memberCount > billedSeatCount`) OR the server's `seat_limit_exceeded` flag. When the server flag fires but exact counts aren't available or don't confirm overage, a generic message is shown without specific numbers.
- Not tested end-to-end — requires a team account in a specific seat mismatch state that wasn't available during development.

Link to Devin session: https://app.devin.ai/sessions/3297c6fa90564002a802713f48b3e22c
Requested by: @AnthonyRonning