### PR TITLE
Pin CI action and tool versions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -11,24 +11,26 @@ jobs:
   build-android:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # was v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.11'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # was v3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/.bun/install/cache
@@ -38,12 +40,13 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1.5.0
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # was v1.5.0
         id: setup-ndk
         with:
           ndk-version: r27c
@@ -51,7 +54,7 @@ jobs:
           local-cache: true
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/.gradle/caches
@@ -63,14 +66,18 @@ jobs:
       - name: Install sccache
         run: |
           SCCACHE_VERSION=0.8.2
-          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -L "$SCCACHE_URL" | tar xz
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
           sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
           chmod +x /usr/local/bin/sccache
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-android-${{ hashFiles('**/Cargo.lock') }}
@@ -79,7 +86,7 @@ jobs:
             ${{ runner.os }}-sccache-
 
       - name: Cache Cargo bin (Tauri CLI)
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cargo/bin/
           key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
@@ -207,7 +214,7 @@ jobs:
         run: sccache --show-stats
 
       - name: Upload Android APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-android-apk
           path: |
@@ -215,7 +222,7 @@ jobs:
           retention-days: 5
 
       - name: Upload Android AAB
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-android-aab
           path: |

--- a/.github/workflows/android-pr-build.yml
+++ b/.github/workflows/android-pr-build.yml
@@ -11,31 +11,32 @@ jobs:
   build-android:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # was v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.11'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # was v3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1.5.0
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # was v1.5.0
         id: setup-ndk
         with:
           ndk-version: r27c
@@ -132,7 +133,7 @@ jobs:
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 
       - name: Upload Android PR APK
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-android-debug-apk
           path: |

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -14,20 +14,23 @@ jobs:
       matrix:
         target: [universal-apple-darwin]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Cache Homebrew
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/Library/Caches/Homebrew
@@ -44,7 +47,7 @@ jobs:
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/Library/Caches/Mozilla.sccache
           key: ${{ runner.os }}-sccache-macos-${{ hashFiles('**/Cargo.lock') }}
@@ -86,7 +89,7 @@ jobs:
           echo "Certificate imported."
 
       - name: Build Tauri App (macOS)
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # was v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -108,7 +111,7 @@ jobs:
         run: sccache --show-stats
 
       - name: Upload macOS Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-macos-universal
           path: |
@@ -119,27 +122,35 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
+        with:
+          toolchain: 1.95.0
 
       - name: Install sccache
         run: |
           SCCACHE_VERSION=0.8.2
-          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -L "$SCCACHE_URL" | tar xz
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
           sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
           chmod +x /usr/local/bin/sccache
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-linux-${{ hashFiles('**/Cargo.lock') }}
@@ -148,7 +159,7 @@ jobs:
             ${{ runner.os }}-sccache-
 
       - name: Cache Cargo bin (Tauri CLI)
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cargo/bin/
           key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
@@ -207,7 +218,7 @@ jobs:
         run: sccache --show-stats
 
       - name: Upload Linux Builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-linux
           path: |

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -14,18 +14,19 @@ jobs:
       matrix:
         target: [universal-apple-darwin]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
       - name: Install frontend dependencies
@@ -42,7 +43,7 @@ jobs:
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 
       - name: Upload macOS PR Build
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-macos-universal-pr
           path: |
@@ -53,17 +54,19 @@ jobs:
   build-linux:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
+        with:
+          toolchain: 1.95.0
 
       - name: Install Linux dependencies
         run: |
@@ -103,7 +106,7 @@ jobs:
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 
       - name: Upload Linux PR Builds
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-linux-pr
           path: |

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -13,15 +13,17 @@ jobs:
   test-frontend:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/.bun/install/cache

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -11,20 +11,23 @@ jobs:
   build-ios:
     runs-on: macos-26-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-apple-ios
 
       - name: Cache Homebrew
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/Library/Caches/Homebrew
@@ -34,7 +37,7 @@ jobs:
             ${{ runner.os }}-brew-
 
       - name: Cache Xcode DerivedData and SourcePackages
-        uses: irgaly/xcode-cache@v1
+        uses: irgaly/xcode-cache@4141f139f00e335c6e1031fb93e667181f86146f # was v1
         with:
           key: xcode-cache-ios-xcode26.2-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
@@ -42,7 +45,7 @@ jobs:
             xcode-cache-ios-xcode26.2-
 
       - name: Cache Cargo bin (Tauri CLI)
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cargo/bin/
           key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
@@ -55,7 +58,7 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Cache ONNX Runtime iOS build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         id: cache-onnxruntime
         with:
           path: |
@@ -110,7 +113,7 @@ jobs:
           cat "${WORKSPACE}/frontend/src-tauri/.cargo/config.toml"
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
         with:
           xcode-version: '26.2'
 
@@ -152,7 +155,7 @@ jobs:
           IPHONEOS_DEPLOYMENT_TARGET: '16.0'
 
       - name: Upload iOS App
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-ios
           path: |

--- a/.github/workflows/mobile-pr-build.yml
+++ b/.github/workflows/mobile-pr-build.yml
@@ -11,22 +11,23 @@ jobs:
   build-ios:
     runs-on: macos-26-xlarge
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-apple-ios-sim
 
       - name: Cache Homebrew
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/Library/Caches/Homebrew
@@ -40,7 +41,7 @@ jobs:
         run: bun install --frozen-lockfile --ignore-scripts
 
       - name: Cache ONNX Runtime iOS build
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         id: cache-onnxruntime
         with:
           path: |
@@ -93,7 +94,7 @@ jobs:
           cat "${WORKSPACE}/frontend/src-tauri/.cargo/config.toml"
 
       - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@v1
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
         with:
           xcode-version: '26.2'
 
@@ -120,7 +121,7 @@ jobs:
           IPHONEOS_DEPLOYMENT_TARGET: '16.0'
 
       - name: Upload iOS PR Simulator App
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-ios-simulator-pr
           path: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,12 @@ jobs:
       release_id: ${{ steps.get_version.outputs.version }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
@@ -37,21 +39,24 @@ jobs:
 
     runs-on: ${{ matrix.platform }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: ${{ matrix.platform == 'macos-latest-xlarge' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
       - name: Cache Homebrew
         if: matrix.platform == 'macos-latest-xlarge'
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/Library/Caches/Homebrew
@@ -72,14 +77,18 @@ jobs:
         if: matrix.platform == 'ubuntu-latest-8-cores'
         run: |
           SCCACHE_VERSION=0.8.2
-          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -L "$SCCACHE_URL" | tar xz
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
           sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
           chmod +x /usr/local/bin/sccache
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ${{ matrix.platform == 'macos-latest-xlarge' && '~/Library/Caches/Mozilla.sccache' || '~/.cache/sccache' }}
           key: ${{ runner.os }}-sccache-release-${{ hashFiles('**/Cargo.lock') }}
@@ -114,7 +123,7 @@ jobs:
           } >> "$GITHUB_ENV"
 
       - name: Build Tauri App
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # was v0
         env:
           APPIMAGE_EXTRACT_AND_RUN: ${{ matrix.platform == 'ubuntu-latest-8-cores' && '1' || '' }}
           NO_STRIP: ${{ matrix.platform == 'ubuntu-latest-8-cores' && 'true' || '' }}
@@ -143,24 +152,26 @@ jobs:
     needs: create-release
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # was v4
         with:
           distribution: 'temurin'
-          java-version: '21'
+          java-version: '21.0.11'
 
       - name: Setup Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407 # was v3
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
         with:
           bun-version: 1.3.5
 
       - name: Cache Bun dependencies
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/.bun/install/cache
@@ -170,12 +181,13 @@ jobs:
             ${{ runner.os }}-bun-
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
+          toolchain: 1.95.0
           targets: aarch64-linux-android,armv7-linux-androideabi,x86_64-linux-android,i686-linux-android
 
       - name: Setup Android NDK
-        uses: nttld/setup-ndk@v1.5.0
+        uses: nttld/setup-ndk@afb4c9964b521afb97c864b7d40b11e6911bd410 # was v1.5.0
         id: setup-ndk
         with:
           ndk-version: r27c
@@ -183,7 +195,7 @@ jobs:
           local-cache: true
 
       - name: Cache Gradle
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/.gradle/caches
@@ -195,14 +207,18 @@ jobs:
       - name: Install sccache
         run: |
           SCCACHE_VERSION=0.8.2
-          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -L "$SCCACHE_URL" | tar xz
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
           sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
           chmod +x /usr/local/bin/sccache
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-android-release-${{ hashFiles('**/Cargo.lock') }}
@@ -211,7 +227,7 @@ jobs:
             ${{ runner.os }}-sccache-
 
       - name: Cache Cargo bin (Tauri CLI)
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cargo/bin/
           key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
@@ -355,7 +371,9 @@ jobs:
     needs: build-tauri
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Download release artifacts
         env:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -13,22 +13,30 @@ jobs:
   rust-tests:
     runs-on: ubuntu-latest-8-cores
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
 
       - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
+        with:
+          toolchain: 1.95.0
 
       - name: Install sccache
         run: |
           SCCACHE_VERSION=0.8.2
-          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
-          curl -L "$SCCACHE_URL" | tar xz
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
           sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
           chmod +x /usr/local/bin/sccache
           sccache --version
 
       - name: Cache sccache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~/.cache/sccache
           key: ${{ runner.os }}-sccache-rust-tests-${{ hashFiles('**/Cargo.lock') }}

--- a/.github/workflows/zapstore-publish.yml
+++ b/.github/workflows/zapstore-publish.yml
@@ -13,8 +13,9 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          persist-credentials: false
           sparse-checkout: |
             zapstore.yaml
             frontend/src-tauri/icons/icon.png
@@ -30,9 +31,9 @@ jobs:
             --dir .
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # was v5
         with:
-          go-version: "1.22.x"
+          go-version: "1.22.12"
 
       - name: Install zsp
         run: |

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -53,7 +53,7 @@
         "@tanstack/router-devtools": "^1.166.13",
         "@tanstack/router-plugin": "^1.167.25",
         "@tauri-apps/cli": "^2.10.1",
-        "@types/bun": "latest",
+        "@types/bun": "1.3.13",
         "@types/node": "^22.19.17",
         "@types/react": "^18.3.28",
         "@types/react-dom": "^18.3.7",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -78,7 +78,7 @@
     "@tanstack/router-devtools": "^1.166.13",
     "@tanstack/router-plugin": "^1.167.25",
     "@tauri-apps/cli": "^2.10.1",
-    "@types/bun": "latest",
+    "@types/bun": "1.3.13",
     "@types/node": "^22.19.17",
     "@types/react": "^18.3.28",
     "@types/react-dom": "^18.3.7",


### PR DESCRIPTION
## Summary
- Pins all GitHub Actions `uses:` refs to the commit currently behind their existing tag or branch refs, with the original ref kept as an inline comment.
- Freezes moving tool selectors used today: Rust `stable` to `1.95.0`, Temurin Java `21` to `21.0.11`, Go `1.22.x` to `1.22.12`, and `@types/bun` `latest` to `1.3.13`.
- Adds SHA-256 verification for the Linux sccache `v0.8.2` tarball while preserving existing cache keys and paths.

## Resolved refs
| Previous ref | Pinned SHA |
| --- | --- |
| `actions/checkout@v4` | `34e114876b0b11c390a56381ad16ebd13914f8d5` |
| `oven-sh/setup-bun@v1` | `f4d14e03ff726c06358e5557344e1da148b56cf7` |
| `dtolnay/rust-toolchain@stable` | `29eef336d9b2848a0b548edc03f92a220660cdb8` |
| `actions/cache@v4` | `0057852bfaa89a56745cba8c7296529d2fc39830` |
| `irgaly/xcode-cache@v1` | `4141f139f00e335c6e1031fb93e667181f86146f` |
| `maxim-lobanov/setup-xcode@v1` | `ed7a3b1fda3918c0306d1b724322adc0b8cc0a90` |
| `actions/upload-artifact@v4` | `ea165f8d65b6e75b540449e92b4886f43607fa02` |
| `tauri-apps/tauri-action@v0` | `84b9d35b5fc46c1e45415bdb6144030364f7ebc5` |
| `actions/setup-java@v4` | `c1e323688fd81a25caa38c78aa6df2d33d3e20d9` |
| `android-actions/setup-android@v3` | `9fc6c4e9069bf8d3d10b2204b1fb8f6ef7065407` |
| `nttld/setup-ndk@v1.5.0` | `afb4c9964b521afb97c864b7d40b11e6911bd410` |
| `actions/setup-go@v5` | `40f1582b2485089dde7abd97c1529aa768e1baff` |

## Validation
- `git diff --check`
- `jq empty frontend/package.json`
- YAML parse of `.github/workflows/*.yml` via the existing frontend `yaml` package
- pre-commit hook: Prettier check, `bun run build`, `bun test`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/523" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Pinned CI/CD actions to specific commit SHAs for more deterministic builds.
  * Fixed Rust to 1.95.0, Java to 21.0.11, and Go to 1.22.12 across workflows.
  * Added SHA-256 verification for downloaded build tools/artifacts.
  * Improved sccache install and caching steps for more reliable caching.
  * Pinned a frontend dev dependency for consistent installs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/523?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->