### PR TITLE
Verify desktop release artifacts before latest.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -452,8 +452,53 @@ jobs:
           MAPLE_REQUIRE_ANDROID_SIGNATURE_VERIFICATION: "1"
         run: nix develop .#android -c ./scripts/ci/verify-release-artifacts.sh artifacts android
 
-  update-latest-json:
+  verify-desktop-release-artifacts:
     needs: build-tauri
+    runs-on: macos-26-xlarge
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
+      - name: Select Xcode 26.5
+        run: |
+          set -euo pipefail
+          for xcode_app in \
+            /Applications/Xcode_26.5.0.app \
+            /Applications/Xcode_26.5_beta_2.app \
+            /Applications/Xcode_26.5_beta.app
+          do
+            if [ -x "${xcode_app}/Contents/Developer/usr/bin/xcodebuild" ]; then
+              sudo xcode-select -s "${xcode_app}/Contents/Developer"
+              xcodebuild -version
+              exit 0
+            fi
+          done
+          echo "Xcode 26.5 is not installed on this runner." >&2
+          ls -1 /Applications/Xcode*.app >&2 || true
+          exit 1
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
+        with:
+          github-token: ""
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${RELEASE_TAG}" -D artifacts
+
+      - name: Verify desktop release artifact reproducibility proofs
+        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts linux macos
+
+  update-latest-json:
+    needs: verify-desktop-release-artifacts
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -510,7 +555,7 @@ jobs:
 
   verify-release-artifacts:
     needs:
-      - build-tauri
+      - verify-desktop-release-artifacts
       - build-ios
       - build-web
       - update-latest-json


### PR DESCRIPTION
## Summary
- add a release-only desktop artifact verifier before latest.json generation
- make updater metadata wait for verified macOS/Linux artifacts
- keep the final release verifier as the full proof including latest.json

## Validation
- nix develop .#ci -c actionlint .github/workflows/release.yml
- nix flake check
- pre-commit hook: Prettier, frontend build, frontend tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow verification for desktop artifacts across Linux and macOS platforms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/550?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->