### PR TITLE
Fix AppImage WebKit runtime helpers

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -528,6 +528,7 @@
         mkShellForHost = if pkgs.stdenv.isDarwin && pkgs ? mkShellNoCC then pkgs.mkShellNoCC else pkgs.mkShell;
 
         linuxShellHook = lib.optionalString pkgs.stdenv.isLinux ''
+          export MAPLE_NIX_CC=${pkgs.stdenv.cc}/bin/cc
           export MAPLE_NIX_GCC_LIB=${pkgs.stdenv.cc.cc.lib}
           export MAPLE_NIX_GDK_PIXBUF_BINARYDIR=${pkgs.gdk-pixbuf}/lib/gdk-pixbuf-2.0/2.10.0
           export MAPLE_NIX_GDK_PIXBUF_MODULEDIR=${pkgs.gdk-pixbuf}/lib/gdk-pixbuf-2.0/2.10.0/loaders

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -2358,7 +2358,7 @@ linux_runtime_closure_store_paths_file() {
 
 linux_runtime_closure_library_for_soname() {
   local soname="$1"
-  local store_paths root candidate
+  local store_paths root candidate lib_root
 
   store_paths="$(linux_runtime_closure_store_paths_file)"
   while IFS= read -r root; do
@@ -2367,6 +2367,14 @@ linux_runtime_closure_library_for_soname() {
         printf '%s\n' "${candidate}"
         return 0
       fi
+    done
+
+    for lib_root in "${root}/lib" "${root}/lib64"; do
+      [ -d "${lib_root}" ] || continue
+      while IFS= read -r -d '' candidate; do
+        printf '%s\n' "${candidate}"
+        return 0
+      done < <(find "${lib_root}" -mindepth 2 -maxdepth 3 \( -type f -o -type l \) -name "${soname}" -print0 | LC_ALL=C sort -z)
     done
   done < "${store_paths}"
 
@@ -2421,6 +2429,396 @@ copy_linux_runtime_library_to_appdir() {
     touch -h -d "@${SOURCE_DATE_EPOCH}" "${dest}"
     printf 'staged-linux-appimage-runtime-lib  %s  %s\n' "${soname}" "${source}"
   fi
+}
+
+linux_runtime_closure_webkitgtk_store_path() {
+  local store_paths root
+
+  store_paths="$(linux_runtime_closure_store_paths_file)"
+  while IFS= read -r root; do
+    if [ -e "${root}/lib/libwebkit2gtk-4.1.so.0" ] &&
+      [ -x "${root}/libexec/webkit2gtk-4.1/WebKitNetworkProcess" ]; then
+      printf '%s\n' "${root}"
+      return 0
+    fi
+  done < "${store_paths}"
+
+  return 1
+}
+
+linux_runtime_closure_executable_named() {
+  local name="$1"
+  local store_paths root candidate
+
+  store_paths="$(linux_runtime_closure_store_paths_file)"
+  while IFS= read -r root; do
+    for candidate in "${root}/bin/${name}" "${root}/libexec/${name}"; do
+      if [ -x "${candidate}" ]; then
+        printf '%s\n' "${candidate}"
+        return 0
+      fi
+    done
+  done < "${store_paths}"
+
+  return 1
+}
+
+copy_linux_appdir_tree() {
+  local source="$1"
+  local dest="$2"
+
+  mkdir -p "${dest}"
+  cp -aL "${source}/." "${dest}/"
+  chmod -R u+w "${dest}" 2>/dev/null || true
+  touch_tree_to_source_date_epoch "${dest}"
+}
+
+sanitize_linux_appdir_executables_under() {
+  local root="$1"
+  local exe
+
+  if [ ! -d "${root}" ]; then
+    return 0
+  fi
+
+  while IFS= read -r -d '' exe; do
+    if patchelf --print-interpreter "${exe}" >/dev/null 2>&1; then
+      chmod u+w "${exe}" 2>/dev/null || true
+      sanitize_linux_package_executable "${exe}"
+      touch -h -d "@${SOURCE_DATE_EPOCH}" "${exe}"
+    fi
+  done < <(find "${root}" -type f -perm /111 -print0)
+}
+
+set_linux_appdir_rpath_under() {
+  local root="$1"
+  local rpath="$2"
+  local elf
+
+  if [ ! -d "${root}" ]; then
+    return 0
+  fi
+
+  while IFS= read -r -d '' elf; do
+    if patchelf --print-needed "${elf}" >/dev/null 2>&1; then
+      chmod u+w "${elf}" 2>/dev/null || true
+      patchelf --set-rpath "${rpath}" "${elf}" 2>/dev/null || true
+      touch -h -d "@${SOURCE_DATE_EPOCH}" "${elf}"
+    fi
+  done < <(find "${root}" -type f -print0)
+}
+
+install_linux_appimage_string_patcher() {
+  local appdir="$1"
+  local runtime_dir source patcher compiler
+
+  runtime_dir="${appdir}/usr/libexec/maple-webkit-runtime"
+  patcher="${runtime_dir}/maple-replace-strings"
+  source="$(mktemp)"
+  compiler="${MAPLE_NIX_CC:-${CC:-cc}}"
+
+  mkdir -p "${runtime_dir}"
+
+  cat > "${source}" <<'EOF'
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+static int replace_all(unsigned char *data, size_t size, const char *needle, const char *replacement) {
+  size_t needle_len = strlen(needle);
+  size_t replacement_len = strlen(replacement);
+  size_t index;
+  int replacements = 0;
+
+  if (needle_len == 0) {
+    fprintf(stderr, "empty replacement needle\n");
+    return 1;
+  }
+
+  if (replacement_len > needle_len) {
+    fprintf(stderr, "replacement is longer than needle\nneedle=%s\nreplacement=%s\n", needle, replacement);
+    return 1;
+  }
+
+  for (index = 0; index + needle_len <= size; index++) {
+    if (memcmp(data + index, needle, needle_len) == 0) {
+      memcpy(data + index, replacement, replacement_len);
+      memset(data + index + replacement_len, 0, needle_len - replacement_len);
+      replacements++;
+      index += needle_len - 1;
+    }
+  }
+
+  if (replacements == 0) {
+    fprintf(stderr, "replacement needle not found: %s\n", needle);
+    return 1;
+  }
+
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  int fd;
+  struct stat st;
+  unsigned char *data;
+  int arg;
+  int status = 0;
+
+  if (argc < 4 || ((argc - 2) % 2) != 0) {
+    fprintf(stderr, "usage: %s FILE NEEDLE REPLACEMENT [NEEDLE REPLACEMENT ...]\n", argv[0]);
+    return 2;
+  }
+
+  fd = open(argv[1], O_RDWR);
+  if (fd < 0) {
+    fprintf(stderr, "open %s: %s\n", argv[1], strerror(errno));
+    return 1;
+  }
+
+  if (fstat(fd, &st) != 0) {
+    fprintf(stderr, "stat %s: %s\n", argv[1], strerror(errno));
+    close(fd);
+    return 1;
+  }
+
+  if (st.st_size <= 0) {
+    fprintf(stderr, "file is empty: %s\n", argv[1]);
+    close(fd);
+    return 1;
+  }
+
+  data = mmap(NULL, (size_t)st.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
+  if (data == MAP_FAILED) {
+    fprintf(stderr, "mmap %s: %s\n", argv[1], strerror(errno));
+    close(fd);
+    return 1;
+  }
+
+  for (arg = 2; arg < argc; arg += 2) {
+    if (replace_all(data, (size_t)st.st_size, argv[arg], argv[arg + 1]) != 0) {
+      status = 1;
+    }
+  }
+
+  if (msync(data, (size_t)st.st_size, MS_SYNC) != 0) {
+    fprintf(stderr, "msync %s: %s\n", argv[1], strerror(errno));
+    status = 1;
+  }
+
+  munmap(data, (size_t)st.st_size);
+  close(fd);
+  return status;
+}
+EOF
+
+  "${compiler}" -x c -O2 -Wall -Wextra "${source}" -o "${patcher}"
+  rm -f "${source}"
+  chmod 0755 "${patcher}"
+  sanitize_linux_package_executable "${patcher}"
+}
+
+write_linux_appimage_webkit_hook() {
+  local appdir="$1"
+  local webkit_store="$2"
+  local bwrap_source="$3"
+  local xdg_dbus_proxy_source="$4"
+  local hook libwebkit_hash
+
+  hook="${appdir}/apprun-hooks/maple-webkitgtk.sh"
+  libwebkit_hash="$(sha256_file "${appdir}/usr/lib/libwebkit2gtk-4.1.so.0" | awk '{ print $1 }')"
+  mkdir -p "$(dirname "${hook}")"
+
+  cat > "${hook}" <<EOF
+#! /usr/bin/env bash
+
+maple_webkit_orig_libexec="${webkit_store}/libexec/webkit2gtk-4.1"
+maple_webkit_orig_injected_bundle="${webkit_store}/lib/webkit2gtk-4.1/injected-bundle/"
+maple_webkit_orig_locale="${webkit_store}/share/locale"
+maple_webkit_orig_share="${webkit_store}/share"
+maple_webkit_orig_lib="${webkit_store}/lib"
+maple_webkit_orig_bwrap="${bwrap_source}"
+maple_webkit_orig_xdg_dbus_proxy="${xdg_dbus_proxy_source}"
+maple_webkit_runtime_id="${libwebkit_hash}"
+
+maple_webkit_path_fits() {
+  local root="\$1"
+  local libexec_path="\${root}/libexec/webkit2gtk-4.1"
+  local injected_bundle_path="\${root}/lib/webkit2gtk-4.1/injected-bundle/"
+  local locale_path="\${root}/share/locale"
+  local share_path="\${root}/share"
+  local lib_path="\${root}/lib"
+  local bwrap_path="\${root}/bin/bwrap"
+  local xdg_dbus_proxy_path="\${root}/bin/xdg-dbus-proxy"
+
+  [ \${#libexec_path} -le \${#maple_webkit_orig_libexec} ] &&
+    [ \${#injected_bundle_path} -le \${#maple_webkit_orig_injected_bundle} ] &&
+    [ \${#locale_path} -le \${#maple_webkit_orig_locale} ] &&
+    [ \${#share_path} -le \${#maple_webkit_orig_share} ] &&
+    [ \${#lib_path} -le \${#maple_webkit_orig_lib} ] &&
+    [ \${#bwrap_path} -le \${#maple_webkit_orig_bwrap} ] &&
+    [ \${#xdg_dbus_proxy_path} -le \${#maple_webkit_orig_xdg_dbus_proxy} ]
+}
+
+maple_webkit_select_runtime_root() {
+  local root
+
+  for root in \\
+    "\${XDG_RUNTIME_DIR:+\${XDG_RUNTIME_DIR%/}/maple-webkitgtk-4.1}" \\
+    "/tmp/maple-webkitgtk-4.1-\$(id -u)"; do
+    [ -n "\${root}" ] || continue
+    if maple_webkit_path_fits "\${root}"; then
+      printf '%s\n' "\${root}"
+      return 0
+    fi
+  done
+
+  echo "Maple AppImage cannot choose a short enough WebKit runtime path." >&2
+  return 1
+}
+
+maple_webkit_runtime_dir_is_safe() {
+  local root="\$1"
+  local owner
+
+  if [ -L "\${root}" ]; then
+    echo "Refusing to use symlinked WebKit runtime directory: \${root}" >&2
+    return 1
+  fi
+
+  if [ -d "\${root}" ]; then
+    owner="\$(stat -c '%u' "\${root}" 2>/dev/null || stat -f '%u' "\${root}" 2>/dev/null || printf unknown)"
+    if [ "\${owner}" != "\$(id -u)" ]; then
+      echo "Refusing to use WebKit runtime directory owned by another user: \${root}" >&2
+      return 1
+    fi
+  fi
+}
+
+maple_webkit_prepare_runtime() {
+  local appdir root patched_lib marker tmp_lib
+
+  appdir="\${APPDIR:-\${this_dir}}"
+  root="\$(maple_webkit_select_runtime_root)"
+  maple_webkit_runtime_dir_is_safe "\${root}"
+
+  mkdir -p "\${root}/bin" "\${root}/lib" "\${root}/libexec"
+  chmod 700 "\${root}"
+
+  ln -sfn "\${appdir}/usr/libexec/webkit2gtk-4.1" "\${root}/libexec/webkit2gtk-4.1"
+  ln -sfn "\${appdir}/usr/lib/webkit2gtk-4.1" "\${root}/lib/webkit2gtk-4.1"
+  ln -sfn "\${appdir}/usr/share" "\${root}/share"
+  ln -sfn "\${appdir}/usr/libexec/maple-webkit-runtime/bin/bwrap" "\${root}/bin/bwrap"
+  ln -sfn "\${appdir}/usr/libexec/maple-webkit-runtime/bin/xdg-dbus-proxy" "\${root}/bin/xdg-dbus-proxy"
+
+  patched_lib="\${root}/lib/libwebkit2gtk-4.1.so.0"
+  marker="\${patched_lib}.maple-id"
+  if [ ! -f "\${patched_lib}" ] || [ "\$(cat "\${marker}" 2>/dev/null || true)" != "\${maple_webkit_runtime_id}" ]; then
+    tmp_lib="\${patched_lib}.tmp.\$\$"
+    cp -f "\${appdir}/usr/lib/libwebkit2gtk-4.1.so.0" "\${tmp_lib}"
+    chmod u+w "\${tmp_lib}"
+    "\${appdir}/usr/libexec/maple-webkit-runtime/maple-replace-strings" "\${tmp_lib}" \\
+      "\${maple_webkit_orig_libexec}" "\${root}/libexec/webkit2gtk-4.1" \\
+      "\${maple_webkit_orig_injected_bundle}" "\${root}/lib/webkit2gtk-4.1/injected-bundle/" \\
+      "\${maple_webkit_orig_locale}" "\${root}/share/locale" \\
+      "\${maple_webkit_orig_share}" "\${root}/share" \\
+      "\${maple_webkit_orig_lib}" "\${root}/lib" \\
+      "\${maple_webkit_orig_bwrap}" "\${root}/bin/bwrap" \\
+      "\${maple_webkit_orig_xdg_dbus_proxy}" "\${root}/bin/xdg-dbus-proxy"
+    mv -f "\${tmp_lib}" "\${patched_lib}"
+    printf '%s\n' "\${maple_webkit_runtime_id}" > "\${marker}"
+  fi
+
+  export MAPLE_WEBKIT_LIBRARY_PATH="\${root}/lib"
+}
+
+maple_webkit_prepare_runtime
+EOF
+  chmod 0755 "${hook}"
+  touch -h -d "@${SOURCE_DATE_EPOCH}" "${hook}"
+}
+
+write_linux_appimage_maple_apprun() {
+  local appdir="$1"
+  local app_run="${appdir}/AppRun"
+
+  cat > "${app_run}" <<'EOF'
+#! /usr/bin/env bash
+
+set -e
+
+this_dir="$(readlink -f "$(dirname "$0")")"
+export APPDIR="${APPDIR:-${this_dir}}"
+
+source "$this_dir"/apprun-hooks/"linuxdeploy-plugin-gtk.sh"
+source "$this_dir"/apprun-hooks/"linuxdeploy-plugin-gstreamer.sh"
+source "$this_dir"/apprun-hooks/"maple-webkitgtk.sh"
+
+export PATH="$this_dir/usr/bin:$this_dir/usr/sbin:$this_dir/usr/games:$this_dir/bin:$this_dir/sbin:$PATH"
+export LD_LIBRARY_PATH="${MAPLE_WEBKIT_LIBRARY_PATH:+${MAPLE_WEBKIT_LIBRARY_PATH}:}$this_dir/usr/lib:$this_dir/usr/lib/i386-linux-gnu:$this_dir/usr/lib/x86_64-linux-gnu:$this_dir/usr/lib32:$this_dir/usr/lib64:$this_dir/lib:$this_dir/lib/i386-linux-gnu:$this_dir/lib/x86_64-linux-gnu:$this_dir/lib32:$this_dir/lib64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export XDG_DATA_DIRS="$this_dir/usr/share:${XDG_DATA_DIRS:-/usr/local/share/:/usr/share/}"
+export GSETTINGS_SCHEMA_DIR="$this_dir/usr/share/glib-2.0/schemas${GSETTINGS_SCHEMA_DIR:+:$GSETTINGS_SCHEMA_DIR}"
+export PYTHONPATH="$this_dir/usr/share/pyshared${PYTHONPATH:+:$PYTHONPATH}"
+export PERLLIB="$this_dir/usr/share/perl5:$this_dir/usr/lib/perl5${PERLLIB:+:$PERLLIB}"
+export QT_PLUGIN_PATH="$this_dir/usr/lib/qt4/plugins:$this_dir/usr/lib/i386-linux-gnu/qt4/plugins:$this_dir/usr/lib/x86_64-linux-gnu/qt4/plugins:$this_dir/usr/lib32/qt4/plugins:$this_dir/usr/lib64/qt4/plugins:$this_dir/usr/lib/qt5/plugins:$this_dir/usr/lib/i386-linux-gnu/qt5/plugins:$this_dir/usr/lib/x86_64-linux-gnu/qt5/plugins:$this_dir/usr/lib32/qt5/plugins:$this_dir/usr/lib64/qt5/plugins${QT_PLUGIN_PATH:+:$QT_PLUGIN_PATH}"
+export GST_PLUGIN_SYSTEM_PATH="$this_dir/usr/lib/gstreamer${GST_PLUGIN_SYSTEM_PATH:+:$GST_PLUGIN_SYSTEM_PATH}"
+export GST_PLUGIN_SYSTEM_PATH_1_0="$this_dir/usr/lib/gstreamer-1.0${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
+export PYTHONDONTWRITEBYTECODE=1
+
+exec "$this_dir/usr/bin/maple" "$@"
+EOF
+  chmod 0755 "${app_run}"
+  touch -h -d "@${SOURCE_DATE_EPOCH}" "${app_run}"
+}
+
+stage_linux_appdir_webkit_runtime() {
+  local appdir="$1"
+  local webkit_store bwrap_source xdg_dbus_proxy_source runtime_dir exe
+
+  if [ ! -e "${appdir}/usr/lib/libwebkit2gtk-4.1.so.0" ]; then
+    return 0
+  fi
+
+  webkit_store="$(linux_runtime_closure_webkitgtk_store_path)"
+  bwrap_source="$(linux_runtime_closure_executable_named bwrap)"
+  xdg_dbus_proxy_source="$(linux_runtime_closure_executable_named xdg-dbus-proxy)"
+  runtime_dir="${appdir}/usr/libexec/maple-webkit-runtime"
+
+  copy_linux_appdir_tree \
+    "${webkit_store}/libexec/webkit2gtk-4.1" \
+    "${appdir}/usr/libexec/webkit2gtk-4.1"
+  copy_linux_appdir_tree \
+    "${webkit_store}/lib/webkit2gtk-4.1" \
+    "${appdir}/usr/lib/webkit2gtk-4.1"
+  copy_linux_appdir_tree \
+    "${webkit_store}/share" \
+    "${appdir}/usr/share"
+
+  mkdir -p "${runtime_dir}/bin"
+  cp -L --preserve=mode,timestamps "${bwrap_source}" "${runtime_dir}/bin/bwrap"
+  cp -L --preserve=mode,timestamps "${xdg_dbus_proxy_source}" "${runtime_dir}/bin/xdg-dbus-proxy"
+
+  sanitize_linux_appdir_executables_under "${appdir}/usr/libexec/webkit2gtk-4.1"
+  sanitize_linux_appdir_executables_under "${runtime_dir}/bin"
+  set_linux_appdir_rpath_under "${appdir}/usr/lib/webkit2gtk-4.1" '$ORIGIN/../..'
+  install_linux_appimage_string_patcher "${appdir}"
+
+  for exe in "${runtime_dir}/bin/bwrap" "${runtime_dir}/bin/xdg-dbus-proxy"; do
+    touch -h -d "@${SOURCE_DATE_EPOCH}" "${exe}"
+  done
+
+  write_linux_appimage_webkit_hook \
+    "${appdir}" \
+    "${webkit_store}" \
+    "${bwrap_source}" \
+    "${xdg_dbus_proxy_source}"
+  write_linux_appimage_maple_apprun "${appdir}"
+
+  printf 'staged-linux-appimage-webkit-runtime  %s\n' "${webkit_store}"
 }
 
 repair_linux_appdir_runtime_closure() {
@@ -2533,6 +2931,66 @@ verify_linux_appdir_runtime_closure() {
   return "${status}"
 }
 
+verify_linux_appdir_webkit_runtime() {
+  local appdir="$1"
+  local status=0
+  local path
+  local required_paths=(
+    "apprun-hooks/maple-webkitgtk.sh"
+    "usr/lib/libwebkit2gtk-4.1.so.0"
+    "usr/libexec/webkit2gtk-4.1/WebKitNetworkProcess"
+    "usr/libexec/webkit2gtk-4.1/WebKitWebProcess"
+    "usr/libexec/webkit2gtk-4.1/WebKitGPUProcess"
+    "usr/lib/webkit2gtk-4.1/injected-bundle/libwebkit2gtkinjectedbundle.so"
+    "usr/libexec/maple-webkit-runtime/bin/bwrap"
+    "usr/libexec/maple-webkit-runtime/bin/xdg-dbus-proxy"
+    "usr/libexec/maple-webkit-runtime/maple-replace-strings"
+  )
+
+  if [ ! -e "${appdir}/usr/lib/libwebkit2gtk-4.1.so.0" ]; then
+    return 0
+  fi
+
+  for path in "${required_paths[@]}"; do
+    if [ ! -e "${appdir}/${path}" ]; then
+      echo "AppImage is missing WebKit runtime payload: ${path}" >&2
+      status=1
+    fi
+  done
+
+  if [ -f "${appdir}/AppRun" ]; then
+    if ! grep -Fq 'apprun-hooks/"maple-webkitgtk.sh"' "${appdir}/AppRun"; then
+      echo "AppImage AppRun does not source the Maple WebKit runtime hook." >&2
+      status=1
+    fi
+    if ! grep -Fq 'exec "$this_dir/usr/bin/maple" "$@"' "${appdir}/AppRun"; then
+      echo "AppImage AppRun does not launch Maple with the verified runtime environment." >&2
+      status=1
+    fi
+  else
+    echo "AppImage is missing AppRun." >&2
+    status=1
+  fi
+
+  for path in \
+    "${appdir}/usr/libexec/webkit2gtk-4.1/WebKitNetworkProcess" \
+    "${appdir}/usr/libexec/webkit2gtk-4.1/WebKitWebProcess" \
+    "${appdir}/usr/libexec/webkit2gtk-4.1/WebKitGPUProcess" \
+    "${appdir}/usr/libexec/maple-webkit-runtime/bin/bwrap" \
+    "${appdir}/usr/libexec/maple-webkit-runtime/bin/xdg-dbus-proxy" \
+    "${appdir}/usr/libexec/maple-webkit-runtime/maple-replace-strings"; do
+    if [ -f "${path}" ]; then
+      verify_linux_package_executable_metadata "${path}" || status=1
+    fi
+  done
+
+  if [ "${status}" -eq 0 ]; then
+    printf 'verified-linux-appimage-webkit-runtime  %s\n' "${appdir}"
+  fi
+
+  return "${status}"
+}
+
 prepare_linux_appdir_for_appimage() {
   local appdir="$1"
   local exe="${appdir}/usr/bin/maple"
@@ -2542,8 +3000,10 @@ prepare_linux_appdir_for_appimage() {
     sanitize_linux_package_executable "${exe}"
   fi
 
+  stage_linux_appdir_webkit_runtime "${appdir}"
   repair_linux_appdir_runtime_closure "${appdir}"
   verify_linux_appdir_runtime_closure "${appdir}"
+  verify_linux_appdir_webkit_runtime "${appdir}"
   touch_tree_to_source_date_epoch "${appdir}"
 }
 
@@ -2587,6 +3047,7 @@ sanitize_linux_package_executable() {
   local interpreter
 
   interpreter="$(linux_system_elf_interpreter_for_file "${exe}")"
+  chmod u+w "${exe}" 2>/dev/null || true
   patchelf --set-interpreter "${interpreter}" --remove-rpath "${exe}"
   verify_linux_package_executable_metadata "${exe}"
 }
@@ -2629,6 +3090,7 @@ verify_linux_appimage_executable_metadata() {
     extract_appimage_tool "${appimage}" "${tmp}/AppDir"
     verify_linux_package_executable_metadata "${tmp}/AppDir/usr/bin/maple"
     verify_linux_appdir_runtime_closure "${tmp}/AppDir"
+    verify_linux_appdir_webkit_runtime "${tmp}/AppDir"
   ) || status=$?
   rm -rf "${tmp}"
   return "${status}"

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -2704,10 +2704,21 @@ maple_webkit_prepare_runtime() {
 
   appdir="\${APPDIR:-\${this_dir}}"
   root="\$(maple_webkit_select_runtime_root)"
-  maple_webkit_runtime_dir_is_safe "\${root}"
 
-  mkdir -p "\${root}/bin" "\${root}/lib" "\${root}/libexec"
+  if [ -e "\${root}" ] || [ -L "\${root}" ]; then
+    maple_webkit_runtime_dir_is_safe "\${root}" || return 1
+  else
+    mkdir "\${root}" || return 1
+  fi
+  maple_webkit_runtime_dir_is_safe "\${root}" || return 1
   chmod 700 "\${root}"
+  for child in bin lib libexec; do
+    if [ -L "\${root}/\${child}" ]; then
+      echo "Refusing to use symlinked WebKit runtime subdirectory: \${root}/\${child}" >&2
+      return 1
+    fi
+  done
+  mkdir -p "\${root}/bin" "\${root}/lib" "\${root}/libexec"
 
   ln -sfn "\${appdir}/usr/libexec/webkit2gtk-4.1" "\${root}/libexec/webkit2gtk-4.1"
   ln -sfn "\${appdir}/usr/lib/webkit2gtk-4.1" "\${root}/lib/webkit2gtk-4.1"

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -2508,6 +2508,41 @@ set_linux_appdir_rpath_under() {
   done < <(find "${root}" -type f -print0)
 }
 
+linux_appdir_portable_library_rpath() {
+  printf '%s\n' '$ORIGIN:$ORIGIN/..:$ORIGIN/../..:$ORIGIN/../../..:$ORIGIN/../../../..'
+}
+
+sanitize_linux_appdir_library_rpaths() {
+  local appdir="$1"
+  local rpath elf
+
+  rpath="$(linux_appdir_portable_library_rpath)"
+  if [ ! -d "${appdir}/usr/lib" ]; then
+    return 0
+  fi
+
+  while IFS= read -r -d '' elf; do
+    if patchelf --print-rpath "${elf}" >/dev/null 2>&1; then
+      chmod u+w "${elf}" 2>/dev/null || true
+      patchelf --set-rpath "${rpath}" "${elf}"
+      touch -h -d "@${SOURCE_DATE_EPOCH}" "${elf}"
+    fi
+  done < <(find "${appdir}/usr/lib" -type f -print0)
+}
+
+remove_linux_appdir_nix_xdg_wrappers() {
+  local appdir="$1"
+  local tool path
+
+  for tool in xdg-open xdg-mime; do
+    path="${appdir}/usr/bin/${tool}"
+    if [ -f "${path}" ] && grep -a -q '/nix/store' "${path}"; then
+      rm -f "${path}"
+      printf 'removed-linux-appimage-nix-xdg-wrapper  %s\n' "${path}"
+    fi
+  done
+}
+
 install_linux_appimage_string_patcher() {
   local appdir="$1"
   local runtime_dir source patcher compiler
@@ -2942,6 +2977,38 @@ verify_linux_appdir_runtime_closure() {
   return "${status}"
 }
 
+verify_linux_appdir_portable_runtime_paths() {
+  local appdir="$1"
+  local status=0
+  local path rpath
+
+  while IFS= read -r -d '' path; do
+    rpath="$(patchelf --print-rpath "${path}" 2>/dev/null || true)"
+    case "${rpath}" in
+      *"/nix/store/"* | *"/home/runner/work/"* | *"/Users/runner/work/"* | *"/Users/tony/"*)
+        echo "AppImage ELF contains build-host paths in RPATH/RUNPATH." >&2
+        echo "rpath=${rpath}" >&2
+        echo "file=${path}" >&2
+        status=1
+        ;;
+    esac
+  done < <(find "${appdir}" -type f -print0)
+
+  for path in "${appdir}/usr/bin/xdg-open" "${appdir}/usr/bin/xdg-mime"; do
+    if [ -f "${path}" ] && grep -a -q '/nix/store' "${path}"; then
+      echo "AppImage bundles a Nix-resolved xdg-utils wrapper." >&2
+      echo "file=${path}" >&2
+      status=1
+    fi
+  done
+
+  if [ "${status}" -eq 0 ]; then
+    printf 'verified-linux-appimage-portable-runtime-paths  %s\n' "${appdir}"
+  fi
+
+  return "${status}"
+}
+
 verify_linux_appdir_webkit_runtime() {
   local appdir="$1"
   local status=0
@@ -3013,7 +3080,10 @@ prepare_linux_appdir_for_appimage() {
 
   stage_linux_appdir_webkit_runtime "${appdir}"
   repair_linux_appdir_runtime_closure "${appdir}"
+  sanitize_linux_appdir_library_rpaths "${appdir}"
+  remove_linux_appdir_nix_xdg_wrappers "${appdir}"
   verify_linux_appdir_runtime_closure "${appdir}"
+  verify_linux_appdir_portable_runtime_paths "${appdir}"
   verify_linux_appdir_webkit_runtime "${appdir}"
   touch_tree_to_source_date_epoch "${appdir}"
 }

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -2532,10 +2532,21 @@ sanitize_linux_appdir_library_rpaths() {
 
 remove_linux_appdir_nix_xdg_wrappers() {
   local appdir="$1"
-  local tool path
+  local tool path target
 
   for tool in xdg-open xdg-mime; do
     path="${appdir}/usr/bin/${tool}"
+    if [ -L "${path}" ]; then
+      target="$(readlink -f "${path}" 2>/dev/null || true)"
+      case "${target}" in
+        /nix/store/*)
+          rm -f "${path}"
+          printf 'removed-linux-appimage-nix-xdg-wrapper  %s\n' "${path}"
+          continue
+          ;;
+      esac
+    fi
+
     if [ -f "${path}" ] && grep -a -q '/nix/store' "${path}"; then
       rm -f "${path}"
       printf 'removed-linux-appimage-nix-xdg-wrapper  %s\n' "${path}"
@@ -2735,7 +2746,7 @@ maple_webkit_runtime_dir_is_safe() {
 }
 
 maple_webkit_prepare_runtime() {
-  local appdir root patched_lib marker tmp_lib
+  local appdir root patched_lib marker tmp_lib leaf
 
   appdir="\${APPDIR:-\${this_dir}}"
   root="\$(maple_webkit_select_runtime_root)"
@@ -2754,6 +2765,17 @@ maple_webkit_prepare_runtime() {
     fi
   done
   mkdir -p "\${root}/bin" "\${root}/lib" "\${root}/libexec"
+
+  for leaf in \\
+    "\${root}/libexec/webkit2gtk-4.1" \\
+    "\${root}/lib/webkit2gtk-4.1" \\
+    "\${root}/share" \\
+    "\${root}/bin/bwrap" \\
+    "\${root}/bin/xdg-dbus-proxy"; do
+    if [ -e "\${leaf}" ] || [ -L "\${leaf}" ]; then
+      rm -rf -- "\${leaf}"
+    fi
+  done
 
   ln -sfn "\${appdir}/usr/libexec/webkit2gtk-4.1" "\${root}/libexec/webkit2gtk-4.1"
   ln -sfn "\${appdir}/usr/lib/webkit2gtk-4.1" "\${root}/lib/webkit2gtk-4.1"
@@ -2980,7 +3002,7 @@ verify_linux_appdir_runtime_closure() {
 verify_linux_appdir_portable_runtime_paths() {
   local appdir="$1"
   local status=0
-  local path rpath
+  local path rpath target
 
   while IFS= read -r -d '' path; do
     rpath="$(patchelf --print-rpath "${path}" 2>/dev/null || true)"
@@ -2995,6 +3017,19 @@ verify_linux_appdir_portable_runtime_paths() {
   done < <(find "${appdir}" -type f -print0)
 
   for path in "${appdir}/usr/bin/xdg-open" "${appdir}/usr/bin/xdg-mime"; do
+    if [ -L "${path}" ]; then
+      target="$(readlink -f "${path}" 2>/dev/null || true)"
+      case "${target}" in
+        /nix/store/*)
+          echo "AppImage bundles a Nix-resolved xdg-utils symlink." >&2
+          echo "file=${path}" >&2
+          echo "target=${target}" >&2
+          status=1
+          continue
+          ;;
+      esac
+    fi
+
     if [ -f "${path}" ] && grep -a -q '/nix/store' "${path}"; then
       echo "AppImage bundles a Nix-resolved xdg-utils wrapper." >&2
       echo "file=${path}" >&2
@@ -3171,6 +3206,7 @@ verify_linux_appimage_executable_metadata() {
     extract_appimage_tool "${appimage}" "${tmp}/AppDir"
     verify_linux_package_executable_metadata "${tmp}/AppDir/usr/bin/maple"
     verify_linux_appdir_runtime_closure "${tmp}/AppDir"
+    verify_linux_appdir_portable_runtime_paths "${tmp}/AppDir"
     verify_linux_appdir_webkit_runtime "${tmp}/AppDir"
   ) || status=$?
   rm -rf "${tmp}"


### PR DESCRIPTION
## Summary
- bundle WebKitGTK helper processes, injected bundle, and sandbox helper binaries into Linux AppImages
- replace the generated AppRun with a Maple launcher that sets a verified runtime library order
- add AppImage verification for WebKit helper payloads so the v3.1.1 class of failure is caught in CI
- pin the Nix compiler path used to build the tiny runtime string patcher

## Validation
- updated verifier fails against the published v3.1.1 AppImage because WebKit helper payloads are missing
- synthetic aarch64 AppDir staging and runtime hook patch check passed
- full local aarch64 Linux PR build passed: Maple Nix toolchain: bun 1.3.5, rustc 1.88.0 (6b00bc388 2025-06-23)
git-commit  04059ccbffc102542f9f9655fc503f337931908c
git-tree  77ed8dcc244c82d2c029b7762236d6b12c02d5a1
bun install v1.3.5 (1e86cebd)

+ @eslint/js@9.39.4
+ @noble/curves@1.9.7
+ @noble/hashes@1.8.0
+ @tanstack/router-devtools@1.166.13
+ @tanstack/router-plugin@1.167.25
+ @tauri-apps/cli@2.11.1
+ @types/bun@1.3.13
+ @types/node@22.19.17
+ @types/react@18.3.28
+ @types/react-dom@18.3.7
+ @types/recordrtc@5.6.15
+ @vitejs/plugin-react@4.7.0
+ autoprefixer@10.5.0
+ eslint@9.39.4
+ eslint-plugin-react-hooks@5.2.0
+ eslint-plugin-react-refresh@0.4.26
+ globals@15.15.0
+ postcss@8.5.10
+ prettier@3.8.3
+ tailwindcss@3.4.19
+ typescript@5.9.3
+ typescript-eslint@8.59.0
+ vite@6.4.2
+ @opensecret/react@3.2.0
+ @radix-ui/react-alert-dialog@1.1.15
+ @radix-ui/react-avatar@1.1.11
+ @radix-ui/react-checkbox@1.3.3
+ @radix-ui/react-dialog@1.1.15
+ @radix-ui/react-dropdown-menu@2.1.16
+ @radix-ui/react-label@2.1.8
+ @radix-ui/react-select@2.2.6
+ @radix-ui/react-separator@1.1.8
+ @radix-ui/react-slot@1.2.4
+ @radix-ui/react-switch@1.2.6
+ @radix-ui/react-tabs@1.1.13
+ @radix-ui/react-tooltip@1.2.8
+ @tanstack/react-query@5.100.1
+ @tanstack/react-router@1.168.24
+ @tauri-apps/api@2.11.0
+ @tauri-apps/plugin-deep-link@2.4.8
+ @tauri-apps/plugin-dialog@2.7.1
+ @tauri-apps/plugin-fs@2.5.1
+ @tauri-apps/plugin-opener@2.5.4
+ @tauri-apps/plugin-os@2.3.2
+ class-variance-authority@0.7.1
+ clsx@2.1.1
+ gpt-tokenizer@3.4.0
+ katex@0.16.45
+ lucide-react@0.436.0
+ openai@5.20.0
+ react@18.3.1
+ react-dom@18.3.1
+ react-markdown@9.1.0
+ recordrtc@5.6.2
+ rehype-highlight@7.0.2
+ rehype-katex@7.0.1
+ rehype-sanitize@6.0.0
+ remark-breaks@4.0.0
+ remark-gfm@4.0.1
+ remark-math@6.0.0
+ tailwind-merge@2.6.1
+ tailwindcss-animate@1.0.7
+ uuid@14.0.0

542 packages installed [2.96s]
SOURCE_DATE_EPOCH=315532800
vite v6.4.2 building for production...
transforming...
✓ 2551 modules transformed.
rendering chunks...
computing gzip size...
dist/index.html                                           3.26 kB │ gzip:   1.12 kB
dist/assets/KaTeX_Size3-Regular-CTq5MqoE.woff             4.42 kB
dist/assets/KaTeX_Size4-Regular-Dl5lxZxV.woff2            4.93 kB
dist/assets/KaTeX_Size2-Regular-Dy4dx90m.woff2            5.21 kB
dist/assets/KaTeX_Size1-Regular-mCD8mA8B.woff2            5.47 kB
dist/assets/KaTeX_Size4-Regular-BF-4gkZK.woff             5.98 kB
dist/assets/KaTeX_Size2-Regular-oD1tc_U0.woff             6.19 kB
dist/assets/KaTeX_Size1-Regular-C195tn64.woff             6.50 kB
dist/assets/KaTeX_Caligraphic-Regular-Di6jR-x-.woff2      6.91 kB
dist/assets/KaTeX_Caligraphic-Bold-Dq_IR9rO.woff2         6.91 kB
dist/assets/KaTeX_Size3-Regular-DgpXs0kz.ttf              7.59 kB
dist/assets/KaTeX_Caligraphic-Regular-CTRA-rTL.woff       7.66 kB
dist/assets/KaTeX_Caligraphic-Bold-BEiXGLvX.woff          7.72 kB
dist/assets/KaTeX_Script-Regular-D3wIWfF6.woff2           9.64 kB
dist/assets/KaTeX_SansSerif-Regular-DDBCnlJ7.woff2       10.34 kB
dist/assets/KaTeX_Size4-Regular-DWFBv043.ttf             10.36 kB
dist/assets/KaTeX_Script-Regular-D5yQViql.woff           10.59 kB
dist/assets/KaTeX_Fraktur-Regular-CTYiF6lA.woff2         11.32 kB
dist/assets/KaTeX_Fraktur-Bold-CL6g_b3V.woff2            11.35 kB
dist/assets/KaTeX_Size2-Regular-B7gKUWhC.ttf             11.51 kB
dist/assets/KaTeX_SansSerif-Italic-C3H0VqGB.woff2        12.03 kB
dist/assets/KaTeX_SansSerif-Bold-D1sUS0GD.woff2          12.22 kB
dist/assets/KaTeX_Size1-Regular-Dbsnue_I.ttf             12.23 kB
dist/assets/KaTeX_SansSerif-Regular-CS6fqUqJ.woff        12.32 kB
dist/assets/KaTeX_Caligraphic-Regular-wX97UBjC.ttf       12.34 kB
dist/assets/KaTeX_Caligraphic-Bold-ATXxdsX0.ttf          12.37 kB
dist/assets/KaTeX_Fraktur-Regular-Dxdc4cR9.woff          13.21 kB
dist/assets/KaTeX_Fraktur-Bold-BsDP51OF.woff             13.30 kB
dist/assets/KaTeX_Typewriter-Regular-CO6r4hn1.woff2      13.57 kB
dist/assets/KaTeX_SansSerif-Italic-DN2j7dab.woff         14.11 kB
dist/assets/KaTeX_SansSerif-Bold-DbIhKOiC.woff           14.41 kB
dist/assets/KaTeX_Typewriter-Regular-C0xS9mPB.woff       16.03 kB
dist/assets/KaTeX_Math-BoldItalic-CZnvNsCZ.woff2         16.40 kB
dist/assets/KaTeX_Math-Italic-t53AETM-.woff2             16.44 kB
dist/assets/KaTeX_Script-Regular-C5JkGWo-.ttf            16.65 kB
dist/assets/KaTeX_Main-BoldItalic-DxDJ3AOS.woff2         16.78 kB
dist/assets/KaTeX_Main-Italic-NWA7e6Wa.woff2             16.99 kB
dist/assets/KaTeX_Math-BoldItalic-iY-2wyZ7.woff          18.67 kB
dist/assets/KaTeX_Math-Italic-DA0__PXp.woff              18.75 kB
dist/assets/KaTeX_Main-BoldItalic-SpSLRI95.woff          19.41 kB
dist/assets/KaTeX_SansSerif-Regular-BNo7hRIc.ttf         19.44 kB
dist/assets/KaTeX_Fraktur-Regular-CB_wures.ttf           19.57 kB
dist/assets/KaTeX_Fraktur-Bold-BdnERNNW.ttf              19.58 kB
dist/assets/KaTeX_Main-Italic-BMLOBm91.woff              19.68 kB
dist/assets/KaTeX_SansSerif-Italic-YYjJ1zSn.ttf          22.36 kB
dist/assets/KaTeX_SansSerif-Bold-CFMepnvq.ttf            24.50 kB
dist/assets/KaTeX_Main-Bold-Cx986IdX.woff2               25.32 kB
dist/assets/KaTeX_Main-Regular-B22Nviop.woff2            26.27 kB
dist/assets/KaTeX_Typewriter-Regular-D3Ib7_Hf.ttf        27.56 kB
dist/assets/KaTeX_AMS-Regular-BQhdFMY1.woff2             28.08 kB
dist/assets/KaTeX_Main-Bold-Jm3AIy58.woff                29.91 kB
dist/assets/KaTeX_Main-Regular-Dr94JaBh.woff             30.77 kB
dist/assets/KaTeX_Math-BoldItalic-B3XSjfu4.ttf           31.20 kB
dist/assets/KaTeX_Math-Italic-flOr_0UB.ttf               31.31 kB
dist/assets/KaTeX_Main-BoldItalic-DzxPMmG6.ttf           32.97 kB
dist/assets/KaTeX_AMS-Regular-DMm9YOAa.woff              33.52 kB
dist/assets/KaTeX_Main-Italic-3WenGoN9.ttf               33.58 kB
dist/assets/KaTeX_Main-Bold-waoOVXN0.ttf                 51.34 kB
dist/assets/KaTeX_Main-Regular-ypZvNtVU.ttf              53.58 kB
dist/assets/KaTeX_AMS-Regular-DRggAlZN.ttf               63.63 kB
dist/assets/index-BBXdh2gw.css                          154.26 kB │ gzip:  29.58 kB
dist/assets/index-Cy4wVQCI.js                             0.33 kB │ gzip:   0.22 kB
dist/assets/index-gUJGA4TF.js                             0.73 kB │ gzip:   0.28 kB
dist/assets/index-DIfEq_Po.js                         2,179.34 kB │ gzip: 623.14 kB
✓ built in 3.84s
sha256-tree  6af7bf14f389748d44280f2f757a7f6789965651ca3dc52b176b9416da82cb34  frontend/dist
ORT_LIB_LOCATION=/Users/tony/Dev/OpenSecret/maple/frontend/src-tauri/onnxruntime-linux/onnxruntime-linux-aarch64-1.22.0
ORT_SKIP_DOWNLOAD=true
ORT_DYLIB_PATH=/Users/tony/Dev/OpenSecret/maple/frontend/src-tauri/onnxruntime-linux/onnxruntime-linux-aarch64-1.22.0/lib/libonnxruntime.so.1.22.0
sha256-file  072f17c0895a85c490282fe5395c5007e5fc75da727e553b3b8fb680feb11578  frontend/src-tauri/target/.tauri/AppRun-aarch64
sha256-file  b12b5cc57bd0921e1f98d73f58aa364503bc1a27f54b7a69fd2870bce7fa2f55  frontend/src-tauri/target/.tauri/linuxdeploy-aarch64.real.AppImage
sha256-file  98229d3a03e39cb78b319eba1b5ca31da206ca0bd89e453b84b177992f491550  frontend/src-tauri/target/.tauri/linuxdeploy-aarch64.AppImage
sha256-file  db717e3d14ef1fbf00a1b53481d1daff06210d934b978202ba53b688a4e435e2  frontend/src-tauri/target/.tauri/linuxdeploy-aarch64.AppDir/AppRun
sha256-file  0315b45e0660adbb6dd809876fd9b3014287eccbafd561517a3dd1387453498c  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-appimage
sha256-file  998c13f1b00c30c5ecfbf43e06c3cc6b89479228f9aa9de867b33d050d96bd2e  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-gtk
sha256-file  eca86e5a6082b8d3f2271279cff729f296944e5939a3d0e862f68cd5a9f447d4  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-gstreamer
sha256-file  83c292149274965a865dcd44c135cfca8ba28c6b7de3eb628d4b8b5f248af17c  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/linuxdeploy-plugin-appimage.real.AppImage
sha256-file  1ee0694ddfd7b0e5f3d0b29a52fbcd6a9ec2a753477519884112610c8cdada19  frontend/src-tauri/target/.tauri/linuxdeploy-plugin-appimage.AppImage
sha256-file  eb1d57ead24ce17caa2695a852ee38b28d3dea7dadce4e7de5b37dae82d0e282  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/linuxdeploy-plugin-appimage.AppDir/AppRun
sha256-file  00cbdfcf917cc6c0ff6d3347d59e0ca1f7f45a6df1a428a0d6d8a78664d87444  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/appimage-runtime-aarch64
sha256-file  e1840075dfaec6a43bde6720c1e7191d36f2c25f1952b0666af1211c70f17fa4  frontend/src-tauri/target/.tauri/linuxdeploy-plugin-gtk.sh
sha256-file  56342bb8053eb78d4854f2f4ea5a8a0852d8993f5d27a5f65adc00f4a59d18b0  frontend/src-tauri/target/.tauri/linuxdeploy-plugin-gstreamer.sh
verified-linuxdeploy-plugin  type=output  api=0  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-appimage
verified-linuxdeploy-plugin  type=input  api=0  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-gstreamer
verified-linuxdeploy-plugin  type=input  api=0  frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-gtk
Available plugins: 
appimage: /Users/tony/Dev/OpenSecret/maple/frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-appimage (type: output, API level: 0) 
gstreamer: /Users/tony/Dev/OpenSecret/maple/frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-gstreamer (type: input, API level: 0) 
gtk: /Users/tony/Dev/OpenSecret/maple/frontend/src-tauri/target/.tauri/maple-linuxdeploy-tools/plugins/linuxdeploy-plugin-gtk (type: input, API level: 0) 
2.86.3
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /Users/tony/Dev/OpenSecret/maple/frontend/src-tauri/target/release/maple
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.cydVfhakYv/data/usr/bin/maple
Executing(%mkbuilddir): /nix/store/rlgii39vy2cp7y4rgxz6l0bl7115nk7a-bash-interactive-5.3p3/bin/bash -e /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/tmp/rpm-tmp.y8mX2B
Executing(%prep): /nix/store/rlgii39vy2cp7y4rgxz6l0bl7115nk7a-bash-interactive-5.3p3/bin/bash -e /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/tmp/rpm-tmp.AmiXoy
Executing(%build): /nix/store/rlgii39vy2cp7y4rgxz6l0bl7115nk7a-bash-interactive-5.3p3/bin/bash -e /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/tmp/rpm-tmp.q8MNzy
Executing(%install): /nix/store/rlgii39vy2cp7y4rgxz6l0bl7115nk7a-bash-interactive-5.3p3/bin/bash -e /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/tmp/rpm-tmp.abzkg0
Processing files: maple-3.1.1-1.aarch64
Provides: maple = 0:3.1.1-1
Requires(rpmlib): rpmlib(CompressedFileNames) <= 3.0.4-1 rpmlib(FileDigests) <= 4.6.0-1 rpmlib(PayloadFilesHavePrefix) <= 4.0-1
Checking for unpackaged file(s): /nix/store/i87kw94z2g9007mn7qhmx3y2kfr3v58c-rpm-4.20.1/lib/rpm/check-files /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/BUILD/maple-3.1.1-build/BUILDROOT
Wrote: /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/RPMS/maple-3.1.1-1.aarch64.rpm
Executing(rmbuild): /nix/store/rlgii39vy2cp7y4rgxz6l0bl7115nk7a-bash-interactive-5.3p3/bin/bash -e /tmp/nix-shell.Yvh1zI/tmp.S2UfG6uUMC/tmp/rpm-tmp.ZQyixa
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/bin/maple
verified-linux-appimage-runtime-closure  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/libexec/webkit2gtk-4.1/WebKitNetworkProcess
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/libexec/webkit2gtk-4.1/WebKitWebProcess
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/libexec/webkit2gtk-4.1/WebKitGPUProcess
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/libexec/maple-webkit-runtime/bin/bwrap
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/libexec/maple-webkit-runtime/bin/xdg-dbus-proxy
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir/usr/libexec/maple-webkit-runtime/maple-replace-strings
verified-linux-appimage-webkit-runtime  /tmp/nix-shell.Yvh1zI/tmp.z6BD9kGBHT/AppDir
verified-linux-package-elf  interpreter=/lib/ld-linux-aarch64.so.1  rpath=<empty>  /tmp/nix-shell.Yvh1zI/tmp.KjucJ0pYuZ/data/usr/bin/maple
dde7984d0cfa8710298846b82c029c7efd0148b8b08c675b85ed6acd43f261be  frontend/src-tauri/target/release/bundle/appimage/Maple_3.1.1_aarch64.AppImage
88d3545179b1648e6f55a5f9d9a1b94b3af31e04236e8a346a6af07e698e87e2  frontend/src-tauri/target/release/bundle/deb/Maple_3.1.1_arm64.deb
38e223b3ce442d1da63504a255dfce0be7bc91dd66fd8485d38bb9681c4e6753  frontend/src-tauri/target/release/bundle/rpm/Maple-3.1.1-1.aarch64.rpm
03023aac32ec59d0078cb4ccd79551d638371cb65ea9d50493a90176651cdecd  frontend/src-tauri/target/release/maple
sha256-file  dde7984d0cfa8710298846b82c029c7efd0148b8b08c675b85ed6acd43f261be  frontend/src-tauri/target/release/bundle/appimage/Maple_3.1.1_aarch64.AppImage
sha256-file  88d3545179b1648e6f55a5f9d9a1b94b3af31e04236e8a346a6af07e698e87e2  frontend/src-tauri/target/release/bundle/deb/Maple_3.1.1_arm64.deb
sha256-file  38e223b3ce442d1da63504a255dfce0be7bc91dd66fd8485d38bb9681c4e6753  frontend/src-tauri/target/release/bundle/rpm/Maple-3.1.1-1.aarch64.rpm
sha256-file  03023aac32ec59d0078cb4ccd79551d638371cb65ea9d50493a90176651cdecd  frontend/src-tauri/target/release/maple
sha256-tree  6af7bf14f389748d44280f2f757a7f6789965651ca3dc52b176b9416da82cb34  frontend/dist
- extracted built AppImage and confirmed the runtime hook patches WebKit helper paths into the private runtime dir
- pre-commit hook passed Prettier, frontend build, and bun tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the Linux development environment to also expose the Nix-provided compiler path via `MAPLE_NIX_CC`.
  * Improved AppImage generation by more accurately repairing Linux runtime library discovery and staging the WebKitGTK runtime bundle, including safer executable sanitization and RPATH setup.
  * Strengthened AppImage/portable runtime verification with additional WebKit runtime checks and improved `patchelf` reliability by ensuring targets are writable before patching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->