### PR TITLE
Harden Bun dependency installs

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -35,7 +35,7 @@ jobs:
           path: |
             ~/.bun/install/cache
             frontend/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Install Tauri CLI
         run: |

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -61,7 +61,7 @@ jobs:
           path: |
             ~/.bun/install/cache
             frontend/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -99,7 +99,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Cache Cargo bin (Tauri CLI)
         uses: actions/cache@v4
@@ -136,4 +136,3 @@ jobs:
             --allowedTools "Bash,Edit,Replace,NotebookEditCell,MultiEdit,Write,Read,Grep,Glob,LS,WebSearch,WebFetch,Task,TodoWrite,BashOutput,KillBash"
             --max-turns 100
             --model claude-sonnet-4-5-20250929
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -126,7 +126,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Configure sccache
         run: |
@@ -173,7 +173,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Install Tauri CLI
         run: |

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -26,13 +26,13 @@ jobs:
           path: |
             ~/.bun/install/cache
             frontend/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
       - name: Install dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Format check
         working-directory: ./frontend

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -54,7 +54,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Cache ONNX Runtime iOS build
         uses: actions/cache@v4

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Get version
         id: get_version
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
@@ -157,7 +157,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Cache Bun dependencies
         uses: actions/cache@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Configure sccache
         run: |
@@ -165,7 +165,7 @@ jobs:
           path: |
             ~/.bun/install/cache
             frontend/node_modules
-          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lockb') }}
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
           restore-keys: |
             ${{ runner.os }}-bun-
 
@@ -226,7 +226,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Install Tauri CLI
         run: |

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: 1.2.2
+          bun-version: 1.3.5
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/testflight-on-comment.yml
+++ b/.github/workflows/testflight-on-comment.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Install frontend dependencies
         working-directory: ./frontend
-        run: bun install
+        run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Cache ONNX Runtime iOS build
         uses: actions/cache@v4

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ Maple is a **Tauri-based AI chat application** that runs on desktop (macOS, Linu
 - **Frontend**: TypeScript + React (Vite), Tailwind CSS, shadcn/ui components
 - **Backend**: Rust (Tauri 2.x) with proxy and PDF extraction features
 - **Auth**: OpenSecret (`@opensecret/react`)
-- **Package Manager**: Bun (v1.2.2+)
+- **Package Manager**: Bun (v1.3.5)
 
 ## Environment
 The user typically runs `nix develop` (using `flake.nix`) before starting Claude. This means you're usually in a Nix shell with all required tools (bun, cargo, rustc, etc.) already available.

--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,3 +1,7 @@
+[install]
+frozenLockfile = true
+minimumReleaseAge = 604800
+
 [test]
 preload = ["src/lib/test/preload.ts", "src/lib/test/der-loader.ts"]
 root = "./src"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "3.0.1",
   "type": "module",
+  "packageManager": "bun@1.3.5",
   "trustedDependencies": [],
   "scripts": {
     "dev": "vite",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "3.0.1",
   "type": "module",
+  "trustedDependencies": [],
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
@@ -12,7 +13,7 @@
     "test": "bun test",
     "test:coverage": "bun test --coverage",
     "preview": "vite preview",
-    "add": "bunx shadcn-ui@latest add",
+    "add": "echo \"Disabled: use a reviewed, pinned shadcn CLI version explicitly\" && exit 1",
     "format": "prettier --write \"src/**/*.{ts,tsx,js,jsx,json,css,md}\"",
     "format:check": "prettier --check \"src/**/*.{ts,tsx,js,jsx,json,css,md}\""
   },


### PR DESCRIPTION
Summary:
- Freeze Bun installs by default with frozenLockfile and a 7-day minimumReleaseAge in bunfig.toml
- Require CI Bun installs to use --frozen-lockfile --ignore-scripts
- Disable the floating bunx shadcn-ui@latest helper and declare no trusted dependency lifecycle scripts
- Point Bun cache keys at the committed text lockfile

Verification:
- jq empty frontend/package.json
- git diff --check
- pre-commit hook ran bun build and bun test successfully

No dependency install, update, or lockfile rewrite was performed manually for this PR.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded the JS runtime across CI/CD to a newer version for consistency.
  * Enforced deterministic installs in CI by requiring the lockfile and skipping install-time scripts.
  * Improved dependency cache keys to align with the lockfile and reduce cache mismatches.
  * Adjusted frontend package config to mark trusted dependencies (empty) and disable a scaffold script.

* **Documentation**
  * Updated package manager version reference in docs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/521?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->