### PR TITLE
Document local OpenSecret API env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ frontend/node_modules/
 .env.*.local
 .envrc
 .direnv/
+.local/
 *.key
 
 # IDE files

--- a/README.md
+++ b/README.md
@@ -98,8 +98,15 @@ bun run dev
 bun tauri dev
 ```
 
-Expects a `VITE_OPEN_SECRET_API_URL` environment variable to be set. The public
-OpenSecret client id defaults to Maple's project id
+Expects a `VITE_OPEN_SECRET_API_URL` environment variable to be set. For local
+OpenSecret development, copy `frontend/.env.example` to `frontend/.env.local`
+and point it at the local API:
+
+```bash
+VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+```
+
+The public OpenSecret client id defaults to Maple's project id
 `ba5a14b5-d915-47b1-b7b1-afda52bc5fc6`, so `VITE_CLIENT_ID` is only needed to
 override the default. (See `.env.example`)
 

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,5 +1,5 @@
-VITE_OPEN_SECRET_API_URL=http://0.0.0.0:3000
 # Public OpenSecret project id. Optional; the app uses this value by default.
 VITE_CLIENT_ID=ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
-#VITE_MAPLE_BILLING_API_URL=http://0.0.0.0:3001
+VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+#VITE_MAPLE_BILLING_API_URL=http://127.0.0.1:3001
 #VITE_DEV_MODEL_OVERRIDE=gpt-4o


### PR DESCRIPTION
## Summary
- document the required local `VITE_OPEN_SECRET_API_URL` setup for Maple web development
- update `.env.example` to use browser-facing loopback URLs instead of `0.0.0.0`
- ignore repo-local `.local/` scratch files used for local test credentials/artifacts

## Verification
- `nix develop -c just build`

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/572" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated environment setup instructions in README with clearer guidance on configuring a `.env.local` file
  * Refined the OpenSecret environment-variable examples, including a concrete `VITE_OPEN_SECRET_API_URL` value
  * Clarified the default public OpenSecret client id behavior and when `VITE_CLIENT_ID` needs to be overridden
* **Chores**
  * Updated `.env` example values for local development (switched to `127.0.0.1`)
  * Updated `.gitignore` to ignore the `.local/` directory
<!-- end of auto-generated comment: release notes by coderabbit.ai -->