### PR TITLE
Update model marketing for GLM 5.2

### DIFF
--- a/docs/support-faq.md
+++ b/docs/support-faq.md
@@ -214,8 +214,8 @@ We keep it open so anyone can review and verify our security claims.
 
 **Answer:**
 - **Free tier:** GPT-OSS 120B, Llama 3.3 70B
-- **Legacy Starter+ tier:** Gemma 4 31B (reasoning, vision), Qwen3-VL 30B (vision)
-- **Pro+ tier:** Kimi K2.6 (reasoning, vision)
+- **Starter tier:** Gemma 4 31B (reasoning, vision)
+- **Pro+ tier:** GLM 5.2 (reasoning), Kimi K2.6 (reasoning, vision)
 
 None of your data is transmitted to model providers - everything stays within secure enclaves.
 

--- a/frontend/src/components/Marketing.tsx
+++ b/frontend/src/components/Marketing.tsx
@@ -27,8 +27,7 @@ const AI_MODELS = [
     alt: "Moonshot",
     labels: ["Kimi K2.6"]
   },
-  { src: "/badge-zai-logo.png", alt: "Z.ai", labels: ["GLM 5.1"] },
-  { src: "/badge-qwen-logo.png", alt: "Qwen", labels: ["Qwen3-VL"] },
+  { src: "/badge-zai-logo.png", alt: "Z.ai", labels: ["GLM 5.2"] },
   { src: "/badge-meta-logo.png", alt: "Meta", labels: ["Meta Llama"] }
 ];
 

--- a/frontend/src/components/PromoDialog.tsx
+++ b/frontend/src/components/PromoDialog.tsx
@@ -29,7 +29,7 @@ export function PromoDialog({ open, onOpenChange, discount }: PromoDialogProps) 
   const benefits = [
     {
       icon: <Cpu className="h-4 w-4" />,
-      text: "Powerful AI models including Gemma 4 31B, GLM 5.1, and Kimi K2.6"
+      text: "Powerful AI models including Gemma 4 31B, GLM 5.2, and Kimi K2.6"
     },
     {
       icon: <Image className="h-4 w-4" />,

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -80,7 +80,7 @@ export function UpgradePromptDialog({
         benefits: [
           "Images stay private with end-to-end encryption",
           "Upload JPEG, PNG, and WebP formats securely",
-          "Use Gemma 4 31B and Qwen3-VL on Starter, plus Kimi K2.6 on Pro and above",
+          "Use Gemma 4 31B on Starter, plus Kimi K2.6 on Pro and above",
           "Analyze diagrams, screenshots, and photos privately",
           "Extract text from images without exposing data"
         ]
@@ -136,7 +136,7 @@ export function UpgradePromptDialog({
           : isPro
             ? [
                 "10x more monthly messages with Max plan",
-                "Access to all AI models including GLM 5.1 and Kimi K2.6",
+                "Access to all AI models including GLM 5.2 and Kimi K2.6",
                 "Highest priority during peak times",
                 "Maximum rate limits for power users",
                 "Or purchase extra credits to keep chatting now"
@@ -170,8 +170,8 @@ export function UpgradePromptDialog({
         requiredPlan: "Pro",
         benefits: [
           "All models run in secure, encrypted environments",
-          "Access to GLM 5.1, Kimi K2.6, and the full model lineup",
-          "OpenAI GPT-OSS, Qwen, and other advanced models",
+          "Access to GLM 5.2, Kimi K2.6, and the full model lineup",
+          "OpenAI GPT-OSS, Gemma, and other advanced models",
           "Higher token limits for longer conversations",
           "Priority access to new models as they launch"
         ]
@@ -215,7 +215,7 @@ export function UpgradePromptDialog({
                 {isFreeTier
                   ? "Plus access to powerful models, image & document processing, and more"
                   : isPro
-                    ? "Plus access to GLM 5.1, Kimi K2.6, 10x more usage, API access, and priority support"
+                    ? "Plus access to GLM 5.2, Kimi K2.6, 10x more usage, API access, and priority support"
                     : "Explore our pricing options for the best plan for your needs"}
               </p>
             </div>

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -54,7 +54,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-red-500" />
       },
       {
-        text: "Paid AI models including Gemma 4 31B, GLM 5.1, and Kimi K2.6",
+        text: "Paid AI models including Gemma 4 31B, GLM 5.2, and Kimi K2.6",
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
       },
@@ -83,7 +83,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "Gemma 4 31B + Qwen3-VL 30B",
+        text: "Gemma 4 31B",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -99,7 +99,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <X className="w-4 h-4 text-red-500" />
       },
       {
-        text: "GLM 5.1 + Kimi K2.6",
+        text: "GLM 5.2 + Kimi K2.6",
         included: false,
         icon: <X className="w-4 h-4 text-red-500" />
       },
@@ -134,7 +134,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "All AI models including GLM 5.1 and Kimi K2.6",
+        text: "All AI models including GLM 5.2 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -184,7 +184,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "All AI models including GLM 5.1 and Kimi K2.6",
+        text: "All AI models including GLM 5.2 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },
@@ -243,7 +243,7 @@ export const PRICING_PLANS: PricingPlan[] = [
         icon: <Check className="w-4 h-4 text-green-500" />
       },
       {
-        text: "All AI models including GLM 5.1 and Kimi K2.6",
+        text: "All AI models including GLM 5.2 and Kimi K2.6",
         included: true,
         icon: <Check className="w-4 h-4 text-green-500" />
       },

--- a/frontend/src/routes/teams.tsx
+++ b/frontend/src/routes/teams.tsx
@@ -127,7 +127,7 @@ function TeamsPage() {
                 { src: "/badge-openai-logo.png", alt: "OpenAI", label: "OpenAI GPT-OSS" },
                 { src: "/badge-google-logo.png", alt: "Google", label: "Gemma 4" },
                 { src: "/badge-kimi-logo.png", alt: "Moonshot", label: "Kimi K2.6" },
-                { src: "/badge-zai-logo.png", alt: "Z.ai", label: "GLM 5.1" },
+                { src: "/badge-zai-logo.png", alt: "Z.ai", label: "GLM 5.2" },
                 { src: "/badge-meta-logo.png", alt: "Meta", label: "Meta Llama" }
               ];
               return (


### PR DESCRIPTION
Summary
- update GLM 5.1 copy to GLM 5.2 across pricing and upgrade surfaces
- remove Qwen3-VL from Maple model marketing, Starter copy, and support FAQ
- keep billing-related frontend copy aligned with the new model lineup

Tests
- bun install --frozen-lockfile
- nix develop -c just lint