### PR TITLE
Split desktop artifact verification by platform

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -169,10 +169,34 @@ jobs:
             frontend/src-tauri/target/reproducibility/*.sha256
           retention-days: 5
 
-  verify-desktop-artifacts:
+  verify-linux-desktop-artifacts:
+    needs:
+      - build-linux
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
+        with:
+          github-token: ""
+
+      - name: Download Linux desktop artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # was v4
+        with:
+          name: maple-linux
+          path: artifacts
+
+      - name: Verify Linux desktop artifact reproducibility proofs
+        run: nix develop .#desktop-linux -c ./scripts/ci/verify-release-artifacts.sh artifacts linux
+
+  verify-macos-desktop-artifacts:
     needs:
       - build-macos
-      - build-linux
     runs-on: macos-26-xlarge
     permissions:
       contents: read
@@ -186,13 +210,14 @@ jobs:
         with:
           github-token: ""
 
-      - name: Download desktop artifacts
+      - name: Download macOS desktop artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # was v4
         with:
+          name: maple-macos-universal
           path: artifacts
 
-      - name: Verify desktop artifact reproducibility proofs
-        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts linux macos
+      - name: Verify macOS desktop artifact reproducibility proofs
+        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts macos
 
   build-windows:
     runs-on: windows-latest
@@ -303,6 +328,32 @@ jobs:
       - name: Show sccache stats
         run: sccache --show-stats
 
+      - name: Collect Windows release checksums
+        shell: bash
+        run: |
+          set -euo pipefail
+          source scripts/ci/_common.sh
+
+          repro_dir="${TAURI_DIR}/target/reproducibility"
+          mkdir -p "${repro_dir}"
+
+          windows_artifacts=()
+          while IFS= read -r -d '' file; do
+            windows_artifacts+=("${file}")
+          done < <(find "${TAURI_DIR}/target/release/bundle/nsis" -type f \( \
+            -name '*.exe' -o \
+            -name '*.nsis.zip' -o \
+            -name '*.nsis.zip.sig' \
+          \) -print0 | LC_ALL=C sort -z)
+
+          if [ "${#windows_artifacts[@]}" -eq 0 ]; then
+            echo "No Windows desktop artifacts found." >&2
+            exit 1
+          fi
+
+          write_sha256_manifest "${repro_dir}/desktop-release-windows-final.sha256" "${windows_artifacts[@]}"
+          print_file_hashes "${windows_artifacts[@]}"
+
       - name: Upload Windows Build
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
@@ -311,4 +362,40 @@ jobs:
             frontend/src-tauri/target/release/bundle/nsis/*.exe
             frontend/src-tauri/target/release/bundle/nsis/*.nsis.zip
             frontend/src-tauri/target/release/bundle/nsis/*.nsis.zip.sig
+            frontend/src-tauri/target/reproducibility/desktop-release-windows-*.sha256
           retention-days: 5
+
+  verify-windows-desktop-artifacts:
+    needs:
+      - build-windows
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
+        with:
+          github-token: ""
+
+      - name: Download Windows desktop artifacts
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # was v4
+        with:
+          name: maple-windows-x64
+          path: artifacts
+
+      - name: Verify Windows desktop artifact reproducibility proofs
+        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts windows
+
+  verify-desktop-artifacts:
+    needs:
+      - verify-linux-desktop-artifacts
+      - verify-macos-desktop-artifacts
+      - verify-windows-desktop-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify desktop artifact checks completed
+        run: echo "Desktop artifact verification completed for Linux, macOS, and Windows."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -448,7 +448,33 @@ jobs:
           MAPLE_REQUIRE_ANDROID_SIGNATURE_VERIFICATION: "1"
         run: nix develop .#android -c ./scripts/ci/verify-release-artifacts.sh artifacts android
 
-  verify-desktop-release-artifacts:
+  verify-linux-desktop-release-artifacts:
+    needs: build-tauri
+    runs-on: ubuntu-latest-8-cores
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
+        with:
+          github-token: ""
+
+      - name: Download release artifacts
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          mkdir -p artifacts
+          gh release download "${RELEASE_TAG}" -D artifacts
+
+      - name: Verify Linux desktop release artifact reproducibility proofs
+        run: nix develop .#desktop-linux -c ./scripts/ci/verify-release-artifacts.sh artifacts linux
+
+  verify-macos-desktop-release-artifacts:
     needs: build-tauri
     runs-on: macos-26-xlarge
     permissions:
@@ -490,8 +516,17 @@ jobs:
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
 
-      - name: Verify desktop release artifact reproducibility proofs
-        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts linux macos
+      - name: Verify macOS desktop release artifact reproducibility proofs
+        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts macos
+
+  verify-desktop-release-artifacts:
+    needs:
+      - verify-linux-desktop-release-artifacts
+      - verify-macos-desktop-release-artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify desktop release artifact checks completed
+        run: echo "Desktop release artifact verification completed for Linux and macOS."
 
   update-latest-json:
     needs: verify-desktop-release-artifacts
@@ -597,6 +632,6 @@ jobs:
           gh release download "${RELEASE_TAG}" -D artifacts
 
       - name: Verify release artifact reproducibility proofs
-        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts linux macos ios web latest-json
+        run: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts macos ios web latest-json
         env:
           MAPLE_ENFORCE_IOS_SIGNED_REPRODUCIBILITY: "1"

--- a/scripts/ci/verify-release-artifacts.sh
+++ b/scripts/ci/verify-release-artifacts.sh
@@ -351,11 +351,18 @@ verify_linux_present() {
 verify_windows() {
   local final_manifest runtime_manifest
 
-  final_manifest="$(proof_file_required desktop-pr-windows-final.sha256)"
-  runtime_manifest="$(proof_file_required desktop-pr-windows-runtime-dlls.sha256)"
+  final_manifest="$(proof_file_optional desktop-release-windows-final.sha256)"
+  runtime_manifest="$(proof_file_optional desktop-release-windows-runtime-dlls.sha256)"
+  if [ -z "${final_manifest}" ]; then
+    final_manifest="$(proof_file_required desktop-pr-windows-final.sha256)"
+    runtime_manifest="$(proof_file_required desktop-pr-windows-runtime-dlls.sha256)"
+  fi
 
   verify_file_manifest "${final_manifest}"
-  verify_file_manifest "${runtime_manifest}"
+  if [ -n "${runtime_manifest}" ]; then
+    verify_file_manifest "${runtime_manifest}"
+  fi
+  verify_tauri_signatures_in_artifacts
 }
 
 verify_canonical_apple_manifest() {
@@ -647,7 +654,9 @@ verify_present() {
     verify_linux_present
   fi
   target_present desktop-release-macos-final.sha256 && verify_macos
-  target_present desktop-pr-windows-final.sha256 && verify_windows
+  if target_present desktop-release-windows-final.sha256 || target_present desktop-pr-windows-final.sha256; then
+    verify_windows
+  fi
   target_present android-release-final.sha256 && verify_android
   target_present ios-release-final.sha256 && verify_ios
   target_present web-final.sha256 && verify_web


### PR DESCRIPTION
## Summary
- split desktop artifact verification so Linux artifacts are verified on Linux and macOS artifacts are verified on macOS
- keep aggregate desktop verifier job names as lightweight gates for existing dependencies/branch protection
- add master Windows artifact checksum proof generation and a separate Windows artifact verifier
- keep release Linux desktop verification out of the final macOS aggregate verifier; the Linux release verifier gates it separately

## Why
The master Desktop App CI failure was caused by the macOS aggregate verifier trying to run Linux package metadata checks. Those checks are intentionally Linux-specific because they inspect AppImage/.deb ELF metadata with Linux tooling.

## Verification
- git diff --check
- nix develop .#ci -c actionlint .github/workflows/desktop-build.yml .github/workflows/release.yml
- nix develop .#ci -c bash -n scripts/ci/verify-release-artifacts.sh scripts/ci/_common.sh
- temporary fixture verified desktop-release-windows-final.sha256 works for windows and present targets
- pre-commit hook passed via nix develop .#ci: Prettier, frontend build, Bun tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/575" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Refactored desktop release artifact reproducibility verification into separate, platform-specific jobs for Linux, macOS, and Windows.
  * Updated the Windows release verification flow to be more resilient by using checksum fallback inputs when release hashes aren’t available.
  * Adjusted the release verification scope to align with the platform-split desktop verification (e.g., removing Linux from a later shared verification step).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->