### PR TITLE
Harden Bun install defaults

### DIFF
--- a/frontend/bunfig.toml
+++ b/frontend/bunfig.toml
@@ -1,5 +1,8 @@
 [install]
+exact = true
 frozenLockfile = true
+ignoreScripts = true
+auto = "disable"
 minimumReleaseAge = 604800
 
 [test]


### PR DESCRIPTION
## Summary
- disable Bun auto-install from project config
- make lifecycle script skipping the project default
- make future Bun dependency saves exact by default

## Validation
- parsed frontend/bunfig.toml with Bun TOML parser
- git diff --check
- pre-commit hook: Prettier, frontend build, Bun tests

No dependencies were installed or updated, and no lockfiles changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package manager configuration to enforce exact dependency resolution and maintain a frozen lockfile, improving build consistency and reproducibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/524?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->