### PR TITLE
Bump to 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,9 @@ These commands automatically update all necessary files:
 - `frontend/src-tauri/gen/apple/maple_iOS/Info.plist`
 - `Cargo.lock` (via cargo check)
 
+Android `versionCode` is internal and increments by one for each Play Store upload.
+Use `just update-android-counter` for another internal/test build with the same visible version.
+
 #### Creating a GitHub Release
 1. Use one of the version commands above to update the version
 2. Create a new release in GitHub:

--- a/docs/android-platform-checks-analysis.md
+++ b/docs/android-platform-checks-analysis.md
@@ -957,11 +957,11 @@ Store in GitHub Secrets:
 
 ### Version Code Management
 
-Tauri automatically generates version codes from `tauri.conf.json`:
-- Formula: `versionCode = major * 1000000 + minor * 1000 + patch`
-- Example: `1.3.2` → `1003002`
+Android `versionCode` is not user-visible; `versionName`/Tauri `version` is what users see.
+Google Play only requires that each uploaded build uses a higher `versionCode` than previous uploads
+and stays at or below `2100000000`.
 
-Override in `tauri.conf.json` if needed:
+Set the override in `tauri.conf.json`:
 ```json
 {
   "bundle": {
@@ -997,9 +997,10 @@ Override in `tauri.conf.json` if needed:
 - **Upload Key SHA256**: `C6:12:09:59:0A:27:73:F9:EA:EC:80:0A:C1:09:07:54:4A:56:6C:62:A5:68:7D:DF:9D:B3:DE:91:19:E4:3B:2A`
 
 ### Version Code Management:
-To avoid conflicts with Tauri's automatic version code generation, we use an extended scheme:
-- Base formula: `major*1000000 + minor*1000 + patch`
-- Extended for builds: Add 3 digits for build number (e.g., 1003002001, 1003002002)
+To avoid conflicts with Tauri's automatic version code generation and Google Play's
+`2100000000` cap, Android builds use a simple sequential `versionCode`:
+- Increment by one for each Play Store upload
+- Keep the user-facing app version in Tauri `version`
 - Configured in `tauri.conf.json` under `bundle.android.versionCode`
 
 ### Still Required for Full Release:

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "2.0.28",
+  "version": "3.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2898,7 +2898,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maple"
-version = "2.0.28"
+version = "3.0.0"
 dependencies = [
  "anyhow",
  "axum",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "2.0.28"
+version = "3.0.0"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.0.28</string>
+	<string>3.0.0</string>
 	<key>CFBundleVersion</key>
-	<string>2.0.28</string>
+	<string>3.0.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 2.0.28
-        CFBundleVersion: 2.0.28
+        CFBundleShortVersionString: 3.0.0
+        CFBundleVersion: 3.0.0
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -89,7 +89,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 3000000000
+      "versionCode": 2000028001
     },
     "windows": {
       "certificateThumbprint": null,

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "2.0.28",
+  "version": "3.0.0",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -89,7 +89,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028000
+      "versionCode": 3000000000
     },
     "windows": {
       "certificateThumbprint": null,

--- a/justfile
+++ b/justfile
@@ -101,10 +101,15 @@ update-version version:
     # Parse version into components
     IFS='.' read -r major minor patch <<< "{{version}}"
     
-    # Calculate Android versionCode: M + MMM (minor) + PPP (patch) + 000 (counter reset)
-    # Format: MMMMPPPCCC (10 digits total)
-    android_version_code=$(printf "%d%03d%03d000" "$major" "$minor" "$patch")
-    echo "Calculated Android versionCode: $android_version_code"
+    # Android versionCode is not user-visible. It only has to increase for
+    # every uploaded Play Store build and must stay <= 2100000000.
+    current_android_version_code=$(jq -r '.bundle.android.versionCode' frontend/src-tauri/tauri.conf.json)
+    android_version_code=$((current_android_version_code + 1))
+    if [ "$android_version_code" -gt 2100000000 ]; then
+        echo "Error: Android versionCode $android_version_code exceeds Google Play maximum 2100000000."
+        exit 1
+    fi
+    echo "Calculated Android versionCode: $android_version_code (previous + 1)"
     
     # Update package.json
     sed -i 's/"version": "[^"]*"/"version": "{{version}}"/' frontend/package.json
@@ -169,7 +174,7 @@ bump-major:
     
     just update-version "$new_version"
 
-# Increment Android versionCode counter (last 3 digits) for Play Store updates
+# Increment Android versionCode for another Play Store upload with the same visible version
 update-android-counter:
     #!/usr/bin/env bash
     set -euo pipefail
@@ -177,23 +182,16 @@ update-android-counter:
     # Get current versionCode from tauri.conf.json
     current_code=$(jq -r '.bundle.android.versionCode' frontend/src-tauri/tauri.conf.json)
     
-    # Extract base (first 7 digits) and counter (last 3 digits)
-    base=$((current_code / 1000))
-    counter=$((current_code % 1000))
+    # Increment by one. This value is internal to Android/Play Store and is not user-visible.
+    new_code=$((current_code + 1))
     
-    # Increment counter
-    new_counter=$((counter + 1))
-    
-    # Ensure counter doesn't exceed 999
-    if [ $new_counter -gt 999 ]; then
-        echo "Error: Counter exceeds maximum (999). Consider bumping the version instead."
+    # Ensure versionCode stays within Google Play's maximum.
+    if [ "$new_code" -gt 2100000000 ]; then
+        echo "Error: Android versionCode $new_code exceeds Google Play maximum 2100000000."
         exit 1
     fi
     
-    # Calculate new versionCode
-    new_code=$((base * 1000 + new_counter))
-    
-    echo "Updating Android versionCode: $current_code → $new_code"
+    echo "Updating Android versionCode: $current_code -> $new_code"
     
     # Update tauri.conf.json Android versionCode
     sed -i "s/\"versionCode\": $current_code/\"versionCode\": $new_code/" frontend/src-tauri/tauri.conf.json


### PR DESCRIPTION

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/507" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Application version updated to 3.0.0
  * iOS minimum system version requirement updated to 16.0
  * Android bundle versionCode incremented

* **Chores / Release tooling**
  * Simplified Android versionCode increment flow in release tooling

* **Documentation**
  * Expanded Android platform-detection guidance, Play Store/deep-linking notes, and README clarification on versionCode handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->