### PR TITLE
chore: bump Maple to v3.1.2

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.1.1",
+  "version": "3.1.2",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2965,7 +2965,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.1.1"
+version = "3.1.2"
 dependencies = [
  "anyhow",
  "axum",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.1.1"
+version = "3.1.2"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.1</string>
+	<string>3.1.2</string>
 	<key>CFBundleVersion</key>
-	<string>3.1.1</string>
+	<string>3.1.2</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.1.1
-        CFBundleVersion: 3.1.1
+        CFBundleShortVersionString: 3.1.2
+        CFBundleVersion: 3.1.2
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -97,7 +97,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028005
+      "versionCode": 2000028006
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- bump Maple visible version from 3.1.1 to 3.1.2 across package, Tauri, Cargo, and iOS metadata
- increment Android versionCode from 2000028005 to 2000028006
- refresh Cargo.lock for the Maple package version

## Test
- nix develop -c just bump-patch (runs cargo check)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented application version from 3.1.1 to 3.1.2 across all platform configurations and build manifests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->