### PR TITLE
Add Windows signed payload reproducibility proof

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -275,6 +275,10 @@ jobs:
         shell: bash
         run: ./scripts/ci/desktop-windows-release.sh build
 
+      - name: Bundle Windows unsigned installer baseline
+        shell: bash
+        run: ./scripts/ci/desktop-windows-release.sh unsigned-bundle
+
       - name: Azure login for Artifact Signing
         uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # was v3
         with:
@@ -319,6 +323,7 @@ jobs:
           ./scripts/ci/attestation-manifest.sh \
             desktop-windows-artifacts.sha256 \
             frontend/src-tauri/target/reproducibility/desktop-release-windows-final.sha256 \
+            frontend/src-tauri/target/reproducibility/desktop-release-windows-signed-canonical.sha256 \
             frontend/src-tauri/target/reproducibility/desktop-release-windows-runtime-dlls.sha256
           cat desktop-windows-artifacts.sha256
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -222,6 +222,10 @@ jobs:
         shell: bash
         run: ./scripts/ci/desktop-windows-release.sh build
 
+      - name: Bundle Windows unsigned installer baseline
+        shell: bash
+        run: ./scripts/ci/desktop-windows-release.sh unsigned-bundle
+
       - name: Azure login for Artifact Signing
         uses: azure/login@2dd0bbf4064d5a1812889dc200bb8eed2597f82a # was v3
         with:
@@ -266,6 +270,7 @@ jobs:
           ./scripts/ci/attestation-manifest.sh \
             windows-release-artifacts.sha256 \
             frontend/src-tauri/target/reproducibility/desktop-release-windows-final.sha256 \
+            frontend/src-tauri/target/reproducibility/desktop-release-windows-signed-canonical.sha256 \
             frontend/src-tauri/target/reproducibility/desktop-release-windows-runtime-dlls.sha256
           cat windows-release-artifacts.sha256
 

--- a/flake.nix
+++ b/flake.nix
@@ -185,6 +185,7 @@
           just
           minisign
           openssl
+          p7zip
           pkg-config
           python3
           sccache

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -1661,6 +1661,20 @@ remove_apple_signing_metadata() {
   scrub_host_metadata_files "${root}"
 }
 
+python3_runner() {
+  local candidate
+
+  for candidate in python3 python py; do
+    if command -v "${candidate}" >/dev/null 2>&1; then
+      printf '%s\n' "${candidate}"
+      return 0
+    fi
+  done
+
+  echo "Python 3 is required but python3, python, and py were not found." >&2
+  return 1
+}
+
 print_canonical_apple_bundle_hash() {
   local bundle="$1"
   local label="${2:-$(repo_relative_path "${bundle}")}"
@@ -1690,7 +1704,7 @@ canonical_apple_bundle_hash_from_path_digest() {
 
 canonical_apple_bundle_hash_digest() {
   local bundle="$1"
-  python3 "${REPO_ROOT}/scripts/ci/canonical-ios-app-hash.py" "${bundle}"
+  "$(python3_runner)" "${REPO_ROOT}/scripts/ci/canonical-ios-app-hash.py" "${bundle}"
 }
 
 find_canonical_app_bundle_under_dir() {
@@ -1785,6 +1799,41 @@ print_canonical_ipa_payload_hash() {
   rm -rf "${tmp}"
 
   printf 'sha256-ios-unsigned-app-tree  %s  %s::Payload/*.app\n' "${digest}" "${label}"
+}
+
+print_canonical_windows_nsis_payload_hash() {
+  local installer="$1"
+  local label="${2:-$(repo_relative_path "${installer}")}"
+
+  "$(python3_runner)" "${REPO_ROOT}/scripts/ci/canonical-windows-nsis-payload-hash.py" \
+    "${installer}" \
+    "${label}"
+}
+
+write_windows_signed_canonical_manifest() {
+  local manifest="$1"
+  local signed_installer="$2"
+  local unsigned_installer="$3"
+  local signed_label unsigned_label output
+
+  signed_label="$(repo_relative_path "${signed_installer}")"
+  unsigned_label="$(repo_relative_path "${unsigned_installer}")"
+
+  output="$(
+    "$(python3_runner)" "${REPO_ROOT}/scripts/ci/canonical-windows-nsis-payload-hash.py" \
+      --compare \
+      "${signed_installer}" \
+      "${unsigned_installer}" \
+      "${signed_label}" \
+      "${unsigned_label}"
+  )"
+  printf '%s\n' "${output}"
+  printf '%s\n' "${output}" | awk '$1 == "sha256-windows-nsis-payload-canonical" { print }' > "${manifest}"
+
+  if [ ! -s "${manifest}" ]; then
+    echo "Windows signed canonical manifest was not written: ${manifest}" >&2
+    return 1
+  fi
 }
 
 tauri_updater_public_key_file() {
@@ -3604,6 +3653,10 @@ windows_release_setup_exe_path() {
 
 windows_release_setup_sig_path() {
   printf '%s.sig\n' "$(windows_release_setup_exe_path)"
+}
+
+windows_release_unsigned_setup_exe_path() {
+  printf '%s\n' "${TAURI_DIR}/target/reproducibility/windows-unsigned/$(windows_release_setup_exe_basename)"
 }
 
 windows_release_setup_exes_found() {

--- a/scripts/ci/canonical-windows-nsis-payload-hash.py
+++ b/scripts/ci/canonical-windows-nsis-payload-hash.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+import argparse
+import hashlib
+import os
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+
+PE_CERTIFICATE_DIRECTORY_INDEX = 4
+
+
+def sha256_bytes(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def read_u16(data, offset):
+    if offset < 0 or offset + 2 > len(data):
+        raise ValueError("offset outside file")
+    return struct.unpack_from("<H", data, offset)[0]
+
+
+def read_u32(data, offset):
+    if offset < 0 or offset + 4 > len(data):
+        raise ValueError("offset outside file")
+    return struct.unpack_from("<I", data, offset)[0]
+
+
+def write_u32(data, offset, value):
+    if offset < 0 or offset + 4 > len(data):
+        raise ValueError("offset outside file")
+    struct.pack_into("<I", data, offset, value)
+
+
+def is_pe(data):
+    if len(data) < 0x40 or data[:2] != b"MZ":
+        return False
+    try:
+        pe_offset = read_u32(data, 0x3C)
+        return pe_offset + 4 <= len(data) and data[pe_offset : pe_offset + 4] == b"PE\0\0"
+    except ValueError:
+        return False
+
+
+def canonical_pe_bytes(data, label):
+    if not is_pe(data):
+        return data
+
+    out = bytearray(data)
+    pe_offset = read_u32(out, 0x3C)
+    coff_offset = pe_offset + 4
+    optional_offset = coff_offset + 20
+    optional_size = read_u16(out, coff_offset + 16)
+
+    if optional_offset + optional_size > len(out):
+        raise ValueError(f"PE optional header exceeds file size: {label}")
+
+    magic = read_u16(out, optional_offset)
+    if magic == 0x10B:
+        data_directory_offset = optional_offset + 96
+    elif magic == 0x20B:
+        data_directory_offset = optional_offset + 112
+    else:
+        raise ValueError(f"Unsupported PE optional header magic 0x{magic:x}: {label}")
+
+    checksum_offset = optional_offset + 64
+    certificate_directory_offset = data_directory_offset + (8 * PE_CERTIFICATE_DIRECTORY_INDEX)
+    if certificate_directory_offset + 8 > optional_offset + optional_size:
+        raise ValueError(f"PE certificate directory is outside optional header: {label}")
+
+    certificate_offset = read_u32(out, certificate_directory_offset)
+    certificate_size = read_u32(out, certificate_directory_offset + 4)
+
+    write_u32(out, checksum_offset, 0)
+    write_u32(out, certificate_directory_offset, 0)
+    write_u32(out, certificate_directory_offset + 4, 0)
+
+    if certificate_offset == 0 and certificate_size == 0:
+        return bytes(out)
+
+    aligned_certificate_size = (certificate_size + 7) & ~7
+    certificate_end = certificate_offset + aligned_certificate_size
+    if certificate_offset > len(out) or certificate_end > len(out):
+        raise ValueError(f"PE certificate table points outside file: {label}")
+
+    if certificate_end != len(out):
+        raise ValueError(
+            f"PE certificate table is not appended at EOF and cannot be safely stripped: {label}"
+        )
+
+    return bytes(out[:certificate_offset])
+
+
+def require_7z():
+    for candidate in [
+        shutil.which("7z"),
+        shutil.which("7z.exe"),
+        os.path.join(os.environ.get("ProgramFiles", ""), "7-Zip", "7z.exe"),
+        os.path.join(os.environ.get("ProgramFiles(x86)", ""), "7-Zip", "7z.exe"),
+    ]:
+        if candidate and os.path.isfile(candidate):
+            return candidate
+    raise RuntimeError("7z is required to extract NSIS installers")
+
+
+def extract_installer(installer, destination):
+    seven_zip = require_7z()
+    subprocess.run(
+        [seven_zip, "x", "-y", f"-o{destination}", installer],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+
+def canonical_tree_entries(root):
+    entries = []
+    for current_root, dirs, files in os.walk(root):
+        dirs.sort()
+        for name in sorted(files):
+            path = os.path.join(current_root, name)
+            rel = os.path.relpath(path, root).replace(os.sep, "/")
+            with open(path, "rb") as f:
+                canonical = canonical_pe_bytes(f.read(), rel)
+            entries.append((rel, len(canonical), sha256_bytes(canonical)))
+    return entries
+
+
+def canonical_tree_hash(installer):
+    with tempfile.TemporaryDirectory() as tmp:
+        extract_installer(installer, tmp)
+        entries = canonical_tree_entries(tmp)
+
+    digest_input = "".join(
+        f"{digest}  {size}  {rel}\n" for rel, size, digest in entries
+    ).encode("utf-8")
+    return sha256_bytes(digest_input), entries
+
+
+def print_manifest(installer, label):
+    digest, _ = canonical_tree_hash(installer)
+    print(f"sha256-windows-nsis-payload-canonical  {digest}  {label}")
+    return digest
+
+
+def compare_installers(signed_installer, unsigned_installer, signed_label, unsigned_label):
+    signed_digest, signed_entries = canonical_tree_hash(signed_installer)
+    unsigned_digest, unsigned_entries = canonical_tree_hash(unsigned_installer)
+
+    if signed_entries != unsigned_entries:
+        print("Windows signed-vs-unsigned NSIS canonical payload mismatch.", file=sys.stderr)
+        signed_by_path = {rel: (size, digest) for rel, size, digest in signed_entries}
+        unsigned_by_path = {rel: (size, digest) for rel, size, digest in unsigned_entries}
+        for rel in sorted(set(signed_by_path) | set(unsigned_by_path)):
+            signed_value = signed_by_path.get(rel)
+            unsigned_value = unsigned_by_path.get(rel)
+            if signed_value != unsigned_value:
+                print(
+                    f"mismatch  {rel}  signed={signed_value}  unsigned={unsigned_value}",
+                    file=sys.stderr,
+                )
+        return 1
+
+    if signed_digest != unsigned_digest:
+        print("Windows signed-vs-unsigned NSIS canonical tree digest mismatch.", file=sys.stderr)
+        print(f"signed={signed_digest}", file=sys.stderr)
+        print(f"unsigned={unsigned_digest}", file=sys.stderr)
+        return 1
+
+    print(f"sha256-windows-nsis-payload-canonical  {signed_digest}  {signed_label}")
+    print(
+        "verified-windows-signed-vs-unsigned-payload-canonical  "
+        f"{signed_digest}  {signed_label}  {unsigned_label}"
+    )
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compute or compare canonical NSIS payload hashes for Windows installers."
+    )
+    parser.add_argument("--compare", action="store_true", help="compare signed and unsigned installers")
+    parser.add_argument("paths", nargs="+")
+    args = parser.parse_args()
+
+    try:
+        if args.compare:
+            if len(args.paths) not in {2, 4}:
+                parser.error("--compare requires signed unsigned [signed-label unsigned-label]")
+            signed_installer = args.paths[0]
+            unsigned_installer = args.paths[1]
+            signed_label = args.paths[2] if len(args.paths) == 4 else signed_installer
+            unsigned_label = args.paths[3] if len(args.paths) == 4 else unsigned_installer
+            return compare_installers(
+                signed_installer,
+                unsigned_installer,
+                signed_label,
+                unsigned_label,
+            )
+
+        if len(args.paths) not in {1, 2}:
+            parser.error("hash mode requires installer [label]")
+        installer = args.paths[0]
+        label = args.paths[1] if len(args.paths) == 2 else installer
+        print_manifest(installer, label)
+        return 0
+    except (OSError, RuntimeError, ValueError, subprocess.CalledProcessError) as exc:
+        print(f"canonical-windows-nsis-payload-hash: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/desktop-windows-release.sh
+++ b/scripts/ci/desktop-windows-release.sh
@@ -5,16 +5,21 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
 
 usage() {
   cat >&2 <<'EOF'
-usage: desktop-windows-release.sh <build|bundle|finalize>
+usage: desktop-windows-release.sh <build|unsigned-bundle|bundle|finalize>
 
 build
   Prepare the reproducible Windows release environment, build frontend assets,
   stage pinned runtime DLLs, and compile maple.exe without bundling.
 
+unsigned-bundle
+  Generate an unsigned release-environment NSIS installer from the built app and
+  save it under target/reproducibility as the signed-build comparison baseline.
+
 bundle
   Generate the NSIS installer. Tauri patches and signs maple.exe through
   bundle.windows.signCommand during bundling, signs the installer, then restores
-  target/release/maple.exe to its original unsigned/unpatched bytes.
+  target/release/maple.exe to its original unsigned/unpatched bytes. The signed
+  installer's canonical payload is compared against the unsigned-bundle baseline.
 
 finalize
   Verify Authenticode signatures on the NSIS installer, create the final Tauri
@@ -25,7 +30,7 @@ EOF
 
 mode="${1:-}"
 case "${mode}" in
-  build | bundle | finalize)
+  build | unsigned-bundle | bundle | finalize)
     ;;
   -h | --help | help)
     usage
@@ -67,7 +72,7 @@ run_build_phase() {
 }
 
 run_bundle_phase() {
-  local app_exe setup_exe
+  local app_exe setup_exe unsigned_setup
 
   print_source_provenance
   configure_sccache
@@ -77,6 +82,13 @@ run_bundle_phase() {
   app_exe="$(windows_release_app_exe)"
   if [ ! -f "${app_exe}" ]; then
     echo "Windows app executable is missing before bundling: ${app_exe}" >&2
+    exit 1
+  fi
+
+  unsigned_setup="$(windows_release_unsigned_setup_exe_path)"
+  if [ ! -f "${unsigned_setup}" ]; then
+    echo "Windows unsigned release baseline is missing: ${unsigned_setup}" >&2
+    echo "Run desktop-windows-release.sh unsigned-bundle before bundle." >&2
     exit 1
   fi
 
@@ -91,7 +103,54 @@ run_bundle_phase() {
   # artifact at this point is the NSIS installer; installed-payload verification
   # should inspect an extracted installer payload, not the restored build output.
   verify_windows_authenticode_signatures "${setup_exe}"
+  write_windows_signed_canonical_manifest \
+    "${TAURI_DIR}/target/reproducibility/desktop-release-windows-signed-canonical.sha256" \
+    "${setup_exe}" \
+    "${unsigned_setup}"
   print_file_hashes "${setup_exe}"
+  verify_frontend_dist_unchanged
+}
+
+run_unsigned_bundle_phase() {
+  local app_exe setup_exe unsigned_setup unsigned_dir app_backup
+
+  print_source_provenance
+  configure_sccache
+  use_release_environment
+  configure_reproducible_build_metadata
+
+  app_exe="$(windows_release_app_exe)"
+  if [ ! -f "${app_exe}" ]; then
+    echo "Windows app executable is missing before unsigned bundling: ${app_exe}" >&2
+    exit 1
+  fi
+
+  cd "${FRONTEND_DIR}"
+  remove_build_tree "${TAURI_DIR}/target/release/bundle/nsis"
+  remove_build_tree "${TAURI_DIR}/target/release/bundle/msi"
+
+  app_backup="$(mktemp)"
+  cp -f "${app_exe}" "${app_backup}"
+  restore_unsigned_bundle_app_exe() {
+    if [ -n "${app_backup:-}" ] && [ -f "${app_backup}" ]; then
+      cp -f "${app_backup}" "${app_exe}"
+      rm -f "${app_backup}"
+    fi
+  }
+  trap restore_unsigned_bundle_app_exe EXIT HUP INT TERM
+
+  bun tauri bundle --verbose --bundles nsis --no-sign --config "$(windows_tauri_release_build_config)"
+  cp -f "${app_backup}" "${app_exe}"
+  rm -f "${app_backup}"
+  trap - EXIT HUP INT TERM
+
+  setup_exe="$(windows_release_setup_exe_required)"
+  unsigned_setup="$(windows_release_unsigned_setup_exe_path)"
+  unsigned_dir="$(dirname "${unsigned_setup}")"
+  mkdir -p "${unsigned_dir}"
+  cp -f "${setup_exe}" "${unsigned_setup}"
+
+  print_file_hashes "${setup_exe}" "${unsigned_setup}"
   verify_frontend_dist_unchanged
 }
 
@@ -136,6 +195,9 @@ run_finalize_phase() {
 case "${mode}" in
   build)
     run_build_phase
+    ;;
+  unsigned-bundle)
+    run_unsigned_bundle_phase
     ;;
   bundle)
     run_bundle_phase

--- a/scripts/ci/verify-release-artifacts.sh
+++ b/scripts/ci/verify-release-artifacts.sh
@@ -184,6 +184,36 @@ verify_windows_runtime_manifest() {
   fi
 }
 
+verify_windows_canonical_manifest() {
+  local manifest="$1"
+  local kind digest label artifact actual
+
+  while read -r kind digest label _; do
+    [ -n "${kind:-}" ] || continue
+
+    if [ "${kind}" != "sha256-windows-nsis-payload-canonical" ]; then
+      echo "Invalid Windows canonical manifest line in ${manifest}: ${kind} ${digest:-} ${label:-}" >&2
+      return 1
+    fi
+
+    if ! [[ "${digest}" =~ ^[0-9a-fA-F]{64}$ ]]; then
+      echo "Invalid Windows canonical digest in ${manifest}: ${digest}" >&2
+      return 1
+    fi
+
+    artifact="$(artifact_for_label "${label}")"
+    actual="$(print_canonical_windows_nsis_payload_hash "${artifact}" "${label}" | awk '{ print $2 }')"
+    if [ "${actual}" != "${digest}" ]; then
+      echo "Windows canonical NSIS payload hash mismatch for ${label}." >&2
+      echo "expected=${digest}" >&2
+      echo "actual=${actual}" >&2
+      return 1
+    fi
+
+    printf 'verified-windows-canonical-payload  %s  %s\n' "${actual}" "${label}"
+  done < "${manifest}"
+}
+
 verify_proof_file_hash() {
   local manifest="$1"
   local digest label file actual
@@ -408,18 +438,24 @@ verify_linux_present() {
 }
 
 verify_windows() {
-  local final_manifest runtime_manifest
+  local final_manifest runtime_manifest canonical_manifest
 
   final_manifest="$(proof_file_optional desktop-release-windows-final.sha256)"
   runtime_manifest="$(proof_file_optional desktop-release-windows-runtime-dlls.sha256)"
-  if [ -z "${final_manifest}" ]; then
+  if [ -n "${final_manifest}" ]; then
+    canonical_manifest="$(proof_file_required desktop-release-windows-signed-canonical.sha256)"
+  else
     final_manifest="$(proof_file_required desktop-pr-windows-final.sha256)"
     runtime_manifest="$(proof_file_required desktop-pr-windows-runtime-dlls.sha256)"
+    canonical_manifest=""
   fi
 
   verify_file_manifest "${final_manifest}"
   if [ -n "${runtime_manifest}" ]; then
     verify_windows_runtime_manifest "${runtime_manifest}"
+  fi
+  if [ -n "${canonical_manifest}" ]; then
+    verify_windows_canonical_manifest "${canonical_manifest}"
   fi
   verify_tauri_signatures_in_artifacts
 }


### PR DESCRIPTION
## Summary
- add a Windows NSIS canonical payload hasher that extracts installers and strips PE Authenticode certificate tables before hashing the installed payload tree
- build an unsigned release-environment Windows installer baseline before Azure signing, then compare the signed installer's canonical payload against it
- publish and verify `desktop-release-windows-signed-canonical.sha256` in master and release Windows artifacts
- add `p7zip` to the flake CI shell for Linux verifier jobs

## Verification
- `bash -n scripts/ci/_common.sh scripts/ci/desktop-windows-release.sh scripts/ci/verify-release-artifacts.sh`
- `python3 -m py_compile scripts/ci/canonical-windows-nsis-payload-hash.py`
- `actionlint`
- `git diff --check`
- `nix flake check`
- verified downloaded signed Windows artifact with injected canonical proof using `verify-release-artifacts.sh ... windows`
- confirmed PR Windows artifacts still verify without release-only canonical proof

Note: PR CI is unsigned. The decisive end-to-end check for the signed-vs-unsigned comparison is the next master signed Windows build after merge.
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->