### PR TITLE
Fix Windows release attestation and artifact verifier

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -324,8 +324,6 @@ jobs:
           cat desktop-windows-artifacts.sha256
 
       - name: Attest Windows release artifacts
-        # Keep uploads/verifiers running if GitHub token policy rejects artifact attestation.
-        continue-on-error: true
         uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # was v4
         with:
           subject-checksums: desktop-windows-artifacts.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,8 +271,6 @@ jobs:
           cat windows-release-artifacts.sha256
 
       - name: Attest Windows release artifacts
-        # Keep release uploads running if GitHub token policy rejects artifact attestation.
-        continue-on-error: true
         uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # was v4
         with:
           subject-checksums: windows-release-artifacts.sha256

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -3670,9 +3670,9 @@ verify_windows_authenticode_signatures() {
         $issuer = $signature.SignerCertificate.Issuer
       }
       if ($subject -ne $expectedSubject) {
-        throw "Authenticode signer subject mismatch for $file. Expected=$expectedSubject Actual=$subject Issuer=$issuer"
+        throw "Authenticode signer subject mismatch for $file. Actual=$subject Issuer=$issuer"
       }
-      Write-Host ("verified-windows-authenticode  {0}  subject={1}  issuer={2}" -f $file, $subject, $issuer)
+      Write-Host ("verified-windows-authenticode  {0}  thumbprint={1}" -f $file, $signature.SignerCertificate.Thumbprint)
     }
   ' "${ps_args[@]}"
 }

--- a/scripts/ci/attestation-manifest.sh
+++ b/scripts/ci/attestation-manifest.sh
@@ -48,4 +48,14 @@ if [ "${#proof_files[@]}" -gt 0 ]; then
       done >> "${out}"
 fi
 
+# actions/attest@v4 splits checksum files on the runner platform EOL.
+# Windows runners need CRLF here even when Git Bash generated the file.
+case "$(host_os)" in
+  mingw* | msys* | cygwin*)
+    tmp="$(mktemp)"
+    awk '{ sub(/\r$/, ""); printf "%s\r\n", $0 }' "${out}" > "${tmp}"
+    mv "${tmp}" "${out}"
+    ;;
+esac
+
 cat "${out}"

--- a/scripts/ci/verify-release-artifacts.sh
+++ b/scripts/ci/verify-release-artifacts.sh
@@ -125,6 +125,65 @@ verify_file_manifest() {
   done < "${manifest}"
 }
 
+verify_windows_runtime_manifest() {
+  local manifest="$1"
+  local digest label path expected_path
+  local count=0
+  local expected_paths=(
+    "frontend/src-tauri/resources/windows/MSVCP140.dll"
+    "frontend/src-tauri/resources/windows/MSVCP140_1.dll"
+    "frontend/src-tauri/resources/windows/onnxruntime.dll"
+    "frontend/src-tauri/resources/windows/VCRUNTIME140.dll"
+    "frontend/src-tauri/resources/windows/VCRUNTIME140_1.dll"
+  )
+  declare -A seen=()
+
+  for expected_path in "${expected_paths[@]}"; do
+    seen["${expected_path}"]=0
+  done
+
+  while read -r digest label _; do
+    [ -n "${digest:-}" ] || continue
+
+    if ! [[ "${digest}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+      echo "Invalid Windows runtime manifest line in ${manifest}: ${digest} ${label:-}" >&2
+      return 1
+    fi
+
+    if [ -z "${label:-}" ]; then
+      echo "Missing Windows runtime manifest label in ${manifest}." >&2
+      return 1
+    fi
+
+    path="$(manifest_label_path "${label}")"
+    if [ -z "${seen[${path}]+x}" ]; then
+      echo "Unexpected Windows runtime DLL proof in ${manifest}: ${path}" >&2
+      return 1
+    fi
+
+    if [ "${seen[${path}]}" = "1" ]; then
+      echo "Duplicate Windows runtime DLL proof in ${manifest}: ${path}" >&2
+      return 1
+    fi
+
+    seen["${path}"]=1
+    count=$((count + 1))
+    printf 'verified-windows-runtime-dll-proof  %s  %s\n' "${digest}" "${label}"
+  done < "${manifest}"
+
+  for expected_path in "${expected_paths[@]}"; do
+    if [ "${seen[${expected_path}]}" != "1" ]; then
+      echo "Missing Windows runtime DLL proof in ${manifest}: ${expected_path}" >&2
+      return 1
+    fi
+  done
+
+  if [ "${count}" -ne "${#expected_paths[@]}" ]; then
+    echo "Unexpected Windows runtime DLL proof count in ${manifest}: ${count}" >&2
+    return 1
+  fi
+}
+
 verify_proof_file_hash() {
   local manifest="$1"
   local digest label file actual
@@ -360,7 +419,7 @@ verify_windows() {
 
   verify_file_manifest "${final_manifest}"
   if [ -n "${runtime_manifest}" ]; then
-    verify_file_manifest "${runtime_manifest}"
+    verify_windows_runtime_manifest "${runtime_manifest}"
   fi
   verify_tauri_signatures_in_artifacts
 }


### PR DESCRIPTION
## Summary
- write Windows attestation checksum manifests with CRLF so actions/attest@v4 parses each subject separately on Windows runners
- make Windows attestation failures fail the build instead of silently continuing
- verify Windows runtime DLL proof manifests as proof manifests instead of requiring raw DLLs in downloaded release artifacts
- make Authenticode success logging explicit without printing the configured expected subject secret

## Verification
- bash -n scripts/ci/_common.sh scripts/ci/attestation-manifest.sh scripts/ci/verify-release-artifacts.sh scripts/ci/desktop-windows-release.sh
- git diff --check
- nix flake check
- downloaded maple-windows-x64 from master run 28209035615 and ran: nix develop .#ci -c ./scripts/ci/verify-release-artifacts.sh /tmp/maple-windows-artifacts.7ptTAj windows
- pre-commit hook via nix develop .#ci: Prettier, web build, bun test

This follows the master run where signed Windows build/finalize passed, but verify-windows-desktop-artifacts failed on missing raw runtime DLLs, and actions/attest silently failed because LF-only checksum records were parsed as one subject on the Windows runner.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/586" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Windows release artifact attestation failures now fail the workflow instead of being tolerated, preventing incomplete or unverified releases.
  * Strengthened Windows runtime DLL proof verification with stricter allowlisting, digest/label checks, and detection of missing or duplicate proof entries.
  * Clarified Windows signer verification output to better highlight subject/issuer mismatches.
  * Fixed Windows checksum/proof manifest line-ending handling by normalizing generated checksum file formatting on Windows runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->