### PR TITLE
Fix Windows Authenticode signer subject check

### DIFF
--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -3634,13 +3634,10 @@ verify_windows_authenticode_signatures() {
     return 1
   fi
 
-  if [ -z "${MAPLE_WINDOWS_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME:-}" ]; then
-    echo "MAPLE_WINDOWS_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME is required to verify the Windows signer identity." >&2
-    return 1
-  fi
-
   local files_manifest
   local file
+  local expected_cn
+  expected_cn="${MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_CN:-Mutiny Wallet Inc. dba OpenSecret}"
   files_manifest="$(mktemp)"
   for file in "$@"; do
     if [ ! -f "${file}" ]; then
@@ -3658,7 +3655,7 @@ verify_windows_authenticode_signatures() {
   # instead of pinning one rotating CA number.
   # shellcheck disable=SC2016
   if ! MAPLE_WINDOWS_AUTHENTICODE_FILES="$(to_windows_path "${files_manifest}")" \
-    MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_CN="${MAPLE_WINDOWS_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME}" \
+    MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_CN="${expected_cn}" \
     MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER="${MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER:-}" \
     MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER_PATTERN="${MAPLE_WINDOWS_AUTHENTICODE_EXPECTED_ISSUER_PATTERN:-^CN=Microsoft ID Verified CS AOC CA [0-9]+,\s*O=Microsoft Corporation,\s*C=US$}" \
     pwsh -NoLogo -NoProfile -ExecutionPolicy Bypass -Command '


### PR DESCRIPTION
## Summary
- decouple Windows Authenticode subject verification from the Azure certificate profile name
- default the expected signer CN to the public production certificate CN observed from the signed master build
- keep the issuer verifier on the Microsoft ID Verified CS AOC CA family pattern

## Verification
- `bash -n scripts/ci/_common.sh scripts/ci/desktop-windows-release.sh`
- `git diff --check`
- `nix develop .#ci -c git commit -m ...` pre-commit hook: Prettier, frontend build, Bun tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->