### PR TITLE
Relax Windows Trusted Signing issuer check

### DIFF
--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -3653,12 +3653,14 @@ verify_windows_authenticode_signatures() {
 
   # Keep the expected identity fields and file list in the environment. Passing
   # them as positional args through Git Bash into pwsh can split values that
-  # contain spaces. The issuer default is Microsoft Trusted Signing's current
-  # ID-verified code-signing CA; override it if Microsoft rotates the CA.
+  # contain spaces. Microsoft Trusted Signing can issue from multiple numbered
+  # ID-verified code-signing CAs, so the default verifies the issuer family
+  # instead of pinning one rotating CA number.
   # shellcheck disable=SC2016
   if ! MAPLE_WINDOWS_AUTHENTICODE_FILES="$(to_windows_path "${files_manifest}")" \
     MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_CN="${MAPLE_WINDOWS_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME}" \
-    MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER="${MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER:-CN=Microsoft ID Verified CS AOC CA 03, O=Microsoft Corporation, C=US}" \
+    MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER="${MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER:-}" \
+    MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER_PATTERN="${MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER_PATTERN:-^CN=Microsoft ID Verified CS AOC CA [0-9]+,\s*O=Microsoft Corporation,\s*C=US$}" \
     pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command '
     $ErrorActionPreference = "Stop"
     $expectedCn = $env:MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_CN
@@ -3666,8 +3668,9 @@ verify_windows_authenticode_signatures() {
       throw "MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_CN is required to verify the Windows signer identity."
     }
     $expectedIssuer = $env:MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER
-    if ([string]::IsNullOrWhiteSpace($expectedIssuer)) {
-      throw "MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER is required to verify the Windows signer identity."
+    $expectedIssuerPattern = $env:MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER_PATTERN
+    if ([string]::IsNullOrWhiteSpace($expectedIssuer) -and [string]::IsNullOrWhiteSpace($expectedIssuerPattern)) {
+      throw "MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER or MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER_PATTERN is required to verify the Windows signer identity."
     }
     $filesManifest = $env:MAPLE_WINDOWS_AUTHENTICODE_FILES
     if ([string]::IsNullOrWhiteSpace($filesManifest)) {
@@ -3688,8 +3691,11 @@ verify_windows_authenticode_signatures() {
         $subject = $signature.SignerCertificate.Subject
         $issuer = $signature.SignerCertificate.Issuer
       }
-      if ($issuer -ne $expectedIssuer) {
+      if (-not [string]::IsNullOrWhiteSpace($expectedIssuer) -and $issuer -ne $expectedIssuer) {
         throw "Authenticode signer issuer mismatch for $file. ActualIssuer=$issuer Subject=$subject"
+      }
+      if ([string]::IsNullOrWhiteSpace($expectedIssuer) -and -not [regex]::IsMatch($issuer, $expectedIssuerPattern)) {
+        throw "Authenticode signer issuer pattern mismatch for $file. ActualIssuer=$issuer Subject=$subject"
       }
       $expectedCnPattern = "(^|,\s*)CN=$([regex]::Escape($expectedCn))(\s*,|$)"
       if (-not [regex]::IsMatch($subject, $expectedCnPattern)) {


### PR DESCRIPTION
## Summary
- accept Microsoft Trusted Signing's rotating numbered ID-verified issuer CA by default
- keep exact signer CN verification against the configured Azure certificate profile name
- keep an exact issuer override for emergency pinning if needed

## Why
The master signed Windows build reached successful Azure signing, then failed our post-sign Authenticode verification because Microsoft issued from CA 04 while the verifier default pinned CA 03.

## Validation
- bash -n scripts/ci/_common.sh scripts/ci/desktop-windows-release.sh
- git diff --check
- nix flake check
- pre-commit hook via nix develop .#ci -c git commit, including frontend format/build/tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/589" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made Windows signature verification more flexible, allowing valid certificates from rotating Microsoft issuer names to pass.
  * Added support for an optional strict issuer check when a specific issuer is provided, while avoiding unnecessary failures for otherwise valid signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->