### PR TITLE
Validate release tag matches app version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,12 +30,8 @@ jobs:
             exit 1
           fi
 
-          if [[ ! "${RELEASE_TAG}" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Refusing to build unexpected release tag: ${RELEASE_TAG}" >&2
-            exit 1
-          fi
-
-          echo "version=${RELEASE_TAG}" >> "${GITHUB_OUTPUT}"
+          version="$(./scripts/ci/validate-release-version.sh "${RELEASE_TAG}")"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
   build-tauri:
     needs: create-release

--- a/flake.nix
+++ b/flake.nix
@@ -662,6 +662,15 @@
               zapstore-publish.yml
             touch "$out"
           '';
+
+          release-metadata = pkgs.runCommand "maple-release-metadata-check" {
+            nativeBuildInputs = commonPackages;
+            src = ./.;
+          } ''
+            cd "$src"
+            bash ./scripts/ci/validate-release-version.sh >/dev/null
+            touch "$out"
+          '';
         };
 
         apps = {

--- a/scripts/ci/validate-release-version.sh
+++ b/scripts/ci/validate-release-version.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+
+release_tag="${1:-${RELEASE_TAG:-${GITHUB_REF_NAME:-}}}"
+package_version="$(jq -er '.version' "${FRONTEND_DIR}/package.json")"
+tauri_version="$(jq -er '.version' "${TAURI_DIR}/tauri.conf.json")"
+
+if [ "${package_version}" != "${tauri_version}" ]; then
+  echo "frontend/package.json version does not match frontend/src-tauri/tauri.conf.json." >&2
+  echo "package=${package_version}" >&2
+  echo "tauri=${tauri_version}" >&2
+  exit 1
+fi
+
+if [ -z "${release_tag}" ]; then
+  printf '%s\n' "${tauri_version}"
+  exit 0
+fi
+
+if [[ ! "${release_tag}" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+  echo "Refusing to build unexpected release tag: ${release_tag}" >&2
+  exit 1
+fi
+
+release_version="${release_tag#v}"
+if [ "${release_version}" != "${tauri_version}" ]; then
+  echo "Release tag version does not match app version." >&2
+  echo "tag=${release_tag}" >&2
+  echo "tag_version=${release_version}" >&2
+  echo "app_version=${tauri_version}" >&2
+  exit 1
+fi
+
+printf '%s\n' "${release_version}"


### PR DESCRIPTION
Summary:
- add a release version validator for package, Tauri, and tag consistency
- use it in the release workflow before any signed builds start
- add a flake check so version drift is caught before release

Validation:
- nix develop .#ci -c ./scripts/ci/validate-release-version.sh v3.0.2
- nix develop .#ci -c ./scripts/ci/validate-release-version.sh v9.9.9 fails as expected
- nix develop .#ci -c actionlint .github/workflows/release.yml
- nix flake check on aarch64-linux
- mac zsh -lc 'cd /Users/tony/Dev/OpenSecret/maple && nix flake check'
- pre-commit hook via nix develop .#ci
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/551" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to validate and compute release versions
  * Added CI check to validate release version metadata
  * Added version consistency validation between frontend and application

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/OpenSecretCloud/Maple/pull/551?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->