### PR TITLE
Extract AppImage tools with unsquashfs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -212,6 +212,7 @@
             patchelf
             desktop-file-utils
             rpm
+            squashfsTools
             webkitgtk_4_1
             xdg-utils
           ];

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -855,12 +855,23 @@ EOF
 extract_appimage_tool() {
   local appimage="$1"
   local out="$2"
-  local tmp
+  local offset tmp
+
+  command -v unsquashfs >/dev/null 2>&1 || {
+    echo "unsquashfs is required to extract AppImage tools without executing their runtime." >&2
+    return 1
+  }
+
+  offset="$(LC_ALL=C grep -abo -m1 'hsqs' "${appimage}" | awk -F: '{ print $1 }' || true)"
+  if [ -z "${offset}" ]; then
+    echo "Could not locate embedded SquashFS payload in AppImage: ${appimage}" >&2
+    return 1
+  fi
 
   tmp="$(mktemp -d)"
   rm -rf "${out}"
 
-  if ! (cd "${tmp}" && "${appimage}" --appimage-extract >/dev/null); then
+  if ! unsquashfs -d "${tmp}/squashfs-root" -o "${offset}" "${appimage}" >/dev/null; then
     rm -rf "${tmp}"
     return 1
   fi


### PR DESCRIPTION
## Summary
- add squashfsTools to the Linux flake shell
- extract pinned linuxdeploy AppImages by SquashFS offset with unsquashfs instead of executing the AppImage runtime
- avoid the x86_64 AppImage runtime stack-smashing abort seen in master Desktop Linux

## Verification
- nix flake check
- flake shell bash syntax check for CI scripts
- local Linux AppImage wrapper smoke test with APPIMAGE_EXTRACT_AND_RUN=1
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/541" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the Linux development environment by integrating additional build tools to better support Tauri application development, compilation, packaging, and deployment workflows.
  * Refined the continuous integration pipeline's portable application container extraction mechanism to increase reliability, enhance security safeguards, improve operational performance, and mitigate potential runtime risks.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/541?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->