### PR TITLE
Install minisign for Windows release finalize

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -299,6 +299,10 @@ jobs:
           setup_exe="$(windows_release_setup_exe_required)"
           echo "MAPLE_WINDOWS_SETUP_EXE_REL=$(repo_relative_path "${setup_exe}")" >> "${GITHUB_ENV}"
 
+      - name: Install minisign
+        shell: pwsh
+        run: ./scripts/ci/install-windows-minisign.ps1
+
       - name: Finalize Windows updater signatures and checksums
         shell: bash
         run: ./scripts/ci/desktop-windows-release.sh finalize

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -246,6 +246,10 @@ jobs:
           setup_exe="$(windows_release_setup_exe_required)"
           echo "MAPLE_WINDOWS_SETUP_EXE_REL=$(repo_relative_path "${setup_exe}")" >> "${GITHUB_ENV}"
 
+      - name: Install minisign
+        shell: pwsh
+        run: ./scripts/ci/install-windows-minisign.ps1
+
       - name: Finalize Windows updater signatures and checksums
         shell: bash
         run: ./scripts/ci/desktop-windows-release.sh finalize

--- a/scripts/ci/install-windows-minisign.ps1
+++ b/scripts/ci/install-windows-minisign.ps1
@@ -1,0 +1,51 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version 3.0
+
+$minisignVersion = "0.12"
+$minisignSha256 = "37b600344e20c19314b2e82813db2bfdcc408b77b876f7727889dbd46d539479"
+$minisignArchive = "minisign-$minisignVersion-win64.zip"
+$minisignUrl = "https://github.com/jedisct1/minisign/releases/download/$minisignVersion/$minisignArchive"
+
+if ([string]::IsNullOrWhiteSpace($env:RUNNER_TEMP)) {
+  $baseTemp = [System.IO.Path]::GetTempPath()
+} else {
+  $baseTemp = $env:RUNNER_TEMP
+}
+
+$downloadDir = Join-Path $baseTemp "maple-minisign-downloads"
+$extractDir = Join-Path $baseTemp "maple-minisign-$minisignVersion"
+$archivePath = Join-Path $downloadDir $minisignArchive
+
+New-Item -ItemType Directory -Force -Path $downloadDir | Out-Null
+Invoke-WebRequest -Uri $minisignUrl -OutFile $archivePath -TimeoutSec 120
+
+$actualSha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $archivePath).Hash.ToLowerInvariant()
+if ($actualSha256 -ne $minisignSha256) {
+  throw "minisign $minisignVersion hash mismatch. Expected $minisignSha256 but got $actualSha256."
+}
+
+if (Test-Path -LiteralPath $extractDir) {
+  Remove-Item -LiteralPath $extractDir -Recurse -Force
+}
+New-Item -ItemType Directory -Force -Path $extractDir | Out-Null
+Expand-Archive -LiteralPath $archivePath -DestinationPath $extractDir -Force
+
+$osArchitecture = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+$minisignArch = switch ($osArchitecture) {
+  "X64" { "x86_64" }
+  "Arm64" { "aarch64" }
+  default { throw "Unsupported Windows architecture for minisign: $osArchitecture" }
+}
+
+$minisignDir = Join-Path (Join-Path $extractDir "minisign-win64") $minisignArch
+$minisignPath = Join-Path $minisignDir "minisign.exe"
+if (-not (Test-Path -LiteralPath $minisignPath)) {
+  throw "minisign.exe was not found at $minisignPath."
+}
+
+if (-not [string]::IsNullOrWhiteSpace($env:GITHUB_PATH)) {
+  $minisignDir | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+}
+
+& $minisignPath -v
+Write-Host "minisign $minisignVersion installed with verified SHA-256 $minisignSha256"


### PR DESCRIPTION
## Summary
- install a pinned Windows minisign binary before Windows release finalize steps
- verify the downloaded minisign archive SHA-256 before extraction
- apply the same setup to desktop master builds and tagged release builds

## Verification
- git diff --check
- bash -n scripts/ci/_common.sh scripts/ci/desktop-windows-release.sh
- nix flake check
- pre-commit hook via nix develop .#ci: Prettier, web build, bun test

This follows up the signed Windows build where Tauri/Azure bundling succeeded, but finalize failed because minisign was unavailable on the non-Nix Windows runner.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/585" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Windows build and release workflows now include a required setup step for signature tooling, improving reliability of Windows packaging and updater preparation.
  * Added a new Windows CI installation script that securely downloads and verifies the tool before use, with support for both x64 and ARM64 runners.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->