### PR TITLE
Enforce iOS signed reproducibility before upload

### DIFF
--- a/.github/workflows/mobile-build.yml
+++ b/.github/workflows/mobile-build.yml
@@ -76,6 +76,7 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
+          MAPLE_ENFORCE_IOS_SIGNED_REPRODUCIBILITY: "1"
         timeout-minutes: 90
 
       - name: Collect iOS release checksums

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -330,6 +330,7 @@ jobs:
           APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
           APPLE_API_PRIVATE_KEY: ${{ secrets.APPLE_API_PRIVATE_KEY }}
           APPLE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
+          MAPLE_ENFORCE_IOS_SIGNED_REPRODUCIBILITY: "1"
         timeout-minutes: 90
 
       - name: Collect iOS release checksums

--- a/scripts/ci/signed-release-rehearsal.sh
+++ b/scripts/ci/signed-release-rehearsal.sh
@@ -155,6 +155,7 @@ run_ios_rehearsal() {
     return 1
   fi
 
+  export MAPLE_ENFORCE_IOS_SIGNED_REPRODUCIBILITY="${MAPLE_ENFORCE_IOS_SIGNED_REPRODUCIBILITY:-1}"
   "${script_dir}/ios-onnxruntime.sh"
   "${script_dir}/ios-release.sh"
 }


### PR DESCRIPTION
## Summary
- enforce signed iOS IPA payload reproducibility during master/release build steps, before upload/submission
- make signed iOS rehearsal strict by default

## Validation
- nix develop .#ci -c bash -n scripts/ci/signed-release-rehearsal.sh scripts/ci/ios-release.sh scripts/ci/verify-release-artifacts.sh
- nix develop .#ci -c python3 -m py_compile scripts/ci/canonical-ios-app-hash.py
- nix develop .#ci -c actionlint .github/workflows/mobile-build.yml .github/workflows/release.yml
- nix flake check
- pre-commit hook: Prettier, frontend build, frontend tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/549" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS signed build consistency and reproducibility across build pipelines to enhance release reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/549?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->