### PR TITLE
Validate AppImage SquashFS offsets

### DIFF
--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -862,7 +862,7 @@ extract_appimage_tool() {
     return 1
   }
 
-  offset="$(LC_ALL=C grep -abo -m1 'hsqs' "${appimage}" | awk -F: '{ print $1 }' || true)"
+  offset="$(appimage_squashfs_offset "${appimage}")"
   if [ -z "${offset}" ]; then
     echo "Could not locate embedded SquashFS payload in AppImage: ${appimage}" >&2
     return 1
@@ -885,6 +885,20 @@ extract_appimage_tool() {
   mv "${tmp}/squashfs-root" "${out}"
   chmod -R u+w "${out}" 2>/dev/null || true
   rm -rf "${tmp}"
+}
+
+appimage_squashfs_offset() {
+  local appimage="$1"
+  local offset _
+
+  while IFS=: read -r offset _; do
+    if unsquashfs -s -o "${offset}" "${appimage}" >/dev/null 2>&1; then
+      printf '%s\n' "${offset}"
+      return 0
+    fi
+  done < <(LC_ALL=C grep -abo 'hsqs' "${appimage}" || true)
+
+  return 1
 }
 
 print_tree_hash() {


### PR DESCRIPTION
## Summary
- validate AppImage SquashFS magic candidates with unsquashfs before extraction
- handle x86_64 linuxdeploy AppImages where an earlier false hsqs byte sequence appears before the real SquashFS payload

## Verification
- flake shell bash syntax check for CI scripts
- extracted the pinned x86_64 linuxdeploy AppImage locally and verified AppRun exists
- local Linux AppImage wrapper smoke test with APPIMAGE_EXTRACT_AND_RUN=1
- git diff --check
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/542" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved internal CI extraction process reliability and robustness.

---

**Note:** This release contains no user-visible changes. Updates are internal to development infrastructure.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/542?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->