### PR TITLE
Fix release AppImage asset selection

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -149,8 +149,8 @@ jobs:
             -name '*.dmg' -o \
             -name '*.app.tar.gz' -o \
             -name '*.app.tar.gz.sig' -o \
-            -name '*.AppImage' -o \
-            -name '*.AppImage.sig' -o \
+            -name 'Maple_*.AppImage' -o \
+            -name 'Maple_*.AppImage.sig' -o \
             -name '*.deb' -o \
             -name '*.deb.sig' -o \
             -name '*.rpm' -o \

--- a/scripts/ci/latest-json.sh
+++ b/scripts/ci/latest-json.sh
@@ -47,8 +47,8 @@ find_one_artifact() {
 
 macos_bundle="$(find_one_artifact '*.app.tar.gz')"
 macos_sig="$(find_one_artifact '*.app.tar.gz.sig')"
-linux_bundle="$(find_one_artifact '*.AppImage')"
-linux_sig="$(find_one_artifact '*.AppImage.sig')"
+linux_bundle="$(find_one_artifact 'Maple_*.AppImage')"
+linux_sig="$(find_one_artifact 'Maple_*.AppImage.sig')"
 windows_bundle_basename="$(windows_release_setup_exe_basename_for_version "${release_tag#v}")"
 windows_bundle="$(find_one_artifact "${windows_bundle_basename}")"
 windows_sig="$(find_one_artifact "${windows_bundle_basename}.sig")"


### PR DESCRIPTION
## Summary
- upload only Maple product AppImages from the release workflow instead of internal linuxdeploy helper AppImages
- make latest.json select Maple_*.AppImage and Maple_*.AppImage.sig explicitly

## Root cause
The release upload glob searched all of frontend/src-tauri/target for *.AppImage, so internal linuxdeploy helper AppImages were uploaded as release assets. The stricter latest.json selector then correctly failed because it found multiple AppImages.

## Verification
- bash -n scripts/ci/latest-json.sh
- git diff --check
- nix develop .#ci -c actionlint .github/workflows/release.yml
- local fixture: old *.AppImage glob found 5 files, new Maple_*.AppImage glob found 1
- pre-commit hook through nix develop .#ci: Prettier, frontend build, Bun tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/593" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->