### PR TITLE
Restore PR build cache parity

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -59,7 +59,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
@@ -105,10 +105,16 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           CARGO_CFG_TARGET_OS: linux

--- a/.github/workflows/android-pr-build.yml
+++ b/.github/workflows/android-pr-build.yml
@@ -29,6 +29,16 @@ jobs:
         with:
           bun-version: 1.3.5
 
+      - name: Cache Bun dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: |
+            ~/.bun/install/cache
+            frontend/node_modules
+          key: ${{ runner.os }}-bun-${{ hashFiles('frontend/bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-
+
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
@@ -43,6 +53,47 @@ jobs:
           add-to-path: true
           local-cache: true
 
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Install sccache
+        run: |
+          SCCACHE_VERSION=0.8.2
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
+          sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
+          chmod +x /usr/local/bin/sccache
+          sccache --version
+
+      - name: Cache sccache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-android-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-android-
+            ${{ runner.os }}-sccache-
+
+      - name: Cache Cargo bin (Tauri CLI)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: ~/.cargo/bin/
+          key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
+          restore-keys: |
+            ${{ runner.os }}-cargo-bin-tauri-cli-
+            ${{ runner.os }}-cargo-bin-
+
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -54,10 +105,16 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           CARGO_CFG_TARGET_OS: linux
@@ -92,6 +149,14 @@ jobs:
           [target.x86_64-linux-android]
           rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
           EOF
+
+      - name: Configure sccache
+        run: |
+          {
+            echo "RUSTC_WRAPPER=sccache"
+            echo "SCCACHE_DIR=$HOME/.cache/sccache"
+            echo "SCCACHE_CACHE_SIZE=2G"
+          } >> "$GITHUB_ENV"
 
       - name: Build Tauri Android App (debug)
         working-directory: ./frontend
@@ -131,6 +196,9 @@ jobs:
           VITE_OPEN_SECRET_API_URL: https://enclave.secretgpt.ai
           VITE_MAPLE_BILLING_API_URL: https://billing-dev.opensecret.cloud
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload Android PR APK
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -186,10 +186,16 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           CARGO_CFG_TARGET_OS: linux

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -29,9 +29,42 @@ jobs:
           toolchain: 1.95.0
           targets: aarch64-apple-darwin,x86_64-apple-darwin
 
+      - name: Cache Homebrew
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: |
+            ~/Library/Caches/Homebrew
+            /opt/homebrew/Cellar/sccache
+            /opt/homebrew/Cellar/openssl@3
+          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/desktop-build.yml') }}
+          restore-keys: |
+            ${{ runner.os }}-brew-
+
+      - name: Install sccache
+        run: |
+          brew install sccache
+          brew link --overwrite --force sccache
+          sccache --version
+
+      - name: Cache sccache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: ~/Library/Caches/Mozilla.sccache
+          key: ${{ runner.os }}-sccache-macos-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-macos-
+            ${{ runner.os }}-sccache-
+
       - name: Install frontend dependencies
         working-directory: ./frontend
         run: bun install --frozen-lockfile --ignore-scripts
+
+      - name: Configure sccache
+        run: |
+          {
+            echo "RUSTC_WRAPPER=sccache"
+            echo "SCCACHE_CACHE_SIZE=2G"
+          } >> "$GITHUB_ENV"
 
       - name: Build Tauri App (macOS, unsigned)
         working-directory: ./frontend
@@ -41,6 +74,9 @@ jobs:
           VITE_OPEN_SECRET_API_URL: https://enclave.secretgpt.ai
           VITE_MAPLE_BILLING_API_URL: https://billing-dev.opensecret.cloud
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload macOS PR Build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
@@ -68,6 +104,37 @@ jobs:
         with:
           toolchain: 1.95.0
 
+      - name: Install sccache
+        run: |
+          SCCACHE_VERSION=0.8.2
+          SCCACHE_SHA256="ecda4ddc89a49f1ec6f35bdce5ecbf6f205b399a680d11119d4ce9f6d962104e"
+          SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl.tar.gz"
+          SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
+          curl --fail --location --show-error --silent "$SCCACHE_URL" --output "$SCCACHE_ARCHIVE"
+          echo "${SCCACHE_SHA256}  ${SCCACHE_ARCHIVE}" | sha256sum --check -
+          tar xzf "$SCCACHE_ARCHIVE"
+          sudo mv sccache-v${SCCACHE_VERSION}-x86_64-unknown-linux-musl/sccache /usr/local/bin/
+          chmod +x /usr/local/bin/sccache
+          sccache --version
+
+      - name: Cache sccache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: ~/.cache/sccache
+          key: ${{ runner.os }}-sccache-linux-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-sccache-linux-
+            ${{ runner.os }}-sccache-
+
+      - name: Cache Cargo bin (Tauri CLI)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: ~/.cargo/bin/
+          key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
+          restore-keys: |
+            ${{ runner.os }}-cargo-bin-tauri-cli-
+            ${{ runner.os }}-cargo-bin-
+
       - name: Install Linux dependencies
         run: |
           sudo apt-get update
@@ -87,13 +154,27 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           CARGO_CFG_TARGET_OS: linux
+
+      - name: Configure sccache
+        run: |
+          {
+            echo "RUSTC_WRAPPER=sccache"
+            echo "SCCACHE_DIR=$HOME/.cache/sccache"
+            echo "SCCACHE_CACHE_SIZE=2G"
+          } >> "$GITHUB_ENV"
 
       - name: Build Tauri App (Linux, unsigned)
         working-directory: ./frontend
@@ -104,6 +185,9 @@ jobs:
           VITE_OPEN_SECRET_API_URL: https://enclave.secretgpt.ai
           VITE_MAPLE_BILLING_API_URL: https://billing-dev.opensecret.cloud
           VITE_CLIENT_ID: ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
+
+      - name: Show sccache stats
+        run: sccache --show-stats
 
       - name: Upload Linux PR Builds
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4

--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -26,6 +26,11 @@ jobs:
           toolchain: 1.95.0
           targets: aarch64-apple-ios
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
+        with:
+          xcode-version: '26.2'
+
       - name: Cache Homebrew
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
@@ -112,17 +117,18 @@ jobs:
           echo "Generated cargo config:"
           cat "${WORKSPACE}/frontend/src-tauri/.cargo/config.toml"
 
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
-        with:
-          xcode-version: '26.2'
-
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           # Workaround for getrandom v0.2.16 (https://github.com/rust-random/getrandom/issues/641)
@@ -173,3 +179,43 @@ jobs:
             --file "$IPA_PATH" \
             --apiKey ${{ secrets.APPLE_API_KEY }} \
             --apiIssuer ${{ secrets.APPLE_API_ISSUER }}
+
+  warm-ios-pr-onnx-cache:
+    runs-on: macos-26-xlarge
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
+        with:
+          xcode-version: '26.2'
+
+      - name: Cache ONNX Runtime iOS simulator build
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        id: cache-onnxruntime-pr
+        with:
+          path: |
+            frontend/src-tauri/onnxruntime-ios
+            frontend/src-tauri/onnxruntime-build
+          key: pr-onnxruntime-ios-simulator-built-1.22.2-xcode26.2-v1
+          restore-keys: |
+            pr-onnxruntime-ios-simulator-built-1.22.2-xcode26.2-
+
+      - name: Build ONNX Runtime for iOS simulator PR cache
+        if: steps.cache-onnxruntime-pr.outputs.cache-hit != 'true'
+        working-directory: ./frontend/src-tauri
+        run: |
+          chmod +x scripts/build-ios-onnxruntime-all.sh
+          ./scripts/build-ios-onnxruntime-all.sh 1.22.2
+        timeout-minutes: 90
+
+      - name: Verify ONNX Runtime simulator files
+        run: |
+          echo "Checking ONNX Runtime xcframework..."
+          ls -la ${{ github.workspace }}/frontend/src-tauri/onnxruntime-ios/onnxruntime.xcframework/
+          ls -la ${{ github.workspace }}/frontend/src-tauri/onnxruntime-ios/onnxruntime.xcframework/ios-arm64-simulator/
+          echo ""
+          echo "Library info:"
+          file ${{ github.workspace }}/frontend/src-tauri/onnxruntime-ios/onnxruntime.xcframework/ios-arm64-simulator/libonnxruntime.a

--- a/.github/workflows/mobile-pr-build.yml
+++ b/.github/workflows/mobile-pr-build.yml
@@ -26,15 +26,37 @@ jobs:
           toolchain: 1.95.0
           targets: aarch64-apple-ios-sim
 
+      - name: Setup Xcode
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
+        with:
+          xcode-version: '26.2'
+
       - name: Cache Homebrew
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: |
             ~/Library/Caches/Homebrew
             /opt/homebrew/Cellar/openssl@3
-          key: ${{ runner.os }}-brew-pr-${{ hashFiles('.github/workflows/mobile-pr-build.yml') }}
+          key: ${{ runner.os }}-brew-${{ hashFiles('.github/workflows/mobile-build.yml') }}
           restore-keys: |
-            ${{ runner.os }}-brew-pr-
+            ${{ runner.os }}-brew-
+
+      - name: Cache Xcode DerivedData and SourcePackages
+        uses: irgaly/xcode-cache@4141f139f00e335c6e1031fb93e667181f86146f # was v1
+        with:
+          key: xcode-cache-ios-xcode26.2-${{ github.workflow }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            xcode-cache-ios-xcode26.2-${{ github.workflow }}-
+            xcode-cache-ios-xcode26.2-
+
+      - name: Cache Cargo bin (Tauri CLI)
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: ~/.cargo/bin/
+          key: ${{ runner.os }}-cargo-bin-tauri-cli-2.9.2
+          restore-keys: |
+            ${{ runner.os }}-cargo-bin-tauri-cli-
+            ${{ runner.os }}-cargo-bin-
 
       - name: Install frontend dependencies
         working-directory: ./frontend
@@ -93,17 +115,18 @@ jobs:
           echo "Generated cargo config:"
           cat "${WORKSPACE}/frontend/src-tauri/.cargo/config.toml"
 
-      - name: Setup Xcode
-        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # was v1
-        with:
-          xcode-version: '26.2'
-
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           CARGO_CFG_TARGET_OS: macos

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,7 +200,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('frontend/src-tauri/gen/android/**/*.gradle*', 'frontend/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
 
@@ -246,10 +246,16 @@ jobs:
 
       - name: Install Tauri CLI
         run: |
-          if ! command -v cargo-tauri &> /dev/null; then
-            cargo install tauri-cli --version "2.9.2" --locked
+          REQUIRED_TAURI_CLI_VERSION="2.9.2"
+          INSTALLED_TAURI_CLI_VERSION=""
+          if command -v cargo-tauri >/dev/null 2>&1; then
+            INSTALLED_TAURI_CLI_VERSION="$(cargo-tauri --version 2>/dev/null | awk '{print $2}')"
+          fi
+
+          if [ "$INSTALLED_TAURI_CLI_VERSION" != "$REQUIRED_TAURI_CLI_VERSION" ]; then
+            cargo install tauri-cli --version "$REQUIRED_TAURI_CLI_VERSION" --locked --force
           else
-            echo "Tauri CLI already installed"
+            echo "Tauri CLI $REQUIRED_TAURI_CLI_VERSION already installed"
           fi
         env:
           CARGO_CFG_TARGET_OS: linux


### PR DESCRIPTION
## Summary
- restore missing PR build caches for Tauri CLI, sccache, Gradle, Bun, Homebrew, and Xcode where they match the signed build workflows
- add a master-only iOS simulator ONNX cache warmer so new PR branches can restore the simulator ONNX cache from the default branch
- keep PR builds unsigned and without signing secrets

## Why
PR iOS builds were paying a cold ONNX source build because the simulator ONNX cache is only created in pull_request scope. GitHub does not make a cache created for one PR branch generally available to future PR branches, so this would recur. The new warmer creates the same simulator cache key on master, where future PRs can restore it.

## Validation
- workflow YAML parsed with Bun + yaml
- git diff --check
- checked workflow-only diff and checkout credential settings
- pre-commit hook: Prettier, frontend build, Bun tests

No package versions, dependencies, or lockfiles changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added sccache and expanded caching across Android and desktop (macOS/Linux) CI to speed Rust builds and report cache stats.
  * Added verification and pinned installs for build tooling and expanded caching of tool binaries to stabilize CI.
  * Added a warm iOS simulator ONNX Runtime cache job to reduce PR rebuilds.
  * Moved Xcode setup earlier and unified Homebrew cache keys to improve cache reuse in mobile workflows.
  * Updated Android/Gradle cache keys and made Tauri CLI installs version-gated in CI and release workflows.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/526?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->