### PR TITLE
Verify latest.json updater artifacts

### DIFF
--- a/scripts/ci/verify-release-artifacts.sh
+++ b/scripts/ci/verify-release-artifacts.sh
@@ -534,7 +534,7 @@ verify_web() {
 
 verify_latest_json() {
   local final_manifest latest_json
-  local platform url signature basename sig_file sig_content
+  local platform url signature basename artifact sig_file sig_content
 
   final_manifest="$(proof_file_required latest-json-final.sha256)"
   verify_file_manifest "${final_manifest}"
@@ -550,6 +550,7 @@ verify_latest_json() {
     url="$(jq -er --arg platform "${platform}" '.platforms[$platform].url' "${latest_json}")"
     signature="$(jq -er --arg platform "${platform}" '.platforms[$platform].signature' "${latest_json}")"
     basename="$(basename "${url}")"
+    artifact="$(artifact_for_label "${basename}")"
     sig_file="$(artifact_for_label "${basename}.sig")"
     sig_content="$(cat "${sig_file}")"
 
@@ -558,6 +559,7 @@ verify_latest_json() {
       return 1
     fi
 
+    verify_tauri_updater_signature "${artifact}" "${sig_file}" "latest.json:${platform}:${basename}"
     printf 'verified-latest-json-signature-entry  %s  %s\n' "${platform}" "${basename}.sig"
   done
 }


### PR DESCRIPTION
## Summary
- require each latest.json updater URL basename to resolve to a downloaded artifact
- verify each latest.json signature sidecar against that artifact with the Tauri updater public key
- keep the existing embedded-signature-vs-sidecar comparison

## Verification
- nix develop .#ci -c bash -n scripts/ci/verify-release-artifacts.sh
- nix flake check
- nix develop .#ci -c bash /tmp/maple-latest-json-fixture.sh
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release artifact verification process with stricter signature validation to ensure integrity across all platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/546?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->