### PR TITLE
Warn users before destructive password reset

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "3.1.1",
+        "@opensecret/react": "3.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -240,7 +240,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opensecret/react": ["@opensecret/react@3.1.1", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-KYKC/jMhbwvXfS8eUTSb5qgSuIAIfqjB1FA/xponberLia61wWt/PnvZxmlEIcXJ0DnvbhfStjcfNfD7YpVlOw=="],
+    "@opensecret/react": ["@opensecret/react@3.2.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-tmn52THsD3M3vzC2IErHJuAq9zKAXce16Y77YuaqEM9Vfg6u4ZU6lUIiR3Uvb7ObZSjUaJjxqhdEs6lSChW4iQ=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@opensecret/react": "3.1.1",
+    "@opensecret/react": "3.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/frontend/src/components/PasswordResetConfirmForm.tsx
+++ b/frontend/src/components/PasswordResetConfirmForm.tsx
@@ -6,7 +6,8 @@ import { AlertDestructive } from "@/components/AlertDestructive";
 import { useOpenSecret } from "@opensecret/react";
 import { useNavigate } from "@tanstack/react-router";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
-import { Loader2 } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+import { Info, Loader2 } from "lucide-react";
 
 interface PasswordResetConfirmFormProps {
   email: string;
@@ -21,6 +22,7 @@ export function PasswordResetConfirmForm({ email, secret }: PasswordResetConfirm
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
   const [redirecting, setRedirecting] = useState(false);
+  const [showCodeHelp, setShowCodeHelp] = useState(false);
   const navigate = useNavigate();
   const os = useOpenSecret();
 
@@ -33,6 +35,19 @@ export function PasswordResetConfirmForm({ email, secret }: PasswordResetConfirm
       return () => clearTimeout(timer);
     }
   }, [success, navigate]);
+
+  useEffect(() => {
+    if (success || code) {
+      setShowCodeHelp(false);
+      return;
+    }
+
+    const timer = setTimeout(() => {
+      setShowCodeHelp(true);
+    }, 30000);
+
+    return () => clearTimeout(timer);
+  }, [success, code]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -86,6 +101,17 @@ export function PasswordResetConfirmForm({ email, secret }: PasswordResetConfirm
       <CardContent>
         <form onSubmit={handleSubmit}>
           <div className="grid gap-4">
+            {showCodeHelp && (
+              <Alert>
+                <Info className="h-4 w-4" aria-hidden="true" />
+                <AlertTitle>No code yet?</AlertTitle>
+                <AlertDescription>
+                  If no code arrives after a few minutes, this account might not use password login.
+                  Try signing in with Apple, Google, or GitHub, or check spam before requesting
+                  another reset.
+                </AlertDescription>
+              </Alert>
+            )}
             <div className="grid gap-2">
               <Label htmlFor="code">Reset Code</Label>
               <Input

--- a/frontend/src/components/PasswordResetRequestForm.tsx
+++ b/frontend/src/components/PasswordResetRequestForm.tsx
@@ -6,25 +6,42 @@ import { AlertDestructive } from "@/components/AlertDestructive";
 import { generateSecureSecret, hashSecret, useOpenSecret } from "@opensecret/react";
 import { PasswordResetConfirmForm } from "./PasswordResetConfirmForm";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle
+} from "@/components/ui/alert-dialog";
+import { AlertTriangle } from "lucide-react";
+import { isPasswordResetHardeningNoticeEnabled } from "@/utils/passwordResetHardeningFlag";
 
 export function PasswordResetRequestForm() {
   const [email, setEmail] = useState("");
+  const [requestedEmail, setRequestedEmail] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showConfirmForm, setShowConfirmForm] = useState(false);
+  const [showResetWarning, setShowResetWarning] = useState(false);
   const [secret, setSecret] = useState("");
   const os = useOpenSecret();
 
-  const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const requestPasswordReset = async () => {
+    const nextEmail = email.trim();
+
     setIsLoading(true);
     setError(null);
+    setShowResetWarning(false);
+    setRequestedEmail(nextEmail);
 
     try {
       // TODO: move this logic to the library
       const generatedSecret = generateSecureSecret();
       const hashedSecret = await hashSecret(generatedSecret);
-      await os.requestPasswordReset(email, hashedSecret);
+      await os.requestPasswordReset(nextEmail, hashedSecret);
       setSecret(generatedSecret);
       setShowConfirmForm(true);
     } catch (err) {
@@ -35,36 +52,80 @@ export function PasswordResetRequestForm() {
     }
   };
 
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    setError(null);
+
+    if (isPasswordResetHardeningNoticeEnabled()) {
+      setShowResetWarning(true);
+      return;
+    }
+
+    void requestPasswordReset();
+  };
+
   if (showConfirmForm) {
-    return <PasswordResetConfirmForm email={email} secret={secret} />;
+    return <PasswordResetConfirmForm email={requestedEmail} secret={secret} />;
   }
 
   return (
-    <Card className="bg-card/70 backdrop-blur-sm mx-auto max-w-[45rem]">
-      <CardHeader>
-        <CardTitle className="text-xl">Reset Password</CardTitle>
-        <CardDescription>Enter your email address to request a password reset.</CardDescription>
-      </CardHeader>
-      <CardContent>
-        <form onSubmit={handleSubmit}>
-          <div className="grid gap-4">
-            <div className="grid gap-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                required
-              />
+    <>
+      <Card className="bg-card/70 backdrop-blur-sm mx-auto max-w-[45rem]">
+        <CardHeader>
+          <CardTitle className="text-xl">Reset Password</CardTitle>
+          <CardDescription>Enter your email address to request a password reset.</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <form onSubmit={handleSubmit}>
+            <div className="grid gap-4">
+              <div className="grid gap-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  disabled={isLoading}
+                  required
+                />
+              </div>
+              {error && <AlertDestructive title="Error" description={error} />}
+              <Button type="submit" className="w-full" disabled={isLoading}>
+                {isLoading ? "Requesting..." : "Request Password Reset"}
+              </Button>
             </div>
-            {error && <AlertDestructive title="Error" description={error} />}
-            <Button type="submit" className="w-full" disabled={isLoading}>
-              {isLoading ? "Requesting..." : "Request Password Reset"}
-            </Button>
-          </div>
-        </form>
-      </CardContent>
-    </Card>
+          </form>
+        </CardContent>
+      </Card>
+      <AlertDialog open={showResetWarning} onOpenChange={setShowResetWarning}>
+        <AlertDialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-lg">
+          <AlertDialogHeader>
+            <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-full bg-destructive/10 text-destructive">
+              <AlertTriangle className="h-5 w-5" aria-hidden="true" />
+            </div>
+            <AlertDialogTitle>Resetting your password deletes private data</AlertDialogTitle>
+            <AlertDialogDescription className="space-y-3">
+              <span className="block">
+                Password reset is account access recovery. It creates a new private key and removes
+                private encrypted content such as chats and saved data.
+              </span>
+              <span className="block">
+                Before continuing, try signing in with your current password or with Apple, Google,
+                or GitHub if that is how you created the account.
+              </span>
+              <span className="block">
+                If you can sign in another way, change your password from account settings instead.
+              </span>
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={isLoading}>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={() => void requestPasswordReset()} disabled={isLoading}>
+              {isLoading ? "Requesting..." : "Continue with Reset"}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   );
 }

--- a/frontend/src/utils/passwordResetHardeningFlag.ts
+++ b/frontend/src/utils/passwordResetHardeningFlag.ts
@@ -1,0 +1,5 @@
+const PASSWORD_RESET_HARDENING_NOTICE_ENABLED_AT_MS = Date.parse("2026-06-18T06:00:00.000Z");
+
+export function isPasswordResetHardeningNoticeEnabled(nowMs = Date.now()) {
+  return nowMs >= PASSWORD_RESET_HARDENING_NOTICE_ENABLED_AT_MS;
+}


### PR DESCRIPTION
## Summary
- add a confirmation dialog before requesting password reset, warning that reset creates a new private key and deletes private encrypted data
- add delayed guidance on the reset-code form for users who may have signed in with Apple, Google, or GitHub instead of password login

## Testing
- nix develop -c bun run --cwd frontend format:check
- pre-commit hook: bun build
- pre-commit hook: bun test
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/568" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a warning confirmation dialog before starting a password reset request (Cancel/Continue; inputs disabled while processing).
  * Added an informational “No code yet?” alert that appears after ~30 seconds if the reset code hasn’t been entered (when the hardening notification setting is enabled).
  * Updated the request/confirm flow to move users into the code confirmation step after initiating the reset.
* **Bug Fixes**
  * Stopped the automatic timed redirect after a successful password reset confirmation.
* **Chores**
  * Updated the `@opensecret/react` dependency to the latest version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->