### PR TITLE
Fix Windows signer subject verification quoting

### DIFF
--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -3631,11 +3631,16 @@ verify_windows_authenticode_signatures() {
     ps_args+=("$(to_windows_path "${file}")")
   done
 
+  # Keep the expected subject in the environment. Passing it as a positional
+  # argument through Git Bash into pwsh can split values that contain spaces.
   # shellcheck disable=SC2016
   pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command '
     $ErrorActionPreference = "Stop"
-    $expectedSubject = $args[0]
-    foreach ($file in $args[1..($args.Count - 1)]) {
+    $expectedSubject = $env:MAPLE_WINDOWS_AUTHENTICODE_SUBJECT
+    if ([string]::IsNullOrWhiteSpace($expectedSubject)) {
+      throw "MAPLE_WINDOWS_AUTHENTICODE_SUBJECT is required to verify the Windows signer identity."
+    }
+    foreach ($file in $args) {
       $signature = Get-AuthenticodeSignature -LiteralPath $file
       if ($signature.Status -ne "Valid") {
         throw "Authenticode signature is not valid for $file. Status=$($signature.Status) Message=$($signature.StatusMessage)"
@@ -3651,7 +3656,7 @@ verify_windows_authenticode_signatures() {
       }
       Write-Host ("verified-windows-authenticode  {0}  subject={1}  issuer={2}" -f $file, $subject, $issuer)
     }
-  ' "${MAPLE_WINDOWS_AUTHENTICODE_SUBJECT}" "${ps_args[@]}"
+  ' "${ps_args[@]}"
 }
 
 import_apple_developer_certificate() {


### PR DESCRIPTION
## Summary
- read the expected Windows Authenticode signer subject from `MAPLE_WINDOWS_AUTHENTICODE_SUBJECT` inside PowerShell instead of passing it as a positional argument
- avoid Git Bash / PowerShell argument splitting when the subject contains spaces, e.g. `Mutiny Wallet Inc. dba OpenSecret`

## Context
The first signed Windows master build proved that Azure OIDC login and Artifact Signing both work: `maple.exe` signed successfully. The next bundle step failed before bundling because the verifier invoked PowerShell with the subject as an argument, and the spaced value was parsed as a command (`Mutiny`).

Failed run: https://github.com/OpenSecretCloud/Maple/actions/runs/28203370056/job/83548230464

## Test plan
- `nix develop .#ci -c bash -n scripts/ci/_common.sh scripts/ci/desktop-windows-release.sh`
- `nix develop .#ci -c shellcheck -e SC1091,SC2163,SC2155,SC2016,SC2034 scripts/ci/_common.sh scripts/ci/desktop-windows-release.sh`
- `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/583" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows signature verification during build/CI runs by reading the expected signing subject from the environment consistently.
  * Reduced the chance of false validation failures when checking signed artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->