### PR TITLE
Harden ONNX Runtime fetches

### DIFF
--- a/frontend/src-tauri/scripts/build-ios-onnxruntime-all.sh
+++ b/frontend/src-tauri/scripts/build-ios-onnxruntime-all.sh
@@ -14,8 +14,11 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/onnxruntime-pins.sh"
+
 TAURI_DIR="$(dirname "$SCRIPT_DIR")"
 ORT_VERSION="${1:-1.22.2}"
+ORT_COMMIT="${ORT_COMMIT:-$(onnxruntime_ios_commit_for_version "${ORT_VERSION}")}"
 BUILD_DIR="${TAURI_DIR}/onnxruntime-build"
 OUTPUT_DIR="${TAURI_DIR}/onnxruntime-ios"
 XCFRAMEWORK_DIR="${OUTPUT_DIR}/onnxruntime.xcframework"
@@ -26,6 +29,7 @@ echo "========================================"
 echo "Building ONNX Runtime ${ORT_VERSION} for iOS"
 echo "(Device + Simulator)"
 echo "========================================"
+echo "Source commit: ${ORT_COMMIT}"
 echo "Build directory: ${BUILD_DIR}"
 echo "Output directory: ${OUTPUT_DIR}"
 echo ""
@@ -46,13 +50,37 @@ fi
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 
-# Clone ONNX Runtime
+# Clone and check out ONNX Runtime at the pinned source commit.
+checkout_onnxruntime_source() {
+    if [ ! -d "onnxruntime/.git" ]; then
+        rm -rf onnxruntime
+        git init onnxruntime
+    fi
+
+    (
+        cd onnxruntime
+        if ! git remote get-url origin >/dev/null 2>&1; then
+            git remote add origin https://github.com/microsoft/onnxruntime.git
+        fi
+        git fetch --depth 1 origin "${ORT_COMMIT}"
+        git checkout --detach FETCH_HEAD
+        git submodule update --init --recursive
+
+        local actual_commit
+        actual_commit="$(git rev-parse HEAD)"
+        if [ "${actual_commit}" != "${ORT_COMMIT}" ]; then
+            echo "Expected ONNX Runtime commit ${ORT_COMMIT}, got ${actual_commit}" >&2
+            return 1
+        fi
+    )
+}
+
 clone_with_retry() {
     local max_attempts=3
     local attempt=1
     while [ $attempt -le $max_attempts ]; do
         echo "Attempt $attempt of $max_attempts..."
-        if git clone --depth 1 --branch "v${ORT_VERSION}" --recursive https://github.com/microsoft/onnxruntime.git; then
+        if checkout_onnxruntime_source; then
             return 0
         fi
         sleep 10
@@ -61,10 +89,8 @@ clone_with_retry() {
     return 1
 }
 
-if [ ! -d "onnxruntime" ]; then
-    echo "Cloning ONNX Runtime repository..."
-    clone_with_retry
-fi
+echo "Checking out ONNX Runtime repository..."
+clone_with_retry
 
 cd onnxruntime
 

--- a/frontend/src-tauri/scripts/build-ios-onnxruntime.sh
+++ b/frontend/src-tauri/scripts/build-ios-onnxruntime.sh
@@ -14,9 +14,12 @@
 set -e
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/onnxruntime-pins.sh"
+
 TAURI_DIR="$(dirname "$SCRIPT_DIR")"
 # Use latest 1.22.2 - older versions have Eigen hash mismatch issues with GitLab
 ORT_VERSION="${1:-1.22.2}"
+ORT_COMMIT="${ORT_COMMIT:-$(onnxruntime_ios_commit_for_version "${ORT_VERSION}")}"
 BUILD_DIR="${TAURI_DIR}/onnxruntime-build"
 OUTPUT_DIR="${TAURI_DIR}/onnxruntime-ios"
 XCFRAMEWORK_DIR="${OUTPUT_DIR}/onnxruntime.xcframework"
@@ -27,6 +30,7 @@ IOS_DEPLOYMENT_TARGET="13.0"
 echo "========================================"
 echo "Building ONNX Runtime ${ORT_VERSION} for iOS"
 echo "========================================"
+echo "Source commit: ${ORT_COMMIT}"
 echo "Build directory: ${BUILD_DIR}"
 echo "Output directory: ${OUTPUT_DIR}"
 echo "iOS deployment target: ${IOS_DEPLOYMENT_TARGET}"
@@ -49,13 +53,37 @@ fi
 mkdir -p "$BUILD_DIR"
 cd "$BUILD_DIR"
 
-# Clone ONNX Runtime if not already cloned (with retry for transient network errors)
+# Clone and check out ONNX Runtime at the pinned source commit.
+checkout_onnxruntime_source() {
+    if [ ! -d "onnxruntime/.git" ]; then
+        rm -rf onnxruntime
+        git init onnxruntime
+    fi
+
+    (
+        cd onnxruntime
+        if ! git remote get-url origin >/dev/null 2>&1; then
+            git remote add origin https://github.com/microsoft/onnxruntime.git
+        fi
+        git fetch --depth 1 origin "${ORT_COMMIT}"
+        git checkout --detach FETCH_HEAD
+        git submodule update --init --recursive
+
+        local actual_commit
+        actual_commit="$(git rev-parse HEAD)"
+        if [ "${actual_commit}" != "${ORT_COMMIT}" ]; then
+            echo "Expected ONNX Runtime commit ${ORT_COMMIT}, got ${actual_commit}" >&2
+            return 1
+        fi
+    )
+}
+
 clone_with_retry() {
     local max_attempts=3
     local attempt=1
     while [ $attempt -le $max_attempts ]; do
         echo "Attempt $attempt of $max_attempts..."
-        if git clone --depth 1 --branch "v${ORT_VERSION}" --recursive https://github.com/microsoft/onnxruntime.git; then
+        if checkout_onnxruntime_source; then
             return 0
         fi
         echo "Clone failed, waiting 10 seconds before retry..."
@@ -66,33 +94,8 @@ clone_with_retry() {
     return 1
 }
 
-submodule_update_with_retry() {
-    local max_attempts=3
-    local attempt=1
-    while [ $attempt -le $max_attempts ]; do
-        echo "Attempt $attempt of $max_attempts..."
-        if git submodule update --init --recursive; then
-            return 0
-        fi
-        echo "Submodule update failed, waiting 10 seconds before retry..."
-        sleep 10
-        attempt=$((attempt + 1))
-    done
-    echo "Failed to update submodules after $max_attempts attempts"
-    return 1
-}
-
-if [ ! -d "onnxruntime" ]; then
-    echo "Cloning ONNX Runtime repository..."
-    clone_with_retry
-else
-    echo "ONNX Runtime repository already cloned"
-    cd onnxruntime
-    git fetch --tags
-    git checkout "v${ORT_VERSION}"
-    submodule_update_with_retry
-    cd ..
-fi
+echo "Checking out ONNX Runtime repository..."
+clone_with_retry
 
 cd onnxruntime
 

--- a/frontend/src-tauri/scripts/onnxruntime-pins.sh
+++ b/frontend/src-tauri/scripts/onnxruntime-pins.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+onnxruntime_linux_x64_archive_sha256_for_version() {
+  case "$1" in
+    1.22.0)
+      printf '%s\n' "8344d55f93d5bc5021ce342db50f62079daf39aaafb5d311a451846228be49b3"
+      ;;
+    *)
+      echo "No pinned Linux x64 ONNX Runtime archive SHA-256 for version '$1'." >&2
+      return 1
+      ;;
+  esac
+}
+
+onnxruntime_linux_x64_dylib_sha256_for_version() {
+  case "$1" in
+    1.22.0)
+      printf '%s\n' "3da6146e14e7b8aaec625dde11d6114c7457c87a5f93d744897da8781e35c673"
+      ;;
+    *)
+      echo "No pinned Linux x64 ONNX Runtime shared-library SHA-256 for version '$1'." >&2
+      return 1
+      ;;
+  esac
+}
+
+onnxruntime_ios_commit_for_version() {
+  case "$1" in
+    1.22.2)
+      printf '%s\n' "5630b081cd25e4eccc7516a652ff956e51676794"
+      ;;
+    *)
+      echo "No pinned ONNX Runtime iOS source commit for version '$1'." >&2
+      return 1
+      ;;
+  esac
+}

--- a/frontend/src-tauri/scripts/provide-linux-onnxruntime.sh
+++ b/frontend/src-tauri/scripts/provide-linux-onnxruntime.sh
@@ -2,18 +2,64 @@
 set -euo pipefail
 
 ORT_VERSION="${ORT_VERSION:-1.22.0}"
-TAURI_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "${SCRIPT_DIR}/onnxruntime-pins.sh"
+
+TAURI_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
 ORT_ROOT="${TAURI_DIR}/onnxruntime-linux"
 ORT_DIR="${ORT_ROOT}/onnxruntime-linux-x64-${ORT_VERSION}"
+ORT_ARCHIVE="onnxruntime-linux-x64-${ORT_VERSION}.tgz"
+ORT_URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ORT_ARCHIVE}"
+ORT_DYLIB="${ORT_DIR}/lib/libonnxruntime.so.${ORT_VERSION}"
+ORT_ARCHIVE_SHA256="$(onnxruntime_linux_x64_archive_sha256_for_version "${ORT_VERSION}")"
+ORT_DYLIB_SHA256="$(onnxruntime_linux_x64_dylib_sha256_for_version "${ORT_VERSION}")"
 
-if [ ! -f "${ORT_DIR}/lib/libonnxruntime.so" ]; then
+sha256_file() {
+  local path="$1"
+
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${path}" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "${path}" | awk '{print $1}'
+  elif command -v openssl >/dev/null 2>&1; then
+    openssl dgst -sha256 -r "${path}" | awk '{print $1}'
+  else
+    echo "No SHA-256 tool found. Install sha256sum, shasum, or openssl." >&2
+    return 1
+  fi
+}
+
+verify_sha256() {
+  local label="$1"
+  local path="$2"
+  local expected="$3"
+  local actual
+
+  actual="$(sha256_file "${path}")"
+  if [ "${actual}" != "${expected}" ]; then
+    echo "${label} SHA-256 mismatch for ${path}" >&2
+    echo "expected: ${expected}" >&2
+    echo "actual:   ${actual}" >&2
+    return 1
+  fi
+}
+
+if [ ! -f "${ORT_DYLIB}" ]; then
   rm -rf "${ORT_ROOT}"
   mkdir -p "${ORT_ROOT}"
+  archive_path="${ORT_ROOT}/${ORT_ARCHIVE}"
+
   curl -fL --retry 5 --retry-delay 2 --retry-all-errors \
-    "https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/onnxruntime-linux-x64-${ORT_VERSION}.tgz" \
-    | tar -xz -C "${ORT_ROOT}"
+    "${ORT_URL}" \
+    --output "${archive_path}"
+
+  verify_sha256 "ONNX Runtime archive" "${archive_path}" "${ORT_ARCHIVE_SHA256}"
+  tar -xzf "${archive_path}" -C "${ORT_ROOT}"
+  rm -f "${archive_path}"
 fi
+
+verify_sha256 "ONNX Runtime shared library" "${ORT_DYLIB}" "${ORT_DYLIB_SHA256}"
 
 echo "ORT_LIB_LOCATION=${ORT_DIR}"
 echo "ORT_SKIP_DOWNLOAD=true"
-echo "ORT_DYLIB_PATH=${ORT_DIR}/lib/libonnxruntime.so.${ORT_VERSION}"
+echo "ORT_DYLIB_PATH=${ORT_DYLIB}"


### PR DESCRIPTION
## Summary
- centralize pinned ONNX Runtime hashes and source commits
- verify Linux ONNX Runtime release archives before extraction
- verify the extracted Linux shared library before exporting ORT paths, including cache hits
- check out iOS ONNX Runtime source by immutable commit instead of mutable tag refs

## Validation
- bash -n for changed ONNX shell scripts
- git diff --check
- confirmed pinned ONNX Runtime v1.22.2 commit checkout via shallow git fetch
- ran Linux provider in a temporary directory and verified archive + shared-library hashes
- pre-commit hook: Prettier, frontend build, Bun tests

No ONNX version changes, dependency updates, or lockfile changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced build reliability by implementing pinned version management for ONNX Runtime dependencies across iOS and Linux builds.
  * Added integrity verification for build artifacts to ensure consistency and reproducibility across different build environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->