### PR TITLE
Harden Android release artifact verification

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -115,4 +115,6 @@ jobs:
           path: artifacts
 
       - name: Verify Android artifact reproducibility proofs
+        env:
+          MAPLE_REQUIRE_ANDROID_SIGNATURE_VERIFICATION: "1"
         run: nix develop .#android -c ./scripts/ci/verify-release-artifacts.sh artifacts android

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -423,6 +423,34 @@ jobs:
             frontend/src-tauri/target/reproducibility/web-final.sha256 \
             --clobber
 
+  verify-android-release-artifacts:
+    needs: build-android
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
+        with:
+          github-token: ""
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${RELEASE_TAG}" -D artifacts
+
+      - name: Verify Android release artifact reproducibility proofs
+        env:
+          MAPLE_REQUIRE_ANDROID_SIGNATURE_VERIFICATION: "1"
+        run: nix develop .#android -c ./scripts/ci/verify-release-artifacts.sh artifacts android
+
   update-latest-json:
     needs: build-tauri
     runs-on: ubuntu-latest
@@ -482,10 +510,10 @@ jobs:
   verify-release-artifacts:
     needs:
       - build-tauri
-      - build-android
       - build-ios
       - build-web
       - update-latest-json
+      - verify-android-release-artifacts
     runs-on: macos-26-xlarge
     permissions:
       contents: read
@@ -527,4 +555,4 @@ jobs:
           gh release download "${RELEASE_TAG}" -D artifacts
 
       - name: Verify release artifact reproducibility proofs
-        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts all
+        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts linux macos ios web latest-json

--- a/scripts/ci/verify-release-artifacts.sh
+++ b/scripts/ci/verify-release-artifacts.sh
@@ -211,7 +211,9 @@ verify_android_payload_equivalence() {
 }
 
 verify_android_signatures_optional() {
-  local artifact
+  local artifact require_signatures
+
+  require_signatures="${MAPLE_REQUIRE_ANDROID_SIGNATURE_VERIFICATION:-0}"
 
   while IFS= read -r -d '' artifact; do
     case "${artifact}" in
@@ -219,6 +221,9 @@ verify_android_signatures_optional() {
         if command -v apksigner >/dev/null 2>&1; then
           apksigner verify --verbose "${artifact}" >/dev/null
           printf 'verified-android-apk-signature  %s\n' "$(basename "${artifact}")"
+        elif [ "${require_signatures}" = "1" ]; then
+          echo "apksigner is required to verify Android APK signatures." >&2
+          return 1
         else
           printf 'skipped-android-apk-signature  missing-apksigner  %s\n' "$(basename "${artifact}")"
         fi
@@ -227,6 +232,9 @@ verify_android_signatures_optional() {
         if command -v jarsigner >/dev/null 2>&1; then
           jarsigner -verify "${artifact}" >/dev/null
           printf 'verified-android-aab-signature  %s\n' "$(basename "${artifact}")"
+        elif [ "${require_signatures}" = "1" ]; then
+          echo "jarsigner is required to verify Android AAB signatures." >&2
+          return 1
         else
           printf 'skipped-android-aab-signature  missing-jarsigner  %s\n' "$(basename "${artifact}")"
         fi


### PR DESCRIPTION
## Summary
- require Android signature verification in Android artifact proof checks
- verify Android release artifacts in the Android flake shell before final release verification
- keep the macOS final release verifier focused on Linux, macOS, iOS, web, and latest.json proofs

## Verification
- nix flake check
- nix develop .#ci -c bash -n scripts/ci/verify-release-artifacts.sh scripts/ci/signed-release-rehearsal.sh scripts/ci/android-release.sh scripts/ci/desktop-release.sh scripts/ci/ios-release.sh
- nix develop .#android -c bash -lc 'command -v apksigner; command -v jarsigner'
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened Android artifact verification with mandatory signature validation requirements in the release workflow.
  * Implemented dedicated Android verification steps to ensure comprehensive quality assurance and integrity checks for all Android releases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/545?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->