### PR TITLE
Add Goose agent mode

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -244,7 +244,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
-          toolchain: 1.88.0
+          toolchain: 1.91.1
 
       - name: Install sccache
         shell: bash

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
       - name: Select Xcode 26.5
@@ -100,6 +101,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
@@ -179,6 +181,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
@@ -204,6 +207,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
@@ -230,6 +234,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
@@ -352,6 +357,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -14,6 +14,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
       - name: Select Xcode 26.5
@@ -72,6 +73,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
@@ -129,6 +131,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
@@ -196,6 +199,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -141,7 +141,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
-          toolchain: 1.88.0
+          toolchain: 1.91.1
 
       - name: Install sccache
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -193,7 +193,7 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # was stable
         with:
-          toolchain: 1.88.0
+          toolchain: 1.91.1
 
       - name: Install sccache
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,6 +56,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
       - name: Select Xcode 26.5
@@ -182,6 +183,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@f4d14e03ff726c06358e5557344e1da148b56cf7 # was v1
@@ -592,6 +594,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
@@ -618,6 +621,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
       - name: Select Xcode 26.5
@@ -663,6 +667,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
           persist-credentials: false
+          submodules: recursive
 
       - name: Install Nix
         uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22

--- a/.gitignore
+++ b/.gitignore
@@ -88,4 +88,3 @@ frontend/*.local
 
 # iOS build backups
 frontend/src-tauri/gen/apple/maple.xcodeproj/project.pbxproj.backup
-frontend/src-tauri/bin/goose*

--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,4 @@ frontend/*.local
 
 # iOS build backups
 frontend/src-tauri/gen/apple/maple.xcodeproj/project.pbxproj.backup
+frontend/src-tauri/bin/goose*

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ThirdParties/goose"]
 	path = ThirdParties/goose
-	url = https://github.com/aaif-goose/goose.git
+	url = https://github.com/AnthonyRonning/goose.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "ThirdParties/goose"]
+	path = ThirdParties/goose
+	url = https://github.com/aaif-goose/goose.git

--- a/docs/goose-embedded-readiness-feedback.md
+++ b/docs/goose-embedded-readiness-feedback.md
@@ -1,0 +1,506 @@
+# Goose Embedded Runtime Readiness Feedback
+
+This note is feedback from Maple's Agent Mode proof of concept. Maple embeds
+Goose inside the Tauri desktop process and uses Maple's local OpenAI-compatible
+proxy as the model provider. The PoC now works, but the path is not clean enough
+to ship without either carrying Goose-specific integration debt or getting a
+more explicit embedded-runtime surface from Goose.
+
+The scope here is intentionally narrow:
+
+- This is about embedding Goose directly in Maple's Rust/Tauri desktop runtime.
+- This is not a critique of ACP as a protocol or of remote ACP interoperability.
+- This is not about Maple frontend UX.
+- This does not cover broad provider compatibility. The provider-specific fixes
+  Maple may need should stay Maple's responsibility unless they expose a concrete
+  Goose parser/runtime bug.
+
+## Current Maple Shape
+
+The current PR embeds Goose by depending on a forked submodule:
+
+- Submodule: `ThirdParties/goose`
+- Rust dependency: `goose = { path = "../../ThirdParties/goose/crates/goose", default-features = false }`
+- Goose runtime entrypoint used by Maple:
+  - `goose::acp::server_factory::{AcpServer, AcpServerFactoryConfig}`
+  - `goose::acp::transport::create_router`
+  - `goose::agents::GoosePlatform`
+  - `goose::config::Config::global()`
+
+Maple starts Goose inside Tauri by:
+
+1. Ensuring Maple's local proxy is running.
+2. Creating a Maple-owned Goose root under Maple's app config directory.
+3. Mutating process environment variables used by Goose.
+4. Writing Goose provider/model/key settings through `Config::global()`.
+5. Creating an `AcpServer`.
+6. Wrapping Goose's router in a local Axum server.
+7. Returning the local endpoint to the Maple frontend.
+
+That is viable for a PoC, but the host app is reaching into internal runtime
+details, global config, process environment, and a forked source checkout.
+
+## P0: Stable Embeddable Runtime Crate
+
+### Problem
+
+Maple currently imports the parent `goose` crate from a Git submodule and calls
+APIs that appear designed primarily for Goose's own desktop/server binaries.
+That creates several shipping problems:
+
+- Maple needs a fork/submodule instead of a normal published crate dependency.
+- The integration depends on internal module layout staying stable.
+- Maple's reproducible builds now depend on a nested source checkout.
+- It is unclear which APIs Goose considers supported for external embedders.
+
+### Current Workaround
+
+Maple carries:
+
+```toml
+[target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
+goose = { path = "../../ThirdParties/goose/crates/goose", default-features = false }
+```
+
+### Requested Goose Improvement
+
+Expose and support a small embeddable runtime crate, for example `goose-runtime`
+or a GDK crate, with a semver-stable API for:
+
+- Constructing a Goose runtime from host-owned config.
+- Starting and stopping the runtime.
+- Selecting built-in tool groups.
+- Configuring provider/model settings.
+- Setting data/config/state/log directories.
+- Receiving structured lifecycle and diagnostics events.
+
+This does not need to expose every Goose internal. The important line is that
+Maple should be able to depend on a normal crate and avoid reaching through the
+same entrypoints used by Goose's own binaries.
+
+## P0: Host-Owned Runtime Configuration
+
+### Problem
+
+The current embedding path is too global. Maple has to configure Goose by
+setting process environment variables, mutating `Config::global()`, and writing
+Goose config/secrets files:
+
+```rust
+std::env::set_var("GOOSE_PATH_ROOT", goose_path_root);
+std::env::set_var("GOOSE_DISABLE_KEYRING", "true");
+std::env::remove_var("GOOSE_MAX_TOKENS");
+
+let config = goose::config::Config::global();
+goose::config::set_active_provider(config, "openai", model)?;
+config.set_param("GOOSE_FAST_MODEL", model)?;
+config.set_param("GOOSE_MODE", mode)?;
+config.set_param("OPENAI_BASE_URL", format!("{maple_proxy_base_url}/v1"))?;
+config.set_secret("OPENAI_API_KEY", &proxy_api_key)?;
+```
+
+This is risky for an embedded desktop app:
+
+- Process-global environment is hard to test and hard to reason about.
+- Two runtimes in one process would conflict.
+- Host apps cannot cleanly separate user config from runtime config.
+- Secrets flow through Goose's default config path even when the host already
+  owns secret storage.
+- The host has to know which global keys to delete, such as `GOOSE_MAX_TOKENS`,
+  to avoid stale behavior.
+
+### Current Workaround
+
+Maple creates `config`, `data`, and `state` directories under its own app config
+root, points `GOOSE_PATH_ROOT` there, disables keyring use, writes Goose config
+values, and locks down file permissions after writing `config.yaml` and
+`secrets.yaml`.
+
+### Requested Goose Improvement
+
+Provide a runtime config builder that does not require process-global mutation:
+
+```rust
+let runtime = GooseRuntime::builder()
+    .path_root(goose_path_root)
+    .config_dir(goose_config_dir)
+    .data_dir(goose_data_dir)
+    .state_dir(goose_state_dir)
+    .disable_keyring(true)
+    .provider(OpenAiCompatibleProvider {
+        base_url: maple_proxy_base_url,
+        api_key: SecretString::new(proxy_api_key),
+        model,
+        fast_model: Some(model),
+    })
+    .mode(mode)
+    .builtins(["developer"])
+    .build()?;
+```
+
+The exact names do not matter. The important requirement is that an embedded
+host can configure Goose with normal Rust values, without environment variables
+or global singleton config.
+
+## P0: Upstream the Streaming Tool-Call Delta Fix
+
+### Problem
+
+The PoC exposed a concrete Goose parser bug in OpenAI-compatible streaming tool
+calls. Some providers stream multiple `tool_calls` entries for the same index in
+one chunk. One entry can carry the tool id/name while another same-index entry
+carries only argument fragments.
+
+Before the patch, Goose could drop the argument-only fragment. The remaining
+arguments then looked truncated, and Goose surfaced a misleading parse failure
+similar to:
+
+```text
+The model's response was truncated -- it hit the output token limit while generating this tool call.
+```
+
+The tool never executed. The model had actually produced a valid tool call, but
+Goose's stream merger lost part of the argument JSON.
+
+### Current Workaround
+
+Maple's Goose submodule points at a fork containing:
+
+- `ThirdParties/goose/crates/goose-provider-types/src/formats/openai.rs`
+- commit: `1e03dbd Merge streaming tool call deltas by index`
+
+The patch merges streaming tool-call deltas by `index`, preserving id, function
+name, argument fragments, and extra metadata.
+
+### Requested Goose Improvement
+
+Upstream this parser behavior and keep a regression test covering:
+
+- Multiple tool-call deltas with the same `index` in a single stream chunk.
+- id/name arriving separately from arguments.
+- Argument fragments being appended in arrival order.
+- No false "output token limit" error when the merged argument JSON is complete.
+
+This is not a broad provider-compatibility ask. It is a concrete streaming
+parser correctness issue that directly affected embedding Goose with Maple's
+local OpenAI-compatible proxy.
+
+## P0: Embedding-Friendly Dependency and MSRV Boundary
+
+### Problem
+
+Embedding Goose changed Maple's desktop build surface. Two concrete issues came
+up:
+
+- Goose v1.41.0 declared `rmcp = "1.4"` in its workspace, but the embedded build
+  did not compile against the current 1.x API without pinning `rmcp = "=1.4.0"`.
+- Maple had to align desktop CI around Rust 1.91.1 after Goose entered the
+  desktop dependency graph.
+
+Those may be reasonable requirements, but embedders need them to be explicit and
+stable. A desktop app with reproducible builds needs to know the exact supported
+dependency and toolchain boundary before shipping.
+
+### Current Workaround
+
+Maple pins `rmcp` next to the Goose path dependency:
+
+```toml
+rmcp = { version = "=1.4.0", default-features = false }
+```
+
+Maple also limits Goose to desktop targets only, so web/iOS/Android do not pull
+the embedded runtime.
+
+### Requested Goose Improvement
+
+For embedders, Goose should publish one of:
+
+- A crate with dependency constraints that compile correctly without Goose's
+  repository lockfile.
+- A documented lockfile/vendor strategy for external hosts.
+- A minimal embedded feature set that avoids pulling CLI/TUI/desktop-only
+  surfaces when the host only needs the agent runtime.
+
+Also document:
+
+- Supported Rust MSRV.
+- Supported desktop platforms.
+- Required native libraries or build-time assumptions.
+- Which Cargo features are intended for embedded host apps.
+
+## P1: Runtime Lifecycle Handle
+
+### Problem
+
+Maple currently wraps Goose's router in its own Axum server task and implements
+readiness, shutdown, and status tracking around it. That is manageable, but the
+host app is inventing lifecycle semantics around a runtime it does not fully
+own.
+
+### Current Workaround
+
+Maple:
+
+- Finds an available local port.
+- Creates a token.
+- Builds a local URL.
+- Spawns `axum::serve(listener, router)`.
+- Polls `/status` until ready.
+- Stores its own `shutdown_tx`.
+- Tracks runtime status separately for the frontend.
+
+### Requested Goose Improvement
+
+Expose a typed embedded runtime handle:
+
+```rust
+let handle = runtime.start().await?;
+handle.wait_until_ready().await?;
+handle.status().await?;
+handle.stop().await?;
+handle.cancel_session(session_id).await?;
+```
+
+The host can still choose whether to expose ACP, a local socket, or a direct
+Rust API. The embedded runtime should own lifecycle semantics and provide typed
+errors when startup fails.
+
+## P1: Host-Visible Diagnostics Hooks
+
+### Problem
+
+When the initial tool-call failures happened, Maple did not have enough
+host-visible evidence from inside Goose to distinguish:
+
+- A model output issue.
+- A provider/proxy cap.
+- A Goose stream parser bug.
+- A malformed tool-call argument.
+
+Maple eventually added proxy-side raw LLM logging and better error-body logging
+to investigate. That was useful, but it is outside Goose. For an embedded
+runtime, the host app needs diagnostics hooks near the point where Goose sends a
+provider request, consumes the stream, parses tool calls, and decides whether to
+execute a tool.
+
+### Current Workaround
+
+Maple writes several logs:
+
+- Tauri app logs.
+- Goose runtime logs.
+- Maple proxy raw request/response logs.
+- Maple Agent Mode session JSONL.
+
+That gives enough evidence now, but it required Maple-specific logging around
+Goose instead of a structured embedded diagnostics API.
+
+### Requested Goose Improvement
+
+Expose opt-in diagnostics hooks with redaction controls:
+
+- Provider request metadata and redacted request bodies.
+- Raw stream chunks before normalization, when enabled.
+- Normalized stream events.
+- Tool-call parse success/failure details.
+- Tool name, tool id, arguments, and parser error context.
+- Finish reason and upstream usage details when available.
+- Retry attempts and retry reasons.
+
+This should not require changing ACP. It can be a Rust callback, event channel,
+or tracing layer attached to the embedded runtime.
+
+## P1: Runtime Tool and Permission Policy Callback
+
+### Problem
+
+Maple can rely on Goose defaults for the PoC, but a shippable embedded desktop
+agent needs a host-owned policy boundary. The host app should be able to decide
+which tools are enabled and when to ask the user before running a tool.
+
+Some of this can be represented over ACP, but the embedded Goose concern is
+lower-level: Maple needs a Rust-side way to apply policy before Goose executes
+tools.
+
+### Current Workaround
+
+Maple selects Goose's `developer` builtins and configures Goose mode. More
+specific permission behavior remains Goose-owned.
+
+### Requested Goose Improvement
+
+Expose a host policy callback before tool execution:
+
+```rust
+runtime.set_tool_policy(|request| async move {
+    match request.tool_name.as_str() {
+        "shell" if request.is_destructive() => ToolDecision::AskUser,
+        "text_editor" => ToolDecision::Allow,
+        _ => ToolDecision::Default,
+    }
+});
+```
+
+The callback should include:
+
+- Tool name and id.
+- Parsed arguments.
+- Working directory.
+- Session id.
+- Whether Goose believes the operation is read-only or mutating, if known.
+- A way to allow, deny, or defer to a host UI prompt.
+
+## P1: Documented Storage Ownership
+
+### Problem
+
+This is not asking Goose to solve ACP session sync. Maple may build its own
+remote backup/sync layer later.
+
+The embedded runtime issue is simpler: Maple needs to know what Goose stores
+under `config`, `data`, and `state`, which files are stable, which are cache,
+which contain secrets, and what can be safely deleted, migrated, exported, or
+backed up.
+
+### Current Workaround
+
+Maple creates a Goose root under its own app config directory and separately
+keeps Agent Mode session JSONL for the UI. Goose still owns its own config,
+data, and state files beneath that root.
+
+### Requested Goose Improvement
+
+Document storage ownership for embedded hosts:
+
+- Which directories Goose needs.
+- Which files contain secrets.
+- Which files are durable session state.
+- Which files are cache/logs.
+- How to safely delete a session.
+- How to migrate or compact state across Goose versions.
+- Whether a host can export/import a Goose session without relying on ACP.
+
+If Goose wants embedders to treat the whole root as opaque, that is acceptable,
+but it should be documented with backup/delete expectations.
+
+## P1: First-Class OpenAI-Compatible Provider Config
+
+### Problem
+
+Maple's model path is intentionally simple: the desktop app ships a local
+OpenAI-compatible proxy, and Goose should call that proxy. Today Maple gets
+there by configuring Goose's `openai` provider name and writing
+`OPENAI_BASE_URL` / `OPENAI_API_KEY`.
+
+That works, but it is awkward for an embedded app because the host already owns
+the local proxy lifecycle and credential generation.
+
+### Current Workaround
+
+Maple starts the proxy, creates/loads a local proxy API key, and writes that key
+into Goose's config as `OPENAI_API_KEY`.
+
+### Requested Goose Improvement
+
+Allow embedded hosts to pass a provider object directly:
+
+```rust
+ProviderConfig::OpenAiCompatible {
+    base_url,
+    api_key,
+    model,
+    headers,
+    timeout,
+}
+```
+
+This should avoid requiring env-style key names or writing provider secrets to a
+Goose secrets file when the host already has a secret manager.
+
+## P2: Clearer Parser Error Wording
+
+### Problem
+
+The tool-call parser error said the model hit an output token limit. In the case
+Maple debugged, that was not the real root cause. The root cause was lost
+streamed argument fragments before JSON parsing.
+
+### Requested Goose Improvement
+
+When Goose reports tool-call truncation, include the evidence that led to that
+conclusion:
+
+- Upstream finish reason, if known.
+- Whether the JSON was incomplete at end of stream.
+- Number of received argument characters.
+- Tool id/name/index.
+- Last argument fragment.
+
+If the upstream finish reason is not a length/token-limit reason, prefer wording
+like "tool-call arguments ended before valid JSON was complete" instead of
+asserting a token limit.
+
+## P2: Minimal Embedded Example
+
+### Problem
+
+Most of the integration time was spent discovering the right entrypoint,
+configuration keys, directory layout, and startup lifecycle.
+
+### Requested Goose Improvement
+
+Add a small embedded Rust example that:
+
+- Starts Goose from another Rust process.
+- Uses an OpenAI-compatible local endpoint.
+- Sets model, mode, config/data/state dirs, and builtins.
+- Installs a diagnostics hook.
+- Starts and stops cleanly.
+
+A Tauri-specific example would be useful, but a plain Rust example is enough if
+the runtime API is explicit.
+
+## Workarounds Maple Should Remove Before Shipping
+
+These are the concrete PoC compromises Maple should not carry long term:
+
+- Forked Goose submodule in `ThirdParties/goose`.
+- Path dependency on `../../ThirdParties/goose/crates/goose`.
+- Direct imports from Goose modules that are not clearly an embedded public API.
+- `rmcp = "=1.4.0"` pin required by embedding outside Goose's lockfile.
+- Process-global `GOOSE_PATH_ROOT`, `GOOSE_DISABLE_KEYRING`, and
+  `GOOSE_MAX_TOKENS` mutation.
+- Runtime writes to Goose `config.yaml` and `secrets.yaml` for provider config.
+- Host-side deletion of stale Goose config keys.
+- Host-wrapped Axum server lifecycle and readiness polling.
+- Maple proxy-side raw LLM logging as the only way to inspect provider stream
+  failures before Goose normalization.
+
+## Suggested Upstream Patch Order
+
+1. Upstream the OpenAI-compatible streaming tool-call merge fix and regression
+   test.
+2. Document the current best supported embedded entrypoint, even if it is not
+   final GDK shape yet.
+3. Add a host-owned runtime config builder that avoids env/global config.
+4. Publish or stabilize a minimal embedded runtime crate/feature set.
+5. Add diagnostics hooks for provider requests, raw stream chunks, parser
+   failures, and tool execution decisions.
+6. Document Goose storage directories and lifecycle expectations for embedded
+   hosts.
+
+## Success Criteria For Maple
+
+Maple can seriously consider shipping embedded Goose when:
+
+- Goose can be consumed as a normal crate without a forked submodule.
+- Maple can configure Goose with Rust values instead of global env/config
+  mutation.
+- Maple can start, stop, and observe Goose through a typed runtime handle.
+- The streaming tool-call parser fix is upstream.
+- The desktop build footprint, MSRV, and features are documented and stable.
+- Maple can attach host diagnostics and tool policy hooks without patching Goose.
+
+At that point Maple can keep Goose as the built-in agent harness while still
+leaving ACP support for external harnesses as a separate integration layer.

--- a/flake.nix
+++ b/flake.nix
@@ -30,7 +30,7 @@
 
         versions = {
           bun = "1.3.5";
-          rust = "1.88.0";
+          rust = "1.91.1";
           jdk = "21";
           xcode = "26.5";
           android = {

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,6 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@aaif/goose-sdk": "0.20.2",
         "@agentclientprotocol/sdk": "0.19.0",
         "@opensecret/react": "3.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
@@ -88,18 +87,6 @@
     "yaml": "^2.8.3",
   },
   "packages": {
-    "@aaif/goose-binary-darwin-arm64": ["@aaif/goose-binary-darwin-arm64@0.20.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "goose": "bin/goose" } }, "sha512-0wv6UcYxg/dZXRuIUBTL+64Hz0D50PfUA2mJiUEBhWkBmiBCgS/Iymore0gYuayxVV7MzQhKrHqdDPBoo0lqIg=="],
-
-    "@aaif/goose-binary-darwin-x64": ["@aaif/goose-binary-darwin-x64@0.20.2", "", { "os": "darwin", "cpu": "x64", "bin": { "goose": "bin/goose" } }, "sha512-dZG6H1QF/lv/kVc1YmHVKRGJCZtoe9o0N2q4vgvDK0Lz+ZJp/ehKcIxUSqE/zebXDqLb4yWByDGelq5Ud2rnCw=="],
-
-    "@aaif/goose-binary-linux-arm64": ["@aaif/goose-binary-linux-arm64@0.20.2", "", { "os": "linux", "cpu": "arm64", "bin": { "goose": "bin/goose" } }, "sha512-DLbm8r21v4c39dGbLepjXDmXNLsdWw0PFFpRbQtBd2m5Q+xIBgYOx1jNm3EygDQT9yGV9R3WS6SW3LvMJLA3xw=="],
-
-    "@aaif/goose-binary-linux-x64": ["@aaif/goose-binary-linux-x64@0.20.2", "", { "os": "linux", "cpu": "x64", "bin": { "goose": "bin/goose" } }, "sha512-+TgB2+MKj18kbw5PBnDMAWvuy8ZijNxXQL4qRBeMebcx07W3dIf6zoy9xD5mSyce61ugG9vsLt9a+3Pm8qZaRw=="],
-
-    "@aaif/goose-binary-win32-x64": ["@aaif/goose-binary-win32-x64@0.20.2", "", { "os": "win32", "cpu": "x64", "bin": { "goose": "bin/goose.exe" } }, "sha512-P0GrtagS0U/98XW4VuzQ77Fy02bw4wFhzyRWWbR9LDVwY+lLG+AkE5m0Ml/KGKgDWS6gd8BtkAqRxdFw3PM9RQ=="],
-
-    "@aaif/goose-sdk": ["@aaif/goose-sdk@0.20.2", "", { "dependencies": { "@modelcontextprotocol/ext-apps": "^0.3.1", "@modelcontextprotocol/sdk": "^1.27.0", "zod": "^3.25.76" }, "optionalDependencies": { "@aaif/goose-binary-darwin-arm64": "0.20.2", "@aaif/goose-binary-darwin-x64": "0.20.2", "@aaif/goose-binary-linux-arm64": "0.20.2", "@aaif/goose-binary-linux-x64": "0.20.2", "@aaif/goose-binary-win32-x64": "0.20.2" }, "peerDependencies": { "@agentclientprotocol/sdk": "^0.19.0" } }, "sha512-HhsspN1OycRqgKgnUBWC/5xOpJ8zuKWmABax0Br0ZfND94AKKZbsBlya8e+pSM+CvztWLXHRz2KxPQuXYoGyBQ=="],
-
     "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.19.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
@@ -1403,8 +1390,6 @@
     "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
-
-    "@aaif/goose-sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@agentclientprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -211,8 +211,6 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
 
-    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
-
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
@@ -235,10 +233,6 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
-    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@0.3.1", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "^1.2.21", "@oven/bun-darwin-x64": "^1.2.21", "@oven/bun-darwin-x64-baseline": "^1.2.21", "@oven/bun-linux-aarch64": "^1.2.21", "@oven/bun-linux-aarch64-musl": "^1.2.21", "@oven/bun-linux-x64": "^1.2.21", "@oven/bun-linux-x64-baseline": "^1.2.21", "@oven/bun-linux-x64-musl": "^1.2.21", "@oven/bun-linux-x64-musl-baseline": "^1.2.21", "@oven/bun-windows-x64": "^1.2.21", "@oven/bun-windows-x64-baseline": "^1.2.21", "@rollup/rollup-darwin-arm64": "^4.53.3", "@rollup/rollup-darwin-x64": "^4.53.3", "@rollup/rollup-linux-arm64-gnu": "^4.53.3", "@rollup/rollup-linux-x64-gnu": "^4.53.3", "@rollup/rollup-win32-arm64-msvc": "^4.53.3", "@rollup/rollup-win32-x64-msvc": "^4.53.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-Iivz2KwWK8xlRbiWwFB/C4NXqE8VJBoRCbBkJCN98ST2UbQvA6kfyebcLsypiqylJS467XOOaBcI9DeQ3t+zqA=="],
-
-    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
-
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -250,28 +244,6 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@opensecret/react": ["@opensecret/react@3.2.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-tmn52THsD3M3vzC2IErHJuAq9zKAXce16Y77YuaqEM9Vfg6u4ZU6lUIiR3Uvb7ObZSjUaJjxqhdEs6lSChW4iQ=="],
-
-    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
-
-    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
-
-    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
-
-    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
-
-    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
-
-    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
-
-    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
-
-    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
-
-    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
-
-    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
-
-    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 
@@ -575,15 +547,11 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
-    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
-
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
-
-    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
@@ -615,8 +583,6 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
-    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
-
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -624,12 +590,6 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
-
-    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
-
-    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
-
-    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -665,19 +625,9 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
-    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
-
-    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
-
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
-    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
-
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
-
-    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
-
-    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -691,8 +641,6 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
-    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
-
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -705,31 +653,17 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
-    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
-
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
-
-    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
-    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
-
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
-
-    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
-
-    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
-
-    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
-
-    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -755,16 +689,6 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
-    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
-    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
-
-    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
-
-    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
-
-    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
-
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -775,8 +699,6 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
-    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
-
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -784,8 +706,6 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
-
-    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -795,11 +715,7 @@
 
     "foreground-child": ["foreground-child@3.3.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "signal-exit": "^4.0.1" } }, "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg=="],
 
-    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
-
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
-
-    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -807,11 +723,7 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
-    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
-
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
-
-    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.10.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A=="],
 
@@ -823,13 +735,9 @@
 
     "goober": ["goober@2.1.16", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g=="],
 
-    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
-
     "gpt-tokenizer": ["gpt-tokenizer@3.4.0", "", {}, "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
-    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -857,13 +765,7 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
-    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
-
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
-
-    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
-
-    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -871,13 +773,7 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
-    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
-
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
-
-    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
-
-    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -901,8 +797,6 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
-    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
-
     "isbot": ["isbot@5.1.39", "", {}, "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
@@ -910,8 +804,6 @@
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
-
-    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -922,8 +814,6 @@
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
-
-    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -956,8 +846,6 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
-
-    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -992,10 +880,6 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
-
-    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
-
-    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -1059,10 +943,6 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
-    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
-
-    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
-
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
@@ -1075,8 +955,6 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
-    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
-
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
@@ -1084,12 +962,6 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
-
-    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
-
-    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
-
-    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "openai": ["openai@5.20.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-Bmc2zLM/YWgFrDpXr9hwXqGGDdMmMpE9+qoZPsaHpn0Y/Qk1Vu26hNqXo7+nHdli+sLsXINvS1f8kR3NKhGKmA=="],
 
@@ -1107,8 +979,6 @@
 
     "parse5": ["parse5@7.2.1", "", { "dependencies": { "entities": "^4.5.0" } }, "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ=="],
 
-    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
-
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -1116,8 +986,6 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -1128,8 +996,6 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
-
-    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
@@ -1151,21 +1017,13 @@
 
     "property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 
-    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
-
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.3", "", {}, "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="],
 
-    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
-
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
-
-    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
-
-    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
@@ -1207,8 +1065,6 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
-    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
-
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1219,45 +1075,25 @@
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
-    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
-
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
-
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
-
     "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
 
-    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
-
-    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
-
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
-
-    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
-
-    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
-
-    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
-
-    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
-
-    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -1293,8 +1129,6 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
-    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
-
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
@@ -1312,8 +1146,6 @@
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
-
-    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -1337,8 +1169,6 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
 
-    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
-
     "unplugin": ["unplugin@2.2.0", "", { "dependencies": { "acorn": "^8.14.0", "webpack-virtual-modules": "^0.6.2" } }, "sha512-m1ekpSwuOT5hxkJeZGRxO7gXbXT3gF26NjQ7GdVHoLoF8/nopLcd/QfPigpCy7i51oFHiRJg/CyHhj4vs2+KGw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1354,8 +1184,6 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
-
-    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1377,8 +1205,6 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
-    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
-
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
@@ -1386,8 +1212,6 @@
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
-
-    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
@@ -1410,12 +1234,6 @@
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
-
-    "@modelcontextprotocol/ext-apps/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
-
-    "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1469,21 +1287,11 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
-    "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
-
-    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
-    "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "espree/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
-    "express/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
-
-    "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "hast-util-to-jsx-runtime/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
@@ -1497,10 +1305,6 @@
 
     "rehype-katex/katex": ["katex@0.16.21", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A=="],
 
-    "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
-    "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
-
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1513,15 +1317,11 @@
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
-    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
-
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
-
-    "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -1534,8 +1334,6 @@
     "@babel/helper-compilation-targets/browserslist/update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
-
-    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.25.9", "", {}, "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="],
 
@@ -1552,8 +1350,6 @@
     "@types/babel__traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.25.9", "", {}, "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="],
 
     "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
-
-    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,6 +5,8 @@
     "": {
       "name": "maple",
       "dependencies": {
+        "@aaif/goose-sdk": "0.20.2",
+        "@agentclientprotocol/sdk": "0.19.0",
         "@opensecret/react": "3.2.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
@@ -86,6 +88,20 @@
     "yaml": "^2.8.3",
   },
   "packages": {
+    "@aaif/goose-binary-darwin-arm64": ["@aaif/goose-binary-darwin-arm64@0.20.2", "", { "os": "darwin", "cpu": "arm64", "bin": { "goose": "bin/goose" } }, "sha512-0wv6UcYxg/dZXRuIUBTL+64Hz0D50PfUA2mJiUEBhWkBmiBCgS/Iymore0gYuayxVV7MzQhKrHqdDPBoo0lqIg=="],
+
+    "@aaif/goose-binary-darwin-x64": ["@aaif/goose-binary-darwin-x64@0.20.2", "", { "os": "darwin", "cpu": "x64", "bin": { "goose": "bin/goose" } }, "sha512-dZG6H1QF/lv/kVc1YmHVKRGJCZtoe9o0N2q4vgvDK0Lz+ZJp/ehKcIxUSqE/zebXDqLb4yWByDGelq5Ud2rnCw=="],
+
+    "@aaif/goose-binary-linux-arm64": ["@aaif/goose-binary-linux-arm64@0.20.2", "", { "os": "linux", "cpu": "arm64", "bin": { "goose": "bin/goose" } }, "sha512-DLbm8r21v4c39dGbLepjXDmXNLsdWw0PFFpRbQtBd2m5Q+xIBgYOx1jNm3EygDQT9yGV9R3WS6SW3LvMJLA3xw=="],
+
+    "@aaif/goose-binary-linux-x64": ["@aaif/goose-binary-linux-x64@0.20.2", "", { "os": "linux", "cpu": "x64", "bin": { "goose": "bin/goose" } }, "sha512-+TgB2+MKj18kbw5PBnDMAWvuy8ZijNxXQL4qRBeMebcx07W3dIf6zoy9xD5mSyce61ugG9vsLt9a+3Pm8qZaRw=="],
+
+    "@aaif/goose-binary-win32-x64": ["@aaif/goose-binary-win32-x64@0.20.2", "", { "os": "win32", "cpu": "x64", "bin": { "goose": "bin/goose.exe" } }, "sha512-P0GrtagS0U/98XW4VuzQ77Fy02bw4wFhzyRWWbR9LDVwY+lLG+AkE5m0Ml/KGKgDWS6gd8BtkAqRxdFw3PM9RQ=="],
+
+    "@aaif/goose-sdk": ["@aaif/goose-sdk@0.20.2", "", { "dependencies": { "@modelcontextprotocol/ext-apps": "^0.3.1", "@modelcontextprotocol/sdk": "^1.27.0", "zod": "^3.25.76" }, "optionalDependencies": { "@aaif/goose-binary-darwin-arm64": "0.20.2", "@aaif/goose-binary-darwin-x64": "0.20.2", "@aaif/goose-binary-linux-arm64": "0.20.2", "@aaif/goose-binary-linux-x64": "0.20.2", "@aaif/goose-binary-win32-x64": "0.20.2" }, "peerDependencies": { "@agentclientprotocol/sdk": "^0.19.0" } }, "sha512-HhsspN1OycRqgKgnUBWC/5xOpJ8zuKWmABax0Br0ZfND94AKKZbsBlya8e+pSM+CvztWLXHRz2KxPQuXYoGyBQ=="],
+
+    "@agentclientprotocol/sdk": ["@agentclientprotocol/sdk@0.19.0", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-U9I8ws9WTOk6jCBAWpXefGSDgVXn14/kV6HFzwWGcstQ02mOQgClMAROHmoIn9GqZbDBDEOkdIbP4P4TEMQdug=="],
+
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
@@ -208,6 +224,8 @@
 
     "@floating-ui/utils": ["@floating-ui/utils@0.2.9", "", {}, "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="],
 
+    "@hono/node-server": ["@hono/node-server@1.19.14", "", { "peerDependencies": { "hono": "^4" } }, "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw=="],
+
     "@humanfs/core": ["@humanfs/core@0.19.1", "", {}, "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA=="],
 
     "@humanfs/node": ["@humanfs/node@0.16.6", "", { "dependencies": { "@humanfs/core": "^0.19.1", "@humanwhocodes/retry": "^0.3.0" } }, "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw=="],
@@ -230,6 +248,10 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@modelcontextprotocol/ext-apps": ["@modelcontextprotocol/ext-apps@0.3.1", "", { "optionalDependencies": { "@oven/bun-darwin-aarch64": "^1.2.21", "@oven/bun-darwin-x64": "^1.2.21", "@oven/bun-darwin-x64-baseline": "^1.2.21", "@oven/bun-linux-aarch64": "^1.2.21", "@oven/bun-linux-aarch64-musl": "^1.2.21", "@oven/bun-linux-x64": "^1.2.21", "@oven/bun-linux-x64-baseline": "^1.2.21", "@oven/bun-linux-x64-musl": "^1.2.21", "@oven/bun-linux-x64-musl-baseline": "^1.2.21", "@oven/bun-windows-x64": "^1.2.21", "@oven/bun-windows-x64-baseline": "^1.2.21", "@rollup/rollup-darwin-arm64": "^4.53.3", "@rollup/rollup-darwin-x64": "^4.53.3", "@rollup/rollup-linux-arm64-gnu": "^4.53.3", "@rollup/rollup-linux-x64-gnu": "^4.53.3", "@rollup/rollup-win32-arm64-msvc": "^4.53.3", "@rollup/rollup-win32-x64-msvc": "^4.53.3" }, "peerDependencies": { "@modelcontextprotocol/sdk": "^1.24.0", "react": "^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^17.0.0 || ^18.0.0 || ^19.0.0", "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-Iivz2KwWK8xlRbiWwFB/C4NXqE8VJBoRCbBkJCN98ST2UbQvA6kfyebcLsypiqylJS467XOOaBcI9DeQ3t+zqA=="],
+
+    "@modelcontextprotocol/sdk": ["@modelcontextprotocol/sdk@1.29.0", "", { "dependencies": { "@hono/node-server": "^1.19.9", "ajv": "^8.17.1", "ajv-formats": "^3.0.1", "content-type": "^1.0.5", "cors": "^2.8.5", "cross-spawn": "^7.0.5", "eventsource": "^3.0.2", "eventsource-parser": "^3.0.0", "express": "^5.2.1", "express-rate-limit": "^8.2.1", "hono": "^4.11.4", "jose": "^6.1.3", "json-schema-typed": "^8.0.2", "pkce-challenge": "^5.0.0", "raw-body": "^3.0.0", "zod": "^3.25 || ^4.0", "zod-to-json-schema": "^3.25.1" }, "peerDependencies": { "@cfworker/json-schema": "^4.1.1" }, "optionalPeers": ["@cfworker/json-schema"] }, "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ=="],
+
     "@noble/curves": ["@noble/curves@1.9.7", "", { "dependencies": { "@noble/hashes": "1.8.0" } }, "sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw=="],
 
     "@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -241,6 +263,28 @@
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
     "@opensecret/react": ["@opensecret/react@3.2.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-tmn52THsD3M3vzC2IErHJuAq9zKAXce16Y77YuaqEM9Vfg6u4ZU6lUIiR3Uvb7ObZSjUaJjxqhdEs6lSChW4iQ=="],
+
+    "@oven/bun-darwin-aarch64": ["@oven/bun-darwin-aarch64@1.3.14", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Omj20SuiHBOUjUBIyqtkNjSUIjOtEOJwmbix/ZyFH4BaQ6OZTaaRWIR4TjHVz0yadHgli6lLTiAh1uarnvD49A=="],
+
+    "@oven/bun-darwin-x64": ["@oven/bun-darwin-x64@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-FFj3QdU/OhlDyZOJ8CWfN5eWLpRlT4qjZg7lMQi7jA6GuoY5ajlO1zWLP/MuHYRSbXQUvV52RejNi8DVnAp13w=="],
+
+    "@oven/bun-darwin-x64-baseline": ["@oven/bun-darwin-x64-baseline@1.3.14", "", { "os": "darwin", "cpu": "x64" }, "sha512-OSfsTZstc898HHElhU4NccaBGOSSDn5VfahiVTnidZ9B/+wb7WTyfZJaBeJcfjwJ9H2W9uTh2TGtl3UfcXgV9g=="],
+
+    "@oven/bun-linux-aarch64": ["@oven/bun-linux-aarch64@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-X5SsPZHs+iYO8R/efIcRtc7gT2Q2DgPfliCxEkx4cXBumwkw0c/EsHMNwH3EgGpCDaZ7IYVPhpCG/xBOQHEwZw=="],
+
+    "@oven/bun-linux-aarch64-musl": ["@oven/bun-linux-aarch64-musl@1.3.14", "", { "os": "linux", "cpu": "arm64" }, "sha512-jmqOA92Cd1NL/1XBd4bFkJLxQ86K0RW7ohxS2qzzAvuitO4JiIxjjTeCspoU44zCozH72HpfZfUE2On31OjnWA=="],
+
+    "@oven/bun-linux-x64": ["@oven/bun-linux-x64@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-7OVTAKvwfPmSbIV1HpdOoVVx5VRc427GuPPne93N6vk4eQBPId9nXmZDh9/zGaKPdbVjVtQSZafWQoUjx38Utw=="],
+
+    "@oven/bun-linux-x64-baseline": ["@oven/bun-linux-x64-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-q/8EdOC0yUE8FPeoOVq8/Pw5I9/tJaYmUfO/uDUAREx8IUnOJH1RJ5A3BjFqre8pvJoiZA9AovPJq5FnNNjSxA=="],
+
+    "@oven/bun-linux-x64-musl": ["@oven/bun-linux-x64-musl@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-GBCB/k/sIqcr06eTNgg7g46qiUv35Jasx4XiccJ/n7RGqrE4RWUD/XJBbWFprVPjvqd59+QtSnS99XGqvftHfg=="],
+
+    "@oven/bun-linux-x64-musl-baseline": ["@oven/bun-linux-x64-musl-baseline@1.3.14", "", { "os": "linux", "cpu": "x64" }, "sha512-n6iE71G4lQE4XkrZhQQcL5YUlxDbnq6nqV7zeQi33PMsLT/0kYE+RvHOtBWZ3w0wMdXZfINmp63hIb9ijUBGtw=="],
+
+    "@oven/bun-windows-x64": ["@oven/bun-windows-x64@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-mUFWL3BoYkNpjd8e9PqROiFF/1Xeotq20mABJsiQH62jM1g5zqWh4khw1RZ6bX8Q8fWvlPaxG1PjofkmjUi3vg=="],
+
+    "@oven/bun-windows-x64-baseline": ["@oven/bun-windows-x64-baseline@1.3.14", "", { "os": "win32", "cpu": "x64" }, "sha512-uIjLUC1S9DWgICzuoMba7vurBJnBruE4S5CxnvmZkdqWVXRzx1Rgu636HoH+k0qeaQCFh3jeG3JQ1y6fRHv0sw=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 
@@ -544,11 +588,15 @@
 
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
 
+    "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
+
     "acorn": ["acorn@8.14.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA=="],
 
     "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
 
     "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
+
+    "ajv-formats": ["ajv-formats@3.0.1", "", { "dependencies": { "ajv": "^8.0.0" } }, "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ=="],
 
     "ansi-regex": ["ansi-regex@6.1.0", "", {}, "sha512-7HSX4QQb4CspciLpVFwyRe79O3xsIZDDLER21kERQ71oaPodF8jL725AgJMFAYbooIqolJoRLuM81SpeUkpkvA=="],
 
@@ -580,6 +628,8 @@
 
     "binary-extensions": ["binary-extensions@2.3.0", "", {}, "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw=="],
 
+    "body-parser": ["body-parser@2.3.0", "", { "dependencies": { "bytes": "^3.1.2", "content-type": "^2.0.0", "debug": "^4.4.3", "http-errors": "^2.0.1", "iconv-lite": "^0.7.2", "on-finished": "^2.4.1", "qs": "^6.15.2", "raw-body": "^3.0.2", "type-is": "^2.1.0" } }, "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
@@ -587,6 +637,12 @@
     "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+
+    "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "call-bind-apply-helpers": ["call-bind-apply-helpers@1.0.2", "", { "dependencies": { "es-errors": "^1.3.0", "function-bind": "^1.1.2" } }, "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ=="],
+
+    "call-bound": ["call-bound@1.0.4", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "get-intrinsic": "^1.3.0" } }, "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg=="],
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
@@ -622,9 +678,19 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "content-disposition": ["content-disposition@1.1.0", "", {}, "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g=="],
+
+    "content-type": ["content-type@1.0.5", "", {}, "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA=="],
+
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
+
     "cookie-es": ["cookie-es@3.1.1", "", {}, "sha512-UaXxwISYJPTr9hwQxMFYZ7kNhSXboMXP+Z3TRX6f1/NyaGPfuNUZOWP1pUEb75B2HjfklIYLVRfWiFZJyC6Npg=="],
+
+    "cookie-signature": ["cookie-signature@1.2.2", "", {}, "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg=="],
+
+    "cors": ["cors@2.8.6", "", { "dependencies": { "object-assign": "^4", "vary": "^1" } }, "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -638,6 +704,8 @@
 
     "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
+    "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
+
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "detect-node-es": ["detect-node-es@1.1.0", "", {}, "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="],
@@ -650,17 +718,31 @@
 
     "dlv": ["dlv@1.1.3", "", {}, "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA=="],
 
+    "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
+
     "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
     "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
 
+    "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
+
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "es-define-property": ["es-define-property@1.0.1", "", {}, "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g=="],
+
+    "es-errors": ["es-errors@1.3.0", "", {}, "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw=="],
+
+    "es-object-atoms": ["es-object-atoms@1.1.2", "", { "dependencies": { "es-errors": "^1.3.0" } }, "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw=="],
 
     "esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 
     "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
+    "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
@@ -686,6 +768,16 @@
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
 
+    "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
+
+    "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
+
+    "eventsource-parser": ["eventsource-parser@3.1.0", "", {}, "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg=="],
+
+    "express": ["express@5.2.1", "", { "dependencies": { "accepts": "^2.0.0", "body-parser": "^2.2.1", "content-disposition": "^1.0.0", "content-type": "^1.0.5", "cookie": "^0.7.1", "cookie-signature": "^1.2.1", "debug": "^4.4.0", "depd": "^2.0.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "finalhandler": "^2.1.0", "fresh": "^2.0.0", "http-errors": "^2.0.0", "merge-descriptors": "^2.0.0", "mime-types": "^3.0.0", "on-finished": "^2.4.1", "once": "^1.4.0", "parseurl": "^1.3.3", "proxy-addr": "^2.0.7", "qs": "^6.14.0", "range-parser": "^1.2.1", "router": "^2.2.0", "send": "^1.1.0", "serve-static": "^2.2.0", "statuses": "^2.0.1", "type-is": "^2.0.1", "vary": "^1.1.2" } }, "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw=="],
+
+    "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
+
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
@@ -696,6 +788,8 @@
 
     "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
 
+    "fast-uri": ["fast-uri@3.1.3", "", {}, "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg=="],
+
     "fastq": ["fastq@1.19.0", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-7SFSRCNjBQIZH/xZR3iy5iQYR8aGBE0h3VG6/cwlbrpdciNYBMotQav8c1XI3HjHH+NikUpP53nPdlZSdWmFzA=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
@@ -703,6 +797,8 @@
     "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
+
+    "finalhandler": ["finalhandler@2.1.1", "", { "dependencies": { "debug": "^4.4.0", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "on-finished": "^2.4.1", "parseurl": "^1.3.3", "statuses": "^2.0.1" } }, "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA=="],
 
     "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
 
@@ -712,7 +808,11 @@
 
     "foreground-child": ["foreground-child@3.3.0", "", { "dependencies": { "cross-spawn": "^7.0.0", "signal-exit": "^4.0.1" } }, "sha512-Ld2g8rrAyMYFXBhEqMz8ZAHBi4J4uS1i/CxGMDnjyFWddMXLVcDp051DZfu+t7+ab7Wv6SMqpWmyFIj5UbfFvg=="],
 
+    "forwarded": ["forwarded@0.2.0", "", {}, "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow=="],
+
     "fraction.js": ["fraction.js@5.3.4", "", {}, "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ=="],
+
+    "fresh": ["fresh@2.0.0", "", {}, "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A=="],
 
     "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
 
@@ -720,7 +820,11 @@
 
     "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
 
+    "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
+
     "get-nonce": ["get-nonce@1.0.1", "", {}, "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q=="],
+
+    "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
 
     "get-tsconfig": ["get-tsconfig@4.10.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A=="],
 
@@ -732,9 +836,13 @@
 
     "goober": ["goober@2.1.16", "", { "peerDependencies": { "csstype": "^3.0.10" } }, "sha512-erjk19y1U33+XAMe1VTvIONHYoSqE4iS7BYUZfHaqeohLmnC0FdxEh7rQU+6MZ4OajItzjZFSRtVANrQwNq6/g=="],
 
+    "gopd": ["gopd@1.2.0", "", {}, "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg=="],
+
     "gpt-tokenizer": ["gpt-tokenizer@3.4.0", "", {}, "sha512-wxFLnhIXTDjYebd9A9pGl3e31ZpSypbpIJSOswbgop5jLte/AsZVDvjlbEuVFlsqZixVKqbcoNmRlFDf6pz/UQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "has-symbols": ["has-symbols@1.1.0", "", {}, "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ=="],
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
@@ -762,7 +870,13 @@
 
     "highlight.js": ["highlight.js@11.11.1", "", {}, "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w=="],
 
+    "hono": ["hono@4.12.27", "", {}, "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q=="],
+
     "html-url-attributes": ["html-url-attributes@3.0.1", "", {}, "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ=="],
+
+    "http-errors": ["http-errors@2.0.1", "", { "dependencies": { "depd": "~2.0.0", "inherits": "~2.0.4", "setprototypeof": "~1.2.0", "statuses": "~2.0.2", "toidentifier": "~1.0.1" } }, "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ=="],
+
+    "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
@@ -770,7 +884,13 @@
 
     "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
 
+    "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
+
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
+
+    "ip-address": ["ip-address@10.2.0", "", {}, "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA=="],
+
+    "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -794,6 +914,8 @@
 
     "is-plain-obj": ["is-plain-obj@4.1.0", "", {}, "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg=="],
 
+    "is-promise": ["is-promise@4.0.0", "", {}, "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="],
+
     "isbot": ["isbot@5.1.39", "", {}, "sha512-obH0yYahGXdzNxo+djmHhBYThUKDkz565cxkIlt2L9hXfv1NlaLKoDBHo6KxXsYrIXx2RK3x5vY36CfZcobxEw=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
@@ -801,6 +923,8 @@
     "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
 
     "jiti": ["jiti@1.21.7", "", { "bin": { "jiti": "bin/jiti.js" } }, "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A=="],
+
+    "jose": ["jose@6.2.3", "", {}, "sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw=="],
 
     "js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 
@@ -811,6 +935,8 @@
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
 
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
@@ -843,6 +969,8 @@
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "markdown-table": ["markdown-table@3.0.4", "", {}, "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="],
+
+    "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "mdast-util-find-and-replace": ["mdast-util-find-and-replace@3.0.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "escape-string-regexp": "^5.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg=="],
 
@@ -877,6 +1005,10 @@
     "mdast-util-to-markdown": ["mdast-util-to-markdown@2.1.2", "", { "dependencies": { "@types/mdast": "^4.0.0", "@types/unist": "^3.0.0", "longest-streak": "^3.0.0", "mdast-util-phrasing": "^4.0.0", "mdast-util-to-string": "^4.0.0", "micromark-util-classify-character": "^2.0.0", "micromark-util-decode-string": "^2.0.0", "unist-util-visit": "^5.0.0", "zwitch": "^2.0.0" } }, "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA=="],
 
     "mdast-util-to-string": ["mdast-util-to-string@4.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0" } }, "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg=="],
+
+    "media-typer": ["media-typer@1.1.0", "", {}, "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw=="],
+
+    "merge-descriptors": ["merge-descriptors@2.0.0", "", {}, "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g=="],
 
     "merge2": ["merge2@1.4.1", "", {}, "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg=="],
 
@@ -940,6 +1072,10 @@
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
 
+    "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
+
+    "mime-types": ["mime-types@3.0.2", "", { "dependencies": { "mime-db": "^1.54.0" } }, "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A=="],
+
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
 
     "minipass": ["minipass@7.1.2", "", {}, "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="],
@@ -952,6 +1088,8 @@
 
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
+    "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
     "normalize-path": ["normalize-path@3.0.0", "", {}, "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA=="],
@@ -959,6 +1097,12 @@
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
     "object-hash": ["object-hash@3.0.0", "", {}, "sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw=="],
+
+    "object-inspect": ["object-inspect@1.13.4", "", {}, "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew=="],
+
+    "on-finished": ["on-finished@2.4.1", "", { "dependencies": { "ee-first": "1.1.1" } }, "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg=="],
+
+    "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "openai": ["openai@5.20.0", "", { "peerDependencies": { "ws": "^8.18.0", "zod": "^3.23.8" }, "optionalPeers": ["ws", "zod"], "bin": { "openai": "bin/cli" } }, "sha512-Bmc2zLM/YWgFrDpXr9hwXqGGDdMmMpE9+qoZPsaHpn0Y/Qk1Vu26hNqXo7+nHdli+sLsXINvS1f8kR3NKhGKmA=="],
 
@@ -976,6 +1120,8 @@
 
     "parse5": ["parse5@7.2.1", "", { "dependencies": { "entities": "^4.5.0" } }, "sha512-BuBYQYlv1ckiPdQi/ohiivi9Sagc9JG+Ozs0r7b/0iK3sKmrb0b9FdWdBbOdx6hBCM/F9Ir82ofnBhtZOjCRPQ=="],
 
+    "parseurl": ["parseurl@1.3.3", "", {}, "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="],
+
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
 
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
@@ -983,6 +1129,8 @@
     "path-parse": ["path-parse@1.0.7", "", {}, "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="],
 
     "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "path-to-regexp": ["path-to-regexp@8.4.2", "", {}, "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA=="],
 
     "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
 
@@ -993,6 +1141,8 @@
     "pify": ["pify@2.3.0", "", {}, "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog=="],
 
     "pirates": ["pirates@4.0.6", "", {}, "sha512-saLsH7WeYYPiD25LDuLRRY/i+6HaPYr6G1OUlN39otzkSTxKnubR9RTxS3/Kk50s1g2JTgFwWQDQyplC5/SHZg=="],
+
+    "pkce-challenge": ["pkce-challenge@5.0.1", "", {}, "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ=="],
 
     "postcss": ["postcss@8.5.10", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ=="],
 
@@ -1014,13 +1164,21 @@
 
     "property-information": ["property-information@6.5.0", "", {}, "sha512-PgTgs/BlvHxOu8QuEN7wi5A0OmXaBcHpmCSTehcs6Uuu9IkDIEo13Hy7n898RHfrQ49vKCoGeWZSaAK01nwVig=="],
 
+    "proxy-addr": ["proxy-addr@2.0.7", "", { "dependencies": { "forwarded": "0.2.0", "ipaddr.js": "1.9.1" } }, "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg=="],
+
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
 
     "pvutils": ["pvutils@1.1.3", "", {}, "sha512-pMpnA0qRdFp32b1sJl1wOJNxZLQ2cbQx+k6tjNtZ8CpvVhNqEPRgivZ2WOUev2YMajecdH7ctUPDvEe87nariQ=="],
 
+    "qs": ["qs@6.15.3", "", { "dependencies": { "es-define-property": "^1.0.1", "side-channel": "^1.1.1" } }, "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A=="],
+
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "range-parser": ["range-parser@1.3.0", "", {}, "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw=="],
+
+    "raw-body": ["raw-body@3.0.2", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.7.0", "unpipe": "~1.0.0" } }, "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA=="],
 
     "react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
 
@@ -1062,6 +1220,8 @@
 
     "remark-stringify": ["remark-stringify@11.0.0", "", { "dependencies": { "@types/mdast": "^4.0.0", "mdast-util-to-markdown": "^2.0.0", "unified": "^11.0.0" } }, "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw=="],
 
+    "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
+
     "resolve": ["resolve@1.22.10", "", { "dependencies": { "is-core-module": "^2.16.0", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w=="],
 
     "resolve-from": ["resolve-from@4.0.0", "", {}, "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="],
@@ -1072,25 +1232,45 @@
 
     "rollup": ["rollup@4.60.2", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.60.2", "@rollup/rollup-android-arm64": "4.60.2", "@rollup/rollup-darwin-arm64": "4.60.2", "@rollup/rollup-darwin-x64": "4.60.2", "@rollup/rollup-freebsd-arm64": "4.60.2", "@rollup/rollup-freebsd-x64": "4.60.2", "@rollup/rollup-linux-arm-gnueabihf": "4.60.2", "@rollup/rollup-linux-arm-musleabihf": "4.60.2", "@rollup/rollup-linux-arm64-gnu": "4.60.2", "@rollup/rollup-linux-arm64-musl": "4.60.2", "@rollup/rollup-linux-loong64-gnu": "4.60.2", "@rollup/rollup-linux-loong64-musl": "4.60.2", "@rollup/rollup-linux-ppc64-gnu": "4.60.2", "@rollup/rollup-linux-ppc64-musl": "4.60.2", "@rollup/rollup-linux-riscv64-gnu": "4.60.2", "@rollup/rollup-linux-riscv64-musl": "4.60.2", "@rollup/rollup-linux-s390x-gnu": "4.60.2", "@rollup/rollup-linux-x64-gnu": "4.60.2", "@rollup/rollup-linux-x64-musl": "4.60.2", "@rollup/rollup-openbsd-x64": "4.60.2", "@rollup/rollup-openharmony-arm64": "4.60.2", "@rollup/rollup-win32-arm64-msvc": "4.60.2", "@rollup/rollup-win32-ia32-msvc": "4.60.2", "@rollup/rollup-win32-x64-gnu": "4.60.2", "@rollup/rollup-win32-x64-msvc": "4.60.2", "fsevents": "~2.3.2" }, "bin": { "rollup": "dist/bin/rollup" } }, "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ=="],
 
+    "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
+
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
+
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
 
     "scheduler": ["scheduler@0.23.2", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
+    "send": ["send@1.2.1", "", { "dependencies": { "debug": "^4.4.3", "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "etag": "^1.8.1", "fresh": "^2.0.0", "http-errors": "^2.0.1", "mime-types": "^3.0.2", "ms": "^2.1.3", "on-finished": "^2.4.1", "range-parser": "^1.2.1", "statuses": "^2.0.2" } }, "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ=="],
+
     "seroval": ["seroval@1.5.2", "", {}, "sha512-xcRN39BdsnO9Tf+VzsE7b3JyTJASItIV1FVFewJKCFcW4s4haIKS3e6vj8PGB9qBwC7tnuOywQMdv5N4qkzi7Q=="],
 
     "seroval-plugins": ["seroval-plugins@1.5.2", "", { "peerDependencies": { "seroval": "^1.0" } }, "sha512-qpY0Cl+fKYFn4GOf3cMiq6l72CpuVaawb6ILjubOQ+diJ54LfOWaSSPsaswN8DRPIPW4Yq+tE1k5aKd7ILyaFg=="],
 
+    "serve-static": ["serve-static@2.2.1", "", { "dependencies": { "encodeurl": "^2.0.0", "escape-html": "^1.0.3", "parseurl": "^1.3.3", "send": "^1.2.0" } }, "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw=="],
+
+    "setprototypeof": ["setprototypeof@1.2.0", "", {}, "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "side-channel": ["side-channel@1.1.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4", "side-channel-list": "^1.0.1", "side-channel-map": "^1.0.1", "side-channel-weakmap": "^1.0.2" } }, "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ=="],
+
+    "side-channel-list": ["side-channel-list@1.0.1", "", { "dependencies": { "es-errors": "^1.3.0", "object-inspect": "^1.13.4" } }, "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w=="],
+
+    "side-channel-map": ["side-channel-map@1.0.1", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3" } }, "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA=="],
+
+    "side-channel-weakmap": ["side-channel-weakmap@1.0.2", "", { "dependencies": { "call-bound": "^1.0.2", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.5", "object-inspect": "^1.13.3", "side-channel-map": "^1.0.1" } }, "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A=="],
 
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
+
+    "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
 
@@ -1126,6 +1306,8 @@
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
 
+    "toidentifier": ["toidentifier@1.0.1", "", {}, "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
     "trough": ["trough@2.2.0", "", {}, "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw=="],
@@ -1143,6 +1325,8 @@
     "tweetnacl": ["tweetnacl@1.0.3", "", {}, "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="],
 
     "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "type-is": ["type-is@2.1.0", "", { "dependencies": { "content-type": "^2.0.0", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
@@ -1166,6 +1350,8 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.1", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-L/PqWzfTP9lzzEa6CKs0k2nARxTdZduw3zyh8d2NVBnsyvHjSX4TWse388YrrQKbvI8w20fGjGlhgT96WwKykw=="],
 
+    "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
+
     "unplugin": ["unplugin@2.2.0", "", { "dependencies": { "acorn": "^8.14.0", "webpack-virtual-modules": "^0.6.2" } }, "sha512-m1ekpSwuOT5hxkJeZGRxO7gXbXT3gF26NjQ7GdVHoLoF8/nopLcd/QfPigpCy7i51oFHiRJg/CyHhj4vs2+KGw=="],
 
     "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
@@ -1181,6 +1367,8 @@
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "uuid": ["uuid@14.0.0", "", { "bin": { "uuid": "dist-node/bin/uuid" } }, "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg=="],
+
+    "vary": ["vary@1.1.2", "", {}, "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="],
 
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
@@ -1202,6 +1390,8 @@
 
     "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
 
+    "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
+
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
@@ -1210,7 +1400,13 @@
 
     "zod": ["zod@3.24.2", "", {}, "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ=="],
 
+    "zod-to-json-schema": ["zod-to-json-schema@3.25.2", "", { "peerDependencies": { "zod": "^3.25.28 || ^4" } }, "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@aaif/goose-sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@agentclientprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/generator/@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -1229,6 +1425,12 @@
     "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
     "@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@modelcontextprotocol/ext-apps/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@modelcontextprotocol/sdk/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "@modelcontextprotocol/sdk/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@radix-ui/react-alert-dialog/@radix-ui/react-slot": ["@radix-ui/react-slot@1.2.3", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A=="],
 
@@ -1282,11 +1484,21 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "ajv-formats/ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
+
+    "body-parser/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
+    "body-parser/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "chokidar/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
     "espree/acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
+    "express/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "fast-glob/glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
+
+    "finalhandler/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "hast-util-to-jsx-runtime/@types/estree": ["@types/estree@1.0.6", "", {}, "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="],
 
@@ -1300,6 +1512,10 @@
 
     "rehype-katex/katex": ["katex@0.16.21", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-XvqR7FgOHtWupfMiigNzmh+MgUVmDGU2kXZm899ZkPfcuoPuFxyHmXsgATDpFZDAXCI8tvinaVcDo8PIIJSo4A=="],
 
+    "router/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "send/debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
     "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
 
     "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
@@ -1312,11 +1528,15 @@
 
     "tsyringe/tslib": ["tslib@1.14.1", "", {}, "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="],
 
+    "type-is/content-type": ["content-type@2.0.0", "", {}, "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ=="],
+
     "wrap-ansi/ansi-styles": ["ansi-styles@6.2.1", "", {}, "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="],
 
     "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
 
     "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "zod-to-json-schema/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/generator/@jridgewell/gen-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
@@ -1329,6 +1549,8 @@
     "@babel/helper-compilation-targets/browserslist/update-browserslist-db": ["update-browserslist-db@1.1.2", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg=="],
 
     "@jridgewell/remapping/@jridgewell/trace-mapping/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
+
+    "@modelcontextprotocol/sdk/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "@types/babel__core/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.25.9", "", {}, "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="],
 
@@ -1345,6 +1567,8 @@
     "@types/babel__traverse/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.25.9", "", {}, "sha512-4A/SCr/2KLd5jrtOMFzaKjVtAei3+2r/NChoBNoZ3EyP/+GlhoaEGoWOZUmFmoITP7zOJyHIMm+DYRd8o3PvHA=="],
 
     "@types/babel__traverse/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.25.9", "", {}, "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ=="],
+
+    "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 
     "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,6 +31,8 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
+    "@aaif/goose-sdk": "0.20.2",
+    "@agentclientprotocol/sdk": "0.19.0",
     "@opensecret/react": "3.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,6 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@aaif/goose-sdk": "0.20.2",
     "@agentclientprotocol/sdk": "0.19.0",
     "@opensecret/react": "3.2.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2811,7 +2811,6 @@ dependencies = [
 [[package]]
 name = "goose"
 version = "1.41.0"
-source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-http",
@@ -2907,7 +2906,6 @@ dependencies = [
 [[package]]
 name = "goose-acp-macros"
 version = "1.41.0"
-source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
 dependencies = [
  "quote",
  "syn 2.0.108",
@@ -2916,7 +2914,6 @@ dependencies = [
 [[package]]
 name = "goose-download-manager"
 version = "1.41.0"
-source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -2930,7 +2927,6 @@ dependencies = [
 [[package]]
 name = "goose-provider-types"
 version = "1.41.0"
-source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2957,7 +2953,6 @@ dependencies = [
 [[package]]
 name = "goose-providers"
 version = "1.41.0"
-source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -2980,7 +2975,6 @@ dependencies = [
 [[package]]
 name = "goose-sdk-types"
 version = "1.41.0"
-source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4015,6 +4015,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "dirs",
+ "futures",
  "futures-util",
  "goose",
  "hound",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "generic-array",
 ]
 
@@ -35,7 +35,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -53,6 +53,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "agent-client-protocol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16302d16c7531355db16593d99c38c8297db0c4653aa7dd80c3556bb17f4cd8c"
+dependencies = [
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "async-process",
+ "blocking",
+ "futures",
+ "futures-concurrency",
+ "rustc-hash",
+ "schemars 1.0.5",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tracing",
+ "uuid",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "agent-client-protocol-derive"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "agent-client-protocol-http"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31ff55efe7a6bb92a5d0226f6055c2f277b7591060d5095c7764f445289ebda3"
+dependencies = [
+ "agent-client-protocol",
+ "async-stream",
+ "axum",
+ "futures",
+ "serde_json",
+ "tokio",
+ "tower-http 0.7.0",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "agent-client-protocol-schema"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac542aba230234b1591ace7286a47c0514fe3efc3037d43296bde31ba7ee5728"
+dependencies = [
+ "anyhow",
+ "derive_more",
+ "schemars 1.0.5",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum 0.28.0",
+ "tracing",
+]
+
+[[package]]
 name = "ahash"
 version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,6 +126,20 @@ dependencies = [
  "getrandom 0.2.16",
  "once_cell",
  "version_check",
+]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -86,6 +165,12 @@ checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
 dependencies = [
  "alloc-no-stdlib",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_log-sys"
@@ -165,9 +250,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arbitrary"
@@ -177,6 +262,29 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.2",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "x11rb",
+]
+
+[[package]]
+name = "arrayref"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76a2e8124351fda1ef8aaaa3bbd7ebbcb486bbcd4225aca0aa0d84bb2db8fecb"
 
 [[package]]
 name = "arrayvec"
@@ -245,6 +353,18 @@ dependencies = [
  "event-listener-strategy",
  "futures-core",
  "pin-project-lite",
+]
+
+[[package]]
+name = "async-compression"
+version = "0.4.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e79b3f8a79cccc2898f31920fc69f304859b3bd567490f75ebf51ae1c792a9ac"
+dependencies = [
+ "compression-codecs",
+ "compression-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]
@@ -400,6 +520,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -441,6 +570,7 @@ checksum = "8a18ed336352031311f4e0b4dd2ff392d4fbb370777c9d18d7fc9d7359f73871"
 dependencies = [
  "axum-core",
  "axum-macros",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -459,8 +589,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -564,12 +696,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa83c34e62843d924f905e0f5c866eb1dd6545fc4d719e803d9ba6030371fce"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.0",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
+dependencies = [
+ "hybrid-array",
 ]
 
 [[package]]
@@ -602,6 +757,12 @@ dependencies = [
  "futures-lite",
  "piper",
 ]
+
+[[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
 
 [[package]]
 name = "borsh"
@@ -648,6 +809,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bs58"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cee35f73844aa3014bb606320a6c1f010249dbdf43342fe54b5a4f6a8ed4b79"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -685,6 +866,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -733,6 +920,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "calendrical_calculations"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5abbd6eeda6885048d357edc66748eea6e0268e3dd11f326fff5bd248d779c26"
+dependencies = [
+ "core_maths",
+ "displaydoc",
+]
+
+[[package]]
 name = "camino"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -761,7 +958,7 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -833,7 +1030,18 @@ checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -843,7 +1051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
 dependencies = [
  "aead",
- "chacha20",
+ "chacha20 0.9.1",
  "cipher",
  "poly1305",
  "zeroize",
@@ -851,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.42"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145052bdd345b87320e369255277e3fb5152762ad123a901ef5c262dd38fe8d2"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -861,6 +1069,16 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6139a8597ed92cf816dfb33f5dd6cf0bb93a6adc938f11039f371bc5bcd26c3"
+dependencies = [
+ "chrono",
+ "phf 0.12.1",
 ]
 
 [[package]]
@@ -896,7 +1114,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "inout",
  "zeroize",
 ]
@@ -942,6 +1160,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
+
+[[package]]
 name = "cmake"
 version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -949,6 +1176,12 @@ checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
 
 [[package]]
 name = "colorchoice"
@@ -965,6 +1198,26 @@ dependencies = [
  "bytes",
  "memchr",
 ]
+
+[[package]]
+name = "compression-codecs"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce2548391e9c1929c21bf6aa2680af86fe4c1b33e6cea9ac1cfeec0bd11218cf"
+dependencies = [
+ "brotli",
+ "compression-core",
+ "flate2",
+ "memchr",
+ "zstd",
+ "zstd-safe",
+]
+
+[[package]]
+name = "compression-core"
+version = "0.4.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
 name = "concurrent-queue"
@@ -1002,13 +1255,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cookie"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
 dependencies = [
+ "percent-encoding",
  "time",
  "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "log",
+ "publicsuffix",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
 ]
 
 [[package]]
@@ -1075,6 +1362,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "core_maths"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77745e017f5edba1a9c1d854f6f3a52dac8a12dd5af5d2f54aecf61e43d80d30"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1084,12 +1380,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "croner"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+dependencies = [
+ "chrono",
+ "derive_builder",
+ "strum 0.27.2",
 ]
 
 [[package]]
@@ -1116,6 +1447,15 @@ name = "crossbeam-epoch"
 version = "0.9.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "803d13fb3b09d88be9f4dbc29062c66b19bf7170867ceb746d2a8689bf6c7a26"
 dependencies = [
  "crossbeam-utils",
 ]
@@ -1156,6 +1496,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "cssparser"
 version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1164,7 +1513,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec 1.15.1",
 ]
 
@@ -1210,7 +1559,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "fiat-crypto",
  "rustc_version",
@@ -1231,19 +1580,29 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
 ]
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
 dependencies = [
  "fnv",
  "ident_case",
@@ -1254,12 +1613,36 @@ dependencies = [
 ]
 
 [[package]]
-name = "darling_macro"
-version = "0.21.3"
+name = "darling_core"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
 dependencies = [
- "darling_core",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core 0.20.11",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.108",
 ]
@@ -1328,6 +1711,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling 0.20.11",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1342,10 +1756,12 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.108",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1354,10 +1770,20 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.1",
+ "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -1437,6 +1863,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "dom_query"
 version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,7 +1879,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash",
+ "foldhash 0.2.0",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -1515,7 +1950,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest",
+ "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
  "signature",
@@ -1527,6 +1962,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -1536,7 +1974,7 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest",
+ "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
@@ -1547,6 +1985,15 @@ dependencies = [
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1643,6 +2090,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
+
+[[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "etcetera"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "euclid"
 version = "0.20.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1681,6 +2155,28 @@ dependencies = [
  "futures-core",
  "nom",
  "pin-project-lite",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e24cb5a94bcae1e5408b0effca5cd7172ea3c5755049c5f3af4cd283a165298"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -1752,6 +2248,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1762,10 +2264,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "fluent-uri"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1918b65d96df47d3591bed19c5cca17e3fa5d0707318e4b5ef2eae01764df7e5"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1825,6 +2355,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1838,9 +2397,9 @@ checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1853,25 +2412,38 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
 ]
 
 [[package]]
-name = "futures-core"
-version = "0.3.31"
+name = "futures-concurrency"
+version = "7.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec 1.15.1",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
@@ -1879,10 +2451,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-io"
-version = "0.3.31"
+name = "futures-intrusive"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -1899,9 +2482,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1910,21 +2493,21 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1934,7 +2517,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -2080,9 +2662,21 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -2093,6 +2687,16 @@ checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
 dependencies = [
  "opaque-debug",
  "polyval",
+]
+
+[[package]]
+name = "gif"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae047235e33e2829703574b54fdec96bfbad892062d97fed2f76022287de61b"
+dependencies = [
+ "color_quant",
+ "weezl",
 ]
 
 [[package]]
@@ -2181,6 +2785,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2189,6 +2806,187 @@ dependencies = [
  "glib-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "goose"
+version = "1.41.0"
+source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
+dependencies = [
+ "agent-client-protocol",
+ "agent-client-protocol-http",
+ "agent-client-protocol-schema",
+ "anyhow",
+ "arboard",
+ "async-stream",
+ "async-trait",
+ "axum",
+ "base64 0.22.1",
+ "blake3",
+ "chrono",
+ "clap",
+ "dirs",
+ "etcetera 0.11.0",
+ "fs-err",
+ "fs2",
+ "futures",
+ "gethostname",
+ "goose-acp-macros",
+ "goose-download-manager",
+ "goose-providers",
+ "goose-sdk-types",
+ "icu_calendar",
+ "icu_locale",
+ "ignore",
+ "image",
+ "include_dir",
+ "indexmap 2.12.0",
+ "indoc",
+ "jsonschema",
+ "jsonwebtoken",
+ "libc",
+ "lru",
+ "minijinja",
+ "nanoid",
+ "oauth2",
+ "once_cell",
+ "pastey",
+ "process-wrap",
+ "pulldown-cmark",
+ "rand 0.10.2",
+ "rayon",
+ "regex",
+ "reqwest 0.13.2",
+ "rmcp",
+ "schemars 1.0.5",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "serde_yaml",
+ "sha2 0.11.0",
+ "shell-words",
+ "shellexpand",
+ "sqlx",
+ "strum 0.28.0",
+ "subtle",
+ "sys-info",
+ "tempfile",
+ "thiserror 2.0.18",
+ "tiktoken-rs",
+ "tokio",
+ "tokio-cron-scheduler",
+ "tokio-stream",
+ "tokio-util",
+ "tower-http 0.7.0",
+ "tracing",
+ "tracing-appender",
+ "tracing-futures",
+ "tracing-subscriber",
+ "tree-sitter",
+ "tree-sitter-go",
+ "tree-sitter-java",
+ "tree-sitter-javascript",
+ "tree-sitter-kotlin-ng",
+ "tree-sitter-python",
+ "tree-sitter-ruby",
+ "tree-sitter-rust",
+ "tree-sitter-swift",
+ "tree-sitter-typescript",
+ "unicode-normalization",
+ "url",
+ "urlencoding",
+ "utoipa",
+ "uuid",
+ "v_htmlescape",
+ "webbrowser",
+ "which",
+ "winapi",
+]
+
+[[package]]
+name = "goose-acp-macros"
+version = "1.41.0"
+source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "goose-download-manager"
+version = "1.41.0"
+source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
+dependencies = [
+ "anyhow",
+ "once_cell",
+ "reqwest 0.13.2",
+ "serde",
+ "tokio",
+ "tracing",
+ "utoipa",
+]
+
+[[package]]
+name = "goose-provider-types"
+version = "1.41.0"
+source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "once_cell",
+ "rand 0.10.2",
+ "regex",
+ "reqwest 0.13.2",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "unicode-normalization",
+ "utoipa",
+ "uuid",
+]
+
+[[package]]
+name = "goose-providers"
+version = "1.41.0"
+source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "chrono",
+ "futures",
+ "goose-provider-types",
+ "reqwest 0.13.2",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "utoipa",
+]
+
+[[package]]
+name = "goose-sdk-types"
+version = "1.41.0"
+source = "git+https://github.com/aaif-goose/goose.git?tag=v1.41.0#39c27c387d726ce4605108d2f974d4feec158ed5"
+dependencies = [
+ "agent-client-protocol",
+ "agent-client-protocol-schema",
+ "schemars 1.0.5",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -2290,7 +3088,7 @@ version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
- "ahash",
+ "ahash 0.7.8",
 ]
 
 [[package]]
@@ -2301,9 +3099,29 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+
+[[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
 
 [[package]]
 name = "hdrhistogram"
@@ -2354,7 +3172,16 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2418,6 +3245,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "hybrid-array"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
+dependencies = [
+ "typenum",
+]
 
 [[package]]
 name = "hyper"
@@ -2520,6 +3356,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_calendar"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f0e52e009b6b16ba9c0693578796f2dd4aaa59a7f8f920423706714a89ac4e"
+dependencies = [
+ "calendrical_calculations",
+ "displaydoc",
+ "icu_locale_core",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_collections"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2533,6 +3383,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_locale"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "532b11722e350ab6bf916ba6eb0efe3ee54b932666afec989465f9243fe6dd60"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_provider",
+ "potential_utf",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
 name = "icu_locale_core"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2540,6 +3404,7 @@ checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
+ "serde",
  "tinystr",
  "writeable",
  "zerovec",
@@ -2593,6 +3458,8 @@ checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
+ "serde",
+ "stable_deref_trait",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2628,6 +3495,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "ignore"
+version = "0.4.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe112b004901c62c2faa11f4f75e9864e0cc5af8da71c9115d184a3aa888749f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
+]
+
+[[package]]
+name = "image"
+version = "0.24.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5690139d2f55868e080017335e4b94cb7414274c74f1669c84fb5feba2c9f69d"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "gif",
+ "jpeg-decoder",
+ "num-traits",
+ "png 0.17.16",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2648,6 +3565,15 @@ dependencies = [
  "hashbrown 0.16.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indoc"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
+dependencies = [
+ "rustversion",
 ]
 
 [[package]]
@@ -2747,7 +3673,7 @@ dependencies = [
  "cesu8",
  "cfg-if",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2755,10 +3681,59 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn 2.0.108",
+]
 
 [[package]]
 name = "jobserver"
@@ -2769,6 +3744,12 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "jpeg-decoder"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00810f1d8b74be64b13dbf3db89ac67740615d6c891f0e7b6179326533011a07"
 
 [[package]]
 name = "js-sys"
@@ -2805,6 +3786,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1b46a0365a611fbf1d2143104dcf910aada96fafd295bab16c60b802bf6fa1d"
+dependencies = [
+ "ahash 0.8.12",
+ "base64 0.22.1",
+ "bytecount",
+ "email_address",
+ "fancy-regex 0.14.0",
+ "fraction",
+ "idna",
+ "itoa",
+ "num-cmp",
+ "num-traits",
+ "once_cell",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "getrandom 0.2.16",
+ "js-sys",
+ "pem",
+ "serde",
+ "serde_json",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2832,6 +3856,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "libappindicator"
@@ -2859,9 +3886,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libdbus-sys"
@@ -2910,6 +3937,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2920,6 +3958,12 @@ name = "litemap"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2958,6 +4002,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2972,6 +4022,7 @@ dependencies = [
  "base64 0.22.1",
  "dirs",
  "futures-util",
+ "goose",
  "hound",
  "keyring",
  "log",
@@ -2986,9 +4037,10 @@ dependencies = [
  "rand_distr",
  "regex",
  "reqwest 0.13.2",
+ "rmcp",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "tauri",
  "tauri-build",
  "tauri-plugin",
@@ -3023,7 +4075,7 @@ dependencies = [
  "serde_json",
  "tokio",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
 ]
@@ -3071,7 +4123,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest",
+ "digest 0.10.7",
 ]
 
 [[package]]
@@ -3079,6 +4131,12 @@ name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+
+[[package]]
+name = "memo-map"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38d1115007560874e373613744c6fba374c17688327a71c1476d1a5954cc857b"
 
 [[package]]
 name = "memoffset"
@@ -3094,6 +4152,26 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "mime_guess"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
+dependencies = [
+ "mime",
+ "unicase",
+]
+
+[[package]]
+name = "minijinja"
+version = "2.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3d648e68cea56d9858d535ee28f9538404e2dd8cb08ed0bd05dca379477f39"
+dependencies = [
+ "memo-map",
+ "serde",
+]
 
 [[package]]
 name = "minimal-lexical"
@@ -3119,9 +4197,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -3145,8 +4223,17 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "nanoid"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628de41fe064cc3f0cf07f3d299ee3e73521adaff72278731d5c8cae3797873"
+dependencies = [
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -3189,7 +4276,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
  "bitflags 2.10.0",
- "jni-sys",
+ "jni-sys 0.3.0",
  "log",
  "ndk-sys",
  "num_enum",
@@ -3198,12 +4285,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
 name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
- "jni-sys",
+ "jni-sys 0.3.0",
 ]
 
 [[package]]
@@ -3226,6 +4319,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3245,6 +4350,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3253,6 +4372,28 @@ dependencies = [
  "num-integer",
  "num-traits",
 ]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec 1.15.1",
+ "zeroize",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
 
 [[package]]
 name = "num-complex"
@@ -3270,11 +4411,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
 dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
  "num-traits",
 ]
 
@@ -3320,6 +4494,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.16",
+ "http",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3355,6 +4548,7 @@ dependencies = [
  "block2 0.6.2",
  "objc2 0.6.4",
  "objc2-core-foundation",
+ "objc2-core-graphics",
  "objc2-foundation 0.3.2",
 ]
 
@@ -3644,8 +4838,8 @@ dependencies = [
  "ring",
  "serde",
  "serde_json",
- "sha2",
- "thiserror 2.0.17",
+ "sha2 0.10.9",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "uuid",
@@ -3760,7 +4954,7 @@ checksum = "e2aba9f5c7c479925205799216e7e5d07cc1d4fa76ea8058c60a9a30f6a4e890"
 dependencies = [
  "flate2",
  "pkg-config",
- "sha2",
+ "sha2 0.10.9",
  "tar",
  "ureq",
 ]
@@ -3788,8 +4982,14 @@ dependencies = [
  "objc2-osa-kit",
  "serde",
  "serde_json",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "p256"
@@ -3800,7 +5000,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2",
+ "sha2 0.10.9",
 ]
 
 [[package]]
@@ -3858,6 +5058,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3879,6 +5085,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3895,12 +5111,21 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "913273894cec178f401a31ec4b656318d95473527be05c0752cc41cdc32be8b7"
+dependencies = [
+ "phf_shared 0.12.1",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
 ]
 
@@ -3911,7 +5136,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3921,7 +5146,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -3931,10 +5156,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -3987,6 +5221,17 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
+]
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
 ]
 
 [[package]]
@@ -4064,7 +5309,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
 dependencies = [
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4076,7 +5321,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.2.17",
  "opaque-debug",
  "universal-hash",
 ]
@@ -4114,6 +5359,8 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
+ "serde_core",
+ "writeable",
  "zerovec",
 ]
 
@@ -4210,6 +5457,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.12.0",
+ "nix 0.31.3",
+ "tokio",
+ "tracing",
+ "windows 0.62.2",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
+
+[[package]]
 name = "ptr_meta"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4227,6 +5494,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "publicsuffix"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42ea446cab60335f76979ec15e12619a2165b5ae2c12166bef27d283a9fadf"
+dependencies = [
+ "idna",
+ "psl-types",
+]
+
+[[package]]
+name = "pulldown-cmark"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
+dependencies = [
+ "bitflags 2.10.0",
+ "memchr",
+ "unicase",
 ]
 
 [[package]]
@@ -4252,7 +5540,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "web-time",
@@ -4274,7 +5562,7 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4310,6 +5598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4334,6 +5628,17 @@ checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
+dependencies = [
+ "chacha20 0.10.1",
+ "getrandom 0.4.3",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -4373,6 +5678,12 @@ checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
 dependencies = [
  "getrandom 0.3.4",
 ]
+
+[[package]]
+name = "rand_core"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "rand_distr"
@@ -4439,7 +5750,7 @@ checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4463,10 +5774,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.12.2"
+name = "referencing"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "c8eff4fa778b5c2a57e85c5f2fe3a709c52f0e60d23146e2151cbef5893f420e"
+dependencies = [
+ "ahash 0.8.12",
+ "fluent-uri",
+ "once_cell",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4487,9 +5812,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rend"
@@ -4534,7 +5859,7 @@ dependencies = [
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4552,7 +5877,10 @@ checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cookie",
+ "cookie_store",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -4565,6 +5893,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -4573,12 +5902,13 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tower",
- "tower-http",
+ "tower-http 0.6.8",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -4662,6 +5992,71 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f542f74cf247da16f19bbc87e298cd201e912314f4083e88cdd671f44f5fcb53"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "oauth2",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.2",
+ "rmcp-macros",
+ "schemars 1.0.5",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest 0.10.7",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4772,7 +6167,7 @@ checksum = "1d99feebc72bae7ab76ba994bb5e121b8d83d910ca40b36e0921f53becc41784"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.21.1",
  "log",
  "once_cell",
  "rustls",
@@ -4841,7 +6236,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -4866,8 +6261,10 @@ version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1317c3bf3e7df961da95b0a56a172a02abead31276215a0497241a7624b487ce"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.0.5",
  "serde",
  "serde_json",
 ]
@@ -4877,6 +6274,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f760a6150d45dd66ec044983c124595ae76912e77ed0b44124cb3e415cce5d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4957,7 +6366,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash",
@@ -5034,6 +6443,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
+ "indexmap 2.12.0",
  "itoa",
  "memchr",
  "ryu",
@@ -5095,11 +6505,12 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.15.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa66c845eee442168b2c8134fec70ac50dc20e760769c8ba0ad1319ca1959b04"
+checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
  "base64 0.22.1",
+ "bs58",
  "chrono",
  "hex",
  "indexmap 1.9.3",
@@ -5114,14 +6525,27 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.15.1"
+version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b91a903660542fced4e99881aa481bdbaec1634568ee02e0b8bd57c64cb38955"
+checksum = "84d57bc0c8b9a17920c178daa6bb924850d54a9c97ab45194bb8c17ad66bb660"
 dependencies = [
- "darling",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap 2.12.0",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
 ]
 
 [[package]]
@@ -5156,14 +6580,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures",
- "digest",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -5173,6 +6619,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
+]
+
+[[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
+name = "shellexpand"
+version = "3.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
+dependencies = [
+ "dirs",
 ]
 
 [[package]]
@@ -5196,7 +6657,7 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest",
+ "digest 0.10.7",
  "rand_core 0.6.4",
 ]
 
@@ -5207,10 +6668,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "siphasher"
@@ -5229,6 +6712,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -5238,12 +6724,12 @@ checksum = "51d44cfb396c3caf6fbfd0ab422af02631b69ddd96d2eff0b0f0724f9024051b"
 
 [[package]]
 name = "socket2"
-version = "0.6.1"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17129e116933cf371d018bb80ae557e889637989d8638274fb25622827b03881"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5306,6 +6792,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "spki"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5313,6 +6808,211 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap 2.12.0",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec 1.15.1",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.108",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest 0.10.7",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2 0.10.9",
+ "smallvec 1.15.1",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64 0.22.1",
+ "bitflags 2.10.0",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera 0.8.0",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "smallvec 1.15.1",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39f24a9b78c40b90817bbcd1821c74ddfd74916aadd29403d001532a9195532d"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5328,6 +7028,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
+name = "streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b2231b7c3057d5e4ad0156fb3dc807d900806020c5ffa3ee6ff2c8c76fb8520"
+
+[[package]]
 name = "string_cache"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5335,7 +7041,7 @@ checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
  "parking_lot",
- "phf_shared",
+ "phf_shared 0.13.1",
  "precomputed-hash",
 ]
 
@@ -5346,9 +7052,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
  "phf_generator",
- "phf_shared",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -5356,6 +7073,48 @@ name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "strum"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
+dependencies = [
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
 
 [[package]]
 name = "subtle"
@@ -5373,6 +7132,12 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -5414,6 +7179,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "sys-info"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
+dependencies = [
+ "cc",
+ "libc",
 ]
 
 [[package]]
@@ -5475,7 +7250,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -5491,7 +7266,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -5548,7 +7323,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -5572,14 +7347,14 @@ dependencies = [
  "tauri-runtime",
  "tauri-runtime-wry",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tokio",
  "tray-icon",
  "url",
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5620,10 +7395,10 @@ dependencies = [
  "semver",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.10.9",
  "syn 2.0.108",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "url",
  "uuid",
@@ -5674,7 +7449,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "url",
  "windows-registry",
@@ -5695,7 +7470,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-plugin-fs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
 ]
 
@@ -5718,7 +7493,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 1.1.0+spec-1.1.0",
  "url",
 ]
@@ -5741,7 +7516,7 @@ dependencies = [
  "swift-rs",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -5761,9 +7536,9 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -5782,7 +7557,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5794,7 +7569,7 @@ dependencies = [
  "serde",
  "tauri",
  "tauri-plugin",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -5807,7 +7582,7 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-plugin-deep-link",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
@@ -5838,7 +7613,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tempfile",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "time",
  "tokio",
  "url",
@@ -5856,7 +7631,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2 0.6.4",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -5864,11 +7639,11 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri-utils",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -5879,7 +7654,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2 0.6.4",
  "objc2-app-kit",
@@ -5893,7 +7668,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5915,7 +7690,7 @@ dependencies = [
  "json-patch",
  "log",
  "memchr",
- "phf",
+ "phf 0.13.1",
  "plist",
  "proc-macro2",
  "quote",
@@ -5927,7 +7702,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "swift-rs",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "toml 1.1.0+spec-1.1.0",
  "url",
  "urlpattern",
@@ -5979,11 +7754,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f63587ca0f12b72a0600bcba1d40081f830876000bb46dd2337a3051618f4fc8"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.17",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5999,9 +7774,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.17"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6015,6 +7790,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tiktoken-rs"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "027853bbf8c7763b77c5c595f1c271c7d536ced7d6f83452911b944621e57fc2"
+dependencies = [
+ "anyhow",
+ "base64 0.22.1",
+ "bstr",
+ "fancy-regex 0.17.0",
+ "lazy_static",
+ "regex",
+ "rustc-hash",
 ]
 
 [[package]]
@@ -6066,6 +7856,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
+ "serde_core",
  "zerovec",
 ]
 
@@ -6086,9 +7877,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.48.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff360e02eab121e0bc37a2d3b4d4dc622e6eda3a8e5253d5435ecf5bd4c68408"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -6102,10 +7893,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-macros"
-version = "2.6.0"
+name = "tokio-cron-scheduler"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "1f50e41f200fd8ed426489bd356910ede4f053e30cebfbd59ef0f856f0d7432a"
+dependencies = [
+ "chrono",
+ "chrono-tz",
+ "croner",
+ "num-derive",
+ "num-traits",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6123,6 +7930,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6130,6 +7960,7 @@ checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
@@ -6281,17 +8112,37 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
+ "async-compression",
  "bitflags 2.10.0",
  "bytes",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
+ "http-body-util",
  "iri-string",
  "pin-project-lite",
+ "tokio",
+ "tokio-util",
  "tower",
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b11f75e912b0c2be01b63d8cf8057b8c3f97cf34abb3d431a3a4c8675498e233"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "http",
+ "percent-encoding",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -6308,9 +8159,9 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -6319,10 +8170,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.30"
+name = "tracing-appender"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6331,12 +8195,24 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
  "valuable",
+]
+
+[[package]]
+name = "tracing-futures"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
+dependencies = [
+ "futures",
+ "futures-task",
+ "pin-project",
+ "tracing",
 ]
 
 [[package]]
@@ -6351,21 +8227,35 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-subscriber"
-version = "0.3.20"
+name = "tracing-serde"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2054a14f5307d601f88daf0553e1cbf472acc4f2c51afab632431cdcd72124d5"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
+ "serde",
+ "serde_json",
  "sharded-slab",
  "smallvec 1.15.1",
  "thread_local",
+ "time",
  "tracing",
  "tracing-core",
  "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -6386,8 +8276,118 @@ dependencies = [
  "once_cell",
  "png 0.18.1",
  "serde",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.26.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c343ed63e3f5c64d1acdecb5d2c13d4e169cb5fde0052106ebaa6c6f27f9e55"
+dependencies = [
+ "cc",
+ "regex",
+ "regex-syntax",
+ "serde_json",
+ "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-go"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-java"
+version = "0.23.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-kotlin-ng"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e800ebbda938acfbf224f4d2c34947a31994b1295ee6e819b65226c7b51b4450"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-language"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-python"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-ruby"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be0484ea4ef6bb9c575b4fdabde7e31340a8d2dbc7d52b321ac83da703249f95"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-rust"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-swift"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
 ]
 
 [[package]]
@@ -6395,6 +8395,23 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
 
 [[package]]
 name = "type1-encoding-parser"
@@ -6413,9 +8430,9 @@ checksum = "bc7d623258602320d5c55d1bc22793b57daff0ec7efc270ea7d55ce1d5f5471c"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uds_windows"
@@ -6470,6 +8487,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+
+[[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6485,10 +8514,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
 name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "universal-hash"
@@ -6496,9 +8537,15 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.6",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -6549,6 +8596,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6585,15 +8638,65 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "uuid"
-version = "1.18.1"
+name = "utoipa"
+version = "4.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
 dependencies = [
- "getrandom 0.3.4",
- "js-sys",
+ "indexmap 2.12.0",
  "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20c24e8ab68ff9ee746aad22d39b5535601e6416d1b0feeabf78be986a5c4392"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.108",
+]
+
+[[package]]
+name = "uuid"
+version = "1.23.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
+dependencies = [
+ "getrandom 0.4.3",
+ "js-sys",
+ "serde_core",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "uuid",
+ "vsimd",
+]
+
+[[package]]
+name = "v_escape-base"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1212fce830b75af194b578e55b3db9049f2c8c45f58d397fb25602fdb50fb3d"
+
+[[package]]
+name = "v_htmlescape"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "befb3d53c9e3ec641417685896cbc8cc5bd264d6a2e190c56aaef1af24740d99"
+dependencies = [
+ "v_escape-base",
 ]
 
 [[package]]
@@ -6625,6 +8728,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"
@@ -6679,6 +8788,12 @@ checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -6787,10 +8902,26 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7cff6eef815df1834fd250e3a2ff436044d82a9f1bc1980ca1dbdf07effc538"
 dependencies = [
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
+]
+
+[[package]]
+name = "webbrowser"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+dependencies = [
+ "core-foundation 0.10.1",
+ "jni 0.22.4",
+ "log",
+ "ndk-context",
+ "objc2 0.6.4",
+ "objc2-foundation 0.3.2",
+ "url",
+ "web-sys",
 ]
 
 [[package]]
@@ -6863,7 +8994,7 @@ checksum = "d4ba622a989277ef3886dd5afb3e280e3dd6d974b766118950a08f8f678ad6a4"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -6886,8 +9017,8 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "36695906a1b53a3bf5c4289621efedac12b73eeb0b89e7e1a89b517302d5d75c"
 dependencies = [
- "thiserror 2.0.17",
- "windows",
+ "thiserror 2.0.18",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -6896,6 +9027,25 @@ name = "weezl"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
+
+[[package]]
+name = "which"
+version = "8.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d7cd18d4acb58fb3cdfe9ea54e6cd96a4e7d4cc45c56338b236e82dad47248"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
 
 [[package]]
 name = "winapi"
@@ -6949,11 +9099,23 @@ version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
- "windows-collections",
+ "windows-collections 0.2.0",
  "windows-core 0.61.2",
- "windows-future",
+ "windows-future 0.2.1",
  "windows-link 0.1.3",
- "windows-numerics",
+ "windows-numerics 0.2.0",
+]
+
+[[package]]
+name = "windows"
+version = "0.62.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+dependencies = [
+ "windows-collections 0.3.2",
+ "windows-core 0.62.2",
+ "windows-future 0.3.2",
+ "windows-numerics 0.3.1",
 ]
 
 [[package]]
@@ -6963,6 +9125,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+dependencies = [
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -6999,7 +9170,18 @@ checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
- "windows-threading",
+ "windows-threading 0.1.0",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
+ "windows-threading 0.2.1",
 ]
 
 [[package]]
@@ -7044,6 +9226,16 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-numerics"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+dependencies = [
+ "windows-core 0.62.2",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -7104,6 +9296,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -7155,6 +9356,21 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -7196,6 +9412,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link 0.2.1",
+]
+
+[[package]]
 name = "windows-version"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7209,6 +9434,12 @@ name = "windows_aarch64_gnullvm"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -7230,6 +9461,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7245,6 +9482,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7278,6 +9521,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7293,6 +9542,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7314,6 +9569,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7329,6 +9590,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7406,7 +9673,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2 0.6.4",
@@ -7418,15 +9685,15 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "raw-window-handle",
- "sha2",
+ "sha2 0.10.9",
  "soup3",
  "tao-macros",
- "thiserror 2.0.17",
+ "thiserror 2.0.18",
  "url",
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -7461,6 +9728,23 @@ dependencies = [
  "once_cell",
  "pkg-config",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "x25519-dalek"
@@ -7550,7 +9834,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "nix 0.30.1",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -7669,6 +9953,7 @@ version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
+ "serde",
  "yoke",
  "zerofrom",
  "zerovec-derive",
@@ -7695,6 +9980,34 @@ dependencies = [
  "crc32fast",
  "indexmap 2.12.0",
  "memchr",
+]
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -2993,6 +2993,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin",
  "tauri-plugin-deep-link",
+ "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
  "tauri-plugin-opener",
@@ -4597,6 +4598,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2 0.6.2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2 0.6.4",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5654,6 +5679,24 @@ dependencies = [
  "url",
  "windows-registry",
  "windows-result 0.3.4",
+]
+
+[[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.17",
+ "url",
 ]
 
 [[package]]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -43,9 +43,9 @@ anyhow = "1.0"
 axum = "0.8"
 pdf-extract = "0.7"
 base64 = "0.22"
-goose = { git = "https://github.com/aaif-goose/goose.git", tag = "v1.41.0", default-features = false }
+goose = { path = "../../ThirdParties/goose/crates/goose", default-features = false }
 # Goose v1.41.0 declares `rmcp = "1.4"` in its workspace, but it does not
-# compile against the current 1.x API when embedded outside that lockfile.
+# compile against the current 1.x API when embedded outside Goose's lockfile.
 rmcp = { version = "=1.4.0", default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -41,6 +41,7 @@ maple-proxy = "0.1.8"
 tauri-plugin-fs = "2.5.1"
 anyhow = "1.0"
 axum = "0.8"
+futures = "0.3"
 pdf-extract = "0.7"
 base64 = "0.22"
 

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["tony@trymaple.ai"]
 license = "MIT"
 repository = "https://github.com/OpenSecretCloud/Maple"
 edition = "2021"
-rust-version = "1.88.0"
+rust-version = "1.91.1"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -43,6 +43,10 @@ anyhow = "1.0"
 axum = "0.8"
 pdf-extract = "0.7"
 base64 = "0.22"
+goose = { git = "https://github.com/aaif-goose/goose.git", tag = "v1.41.0", default-features = false }
+# Goose v1.41.0 declares `rmcp = "1.4"` in its workspace, but it does not
+# compile against the current 1.x API when embedded outside that lockfile.
+rmcp = { version = "=1.4.0", default-features = false }
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 # TTS dependencies (Supertonic) - desktop only

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -43,10 +43,14 @@ anyhow = "1.0"
 axum = "0.8"
 pdf-extract = "0.7"
 base64 = "0.22"
+
+# BEGIN MAPLE_DESKTOP_GOOSE_DEPENDENCIES
+[target.'cfg(any(target_os = "macos", target_os = "windows", target_os = "linux"))'.dependencies]
 goose = { path = "../../ThirdParties/goose/crates/goose", default-features = false }
 # Goose v1.41.0 declares `rmcp = "1.4"` in its workspace, but it does not
 # compile against the current 1.x API when embedded outside Goose's lockfile.
 rmcp = { version = "=1.4.0", default-features = false }
+# END MAPLE_DESKTOP_GOOSE_DEPENDENCIES
 
 [target.'cfg(any(target_os = "macos", target_os = "windows"))'.dependencies]
 # TTS dependencies (Supertonic) - desktop only

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -33,6 +33,7 @@ tauri-plugin-deep-link = "=2.4.7"
 tauri-plugin-single-instance = { version = "=2.4.0", features = ["deep-link"] }
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-os = "2.3.2"
+tauri-plugin-dialog = "2.4.1"
 tauri-plugin-sign-in-with-apple = "1.0.2"
 tokio = { version = "1.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
 once_cell = "1.18.0"

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,12 +1,7 @@
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
-    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     if target_os == "ios" {
         println!("cargo:rustc-link-lib=c++");
-    }
-
-    if target_os != "ios" && target_os != "android" {
-        stage_goose_binary(&target_os, &target_arch);
     }
 
     tauri_build::build();
@@ -17,109 +12,6 @@ fn main() {
     if target_os == "ios" {
         ensure_ios_custom_url_scheme();
     }
-}
-
-fn stage_goose_binary(target_os: &str, target_arch: &str) {
-    println!("cargo:rerun-if-env-changed=MAPLE_GOOSE_BINARY");
-    println!("cargo:rerun-if-env-changed=MAPLE_SKIP_STAGE_GOOSE_BINARY");
-
-    if std::env::var("MAPLE_SKIP_STAGE_GOOSE_BINARY").as_deref() == Ok("1") {
-        return;
-    }
-
-    let binary_name = if target_os == "windows" {
-        "goose.exe"
-    } else {
-        "goose"
-    };
-    let target_dir = std::path::Path::new("bin");
-    if let Err(error) = std::fs::create_dir_all(target_dir) {
-        println!("cargo:warning=failed to create Goose staging dir: {error}");
-        return;
-    }
-
-    let destination = target_dir.join(binary_name);
-    let source = std::env::var("MAPLE_GOOSE_BINARY")
-        .ok()
-        .map(std::path::PathBuf::from)
-        .filter(|path| path.is_file())
-        .or_else(|| goose_binary_package_source(target_os, target_arch, binary_name));
-
-    let Some(source) = source else {
-        println!(
-            "cargo:warning=Goose binary not staged; install @aaif/goose-sdk optional binary package or set MAPLE_GOOSE_BINARY"
-        );
-        return;
-    };
-
-    println!("cargo:rerun-if-changed={}", source.display());
-    if staged_binary_matches(&source, &destination) {
-        ensure_executable(&destination);
-        println!(
-            "cargo:warning=Goose binary already staged from {}",
-            source.display()
-        );
-        return;
-    }
-
-    match std::fs::copy(&source, &destination) {
-        Ok(_) => {
-            ensure_executable(&destination);
-            println!(
-                "cargo:warning=staged Goose binary from {}",
-                source.display()
-            );
-        }
-        Err(error) => {
-            println!(
-                "cargo:warning=failed to stage Goose binary from {}: {error}",
-                source.display()
-            );
-        }
-    }
-}
-
-fn staged_binary_matches(source: &std::path::Path, destination: &std::path::Path) -> bool {
-    match (std::fs::metadata(source), std::fs::metadata(destination)) {
-        (Ok(source_meta), Ok(destination_meta)) => source_meta.len() == destination_meta.len(),
-        _ => false,
-    }
-}
-
-fn ensure_executable(path: &std::path::Path) {
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755));
-    }
-
-    #[cfg(not(unix))]
-    {
-        let _ = path;
-    }
-}
-
-fn goose_binary_package_source(
-    target_os: &str,
-    target_arch: &str,
-    binary_name: &str,
-) -> Option<std::path::PathBuf> {
-    let package = match (target_os, target_arch) {
-        ("macos", "aarch64") => "goose-binary-darwin-arm64",
-        ("macos", "x86_64") => "goose-binary-darwin-x64",
-        ("linux", "aarch64") => "goose-binary-linux-arm64",
-        ("linux", "x86_64") => "goose-binary-linux-x64",
-        ("windows", "x86_64") => "goose-binary-win32-x64",
-        _ => return None,
-    };
-
-    let candidate = std::path::Path::new("..")
-        .join("node_modules")
-        .join("@aaif")
-        .join(package)
-        .join("bin")
-        .join(binary_name);
-    candidate.is_file().then_some(candidate)
 }
 
 #[allow(dead_code)]

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,7 +1,12 @@
 fn main() {
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
     if target_os == "ios" {
         println!("cargo:rustc-link-lib=c++");
+    }
+
+    if target_os != "ios" && target_os != "android" {
+        stage_goose_binary(&target_os, &target_arch);
     }
 
     tauri_build::build();
@@ -12,6 +17,109 @@ fn main() {
     if target_os == "ios" {
         ensure_ios_custom_url_scheme();
     }
+}
+
+fn stage_goose_binary(target_os: &str, target_arch: &str) {
+    println!("cargo:rerun-if-env-changed=MAPLE_GOOSE_BINARY");
+    println!("cargo:rerun-if-env-changed=MAPLE_SKIP_STAGE_GOOSE_BINARY");
+
+    if std::env::var("MAPLE_SKIP_STAGE_GOOSE_BINARY").as_deref() == Ok("1") {
+        return;
+    }
+
+    let binary_name = if target_os == "windows" {
+        "goose.exe"
+    } else {
+        "goose"
+    };
+    let target_dir = std::path::Path::new("bin");
+    if let Err(error) = std::fs::create_dir_all(target_dir) {
+        println!("cargo:warning=failed to create Goose staging dir: {error}");
+        return;
+    }
+
+    let destination = target_dir.join(binary_name);
+    let source = std::env::var("MAPLE_GOOSE_BINARY")
+        .ok()
+        .map(std::path::PathBuf::from)
+        .filter(|path| path.is_file())
+        .or_else(|| goose_binary_package_source(target_os, target_arch, binary_name));
+
+    let Some(source) = source else {
+        println!(
+            "cargo:warning=Goose binary not staged; install @aaif/goose-sdk optional binary package or set MAPLE_GOOSE_BINARY"
+        );
+        return;
+    };
+
+    println!("cargo:rerun-if-changed={}", source.display());
+    if staged_binary_matches(&source, &destination) {
+        ensure_executable(&destination);
+        println!(
+            "cargo:warning=Goose binary already staged from {}",
+            source.display()
+        );
+        return;
+    }
+
+    match std::fs::copy(&source, &destination) {
+        Ok(_) => {
+            ensure_executable(&destination);
+            println!(
+                "cargo:warning=staged Goose binary from {}",
+                source.display()
+            );
+        }
+        Err(error) => {
+            println!(
+                "cargo:warning=failed to stage Goose binary from {}: {error}",
+                source.display()
+            );
+        }
+    }
+}
+
+fn staged_binary_matches(source: &std::path::Path, destination: &std::path::Path) -> bool {
+    match (std::fs::metadata(source), std::fs::metadata(destination)) {
+        (Ok(source_meta), Ok(destination_meta)) => source_meta.len() == destination_meta.len(),
+        _ => false,
+    }
+}
+
+fn ensure_executable(path: &std::path::Path) {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let _ = std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755));
+    }
+
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+}
+
+fn goose_binary_package_source(
+    target_os: &str,
+    target_arch: &str,
+    binary_name: &str,
+) -> Option<std::path::PathBuf> {
+    let package = match (target_os, target_arch) {
+        ("macos", "aarch64") => "goose-binary-darwin-arm64",
+        ("macos", "x86_64") => "goose-binary-darwin-x64",
+        ("linux", "aarch64") => "goose-binary-linux-arm64",
+        ("linux", "x86_64") => "goose-binary-linux-x64",
+        ("windows", "x86_64") => "goose-binary-win32-x64",
+        _ => return None,
+    };
+
+    let candidate = std::path::Path::new("..")
+        .join("node_modules")
+        .join("@aaif")
+        .join(package)
+        .join("bin")
+        .join(binary_name);
+    candidate.is_file().then_some(candidate)
 }
 
 #[allow(dead_code)]

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   "permissions": [
     "core:default",
     "updater:default",
+    "dialog:default",
     "fs:default",
     {
       "identifier": "fs:allow-read-file",

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -1,0 +1,747 @@
+use crate::proxy;
+use rand::{rngs::OsRng, RngCore};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use std::fs::{self, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::{AppHandle, Manager, State};
+use tokio::sync::Mutex;
+
+const DEFAULT_AGENT_MODEL: &str = "auto:powerful";
+const DEFAULT_GOOSE_MODE: &str = "approve";
+const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
+const READINESS_INTERVAL: Duration = Duration::from_millis(100);
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentConfig {
+    pub default_project_root: Option<String>,
+    pub default_model: String,
+    #[serde(default = "default_runtime_kind")]
+    pub runtime_kind: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub external_acp_url: Option<String>,
+}
+
+fn default_runtime_kind() -> String {
+    "goose".to_string()
+}
+
+impl Default for AgentConfig {
+    fn default() -> Self {
+        Self {
+            default_project_root: None,
+            default_model: DEFAULT_AGENT_MODEL.to_string(),
+            runtime_kind: default_runtime_kind(),
+            external_acp_url: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentStartRequest {
+    pub project_root: Option<String>,
+    pub model: Option<String>,
+    pub goose_binary: Option<String>,
+    pub mode: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRuntimeStatus {
+    pub running: bool,
+    pub acp_url: Option<String>,
+    pub redacted_acp_url: Option<String>,
+    pub http_base_url: Option<String>,
+    pub status_url: Option<String>,
+    pub project_root: Option<String>,
+    pub goose_binary: Option<String>,
+    pub pid: Option<u32>,
+    pub model: Option<String>,
+    pub mode: Option<String>,
+    pub maple_proxy_base_url: Option<String>,
+    pub config_dir: String,
+    pub goose_path_root: Option<String>,
+    pub log_path: Option<String>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RecentProjectRoot {
+    pub path: String,
+    pub name: String,
+    pub last_used_ms: u128,
+}
+
+struct AgentRuntime {
+    child: Child,
+    acp_url: String,
+    redacted_acp_url: String,
+    http_base_url: String,
+    status_url: String,
+    project_root: PathBuf,
+    goose_binary: PathBuf,
+    model: String,
+    mode: String,
+    maple_proxy_base_url: String,
+    config_dir: PathBuf,
+    goose_path_root: PathBuf,
+    log_path: PathBuf,
+}
+
+impl AgentRuntime {
+    fn status(&self, running: bool, error: Option<String>) -> AgentRuntimeStatus {
+        AgentRuntimeStatus {
+            running,
+            acp_url: if running {
+                Some(self.acp_url.clone())
+            } else {
+                None
+            },
+            redacted_acp_url: Some(self.redacted_acp_url.clone()),
+            http_base_url: Some(self.http_base_url.clone()),
+            status_url: Some(self.status_url.clone()),
+            project_root: Some(path_string(&self.project_root)),
+            goose_binary: Some(path_string(&self.goose_binary)),
+            pid: Some(self.child.id()),
+            model: Some(self.model.clone()),
+            mode: Some(self.mode.clone()),
+            maple_proxy_base_url: Some(self.maple_proxy_base_url.clone()),
+            config_dir: path_string(&self.config_dir),
+            goose_path_root: Some(path_string(&self.goose_path_root)),
+            log_path: Some(path_string(&self.log_path)),
+            error,
+        }
+    }
+}
+
+pub struct AgentRuntimeState {
+    inner: Arc<Mutex<Option<AgentRuntime>>>,
+    session_log: Arc<Mutex<()>>,
+}
+
+impl AgentRuntimeState {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(None)),
+            session_log: Arc::new(Mutex::new(())),
+        }
+    }
+}
+
+#[tauri::command]
+pub async fn agent_get_runtime_status(
+    app_handle: AppHandle,
+    state: State<'_, AgentRuntimeState>,
+) -> Result<AgentRuntimeStatus, String> {
+    let config_dir = agent_config_dir(&app_handle).map_err(|e| e.to_string())?;
+    let mut runtime = state.inner.lock().await;
+
+    if let Some(current) = runtime.as_mut() {
+        match current.child.try_wait() {
+            Ok(Some(exit_status)) => {
+                let status = current.status(
+                    false,
+                    Some(format!("Goose exited with status {exit_status}")),
+                );
+                *runtime = None;
+                return Ok(status);
+            }
+            Ok(None) => return Ok(current.status(true, None)),
+            Err(e) => {
+                let status = current.status(false, Some(format!("Failed to inspect Goose: {e}")));
+                *runtime = None;
+                return Ok(status);
+            }
+        }
+    }
+
+    Ok(stopped_status(config_dir, None))
+}
+
+#[tauri::command]
+pub async fn agent_start_runtime(
+    app_handle: AppHandle,
+    state: State<'_, AgentRuntimeState>,
+    proxy_state: State<'_, proxy::ProxyState>,
+    request: Option<AgentStartRequest>,
+) -> Result<AgentRuntimeStatus, String> {
+    clear_exited_runtime(&state).await;
+
+    {
+        let runtime = state.inner.lock().await;
+        if let Some(current) = runtime.as_ref() {
+            return Ok(current.status(true, None));
+        }
+    }
+
+    let agent_config = load_agent_config_inner(&app_handle).unwrap_or_default();
+    let request = request.unwrap_or(AgentStartRequest {
+        project_root: None,
+        model: None,
+        goose_binary: None,
+        mode: None,
+    });
+
+    let proxy_status = proxy::ensure_proxy_running(app_handle.clone(), proxy_state).await?;
+    let proxy_config = proxy_status.config;
+    let proxy_host = if proxy_config.host == "0.0.0.0" {
+        "127.0.0.1".to_string()
+    } else {
+        proxy_config.host.clone()
+    };
+    let maple_proxy_base_url = format!("http://{}:{}", proxy_host, proxy_config.port);
+
+    let project_root =
+        resolve_project_root(request.project_root.as_deref(), &agent_config).map_err(|e| {
+            format!("Failed to resolve Agent Mode project root: {e}")
+        })?;
+    let model = request
+        .model
+        .or_else(|| std::env::var("MAPLE_GOOSE_MODEL").ok())
+        .unwrap_or(agent_config.default_model);
+    let mode = request
+        .mode
+        .or_else(|| std::env::var("MAPLE_GOOSE_MODE").ok())
+        .unwrap_or_else(|| DEFAULT_GOOSE_MODE.to_string());
+    let goose_binary =
+        resolve_goose_binary(&app_handle, request.goose_binary.as_deref()).map_err(|e| {
+            format!("Failed to resolve Goose binary: {e}")
+        })?;
+
+    let config_dir = agent_config_dir(&app_handle).map_err(|e| e.to_string())?;
+    let goose_path_root = std::env::var("MAPLE_GOOSE_PATH_ROOT")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| config_dir.join("goose"));
+    let log_dir = config_dir.join("logs");
+    fs::create_dir_all(&log_dir).map_err(|e| format!("Failed to create log dir: {e}"))?;
+    fs::create_dir_all(&goose_path_root)
+        .map_err(|e| format!("Failed to create Goose data dir: {e}"))?;
+    let log_path = log_dir.join("goose-serve.log");
+
+    let port = find_available_port().map_err(|e| format!("Failed to allocate Goose port: {e}"))?;
+    let token = secure_token();
+    let http_base_url = format!("http://127.0.0.1:{port}");
+    let status_url = format!("{http_base_url}/status");
+    let acp_url = format!("ws://127.0.0.1:{port}/acp?token={token}");
+    let redacted_acp_url = format!("ws://127.0.0.1:{port}/acp?token=REDACTED");
+
+    let log_file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&log_path)
+        .map_err(|e| format!("Failed to open Goose log: {e}"))?;
+    set_owner_only_permissions(&log_path);
+    let stdout_file = log_file
+        .try_clone()
+        .map_err(|e| format!("Failed to clone Goose log handle: {e}"))?;
+
+    let mut command = Command::new(&goose_binary);
+    let port_arg = port.to_string();
+    command
+        .args([
+            "serve",
+            "--host",
+            "127.0.0.1",
+            "--port",
+            &port_arg,
+        ])
+        .current_dir(&project_root)
+        .env("GOOSE_SERVER__SECRET_KEY", &token)
+        .env("GOOSE_PROVIDER", "openai")
+        .env("GOOSE_MODEL", &model)
+        .env("GOOSE_FAST_MODEL", &model)
+        .env("GOOSE_MODE", &mode)
+        .env("GOOSE_DISABLE_KEYRING", "true")
+        .env("GOOSE_PATH_ROOT", &goose_path_root)
+        .env("OPENAI_BASE_URL", format!("{}/v1", maple_proxy_base_url))
+        .env("OPENAI_API_KEY", proxy_config.api_key)
+        .stdout(Stdio::from(stdout_file))
+        .stderr(Stdio::from(log_file));
+
+    if let Some(parent) = goose_binary.parent() {
+        prepend_path_env(&mut command, parent);
+    }
+
+    log::info!(
+        "Starting Goose ACP runtime from {} in {} on {}",
+        goose_binary.display(),
+        project_root.display(),
+        redacted_acp_url
+    );
+
+    let mut child = command
+        .spawn()
+        .map_err(|e| format!("Failed to spawn Goose: {e}"))?;
+
+    if let Err(e) = wait_for_goose_ready(&status_url, &mut child).await {
+        let _ = child.kill();
+        let _ = child.wait();
+        return Err(format!("{e}. See {}", log_path.display()));
+    }
+
+    let runtime = AgentRuntime {
+        child,
+        acp_url,
+        redacted_acp_url,
+        http_base_url,
+        status_url,
+        project_root: project_root.clone(),
+        goose_binary,
+        model: model.clone(),
+        mode,
+        maple_proxy_base_url,
+        config_dir: config_dir.clone(),
+        goose_path_root,
+        log_path,
+    };
+
+    let status = runtime.status(true, None);
+    {
+        let mut guard = state.inner.lock().await;
+        *guard = Some(runtime);
+    }
+
+    let _ = save_recent_project_root_inner(&app_handle, &project_root);
+    let mut next_config = load_agent_config_inner(&app_handle).unwrap_or_default();
+    next_config.default_project_root = Some(path_string(&project_root));
+    next_config.default_model = model;
+    let _ = save_agent_config_inner(&app_handle, &next_config);
+
+    Ok(status)
+}
+
+#[tauri::command]
+pub async fn agent_stop_runtime(
+    app_handle: AppHandle,
+    state: State<'_, AgentRuntimeState>,
+) -> Result<AgentRuntimeStatus, String> {
+    let config_dir = agent_config_dir(&app_handle).map_err(|e| e.to_string())?;
+    stop_runtime_inner(&state).await?;
+    Ok(stopped_status(config_dir, None))
+}
+
+#[tauri::command]
+pub async fn agent_restart_runtime(
+    app_handle: AppHandle,
+    state: State<'_, AgentRuntimeState>,
+    proxy_state: State<'_, proxy::ProxyState>,
+    request: Option<AgentStartRequest>,
+) -> Result<AgentRuntimeStatus, String> {
+    stop_runtime_inner(&state).await?;
+    agent_start_runtime(app_handle, state, proxy_state, request).await
+}
+
+#[tauri::command]
+pub async fn agent_load_config(app_handle: AppHandle) -> Result<AgentConfig, String> {
+    load_agent_config_inner(&app_handle).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn agent_save_config(app_handle: AppHandle, config: AgentConfig) -> Result<(), String> {
+    save_agent_config_inner(&app_handle, &config).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn agent_list_recent_project_roots(
+    app_handle: AppHandle,
+) -> Result<Vec<RecentProjectRoot>, String> {
+    load_recent_project_roots_inner(&app_handle).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn agent_save_recent_project_root(
+    app_handle: AppHandle,
+    path: String,
+) -> Result<Vec<RecentProjectRoot>, String> {
+    let project_root = normalize_project_root(Path::new(&path))?;
+    save_recent_project_root_inner(&app_handle, &project_root).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn agent_append_session_event(
+    app_handle: AppHandle,
+    state: State<'_, AgentRuntimeState>,
+    session_id: String,
+    event: Value,
+) -> Result<(), String> {
+    let _guard = state.session_log.lock().await;
+    append_session_event_inner(&app_handle, &session_id, event).map_err(|e| e.to_string())
+}
+
+async fn clear_exited_runtime(state: &State<'_, AgentRuntimeState>) {
+    let mut runtime = state.inner.lock().await;
+    if let Some(current) = runtime.as_mut() {
+        if matches!(current.child.try_wait(), Ok(Some(_)) | Err(_)) {
+            *runtime = None;
+        }
+    }
+}
+
+async fn stop_runtime_inner(state: &State<'_, AgentRuntimeState>) -> Result<(), String> {
+    let mut runtime = state.inner.lock().await;
+    if let Some(mut current) = runtime.take() {
+        log::info!("Stopping Goose ACP runtime");
+        if let Err(e) = current.child.kill() {
+            log::warn!("Failed to kill Goose runtime: {e}");
+        }
+        if let Err(e) = current.child.wait() {
+            log::warn!("Failed to wait for Goose runtime exit: {e}");
+        }
+    }
+    Ok(())
+}
+
+async fn wait_for_goose_ready(status_url: &str, child: &mut Child) -> Result<(), String> {
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(1))
+        .build()
+        .map_err(|e| format!("Failed to build readiness client: {e}"))?;
+    let deadline = std::time::Instant::now() + READINESS_TIMEOUT;
+
+    while std::time::Instant::now() < deadline {
+        match child.try_wait() {
+            Ok(Some(exit_status)) => {
+                return Err(format!("Goose exited before becoming ready: {exit_status}"));
+            }
+            Ok(None) => {}
+            Err(e) => return Err(format!("Failed to inspect Goose readiness: {e}")),
+        }
+
+        if let Ok(response) = client.get(status_url).send().await {
+            if response.status().is_success() {
+                return Ok(());
+            }
+        }
+
+        tokio::time::sleep(READINESS_INTERVAL).await;
+    }
+
+    Err(format!("Goose did not become ready on {status_url}"))
+}
+
+fn stopped_status(config_dir: PathBuf, error: Option<String>) -> AgentRuntimeStatus {
+    AgentRuntimeStatus {
+        running: false,
+        acp_url: None,
+        redacted_acp_url: None,
+        http_base_url: None,
+        status_url: None,
+        project_root: None,
+        goose_binary: None,
+        pid: None,
+        model: None,
+        mode: None,
+        maple_proxy_base_url: None,
+        config_dir: path_string(&config_dir),
+        goose_path_root: None,
+        log_path: None,
+        error,
+    }
+}
+
+fn resolve_project_root(
+    requested: Option<&str>,
+    config: &AgentConfig,
+) -> Result<PathBuf, String> {
+    if let Some(path) = requested.filter(|value| !value.trim().is_empty()) {
+        return normalize_project_root(Path::new(path));
+    }
+
+    if let Some(path) = config
+        .default_project_root
+        .as_deref()
+        .filter(|value| !value.trim().is_empty())
+    {
+        if let Ok(root) = normalize_project_root(Path::new(path)) {
+            return Ok(root);
+        }
+    }
+
+    std::env::current_dir()
+        .map_err(|e| format!("Failed to read current directory: {e}"))
+        .and_then(|path| normalize_project_root(&path))
+}
+
+fn normalize_project_root(path: &Path) -> Result<PathBuf, String> {
+    let canonical = path
+        .canonicalize()
+        .map_err(|e| format!("{}: {e}", path.display()))?;
+    if !canonical.is_dir() {
+        return Err(format!("{} is not a folder", canonical.display()));
+    }
+    Ok(canonical)
+}
+
+fn resolve_goose_binary(app_handle: &AppHandle, requested: Option<&str>) -> Result<PathBuf, String> {
+    let mut candidates = Vec::new();
+
+    if let Some(path) = requested.filter(|value| !value.trim().is_empty()) {
+        candidates.push(PathBuf::from(path));
+    }
+
+    if let Ok(path) = std::env::var("MAPLE_GOOSE_BINARY") {
+        candidates.push(PathBuf::from(path));
+    }
+
+    if let Ok(path) = std::env::var("GOOSE_BINARY") {
+        candidates.push(PathBuf::from(path));
+    }
+
+    if let Ok(resource_dir) = app_handle.path().resource_dir() {
+        candidates.push(resource_dir.join("bin").join(goose_binary_name()));
+        candidates.push(resource_dir.join(goose_binary_name()));
+    }
+
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    candidates.push(
+        manifest_dir
+            .join("..")
+            .join("node_modules")
+            .join("@aaif")
+            .join(goose_binary_package_name())
+            .join("bin")
+            .join(goose_binary_name()),
+    );
+    candidates.push(
+        manifest_dir
+            .join("bin")
+            .join(goose_binary_name()),
+    );
+
+    if cfg!(debug_assertions) {
+        if let Some(path) = find_on_path(goose_binary_name()) {
+            candidates.push(path);
+        }
+    }
+
+    for candidate in candidates {
+        let candidate = expand_home(candidate);
+        if candidate.is_file() {
+            return Ok(candidate);
+        }
+    }
+
+    Err("Goose binary not found. Set MAPLE_GOOSE_BINARY in development or bundle bin/goose with Maple.".to_string())
+}
+
+fn goose_binary_name() -> &'static str {
+    if cfg!(target_os = "windows") {
+        "goose.exe"
+    } else {
+        "goose"
+    }
+}
+
+fn goose_binary_package_name() -> &'static str {
+    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
+        "goose-binary-darwin-arm64"
+    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
+        "goose-binary-darwin-x64"
+    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
+        "goose-binary-linux-arm64"
+    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
+        "goose-binary-linux-x64"
+    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
+        "goose-binary-win32-x64"
+    } else {
+        "goose-binary-unsupported"
+    }
+}
+
+fn find_available_port() -> std::io::Result<u16> {
+    let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
+    Ok(listener.local_addr()?.port())
+}
+
+fn secure_token() -> String {
+    let mut bytes = [0u8; 32];
+    OsRng.fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn prepend_path_env(command: &mut Command, dir: &Path) {
+    let key = if cfg!(target_os = "windows") {
+        "Path"
+    } else {
+        "PATH"
+    };
+    let current = std::env::var_os(key).unwrap_or_default();
+    let mut paths = vec![dir.to_path_buf()];
+    paths.extend(std::env::split_paths(&current));
+    if let Ok(joined) = std::env::join_paths(paths) {
+        command.env(key, joined);
+    }
+}
+
+fn find_on_path(binary: &str) -> Option<PathBuf> {
+    let path_var = std::env::var_os(if cfg!(target_os = "windows") {
+        "Path"
+    } else {
+        "PATH"
+    })?;
+    std::env::split_paths(&path_var)
+        .map(|dir| dir.join(binary))
+        .find(|candidate| candidate.is_file())
+}
+
+fn expand_home(path: PathBuf) -> PathBuf {
+    let path_string = path.to_string_lossy();
+    if path_string == "~" {
+        return home_dir().unwrap_or(path);
+    }
+    if let Some(rest) = path_string.strip_prefix("~/") {
+        if let Some(home) = home_dir() {
+            return home.join(rest);
+        }
+    }
+    path
+}
+
+fn home_dir() -> Option<PathBuf> {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
+}
+
+fn agent_config_dir(app_handle: &AppHandle) -> Result<PathBuf, anyhow::Error> {
+    let base = if cfg!(target_os = "windows") {
+        app_handle
+            .path()
+            .app_config_dir()
+            .map_err(|e| anyhow::anyhow!("Failed to resolve app config dir: {e}"))?
+    } else {
+        let home = std::env::var("HOME")
+            .map_err(|_| anyhow::anyhow!("Failed to get home directory"))?;
+        PathBuf::from(home).join(".config").join("maple")
+    };
+    let path = base.join("agent");
+    fs::create_dir_all(&path)?;
+    Ok(path)
+}
+
+fn load_agent_config_inner(app_handle: &AppHandle) -> Result<AgentConfig, anyhow::Error> {
+    let path = agent_config_dir(app_handle)?.join("config.json");
+    if !path.exists() {
+        return Ok(AgentConfig::default());
+    }
+    let contents = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+fn save_agent_config_inner(
+    app_handle: &AppHandle,
+    config: &AgentConfig,
+) -> Result<(), anyhow::Error> {
+    let path = agent_config_dir(app_handle)?.join("config.json");
+    write_json_file(&path, config)
+}
+
+fn load_recent_project_roots_inner(
+    app_handle: &AppHandle,
+) -> Result<Vec<RecentProjectRoot>, anyhow::Error> {
+    let path = agent_config_dir(app_handle)?.join("recent_roots.json");
+    if !path.exists() {
+        return Ok(Vec::new());
+    }
+    let contents = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+fn save_recent_project_root_inner(
+    app_handle: &AppHandle,
+    project_root: &Path,
+) -> Result<Vec<RecentProjectRoot>, anyhow::Error> {
+    let mut roots = load_recent_project_roots_inner(app_handle).unwrap_or_default();
+    let path = path_string(project_root);
+    roots.retain(|root| root.path != path);
+    roots.insert(
+        0,
+        RecentProjectRoot {
+            name: project_root
+                .file_name()
+                .and_then(|value| value.to_str())
+                .unwrap_or(&path)
+                .to_string(),
+            path,
+            last_used_ms: unix_ms(),
+        },
+    );
+    roots.truncate(20);
+
+    let file_path = agent_config_dir(app_handle)?.join("recent_roots.json");
+    write_json_file(&file_path, &roots)?;
+    Ok(roots)
+}
+
+fn append_session_event_inner(
+    app_handle: &AppHandle,
+    session_id: &str,
+    event: Value,
+) -> Result<(), anyhow::Error> {
+    let sessions_dir = agent_config_dir(app_handle)?.join("sessions");
+    fs::create_dir_all(&sessions_dir)?;
+    let path = sessions_dir.join(format!("{}.jsonl", sanitize_file_id(session_id)));
+    let mut file = OpenOptions::new().create(true).append(true).open(&path)?;
+    set_owner_only_permissions(&path);
+    let row = serde_json::json!({
+        "ts": unix_ms(),
+        "event": event,
+    });
+    serde_json::to_writer(&mut file, &row)?;
+    file.write_all(b"\n")?;
+    Ok(())
+}
+
+fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), anyhow::Error> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    fs::write(path, serde_json::to_string_pretty(value)?)?;
+    set_owner_only_permissions(path);
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_owner_only_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_permissions(_path: &Path) {}
+
+fn sanitize_file_id(value: &str) -> String {
+    let sanitized: String = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '-' || ch == '_' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    if sanitized.is_empty() {
+        "session".to_string()
+    } else {
+        sanitized
+    }
+}
+
+fn unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+fn path_string(path: &Path) -> String {
+    path.to_string_lossy().to_string()
+}

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -76,6 +76,8 @@ pub struct AgentRuntimeStatus {
     pub config_dir: String,
     pub goose_path_root: Option<String>,
     pub log_path: Option<String>,
+    pub llm_log_dir: Option<String>,
+    pub latest_llm_log_path: Option<String>,
     pub error: Option<String>,
 }
 
@@ -124,6 +126,10 @@ impl AgentRuntime {
             config_dir: path_string(&self.config_dir),
             goose_path_root: Some(path_string(&self.goose_path_root)),
             log_path: Some(path_string(&self.log_path)),
+            llm_log_dir: Some(path_string(&goose_llm_log_dir(&self.goose_path_root))),
+            latest_llm_log_path: Some(path_string(&latest_goose_llm_log_path(
+                &self.goose_path_root,
+            ))),
             error,
         }
     }
@@ -224,6 +230,8 @@ pub async fn agent_start_runtime(
     fs::create_dir_all(&goose_path_root)
         .map_err(|e| format!("Failed to create Goose data dir: {e}"))?;
     let log_path = log_dir.join("goose-embedded.log");
+    let llm_log_dir = goose_llm_log_dir(&goose_path_root);
+    let latest_llm_log_path = latest_goose_llm_log_path(&goose_path_root);
 
     let port = find_available_port().map_err(|e| format!("Failed to allocate Goose port: {e}"))?;
     let token = secure_token();
@@ -269,11 +277,13 @@ pub async fn agent_start_runtime(
     append_runtime_log(
         &log_path,
         &format!(
-            "starting embedded Goose ACP runtime: project_root={}, acp={}, proxy=http://{}:{}, allowed_origins={}",
+            "starting embedded Goose ACP runtime: project_root={}, acp={}, proxy=http://{}:{}, llm_log_dir={}, latest_llm_log={}, allowed_origins={}",
             project_root.display(),
             redacted_acp_url,
             proxy_host,
             proxy_config.port,
+            llm_log_dir.display(),
+            latest_llm_log_path.display(),
             allowed_origin_log
         ),
     );
@@ -501,6 +511,8 @@ fn configure_embedded_goose(
     config
         .set_secret("OPENAI_API_KEY", &proxy_api_key)
         .map_err(|e| format!("Failed to configure Goose OpenAI API key: {e}"))?;
+    goose::providers::utils::init_goose_request_log()
+        .map_err(|e| format!("Failed to initialize Goose LLM request logging: {e}"))?;
 
     set_owner_only_permissions(&goose_path_root.join("config").join("config.yaml"));
     set_owner_only_permissions(&goose_path_root.join("config").join("secrets.yaml"));
@@ -530,8 +542,18 @@ fn stopped_status(config_dir: PathBuf, error: Option<String>) -> AgentRuntimeSta
         config_dir: path_string(&config_dir),
         goose_path_root: None,
         log_path: None,
+        llm_log_dir: None,
+        latest_llm_log_path: None,
         error,
     }
+}
+
+fn goose_llm_log_dir(goose_path_root: &Path) -> PathBuf {
+    goose_path_root.join("state").join("logs")
+}
+
+fn latest_goose_llm_log_path(goose_path_root: &Path) -> PathBuf {
+    goose_llm_log_dir(goose_path_root).join("llm_request.0.jsonl")
 }
 
 fn resolve_project_root(requested: Option<&str>, config: &AgentConfig) -> Result<PathBuf, String> {

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -3,6 +3,7 @@ use axum::http::HeaderValue;
 use goose::acp::server_factory::{AcpServer, AcpServerFactoryConfig};
 use goose::acp::transport::create_router as create_goose_acp_router;
 use goose::agents::GoosePlatform;
+use goose::config::ConfigError;
 use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -479,8 +480,10 @@ fn configure_embedded_goose(
 
     std::env::set_var("GOOSE_PATH_ROOT", goose_path_root);
     std::env::set_var("GOOSE_DISABLE_KEYRING", "true");
+    std::env::remove_var("GOOSE_MAX_TOKENS");
 
     let config = goose::config::Config::global();
+    delete_goose_config_key(config, "GOOSE_MAX_TOKENS")?;
     goose::config::set_active_provider(config, "openai", model)
         .map_err(|e| format!("Failed to configure Goose provider: {e}"))?;
     config
@@ -502,6 +505,13 @@ fn configure_embedded_goose(
     set_owner_only_permissions(&goose_path_root.join("config").join("config.yaml"));
     set_owner_only_permissions(&goose_path_root.join("config").join("secrets.yaml"));
     Ok(())
+}
+
+fn delete_goose_config_key(config: &goose::config::Config, key: &str) -> Result<(), String> {
+    match config.delete(key) {
+        Ok(()) | Err(ConfigError::NotFound(_)) => Ok(()),
+        Err(e) => Err(format!("Failed to clear Goose config key {key}: {e}")),
+    }
 }
 
 fn stopped_status(config_dir: PathBuf, error: Option<String>) -> AgentRuntimeStatus {

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -78,6 +78,8 @@ pub struct AgentRuntimeStatus {
     pub log_path: Option<String>,
     pub llm_log_dir: Option<String>,
     pub latest_llm_log_path: Option<String>,
+    pub proxy_llm_log_dir: Option<String>,
+    pub latest_proxy_llm_log_path: Option<String>,
     pub error: Option<String>,
 }
 
@@ -130,6 +132,8 @@ impl AgentRuntime {
             latest_llm_log_path: Some(path_string(&latest_goose_llm_log_path(
                 &self.goose_path_root,
             ))),
+            proxy_llm_log_dir: Some(path_string(&proxy_llm_log_dir(&self.config_dir))),
+            latest_proxy_llm_log_path: latest_proxy_llm_log_path(&self.config_dir),
             error,
         }
     }
@@ -232,6 +236,7 @@ pub async fn agent_start_runtime(
     let log_path = log_dir.join("goose-embedded.log");
     let llm_log_dir = goose_llm_log_dir(&goose_path_root);
     let latest_llm_log_path = latest_goose_llm_log_path(&goose_path_root);
+    let proxy_llm_log_dir = proxy_llm_log_dir(&config_dir);
 
     let port = find_available_port().map_err(|e| format!("Failed to allocate Goose port: {e}"))?;
     let token = secure_token();
@@ -277,13 +282,14 @@ pub async fn agent_start_runtime(
     append_runtime_log(
         &log_path,
         &format!(
-            "starting embedded Goose ACP runtime: project_root={}, acp={}, proxy=http://{}:{}, llm_log_dir={}, latest_llm_log={}, allowed_origins={}",
+            "starting embedded Goose ACP runtime: project_root={}, acp={}, proxy=http://{}:{}, llm_log_dir={}, latest_llm_log={}, proxy_llm_log_dir={}, allowed_origins={}",
             project_root.display(),
             redacted_acp_url,
             proxy_host,
             proxy_config.port,
             llm_log_dir.display(),
             latest_llm_log_path.display(),
+            proxy_llm_log_dir.display(),
             allowed_origin_log
         ),
     );
@@ -544,6 +550,8 @@ fn stopped_status(config_dir: PathBuf, error: Option<String>) -> AgentRuntimeSta
         log_path: None,
         llm_log_dir: None,
         latest_llm_log_path: None,
+        proxy_llm_log_dir: Some(path_string(&proxy_llm_log_dir(&config_dir))),
+        latest_proxy_llm_log_path: latest_proxy_llm_log_path(&config_dir),
         error,
     }
 }
@@ -554,6 +562,27 @@ fn goose_llm_log_dir(goose_path_root: &Path) -> PathBuf {
 
 fn latest_goose_llm_log_path(goose_path_root: &Path) -> PathBuf {
     goose_llm_log_dir(goose_path_root).join("llm_request.0.jsonl")
+}
+
+fn proxy_llm_log_dir(agent_config_dir: &Path) -> PathBuf {
+    agent_config_dir.join("proxy-llm-logs")
+}
+
+fn latest_proxy_llm_log_path(agent_config_dir: &Path) -> Option<String> {
+    let dir = proxy_llm_log_dir(agent_config_dir);
+    let entries = fs::read_dir(dir).ok()?;
+    entries
+        .filter_map(|entry| {
+            let entry = entry.ok()?;
+            let path = entry.path();
+            if path.extension().and_then(|value| value.to_str()) != Some("jsonl") {
+                return None;
+            }
+            let modified = entry.metadata().ok()?.modified().ok()?;
+            Some((modified, path))
+        })
+        .max_by_key(|(modified, _)| *modified)
+        .map(|(_, path)| path_string(&path))
 }
 
 fn resolve_project_root(requested: Option<&str>, config: &AgentConfig) -> Result<PathBuf, String> {

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -1,4 +1,5 @@
 use crate::proxy;
+use axum::http::HeaderValue;
 use goose::acp::server_factory::{AcpServer, AcpServerFactoryConfig};
 use goose::acp::transport::create_router as create_goose_acp_router;
 use goose::agents::GoosePlatform;
@@ -192,6 +193,7 @@ pub async fn agent_start_runtime(
         mode: None,
     });
 
+    log::info!("Agent Mode requested embedded Goose runtime start");
     let proxy_status = proxy::ensure_proxy_running(app_handle.clone(), proxy_state).await?;
     let proxy_config = proxy_status.config;
     let proxy_host = if proxy_config.host == "0.0.0.0" {
@@ -228,6 +230,12 @@ pub async fn agent_start_runtime(
     let status_url = format!("{http_base_url}/status");
     let acp_url = format!("ws://127.0.0.1:{port}/acp?token={token}");
     let redacted_acp_url = format!("ws://127.0.0.1:{port}/acp?token=REDACTED");
+    let allowed_origins = tauri_acp_allowed_origins();
+    let allowed_origin_log = allowed_origins
+        .iter()
+        .filter_map(|origin| origin.to_str().ok())
+        .collect::<Vec<_>>()
+        .join(", ");
 
     configure_embedded_goose(
         &goose_path_root,
@@ -248,20 +256,24 @@ pub async fn agent_start_runtime(
         additional_source_roots: Vec::new(),
         scheduler: None,
     }));
-    let router = create_goose_acp_router(acp_server, token, true, Vec::new());
+    let router = create_goose_acp_router(acp_server, token, true, allowed_origins);
     let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
     log::info!(
-        "Starting embedded Goose ACP runtime in {} on {}",
+        "Starting embedded Goose ACP runtime in {} on {} with allowed origins: {}",
         project_root.display(),
-        redacted_acp_url
+        redacted_acp_url,
+        allowed_origin_log
     );
     append_runtime_log(
         &log_path,
         &format!(
-            "starting embedded Goose ACP runtime: project_root={}, acp={}",
+            "starting embedded Goose ACP runtime: project_root={}, acp={}, proxy=http://{}:{}, allowed_origins={}",
             project_root.display(),
-            redacted_acp_url
+            redacted_acp_url,
+            proxy_host,
+            proxy_config.port,
+            allowed_origin_log
         ),
     );
 
@@ -275,10 +287,20 @@ pub async fn agent_start_runtime(
     });
 
     if let Err(e) = wait_for_goose_ready(&status_url).await {
+        append_runtime_log(
+            &log_path,
+            &format!("embedded Goose ACP runtime readiness failed: {e}"),
+        );
         let _ = shutdown_tx.send(());
         server_task.abort();
         return Err(format!("{e}. See {}", log_path.display()));
     }
+
+    append_runtime_log(
+        &log_path,
+        &format!("embedded Goose ACP runtime ready: status={status_url}, acp={redacted_acp_url}"),
+    );
+    log::info!("Embedded Goose ACP runtime ready on {redacted_acp_url}");
 
     let runtime = AgentRuntime {
         shutdown: Some(shutdown_tx),
@@ -367,6 +389,20 @@ pub async fn agent_append_session_event(
 ) -> Result<(), String> {
     let _guard = state.session_log.lock().await;
     append_session_event_inner(&app_handle, &session_id, event).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+pub async fn agent_append_runtime_log(
+    app_handle: AppHandle,
+    message: String,
+) -> Result<(), String> {
+    let log_path = agent_config_dir(&app_handle)
+        .map_err(|e| e.to_string())?
+        .join("logs")
+        .join("goose-embedded.log");
+    log::info!("[Agent Mode] {message}");
+    append_runtime_log(&log_path, &format!("frontend {}", message));
+    Ok(())
 }
 
 async fn clear_exited_runtime(state: &State<'_, AgentRuntimeState>) {
@@ -527,6 +563,36 @@ fn secure_token() -> String {
     let mut bytes = [0u8; 32];
     OsRng.fill_bytes(&mut bytes);
     bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+fn tauri_acp_allowed_origins() -> Vec<HeaderValue> {
+    let mut origins = vec![
+        HeaderValue::from_static("http://localhost:5173"),
+        HeaderValue::from_static("http://127.0.0.1:5173"),
+        HeaderValue::from_static("http://tauri.localhost"),
+        HeaderValue::from_static("https://tauri.localhost"),
+        HeaderValue::from_static("tauri://localhost"),
+        HeaderValue::from_static("null"),
+        HeaderValue::from_static("file://"),
+    ];
+
+    if let Ok(extra_origins) = std::env::var("MAPLE_GOOSE_ACP_ALLOWED_ORIGINS") {
+        for origin in extra_origins
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+        {
+            match HeaderValue::from_str(origin) {
+                Ok(header) if !origins.contains(&header) => origins.push(header),
+                Ok(_) => {}
+                Err(error) => {
+                    log::warn!("Ignoring invalid MAPLE_GOOSE_ACP_ALLOWED_ORIGINS entry {origin:?}: {error}");
+                }
+            }
+        }
+    }
+
+    origins
 }
 
 fn agent_config_dir(app_handle: &AppHandle) -> Result<PathBuf, anyhow::Error> {

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -1,20 +1,24 @@
 use crate::proxy;
+use goose::acp::server_factory::{AcpServer, AcpServerFactoryConfig};
+use goose::acp::transport::create_router as create_goose_acp_router;
+use goose::agents::GoosePlatform;
 use rand::{rngs::OsRng, RngCore};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::fs::{self, OpenOptions};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command, Stdio};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Manager, State};
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
+use tokio::task::JoinHandle;
 
 const DEFAULT_AGENT_MODEL: &str = "auto:powerful";
 const DEFAULT_GOOSE_MODE: &str = "approve";
 const READINESS_TIMEOUT: Duration = Duration::from_secs(30);
 const READINESS_INTERVAL: Duration = Duration::from_millis(100);
+const SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -47,6 +51,8 @@ impl Default for AgentConfig {
 pub struct AgentStartRequest {
     pub project_root: Option<String>,
     pub model: Option<String>,
+    // Kept so older frontend state or dev tools can pass the old field without
+    // breaking deserialization. Built-in Goose now runs in-process.
     pub goose_binary: Option<String>,
     pub mode: Option<String>,
 }
@@ -80,13 +86,13 @@ pub struct RecentProjectRoot {
 }
 
 struct AgentRuntime {
-    child: Child,
+    shutdown: Option<oneshot::Sender<()>>,
+    server_task: JoinHandle<Result<(), String>>,
     acp_url: String,
     redacted_acp_url: String,
     http_base_url: String,
     status_url: String,
     project_root: PathBuf,
-    goose_binary: PathBuf,
     model: String,
     mode: String,
     maple_proxy_base_url: String,
@@ -108,8 +114,8 @@ impl AgentRuntime {
             http_base_url: Some(self.http_base_url.clone()),
             status_url: Some(self.status_url.clone()),
             project_root: Some(path_string(&self.project_root)),
-            goose_binary: Some(path_string(&self.goose_binary)),
-            pid: Some(self.child.id()),
+            goose_binary: None,
+            pid: None,
             model: Some(self.model.clone()),
             mode: Some(self.mode.clone()),
             maple_proxy_base_url: Some(self.maple_proxy_base_url.clone()),
@@ -144,22 +150,19 @@ pub async fn agent_get_runtime_status(
     let mut runtime = state.inner.lock().await;
 
     if let Some(current) = runtime.as_mut() {
-        match current.child.try_wait() {
-            Ok(Some(exit_status)) => {
-                let status = current.status(
-                    false,
-                    Some(format!("Goose exited with status {exit_status}")),
-                );
-                *runtime = None;
-                return Ok(status);
-            }
-            Ok(None) => return Ok(current.status(true, None)),
-            Err(e) => {
-                let status = current.status(false, Some(format!("Failed to inspect Goose: {e}")));
-                *runtime = None;
-                return Ok(status);
-            }
+        if !current.server_task.is_finished() {
+            return Ok(current.status(true, None));
         }
+    }
+
+    if let Some(current) = runtime.take() {
+        drop(runtime);
+        let error = match current.server_task.await {
+            Ok(Ok(())) => Some("Goose ACP server stopped".to_string()),
+            Ok(Err(error)) => Some(error),
+            Err(error) => Some(format!("Goose ACP server task failed: {error}")),
+        };
+        return Ok(stopped_status(config_dir, error));
     }
 
     Ok(stopped_status(config_dir, None))
@@ -198,10 +201,8 @@ pub async fn agent_start_runtime(
     };
     let maple_proxy_base_url = format!("http://{}:{}", proxy_host, proxy_config.port);
 
-    let project_root =
-        resolve_project_root(request.project_root.as_deref(), &agent_config).map_err(|e| {
-            format!("Failed to resolve Agent Mode project root: {e}")
-        })?;
+    let project_root = resolve_project_root(request.project_root.as_deref(), &agent_config)
+        .map_err(|e| format!("Failed to resolve Agent Mode project root: {e}"))?;
     let model = request
         .model
         .or_else(|| std::env::var("MAPLE_GOOSE_MODEL").ok())
@@ -210,10 +211,6 @@ pub async fn agent_start_runtime(
         .mode
         .or_else(|| std::env::var("MAPLE_GOOSE_MODE").ok())
         .unwrap_or_else(|| DEFAULT_GOOSE_MODE.to_string());
-    let goose_binary =
-        resolve_goose_binary(&app_handle, request.goose_binary.as_deref()).map_err(|e| {
-            format!("Failed to resolve Goose binary: {e}")
-        })?;
 
     let config_dir = agent_config_dir(&app_handle).map_err(|e| e.to_string())?;
     let goose_path_root = std::env::var("MAPLE_GOOSE_PATH_ROOT")
@@ -223,7 +220,7 @@ pub async fn agent_start_runtime(
     fs::create_dir_all(&log_dir).map_err(|e| format!("Failed to create log dir: {e}"))?;
     fs::create_dir_all(&goose_path_root)
         .map_err(|e| format!("Failed to create Goose data dir: {e}"))?;
-    let log_path = log_dir.join("goose-serve.log");
+    let log_path = log_dir.join("goose-embedded.log");
 
     let port = find_available_port().map_err(|e| format!("Failed to allocate Goose port: {e}"))?;
     let token = secure_token();
@@ -232,68 +229,65 @@ pub async fn agent_start_runtime(
     let acp_url = format!("ws://127.0.0.1:{port}/acp?token={token}");
     let redacted_acp_url = format!("ws://127.0.0.1:{port}/acp?token=REDACTED");
 
-    let log_file = OpenOptions::new()
-        .create(true)
-        .append(true)
-        .open(&log_path)
-        .map_err(|e| format!("Failed to open Goose log: {e}"))?;
-    set_owner_only_permissions(&log_path);
-    let stdout_file = log_file
-        .try_clone()
-        .map_err(|e| format!("Failed to clone Goose log handle: {e}"))?;
+    configure_embedded_goose(
+        &goose_path_root,
+        &model,
+        &mode,
+        &maple_proxy_base_url,
+        &proxy_config.api_key,
+    )?;
 
-    let mut command = Command::new(&goose_binary);
-    let port_arg = port.to_string();
-    command
-        .args([
-            "serve",
-            "--host",
-            "127.0.0.1",
-            "--port",
-            &port_arg,
-        ])
-        .current_dir(&project_root)
-        .env("GOOSE_SERVER__SECRET_KEY", &token)
-        .env("GOOSE_PROVIDER", "openai")
-        .env("GOOSE_MODEL", &model)
-        .env("GOOSE_FAST_MODEL", &model)
-        .env("GOOSE_MODE", &mode)
-        .env("GOOSE_DISABLE_KEYRING", "true")
-        .env("GOOSE_PATH_ROOT", &goose_path_root)
-        .env("OPENAI_BASE_URL", format!("{}/v1", maple_proxy_base_url))
-        .env("OPENAI_API_KEY", proxy_config.api_key)
-        .stdout(Stdio::from(stdout_file))
-        .stderr(Stdio::from(log_file));
-
-    if let Some(parent) = goose_binary.parent() {
-        prepend_path_env(&mut command, parent);
-    }
+    let listener = tokio::net::TcpListener::bind(("127.0.0.1", port))
+        .await
+        .map_err(|e| format!("Failed to bind Goose ACP listener: {e}"))?;
+    let acp_server = Arc::new(AcpServer::new(AcpServerFactoryConfig {
+        builtins: vec!["developer".to_string()],
+        data_dir: goose_path_root.join("data"),
+        config_dir: goose_path_root.join("config"),
+        goose_platform: GoosePlatform::GooseDesktop,
+        additional_source_roots: Vec::new(),
+        scheduler: None,
+    }));
+    let router = create_goose_acp_router(acp_server, token, true, Vec::new());
+    let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
 
     log::info!(
-        "Starting Goose ACP runtime from {} in {} on {}",
-        goose_binary.display(),
+        "Starting embedded Goose ACP runtime in {} on {}",
         project_root.display(),
         redacted_acp_url
     );
+    append_runtime_log(
+        &log_path,
+        &format!(
+            "starting embedded Goose ACP runtime: project_root={}, acp={}",
+            project_root.display(),
+            redacted_acp_url
+        ),
+    );
 
-    let mut child = command
-        .spawn()
-        .map_err(|e| format!("Failed to spawn Goose: {e}"))?;
+    let server_task = tokio::spawn(async move {
+        axum::serve(listener, router)
+            .with_graceful_shutdown(async {
+                let _ = shutdown_rx.await;
+            })
+            .await
+            .map_err(|e| format!("Goose ACP server stopped with error: {e}"))
+    });
 
-    if let Err(e) = wait_for_goose_ready(&status_url, &mut child).await {
-        let _ = child.kill();
-        let _ = child.wait();
+    if let Err(e) = wait_for_goose_ready(&status_url).await {
+        let _ = shutdown_tx.send(());
+        server_task.abort();
         return Err(format!("{e}. See {}", log_path.display()));
     }
 
     let runtime = AgentRuntime {
-        child,
+        shutdown: Some(shutdown_tx),
+        server_task,
         acp_url,
         redacted_acp_url,
         http_base_url,
         status_url,
         project_root: project_root.clone(),
-        goose_binary,
         model: model.clone(),
         mode,
         maple_proxy_base_url,
@@ -377,28 +371,43 @@ pub async fn agent_append_session_event(
 
 async fn clear_exited_runtime(state: &State<'_, AgentRuntimeState>) {
     let mut runtime = state.inner.lock().await;
-    if let Some(current) = runtime.as_mut() {
-        if matches!(current.child.try_wait(), Ok(Some(_)) | Err(_)) {
-            *runtime = None;
-        }
+    if runtime
+        .as_ref()
+        .map(|current| current.server_task.is_finished())
+        .unwrap_or(false)
+    {
+        *runtime = None;
     }
 }
 
 async fn stop_runtime_inner(state: &State<'_, AgentRuntimeState>) -> Result<(), String> {
     let mut runtime = state.inner.lock().await;
     if let Some(mut current) = runtime.take() {
-        log::info!("Stopping Goose ACP runtime");
-        if let Err(e) = current.child.kill() {
-            log::warn!("Failed to kill Goose runtime: {e}");
+        log::info!("Stopping embedded Goose ACP runtime");
+        append_runtime_log(&current.log_path, "stopping embedded Goose ACP runtime");
+        if let Some(shutdown) = current.shutdown.take() {
+            let _ = shutdown.send(());
         }
-        if let Err(e) = current.child.wait() {
-            log::warn!("Failed to wait for Goose runtime exit: {e}");
+        let mut server_task = current.server_task;
+        tokio::select! {
+            result = &mut server_task => {
+                match result {
+                    Ok(Ok(())) => {}
+                    Ok(Err(error)) => log::warn!("{error}"),
+                    Err(error) => log::warn!("Goose ACP server task failed: {error}"),
+                }
+            }
+            _ = tokio::time::sleep(SHUTDOWN_TIMEOUT) => {
+                server_task.abort();
+                let _ = server_task.await;
+                log::warn!("Timed out stopping Goose ACP server; aborted task");
+            }
         }
     }
     Ok(())
 }
 
-async fn wait_for_goose_ready(status_url: &str, child: &mut Child) -> Result<(), String> {
+async fn wait_for_goose_ready(status_url: &str) -> Result<(), String> {
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(1))
         .build()
@@ -406,14 +415,6 @@ async fn wait_for_goose_ready(status_url: &str, child: &mut Child) -> Result<(),
     let deadline = std::time::Instant::now() + READINESS_TIMEOUT;
 
     while std::time::Instant::now() < deadline {
-        match child.try_wait() {
-            Ok(Some(exit_status)) => {
-                return Err(format!("Goose exited before becoming ready: {exit_status}"));
-            }
-            Ok(None) => {}
-            Err(e) => return Err(format!("Failed to inspect Goose readiness: {e}")),
-        }
-
         if let Ok(response) = client.get(status_url).send().await {
             if response.status().is_success() {
                 return Ok(());
@@ -424,6 +425,47 @@ async fn wait_for_goose_ready(status_url: &str, child: &mut Child) -> Result<(),
     }
 
     Err(format!("Goose did not become ready on {status_url}"))
+}
+
+fn configure_embedded_goose(
+    goose_path_root: &Path,
+    model: &str,
+    mode: &str,
+    maple_proxy_base_url: &str,
+    proxy_api_key: &str,
+) -> Result<(), String> {
+    fs::create_dir_all(goose_path_root.join("config"))
+        .map_err(|e| format!("Failed to create Goose config dir: {e}"))?;
+    fs::create_dir_all(goose_path_root.join("data"))
+        .map_err(|e| format!("Failed to create Goose data dir: {e}"))?;
+    fs::create_dir_all(goose_path_root.join("state"))
+        .map_err(|e| format!("Failed to create Goose state dir: {e}"))?;
+
+    std::env::set_var("GOOSE_PATH_ROOT", goose_path_root);
+    std::env::set_var("GOOSE_DISABLE_KEYRING", "true");
+
+    let config = goose::config::Config::global();
+    goose::config::set_active_provider(config, "openai", model)
+        .map_err(|e| format!("Failed to configure Goose provider: {e}"))?;
+    config
+        .set_param("GOOSE_FAST_MODEL", model)
+        .map_err(|e| format!("Failed to configure Goose fast model: {e}"))?;
+    config
+        .set_param("GOOSE_MODE", mode)
+        .map_err(|e| format!("Failed to configure Goose mode: {e}"))?;
+    config
+        .set_param("OPENAI_BASE_URL", format!("{maple_proxy_base_url}/v1"))
+        .map_err(|e| format!("Failed to configure Goose OpenAI base URL: {e}"))?;
+    config
+        .set_param("GOOSE_DISABLE_KEYRING", true)
+        .map_err(|e| format!("Failed to configure Goose keyring mode: {e}"))?;
+    config
+        .set_secret("OPENAI_API_KEY", &proxy_api_key)
+        .map_err(|e| format!("Failed to configure Goose OpenAI API key: {e}"))?;
+
+    set_owner_only_permissions(&goose_path_root.join("config").join("config.yaml"));
+    set_owner_only_permissions(&goose_path_root.join("config").join("secrets.yaml"));
+    Ok(())
 }
 
 fn stopped_status(config_dir: PathBuf, error: Option<String>) -> AgentRuntimeStatus {
@@ -446,10 +488,7 @@ fn stopped_status(config_dir: PathBuf, error: Option<String>) -> AgentRuntimeSta
     }
 }
 
-fn resolve_project_root(
-    requested: Option<&str>,
-    config: &AgentConfig,
-) -> Result<PathBuf, String> {
+fn resolve_project_root(requested: Option<&str>, config: &AgentConfig) -> Result<PathBuf, String> {
     if let Some(path) = requested.filter(|value| !value.trim().is_empty()) {
         return normalize_project_root(Path::new(path));
     }
@@ -479,82 +518,6 @@ fn normalize_project_root(path: &Path) -> Result<PathBuf, String> {
     Ok(canonical)
 }
 
-fn resolve_goose_binary(app_handle: &AppHandle, requested: Option<&str>) -> Result<PathBuf, String> {
-    let mut candidates = Vec::new();
-
-    if let Some(path) = requested.filter(|value| !value.trim().is_empty()) {
-        candidates.push(PathBuf::from(path));
-    }
-
-    if let Ok(path) = std::env::var("MAPLE_GOOSE_BINARY") {
-        candidates.push(PathBuf::from(path));
-    }
-
-    if let Ok(path) = std::env::var("GOOSE_BINARY") {
-        candidates.push(PathBuf::from(path));
-    }
-
-    if let Ok(resource_dir) = app_handle.path().resource_dir() {
-        candidates.push(resource_dir.join("bin").join(goose_binary_name()));
-        candidates.push(resource_dir.join(goose_binary_name()));
-    }
-
-    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
-    candidates.push(
-        manifest_dir
-            .join("..")
-            .join("node_modules")
-            .join("@aaif")
-            .join(goose_binary_package_name())
-            .join("bin")
-            .join(goose_binary_name()),
-    );
-    candidates.push(
-        manifest_dir
-            .join("bin")
-            .join(goose_binary_name()),
-    );
-
-    if cfg!(debug_assertions) {
-        if let Some(path) = find_on_path(goose_binary_name()) {
-            candidates.push(path);
-        }
-    }
-
-    for candidate in candidates {
-        let candidate = expand_home(candidate);
-        if candidate.is_file() {
-            return Ok(candidate);
-        }
-    }
-
-    Err("Goose binary not found. Set MAPLE_GOOSE_BINARY in development or bundle bin/goose with Maple.".to_string())
-}
-
-fn goose_binary_name() -> &'static str {
-    if cfg!(target_os = "windows") {
-        "goose.exe"
-    } else {
-        "goose"
-    }
-}
-
-fn goose_binary_package_name() -> &'static str {
-    if cfg!(all(target_os = "macos", target_arch = "aarch64")) {
-        "goose-binary-darwin-arm64"
-    } else if cfg!(all(target_os = "macos", target_arch = "x86_64")) {
-        "goose-binary-darwin-x64"
-    } else if cfg!(all(target_os = "linux", target_arch = "aarch64")) {
-        "goose-binary-linux-arm64"
-    } else if cfg!(all(target_os = "linux", target_arch = "x86_64")) {
-        "goose-binary-linux-x64"
-    } else if cfg!(all(target_os = "windows", target_arch = "x86_64")) {
-        "goose-binary-win32-x64"
-    } else {
-        "goose-binary-unsupported"
-    }
-}
-
 fn find_available_port() -> std::io::Result<u16> {
     let listener = std::net::TcpListener::bind(("127.0.0.1", 0))?;
     Ok(listener.local_addr()?.port())
@@ -566,50 +529,6 @@ fn secure_token() -> String {
     bytes.iter().map(|byte| format!("{byte:02x}")).collect()
 }
 
-fn prepend_path_env(command: &mut Command, dir: &Path) {
-    let key = if cfg!(target_os = "windows") {
-        "Path"
-    } else {
-        "PATH"
-    };
-    let current = std::env::var_os(key).unwrap_or_default();
-    let mut paths = vec![dir.to_path_buf()];
-    paths.extend(std::env::split_paths(&current));
-    if let Ok(joined) = std::env::join_paths(paths) {
-        command.env(key, joined);
-    }
-}
-
-fn find_on_path(binary: &str) -> Option<PathBuf> {
-    let path_var = std::env::var_os(if cfg!(target_os = "windows") {
-        "Path"
-    } else {
-        "PATH"
-    })?;
-    std::env::split_paths(&path_var)
-        .map(|dir| dir.join(binary))
-        .find(|candidate| candidate.is_file())
-}
-
-fn expand_home(path: PathBuf) -> PathBuf {
-    let path_string = path.to_string_lossy();
-    if path_string == "~" {
-        return home_dir().unwrap_or(path);
-    }
-    if let Some(rest) = path_string.strip_prefix("~/") {
-        if let Some(home) = home_dir() {
-            return home.join(rest);
-        }
-    }
-    path
-}
-
-fn home_dir() -> Option<PathBuf> {
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .or_else(|| std::env::var_os("USERPROFILE").map(PathBuf::from))
-}
-
 fn agent_config_dir(app_handle: &AppHandle) -> Result<PathBuf, anyhow::Error> {
     let base = if cfg!(target_os = "windows") {
         app_handle
@@ -617,8 +536,8 @@ fn agent_config_dir(app_handle: &AppHandle) -> Result<PathBuf, anyhow::Error> {
             .app_config_dir()
             .map_err(|e| anyhow::anyhow!("Failed to resolve app config dir: {e}"))?
     } else {
-        let home = std::env::var("HOME")
-            .map_err(|_| anyhow::anyhow!("Failed to get home directory"))?;
+        let home =
+            std::env::var("HOME").map_err(|_| anyhow::anyhow!("Failed to get home directory"))?;
         PathBuf::from(home).join(".config").join("maple")
     };
     let path = base.join("agent");
@@ -697,6 +616,21 @@ fn append_session_event_inner(
     serde_json::to_writer(&mut file, &row)?;
     file.write_all(b"\n")?;
     Ok(())
+}
+
+fn append_runtime_log(path: &Path, message: &str) {
+    let result = (|| -> Result<(), anyhow::Error> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let mut file = OpenOptions::new().create(true).append(true).open(path)?;
+        set_owner_only_permissions(path);
+        writeln!(file, "{} {}", unix_ms(), message)?;
+        Ok(())
+    })();
+    if let Err(error) = result {
+        log::warn!("Failed to write Goose runtime log: {error}");
+    }
 }
 
 fn write_json_file<T: Serialize>(path: &Path, value: &T) -> Result<(), anyhow::Error> {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -3,6 +3,8 @@ use tauri_plugin_deep_link::DeepLinkExt;
 
 mod pdf_extractor;
 mod proxy;
+#[cfg(desktop)]
+mod agent;
 // TTS is available on desktop and iOS (not Android)
 #[cfg(any(desktop, target_os = "ios"))]
 mod tts;
@@ -33,12 +35,23 @@ pub fn run() {
         }))
         .plugin(tauri_plugin_log::Builder::default().level(log::LevelFilter::Info).build())
         .plugin(tauri_plugin_deep_link::init())
+        .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_fs::init())
+        .manage(agent::AgentRuntimeState::new())
         .manage(proxy::ProxyState::new())
         .manage(tts::TTSState::new())
         .invoke_handler(tauri::generate_handler![
+            agent::agent_get_runtime_status,
+            agent::agent_start_runtime,
+            agent::agent_stop_runtime,
+            agent::agent_restart_runtime,
+            agent::agent_load_config,
+            agent::agent_save_config,
+            agent::agent_list_recent_project_roots,
+            agent::agent_save_recent_project_root,
+            agent::agent_append_session_event,
             proxy::start_proxy,
             proxy::stop_proxy,
             proxy::get_proxy_status,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,10 +1,10 @@
 use tauri::Emitter;
 use tauri_plugin_deep_link::DeepLinkExt;
 
-mod pdf_extractor;
-mod proxy;
 #[cfg(desktop)]
 mod agent;
+mod pdf_extractor;
+mod proxy;
 // TTS is available on desktop and iOS (not Android)
 #[cfg(any(desktop, target_os = "ios"))]
 mod tts;

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -52,6 +52,7 @@ pub fn run() {
             agent::agent_list_recent_project_roots,
             agent::agent_save_recent_project_root,
             agent::agent_append_session_event,
+            agent::agent_append_runtime_log,
             proxy::start_proxy,
             proxy::stop_proxy,
             proxy::get_proxy_status,

--- a/frontend/src-tauri/src/proxy.rs
+++ b/frontend/src-tauri/src/proxy.rs
@@ -382,7 +382,7 @@ async fn log_chat_completion_traffic(
             "raw_has_max_completion_tokens": raw_body.get("max_completion_tokens").is_some(),
             "raw_has_max_output_tokens": raw_body.get("max_output_tokens").is_some(),
             "raw_body": raw_body,
-            "note": "Logged in Maple proxy middleware before maple-proxy parses the request; response_chunk rows are raw SSE/HTTP body bytes returned by maple-proxy to Goose.",
+            "note": "Logged in Maple proxy middleware before maple-proxy parses the request; response_chunk and response_error_body rows are raw SSE/HTTP body bytes returned by maple-proxy to Goose.",
         }),
     );
 
@@ -410,6 +410,44 @@ async fn log_chat_completion_traffic(
             "status": status.as_u16(),
         }),
     );
+
+    if !status.is_success() {
+        let error_body = match to_bytes(response_body, usize::MAX).await {
+            Ok(bytes) => bytes,
+            Err(error) => {
+                append_proxy_llm_log_row(
+                    llm_log.as_ref(),
+                    serde_json::json!({
+                        "type": "response_body_error",
+                        "request_id": request_id,
+                        "ts": unix_ms(),
+                        "error": error.to_string(),
+                    }),
+                );
+                return Response::from_parts(response_parts, Body::empty());
+            }
+        };
+
+        append_proxy_llm_log_row(
+            llm_log.as_ref(),
+            serde_json::json!({
+                "type": "response_error_body",
+                "request_id": request_id,
+                "ts": unix_ms(),
+                "bytes_len": error_body.len(),
+                "body_utf8_lossy": String::from_utf8_lossy(&error_body),
+            }),
+        );
+        append_proxy_llm_log_row(
+            llm_log.as_ref(),
+            serde_json::json!({
+                "type": "response_done",
+                "request_id": request_id,
+                "ts": unix_ms(),
+            }),
+        );
+        return Response::from_parts(response_parts, Body::from(error_body));
+    }
 
     let response_stream = response_body.into_data_stream();
     let logged_stream = log_response_body_stream(response_stream, request_id, llm_log);

--- a/frontend/src-tauri/src/proxy.rs
+++ b/frontend/src-tauri/src/proxy.rs
@@ -60,6 +60,14 @@ impl ProxyState {
             running: Arc::new(Mutex::new(false)),
         }
     }
+
+    pub async fn status(&self) -> ProxyStatus {
+        ProxyStatus {
+            running: *self.running.lock().await,
+            config: self.config.lock().await.clone(),
+            error: None,
+        }
+    }
 }
 
 // On Windows the proxy config lives in the roaming %APPDATA% profile, so a
@@ -245,14 +253,7 @@ pub async fn stop_proxy(state: State<'_, ProxyState>) -> Result<ProxyStatus, Str
 
 #[tauri::command]
 pub async fn get_proxy_status(state: State<'_, ProxyState>) -> Result<ProxyStatus, String> {
-    let running = *state.running.lock().await;
-    let config = state.config.lock().await.clone();
-
-    Ok(ProxyStatus {
-        running,
-        config,
-        error: None,
-    })
+    Ok(state.status().await)
 }
 
 #[tauri::command]
@@ -354,7 +355,7 @@ async fn save_proxy_config(app_handle: &AppHandle, config: &ProxyConfig) -> Resu
     Ok(())
 }
 
-async fn load_saved_proxy_config(app_handle: &AppHandle) -> Result<ProxyConfig> {
+pub async fn load_saved_proxy_config(app_handle: &AppHandle) -> Result<ProxyConfig> {
     let path = get_config_path(app_handle).await?;
 
     if !path.exists() {
@@ -375,6 +376,26 @@ async fn load_saved_proxy_config(app_handle: &AppHandle) -> Result<ProxyConfig> 
     }
 
     Ok(config)
+}
+
+pub async fn ensure_proxy_running(
+    app_handle: AppHandle,
+    state: State<'_, ProxyState>,
+) -> Result<ProxyStatus, String> {
+    let current = state.status().await;
+    if current.running {
+        return Ok(current);
+    }
+
+    let config = load_saved_proxy_config(&app_handle)
+        .await
+        .map_err(|e| format!("Failed to load proxy config: {e}"))?;
+
+    if config.api_key.trim().is_empty() {
+        return Err("Maple proxy is not configured with an API key yet".to_string());
+    }
+
+    start_proxy(app_handle, state, config).await
 }
 
 // Initialize proxy on app startup if auto_start is enabled

--- a/frontend/src-tauri/src/proxy.rs
+++ b/frontend/src-tauri/src/proxy.rs
@@ -1,11 +1,28 @@
 use anyhow::{anyhow, Result};
+use axum::{
+    body::{to_bytes, Body, Bytes},
+    extract::{Request, State as AxumState},
+    http::{Method, StatusCode},
+    middleware::{self, Next},
+    response::{IntoResponse, Response},
+    Router,
+};
+use futures::{Stream, StreamExt};
 use maple_proxy::{create_app, Config};
 use serde::{Deserialize, Serialize};
-use std::path::PathBuf;
-use std::sync::Arc;
+use serde_json::Value;
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, State};
 use tokio::net::TcpListener;
 use tokio::sync::Mutex;
+
+static PROXY_LLM_LOG_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProxyConfig {
@@ -50,6 +67,18 @@ pub struct ProxyState {
     handle: Arc<Mutex<Option<tokio::task::JoinHandle<()>>>>,
     config: Arc<Mutex<ProxyConfig>>,
     running: Arc<Mutex<bool>>,
+}
+
+#[derive(Clone)]
+struct LoggedProxyState {
+    llm_log_dir: PathBuf,
+}
+
+#[derive(Clone)]
+struct ProxyLlmLog {
+    request_id: String,
+    path: PathBuf,
+    file: Arc<StdMutex<File>>,
 }
 
 impl ProxyState {
@@ -192,8 +221,13 @@ pub async fn start_proxy(
         }
     };
 
-    // Create the app
-    let app = create_app(proxy_config);
+    let llm_log_dir = proxy_llm_log_dir(&app_handle)
+        .map_err(|e| format!("Failed to create proxy LLM log dir: {e}"))?;
+    log::info!("Maple proxy LLM logs enabled at {}", llm_log_dir.display());
+
+    // Create the app. This mirrors maple-proxy's OpenAI-compatible routes, but
+    // tees chat completion traffic into local JSONL logs before Goose parses it.
+    let app = create_logged_proxy_app(proxy_config, llm_log_dir);
 
     // Spawn the proxy server
     let handle = tokio::spawn(async move {
@@ -284,6 +318,230 @@ pub async fn test_proxy_port(host: String, port: u16) -> Result<bool, String> {
             }
         }
     }
+}
+
+fn create_logged_proxy_app(config: Config, llm_log_dir: PathBuf) -> Router {
+    create_app(config).layer(middleware::from_fn_with_state(
+        Arc::new(LoggedProxyState { llm_log_dir }),
+        log_chat_completion_traffic,
+    ))
+}
+
+async fn log_chat_completion_traffic(
+    AxumState(state): AxumState<Arc<LoggedProxyState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    if request.method() != Method::POST || request.uri().path() != "/v1/chat/completions" {
+        return next.run(request).await;
+    }
+
+    let request_id = next_proxy_llm_request_id();
+    let llm_log = create_proxy_llm_log(&state.llm_log_dir, &request_id);
+    let (parts, body) = request.into_parts();
+    let path = parts.uri.path().to_string();
+
+    let body_bytes = match to_bytes(body, usize::MAX).await {
+        Ok(bytes) => bytes,
+        Err(error) => {
+            append_proxy_llm_log_row(
+                llm_log.as_ref(),
+                serde_json::json!({
+                    "type": "request_read_error",
+                    "request_id": request_id,
+                    "ts": unix_ms(),
+                    "path": path,
+                    "error": error.to_string(),
+                }),
+            );
+            return (StatusCode::BAD_REQUEST, "Failed to read proxy request body").into_response();
+        }
+    };
+
+    let raw_body = parse_body_json(&body_bytes);
+    let model = raw_body
+        .get("model")
+        .and_then(Value::as_str)
+        .unwrap_or("<missing>");
+    let is_streaming = raw_body
+        .get("stream")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    append_proxy_llm_log_row(
+        llm_log.as_ref(),
+        serde_json::json!({
+            "type": "request",
+            "request_id": request_id,
+            "ts": unix_ms(),
+            "path": path,
+            "model": model,
+            "stream": is_streaming,
+            "tools_len": raw_body.get("tools").and_then(Value::as_array).map(|tools| tools.len()).unwrap_or(0),
+            "raw_has_max_tokens": raw_body.get("max_tokens").is_some(),
+            "raw_has_max_completion_tokens": raw_body.get("max_completion_tokens").is_some(),
+            "raw_has_max_output_tokens": raw_body.get("max_output_tokens").is_some(),
+            "raw_body": raw_body,
+            "note": "Logged in Maple proxy middleware before maple-proxy parses the request; response_chunk rows are raw SSE/HTTP body bytes returned by maple-proxy to Goose.",
+        }),
+    );
+
+    log::info!(
+        "Proxy LLM request {request_id} model={} stream={} log={}",
+        model,
+        is_streaming,
+        llm_log
+            .as_ref()
+            .map(|log| log.path.display().to_string())
+            .unwrap_or_else(|| "unavailable".to_string())
+    );
+
+    let request = Request::from_parts(parts, Body::from(body_bytes));
+    let response = next.run(request).await;
+    let (response_parts, response_body) = response.into_parts();
+    let status = response_parts.status;
+
+    append_proxy_llm_log_row(
+        llm_log.as_ref(),
+        serde_json::json!({
+            "type": "response_start",
+            "request_id": request_id,
+            "ts": unix_ms(),
+            "status": status.as_u16(),
+        }),
+    );
+
+    let response_stream = response_body.into_data_stream();
+    let logged_stream = log_response_body_stream(response_stream, request_id, llm_log);
+    Response::from_parts(response_parts, Body::from_stream(logged_stream))
+}
+
+fn parse_body_json(body: &Bytes) -> Value {
+    serde_json::from_slice::<Value>(body).unwrap_or_else(|error| {
+        serde_json::json!({
+            "_parse_error": error.to_string(),
+            "_raw_utf8_lossy": String::from_utf8_lossy(body),
+        })
+    })
+}
+
+fn log_response_body_stream<S>(
+    stream: S,
+    request_id: String,
+    llm_log: Option<ProxyLlmLog>,
+) -> impl Stream<Item = Result<Bytes, axum::Error>> + Send
+where
+    S: Stream<Item = Result<Bytes, axum::Error>> + Send + 'static,
+{
+    type BoxedBodyStream = Pin<Box<dyn Stream<Item = Result<Bytes, axum::Error>> + Send>>;
+    let stream: BoxedBodyStream = Box::pin(stream);
+
+    futures::stream::unfold((stream, llm_log), move |(mut stream, llm_log)| {
+        let request_id = request_id.clone();
+        async move {
+            match stream.next().await {
+                Some(Ok(bytes)) => {
+                    append_proxy_llm_log_row(
+                        llm_log.as_ref(),
+                        serde_json::json!({
+                            "type": "response_chunk",
+                            "request_id": request_id,
+                            "ts": unix_ms(),
+                            "bytes_len": bytes.len(),
+                            "body_utf8_lossy": String::from_utf8_lossy(&bytes),
+                        }),
+                    );
+                    Some((Ok(bytes), (stream, llm_log)))
+                }
+                Some(Err(error)) => {
+                    append_proxy_llm_log_row(
+                        llm_log.as_ref(),
+                        serde_json::json!({
+                            "type": "response_body_error",
+                            "request_id": request_id,
+                            "ts": unix_ms(),
+                            "error": error.to_string(),
+                        }),
+                    );
+                    Some((Err(error), (stream, llm_log)))
+                }
+                None => {
+                    append_proxy_llm_log_row(
+                        llm_log.as_ref(),
+                        serde_json::json!({
+                            "type": "response_done",
+                            "request_id": request_id,
+                            "ts": unix_ms(),
+                        }),
+                    );
+                    None
+                }
+            }
+        }
+    })
+}
+
+fn create_proxy_llm_log(log_dir: &Path, request_id: &str) -> Option<ProxyLlmLog> {
+    let path = log_dir.join(format!("{request_id}.jsonl"));
+    match OpenOptions::new().create(true).append(true).open(&path) {
+        Ok(file) => {
+            set_owner_only_permissions(&path);
+            Some(ProxyLlmLog {
+                request_id: request_id.to_string(),
+                path,
+                file: Arc::new(StdMutex::new(file)),
+            })
+        }
+        Err(error) => {
+            log::warn!("Failed to create proxy LLM log {}: {error}", path.display());
+            None
+        }
+    }
+}
+
+fn append_proxy_llm_log_row(log: Option<&ProxyLlmLog>, mut row: Value) {
+    let Some(log) = log else {
+        return;
+    };
+    if let Value::Object(ref mut object) = row {
+        object
+            .entry("request_id")
+            .or_insert_with(|| Value::String(log.request_id.clone()));
+    }
+
+    let result = (|| -> Result<()> {
+        let mut file = log
+            .file
+            .lock()
+            .map_err(|_| anyhow!("proxy LLM log lock poisoned"))?;
+        serde_json::to_writer(&mut *file, &row)?;
+        file.write_all(b"\n")?;
+        file.flush()?;
+        Ok(())
+    })();
+
+    if let Err(error) = result {
+        log::warn!(
+            "Failed to write proxy LLM log {}: {error}",
+            log.path.display()
+        );
+    }
+}
+
+fn proxy_llm_log_dir(app_handle: &AppHandle) -> Result<PathBuf> {
+    let base = if cfg!(target_os = "windows") {
+        app_handle
+            .path()
+            .app_config_dir()
+            .map_err(|e| anyhow!("Failed to resolve app config dir: {e}"))?
+    } else {
+        let home = std::env::var("HOME").map_err(|_| anyhow!("Failed to get home directory"))?;
+        PathBuf::from(home).join(".config").join("maple")
+    };
+    let path = base.join("agent").join("proxy-llm-logs");
+    fs::create_dir_all(&path)?;
+    set_owner_only_dir_permissions(&path);
+    Ok(path)
 }
 
 // Helper functions for config persistence.
@@ -444,3 +702,33 @@ pub async fn init_proxy_on_startup_simple(app_handle: AppHandle) -> Result<()> {
 
     Ok(())
 }
+
+fn next_proxy_llm_request_id() -> String {
+    let counter = PROXY_LLM_LOG_COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!("proxy_llm_{}_{}", unix_ms(), counter)
+}
+
+fn unix_ms() -> u128 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis())
+        .unwrap_or_default()
+}
+
+#[cfg(unix)]
+fn set_owner_only_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o600));
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_permissions(_path: &Path) {}
+
+#[cfg(unix)]
+fn set_owner_only_dir_permissions(path: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let _ = fs::set_permissions(path, fs::Permissions::from_mode(0o700));
+}
+
+#[cfg(not(unix))]
+fn set_owner_only_dir_permissions(_path: &Path) {}

--- a/frontend/src-tauri/src/proxy.rs
+++ b/frontend/src-tauri/src/proxy.rs
@@ -384,6 +384,11 @@ pub async fn ensure_proxy_running(
 ) -> Result<ProxyStatus, String> {
     let current = state.status().await;
     if current.running {
+        log::info!(
+            "Maple proxy already running on {}:{}",
+            current.config.host,
+            current.config.port
+        );
         return Ok(current);
     }
 
@@ -392,9 +397,15 @@ pub async fn ensure_proxy_running(
         .map_err(|e| format!("Failed to load proxy config: {e}"))?;
 
     if config.api_key.trim().is_empty() {
+        log::warn!("Maple proxy cannot auto-start because saved config has no API key");
         return Err("Maple proxy is not configured with an API key yet".to_string());
     }
 
+    log::info!(
+        "Starting Maple proxy from saved config on {}:{}",
+        config.host,
+        config.port
+    );
     start_proxy(app_handle, state, config).await
 }
 

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -65,7 +65,6 @@
     "active": true,
     "targets": ["nsis", "deb", "appimage", "rpm", "dmg", "app"],
     "publisher": "OpenSecret",
-    "resources": ["bin/*"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -58,13 +58,14 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; connect-src 'self' https://opensecret.cloud https://*.opensecret.cloud https://trymaple.ai https://*.trymaple.ai https://secretgpt.ai https://*.secretgpt.ai https://*.maple-ca8.pages.dev https://raw.githubusercontent.com localhost:* http://localhost:* http://0.0.0.0:* http://127.0.0.1:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:; media-src 'self' blob: mediastream:"
+      "csp": "default-src 'self'; connect-src 'self' https://opensecret.cloud https://*.opensecret.cloud https://trymaple.ai https://*.trymaple.ai https://secretgpt.ai https://*.secretgpt.ai https://*.maple-ca8.pages.dev https://raw.githubusercontent.com localhost:* http://localhost:* http://0.0.0.0:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob:; font-src 'self' data:; worker-src 'self' blob:; media-src 'self' blob: mediastream:"
     }
   },
   "bundle": {
     "active": true,
     "targets": ["nsis", "deb", "appimage", "rpm", "dmg", "app"],
     "publisher": "OpenSecret",
+    "resources": ["bin/*"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -55,13 +55,15 @@ import { isTauriDesktop } from "@/utils/platform";
 
 type AgentMessageRole = "user" | "assistant" | "thought" | "system";
 
-interface AgentMessage {
+interface AgentMessageItem {
+  type: "message";
   id: string;
   role: AgentMessageRole;
   text: string;
 }
 
-interface AgentToolState {
+interface AgentToolItem {
+  type: "tool";
   id: string;
   title: string;
   kind?: string;
@@ -72,6 +74,8 @@ interface AgentToolState {
   locations?: ToolCallLocation[];
   meta?: Record<string, unknown> | null;
 }
+
+type AgentTimelineItem = AgentMessageItem | AgentToolItem;
 
 const DEFAULT_MODEL = "auto:powerful";
 
@@ -86,8 +90,7 @@ export function AgentMode() {
   const [projectRoot, setProjectRoot] = useState("");
   const [model, setModel] = useState(DEFAULT_MODEL);
   const [sessionId, setSessionId] = useState<string | null>(null);
-  const [messages, setMessages] = useState<AgentMessage[]>([]);
-  const [tools, setTools] = useState<AgentToolState[]>([]);
+  const [timelineItems, setTimelineItems] = useState<AgentTimelineItem[]>([]);
   const [planEntries, setPlanEntries] = useState<PlanEntry[]>([]);
   const [usage, setUsage] = useState<UsageUpdate | null>(null);
   const [pendingPermissions, setPendingPermissions] = useState<PermissionRequestHandle[]>([]);
@@ -110,7 +113,7 @@ export function AgentMode() {
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView({ block: "end" });
-  }, [messages, tools, pendingPermissions, planEntries]);
+  }, [timelineItems, pendingPermissions, planEntries]);
 
   const activeRootLabel = useMemo(() => {
     if (!projectRoot) return "Select folder";
@@ -339,7 +342,7 @@ export function AgentMode() {
     clientRef.current?.close();
     clientRef.current = null;
     setSessionId(null);
-    setTools([]);
+    setTimelineItems([]);
     setPlanEntries([]);
     setUsage(null);
     setPendingPermissions([]);
@@ -375,12 +378,16 @@ export function AgentMode() {
     setError(null);
     setInput("");
     setIsSending(true);
-    setTools([]);
     setPlanEntries([]);
     setUsage(null);
     setPendingPermissions([]);
-    const userMessage: AgentMessage = { id: crypto.randomUUID(), role: "user", text };
-    setMessages((current) => [...current, userMessage]);
+    const userMessage: AgentMessageItem = {
+      type: "message",
+      id: crypto.randomUUID(),
+      role: "user",
+      text
+    };
+    setTimelineItems((current) => [...current, userMessage]);
 
     try {
       const active = await ensureConnectedSession();
@@ -391,9 +398,14 @@ export function AgentMode() {
       await active.client.prompt(active.sessionId, text);
     } catch (sendError) {
       setError(errorMessage(sendError));
-      setMessages((current) => [
+      setTimelineItems((current) => [
         ...current,
-        { id: crypto.randomUUID(), role: "system", text: errorMessage(sendError) }
+        {
+          type: "message",
+          id: crypto.randomUUID(),
+          role: "system",
+          text: errorMessage(sendError)
+        }
       ]);
     } finally {
       setIsSending(false);
@@ -532,7 +544,7 @@ export function AgentMode() {
         <main className="flex min-h-0 flex-1 flex-col">
           <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
             <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
-              {messages.length === 0 && tools.length === 0 ? (
+              {timelineItems.length === 0 ? (
                 <div className="flex min-h-[42vh] items-center justify-center">
                   <div className="flex w-full max-w-2xl flex-col items-center gap-5 text-center">
                     <h2 className="font-displayWide text-3xl font-normal brand-gradient-text">
@@ -559,9 +571,8 @@ export function AgentMode() {
                 </div>
               ) : (
                 <>
-                  <MessageTranscript messages={messages} />
+                  <AgentTimeline items={timelineItems} />
                   {planEntries.length > 0 && <PlanList entries={planEntries} />}
-                  {tools.length > 0 && <ToolCallList tools={tools} />}
                   {pendingPermissions.length > 0 && (
                     <PermissionList
                       requests={pendingPermissions}
@@ -576,7 +587,7 @@ export function AgentMode() {
             </div>
           </div>
 
-          {messages.length > 0 || tools.length > 0 ? (
+          {timelineItems.length > 0 ? (
             <div className="shrink-0 border-t border-border/35 bg-background px-4 py-3">
               <div className="mx-auto max-w-4xl">
                 <AgentComposer
@@ -610,37 +621,47 @@ export function AgentMode() {
     text: string
   ) {
     if (!text) return;
-    setMessages((current) => {
+    setTimelineItems((current) => {
       const index = messageId
-        ? current.findIndex((message) => message.id === messageId)
+        ? current.findIndex((item) => item.type === "message" && item.id === messageId)
         : current.length - 1;
       const existing = index >= 0 ? current[index] : null;
-      if (!messageId && existing?.role !== role) {
-        return [...current, { id: `${role}-${crypto.randomUUID()}`, role, text }];
+      if (!messageId && (existing?.type !== "message" || existing.role !== role)) {
+        return [...current, { type: "message", id: `${role}-${crypto.randomUUID()}`, role, text }];
       }
       if (index >= 0) {
         const next = [...current];
-        next[index] = { ...next[index], text: next[index].text + text };
+        const message = next[index];
+        if (message.type === "message") {
+          next[index] = { ...message, text: message.text + text };
+        }
         return next;
       }
-      return [...current, { id: messageId || `${role}-${crypto.randomUUID()}`, role, text }];
+      return [
+        ...current,
+        { type: "message", id: messageId || `${role}-${crypto.randomUUID()}`, role, text }
+      ];
     });
   }
 
   function mergeToolCall(update: (ToolCall | ToolCallUpdate) & { sessionUpdate: string }) {
-    setTools((current) => {
-      const index = current.findIndex((tool) => tool.id === update.toolCallId);
+    setTimelineItems((current) => {
+      const index = current.findIndex(
+        (item) => item.type === "tool" && item.id === update.toolCallId
+      );
       const previous = index >= 0 ? current[index] : null;
-      const nextTool: AgentToolState = {
+      const nextTool: AgentToolItem = {
+        type: "tool",
         id: update.toolCallId,
-        title: update.title ?? previous?.title ?? "Tool call",
-        kind: update.kind ?? previous?.kind,
-        status: update.status ?? previous?.status,
-        input: update.rawInput ?? previous?.input,
-        output: update.rawOutput ?? previous?.output,
-        content: update.content ?? previous?.content,
-        locations: update.locations ?? previous?.locations,
-        meta: update._meta ?? previous?.meta
+        title:
+          update.title ?? (previous?.type === "tool" ? previous.title : undefined) ?? "Tool call",
+        kind: update.kind ?? (previous?.type === "tool" ? previous.kind : undefined),
+        status: update.status ?? (previous?.type === "tool" ? previous.status : undefined),
+        input: update.rawInput ?? (previous?.type === "tool" ? previous.input : undefined),
+        output: update.rawOutput ?? (previous?.type === "tool" ? previous.output : undefined),
+        content: update.content ?? (previous?.type === "tool" ? previous.content : undefined),
+        locations: update.locations ?? (previous?.type === "tool" ? previous.locations : undefined),
+        meta: update._meta ?? (previous?.type === "tool" ? previous.meta : undefined)
       };
 
       if (index >= 0) {
@@ -777,32 +798,38 @@ function AgentComposer({
   );
 }
 
-function MessageTranscript({ messages }: { messages: AgentMessage[] }) {
+function AgentTimeline({ items }: { items: AgentTimelineItem[] }) {
   return (
     <div className="flex flex-col gap-3">
-      {messages.map((message) =>
-        message.role === "thought" ? (
-          <ThinkingMessage key={message.id} text={message.text} />
+      {items.map((item) =>
+        item.type === "message" ? (
+          <MessageBubble key={item.id} message={item} />
         ) : (
-          <div
-            key={message.id}
-            className={cn("flex", message.role === "user" ? "justify-end" : "justify-start")}
-          >
-            <div
-              className={cn(
-                "max-w-[82%] rounded-lg px-3 py-2 text-sm leading-6",
-                message.role === "user"
-                  ? "bg-[hsl(var(--maple-primary))] text-primary-foreground"
-                  : "border border-border/45 bg-muted/45 text-foreground",
-                message.role === "system" &&
-                  "border-destructive/30 bg-destructive/5 text-destructive"
-              )}
-            >
-              <div className="whitespace-pre-wrap break-words">{message.text}</div>
-            </div>
-          </div>
+          <ToolCallList key={item.id} tools={[item]} />
         )
       )}
+    </div>
+  );
+}
+
+function MessageBubble({ message }: { message: AgentMessageItem }) {
+  if (message.role === "thought") {
+    return <ThinkingMessage text={message.text} />;
+  }
+
+  return (
+    <div className={cn("flex", message.role === "user" ? "justify-end" : "justify-start")}>
+      <div
+        className={cn(
+          "max-w-[82%] rounded-lg px-3 py-2 text-sm leading-6",
+          message.role === "user"
+            ? "bg-[hsl(var(--maple-primary))] text-primary-foreground"
+            : "border border-border/45 bg-muted/45 text-foreground",
+          message.role === "system" && "border-destructive/30 bg-destructive/5 text-destructive"
+        )}
+      >
+        <div className="whitespace-pre-wrap break-words">{message.text}</div>
+      </div>
     </div>
   );
 }
@@ -819,55 +846,70 @@ function ThinkingMessage({ text }: { text: string }) {
   );
 }
 
-function ToolCallList({ tools }: { tools: AgentToolState[] }) {
+function ToolCallList({ tools }: { tools: AgentToolItem[] }) {
   return (
     <div className="space-y-2">
-      {tools.map((tool) => (
-        <details
-          key={tool.id}
-          open={tool.status === "failed"}
-          className={cn(
-            "group rounded-lg border bg-muted/30 px-3 py-2",
-            tool.status === "failed" ? "border-destructive/35" : "border-border/45"
-          )}
-        >
-          <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
-            <div className="flex min-w-0 items-center gap-2">
-              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
-              <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
-              <span className="truncate text-sm font-medium">{tool.title}</span>
+      {tools.map((tool) => {
+        const isFailed = tool.status === "failed";
+        const hasDetails = toolHasDetails(tool);
+
+        return (
+          <details
+            key={tool.id}
+            open={isFailed}
+            className={cn(
+              "group rounded-lg border bg-muted/30 px-3 py-2",
+              isFailed ? "border-destructive/35" : "border-border/45"
+            )}
+          >
+            <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
+              <div className="flex min-w-0 items-center gap-2">
+                <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
+                <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate text-sm font-medium">{tool.title}</span>
+              </div>
+              <Badge
+                variant="secondary"
+                className={cn(
+                  "shrink-0 capitalize",
+                  isFailed && "border-destructive/40 bg-destructive/15 text-destructive"
+                )}
+              >
+                {tool.status || "pending"}
+              </Badge>
+            </summary>
+            <div className="mt-2 space-y-2 pl-6">
+              <ToolDetail label="Summary" value={toolSummary(tool)} />
+              {tool.kind && <p className="text-xs text-muted-foreground">{tool.kind}</p>}
+              {tool.locations?.length ? (
+                <ToolDetail
+                  label="Locations"
+                  value={tool.locations.map((item) => item.path).join("\n")}
+                />
+              ) : null}
+              {tool.content?.length ? (
+                <ToolDetail
+                  label="Content"
+                  value={tool.content.map(toolContentText).filter(Boolean).join("\n")}
+                />
+              ) : null}
+              {tool.input !== undefined ? (
+                <ToolDetail label="Input" value={formatUnknown(tool.input)} />
+              ) : null}
+              {tool.output !== undefined ? (
+                <ToolDetail label="Output" value={formatUnknown(tool.output)} />
+              ) : null}
+              {tool.meta ? <ToolDetail label="Metadata" value={formatUnknown(tool.meta)} /> : null}
+              {!hasDetails && isFailed ? (
+                <ToolDetail
+                  label="Missing Details"
+                  value="ACP reported this tool call as failed but did not include input, output, content, locations, or metadata. Check the Agent Mode runtime log and session JSONL for the raw event."
+                />
+              ) : null}
             </div>
-            <Badge
-              variant={tool.status === "failed" ? "destructive" : "secondary"}
-              className="shrink-0 capitalize"
-            >
-              {tool.status || "pending"}
-            </Badge>
-          </summary>
-          <div className="mt-2 space-y-2 pl-6">
-            {tool.kind && <p className="text-xs text-muted-foreground">{tool.kind}</p>}
-            {tool.locations?.length ? (
-              <ToolDetail
-                label="Locations"
-                value={tool.locations.map((item) => item.path).join("\n")}
-              />
-            ) : null}
-            {tool.content?.length ? (
-              <ToolDetail
-                label="Content"
-                value={tool.content.map(toolContentText).filter(Boolean).join("\n")}
-              />
-            ) : null}
-            {tool.input !== undefined ? (
-              <ToolDetail label="Input" value={formatUnknown(tool.input)} />
-            ) : null}
-            {tool.output !== undefined ? (
-              <ToolDetail label="Output" value={formatUnknown(tool.output)} />
-            ) : null}
-            {tool.meta ? <ToolDetail label="Metadata" value={formatUnknown(tool.meta)} /> : null}
-          </div>
-        </details>
-      ))}
+          </details>
+        );
+      })}
     </div>
   );
 }
@@ -882,6 +924,34 @@ function ToolDetail({ label, value }: { label: string; value: string }) {
       </pre>
     </div>
   );
+}
+
+function toolHasDetails(tool: AgentToolItem): boolean {
+  return Boolean(
+    tool.kind ||
+    tool.input !== undefined ||
+    tool.output !== undefined ||
+    tool.content?.length ||
+    tool.locations?.length ||
+    tool.meta
+  );
+}
+
+function toolSummary(tool: AgentToolItem): string {
+  const parts = [`id: ${tool.id}`, `status: ${tool.status || "pending"}`];
+  const toolName = gooseToolName(tool.meta);
+  if (toolName) parts.push(`tool: ${toolName}`);
+  if (tool.kind) parts.push(`kind: ${tool.kind}`);
+  return parts.join("\n");
+}
+
+function gooseToolName(meta: Record<string, unknown> | null | undefined): string | null {
+  const goose = meta?.goose;
+  if (!goose || typeof goose !== "object") return null;
+  const toolCall = (goose as Record<string, unknown>).toolCall;
+  if (!toolCall || typeof toolCall !== "object") return null;
+  const name = (toolCall as Record<string, unknown>).toolName;
+  return typeof name === "string" ? name : null;
 }
 
 function PermissionList({
@@ -1036,14 +1106,14 @@ function messageIdFromUpdate(update: { messageId?: string | null; _meta?: unknow
 
 function toolFailureSummary(update: ToolCallUpdate): string {
   const output =
-    typeof update.rawOutput === "string" && update.rawOutput.trim()
-      ? update.rawOutput.trim()
+    update.rawOutput !== undefined
+      ? formatUnknown(update.rawOutput).trim()
       : update.content?.map(toolContentText).filter(Boolean).join(" ").trim() || "";
   return [
     `id=${update.toolCallId}`,
     update.title ? `title=${update.title}` : null,
     update.kind ? `kind=${update.kind}` : null,
-    output ? `output=${truncate(output, 500)}` : null
+    output ? `output=${truncate(output, 500)}` : "output=no ACP error details"
   ]
     .filter(Boolean)
     .join(" ");

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
+import { Markdown } from "@/components/markdown";
 import {
   Select,
   SelectContent,
@@ -137,7 +138,7 @@ export function AgentMode() {
       return response.key;
     });
     appendRuntimeLog(
-      `Maple proxy ready for Agent Mode on ${status.config.host}:${status.config.port}`
+      `Maple proxy ready for Agent Mode on ${status.config.host}:${status.config.port} backend=${status.config.backend_url || "default"}`
     );
     return status;
   }, [appendRuntimeLog, createApiKey]);
@@ -625,8 +626,9 @@ export function AgentMode() {
   ) {
     if (!text) return;
     setTimelineItems((current) => {
+      const timelineMessageId = messageId ? `${messageId}:${role}` : undefined;
       const index = messageId
-        ? current.findIndex((item) => item.type === "message" && item.id === messageId)
+        ? current.findIndex((item) => item.type === "message" && item.id === timelineMessageId)
         : current.length - 1;
       const existing = index >= 0 ? current[index] : null;
       if (!messageId && (existing?.type !== "message" || existing.role !== role)) {
@@ -642,7 +644,12 @@ export function AgentMode() {
       }
       return [
         ...current,
-        { type: "message", id: messageId || `${role}-${crypto.randomUUID()}`, role, text }
+        {
+          type: "message",
+          id: timelineMessageId || `${role}-${crypto.randomUUID()}`,
+          role,
+          text
+        }
       ];
     });
   }
@@ -831,7 +838,11 @@ function MessageBubble({ message }: { message: AgentMessageItem }) {
           message.role === "system" && "border-destructive/30 bg-destructive/5 text-destructive"
         )}
       >
-        <div className="whitespace-pre-wrap break-words">{message.text}</div>
+        {message.role === "assistant" ? (
+          <Markdown content={message.text} />
+        ) : (
+          <div className="whitespace-pre-wrap break-words">{message.text}</div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -200,6 +200,9 @@ export function AgentMode() {
           break;
         case "tool_call":
           mergeToolCall(update);
+          if (update.status === "failed") {
+            appendRuntimeLog(`[ACP tool failed] ${toolFailureSummary(update)}`);
+          }
           break;
         case "tool_call_update":
           mergeToolCall(update);
@@ -1081,7 +1084,11 @@ function toolContentText(content: ToolCallContent): string {
 
 function formatUnknown(value: unknown): string {
   if (typeof value === "string") return value;
-  return JSON.stringify(value, null, 2);
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }
 
 function basename(path: string): string {
@@ -1094,8 +1101,22 @@ function formatPermission(value: string): string {
 }
 
 function errorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  const details = errorDetails(error);
+  return details ? `${message}: ${details}` : message;
+}
+
+function errorDetails(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const record = error as Record<string, unknown>;
+  const parts: string[] = [];
+  if (typeof record.code === "number") {
+    parts.push(`code=${record.code}`);
+  }
+  if ("data" in record && record.data !== undefined) {
+    parts.push(`data=${formatUnknown(record.data)}`);
+  }
+  return parts.join(" ");
 }
 
 function messageIdFromUpdate(update: { messageId?: string | null; _meta?: unknown }) {
@@ -1104,7 +1125,8 @@ function messageIdFromUpdate(update: { messageId?: string | null; _meta?: unknow
   return typeof goose?.messageId === "string" ? goose.messageId : undefined;
 }
 
-function toolFailureSummary(update: ToolCallUpdate): string {
+function toolFailureSummary(update: ToolCall | ToolCallUpdate): string {
+  const input = update.rawInput !== undefined ? formatUnknown(update.rawInput).trim() : "";
   const output =
     update.rawOutput !== undefined
       ? formatUnknown(update.rawOutput).trim()
@@ -1113,6 +1135,7 @@ function toolFailureSummary(update: ToolCallUpdate): string {
     `id=${update.toolCallId}`,
     update.title ? `title=${update.title}` : null,
     update.kind ? `kind=${update.kind}` : null,
+    input ? `input=${truncate(input, 500)}` : null,
     output ? `output=${truncate(output, 500)}` : "output=no ACP error details"
   ]
     .filter(Boolean)

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useOpenSecret } from "@opensecret/react";
 import {
   AlertCircle,
   Bot,
@@ -45,6 +46,7 @@ import {
   type AgentRuntimeStatus,
   type RecentProjectRoot
 } from "@/services/agentRuntimeService";
+import { proxyService } from "@/services/proxyService";
 import { SIDEBAR_GRID_COLUMNS_CLASS, getSidebarLayoutStyle } from "@/constants/layout";
 import { cn, useIsLandscapeMobile, useIsMobile } from "@/utils/utils";
 import { isTauriDesktop } from "@/utils/platform";
@@ -70,6 +72,7 @@ interface AgentToolState {
 const DEFAULT_MODEL = "auto:powerful";
 
 export function AgentMode() {
+  const { createApiKey } = useOpenSecret();
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
@@ -90,11 +93,47 @@ export function AgentMode() {
   const [isSending, setIsSending] = useState(false);
   const clientRef = useRef<AgentAcpClient | null>(null);
   const sessionIdRef = useRef<string | null>(null);
+  const didRunInitialProxyInitRef = useRef(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     setIsSidebarOpen(!isCompactLayout);
   }, [isCompactLayout]);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: "end" });
+  }, [messages, tools, pendingPermissions, planEntries]);
+
+  const activeRootLabel = useMemo(() => {
+    if (!projectRoot) return "Select folder";
+    return recentRoots.find((root) => root.path === projectRoot)?.name || basename(projectRoot);
+  }, [projectRoot, recentRoots]);
+
+  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+
+  const appendRuntimeLog = useCallback((message: string) => {
+    if (!isTauriDesktop()) return;
+    void agentRuntimeService.appendRuntimeLog(message).catch(() => {
+      // Logging must never block Agent Mode interaction.
+    });
+  }, []);
+
+  const ensureMapleProxyReady = useCallback(async () => {
+    appendRuntimeLog("Ensuring Maple proxy is ready for Agent Mode");
+    const status = await proxyService.ensureProxyReady(async (name) => {
+      appendRuntimeLog(`Creating Agent Mode proxy API key ${name}`);
+      const response = await createApiKey(name);
+      return response.key;
+    });
+    appendRuntimeLog(
+      `Maple proxy ready for Agent Mode on ${status.config.host}:${status.config.port}`
+    );
+    return status;
+  }, [appendRuntimeLog, createApiKey]);
 
   useEffect(() => {
     let cancelled = false;
@@ -112,6 +151,11 @@ export function AgentMode() {
         const root = status.projectRoot || config.defaultProjectRoot || roots[0]?.path || "";
         setProjectRoot(root);
         setModel(status.model || config.defaultModel || DEFAULT_MODEL);
+
+        if (!didRunInitialProxyInitRef.current) {
+          didRunInitialProxyInitRef.current = true;
+          await ensureMapleProxyReady();
+        }
       } catch (loadError) {
         if (!cancelled) setError(errorMessage(loadError));
       }
@@ -122,22 +166,7 @@ export function AgentMode() {
       clientRef.current?.close();
       clientRef.current = null;
     };
-  }, []);
-
-  useEffect(() => {
-    sessionIdRef.current = sessionId;
-  }, [sessionId]);
-
-  useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ block: "end" });
-  }, [messages, tools, pendingPermissions, planEntries]);
-
-  const activeRootLabel = useMemo(() => {
-    if (!projectRoot) return "Select folder";
-    return recentRoots.find((root) => root.path === projectRoot)?.name || basename(projectRoot);
-  }, [projectRoot, recentRoots]);
-
-  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+  }, [ensureMapleProxyReady]);
 
   const handleSessionUpdate = useCallback((notification: SessionNotification) => {
     const update = notification.update;
@@ -180,11 +209,14 @@ export function AgentMode() {
       onPermissionRequest: (request) => {
         setPendingPermissions((current) => [...current, request]);
       },
+      onDiagnostic: (diagnostic) => {
+        appendRuntimeLog(`[ACP ${diagnostic.phase}] ${diagnostic.message}`);
+      },
       onClosed: () => {
         clientRef.current = null;
       }
     });
-  }, [handleSessionUpdate]);
+  }, [appendRuntimeLog, handleSessionUpdate]);
 
   const refreshRuntimeStatus = useCallback(async () => {
     if (!isTauriDesktop()) return;
@@ -216,17 +248,22 @@ export function AgentMode() {
       throw new Error("Select a project folder first");
     }
 
+    await ensureMapleProxyReady();
+
     let status = await agentRuntimeService.getRuntimeStatus();
     if (!status.running || !status.acpUrl) {
       setIsStarting(true);
-      status = await agentRuntimeService.startRuntime({
-        projectRoot,
-        model: model || DEFAULT_MODEL,
-        mode: "approve"
-      });
-      setRuntimeStatus(status);
-      setRecentRoots(await agentRuntimeService.listRecentProjectRoots());
-      setIsStarting(false);
+      try {
+        status = await agentRuntimeService.startRuntime({
+          projectRoot,
+          model: model || DEFAULT_MODEL,
+          mode: "approve"
+        });
+        setRuntimeStatus(status);
+        setRecentRoots(await agentRuntimeService.listRecentProjectRoots());
+      } finally {
+        setIsStarting(false);
+      }
     }
 
     if (!status.acpUrl) {
@@ -252,7 +289,7 @@ export function AgentMode() {
     }
 
     return { client: clientRef.current, sessionId: activeSessionId };
-  }, [createClient, model, projectRoot]);
+  }, [createClient, ensureMapleProxyReady, model, projectRoot]);
 
   const startRuntime = useCallback(async () => {
     setError(null);
@@ -261,6 +298,7 @@ export function AgentMode() {
       if (!projectRoot) {
         throw new Error("Select a project folder first");
       }
+      await ensureMapleProxyReady();
       const status = await agentRuntimeService.startRuntime({
         projectRoot: projectRoot || null,
         model: model || DEFAULT_MODEL,
@@ -275,7 +313,7 @@ export function AgentMode() {
     } finally {
       setIsStarting(false);
     }
-  }, [model, projectRoot]);
+  }, [ensureMapleProxyReady, model, projectRoot]);
 
   const restartRuntime = useCallback(async () => {
     setError(null);
@@ -288,6 +326,7 @@ export function AgentMode() {
     setUsage(null);
     setPendingPermissions([]);
     try {
+      await ensureMapleProxyReady();
       const status = await agentRuntimeService.restartRuntime({
         projectRoot: projectRoot || null,
         model: model || DEFAULT_MODEL,
@@ -301,7 +340,7 @@ export function AgentMode() {
     } finally {
       setIsStarting(false);
     }
-  }, [model, projectRoot]);
+  }, [ensureMapleProxyReady, model, projectRoot]);
 
   const stopRuntime = useCallback(async () => {
     clientRef.current?.close();

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -1,0 +1,893 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  AlertCircle,
+  Bot,
+  Check,
+  Circle,
+  FolderOpen,
+  Loader2,
+  Play,
+  RotateCcw,
+  Send,
+  Square,
+  Terminal,
+  X
+} from "lucide-react";
+import {
+  type ContentBlock,
+  type PlanEntry,
+  type SessionNotification,
+  type ToolCall,
+  type ToolCallContent,
+  type ToolCallUpdate,
+  type UsageUpdate
+} from "@agentclientprotocol/sdk";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { Badge } from "@/components/ui/badge";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Input } from "@/components/ui/input";
+import { Sidebar, SidebarToggle } from "@/components/Sidebar";
+import { MapleWordmark } from "@/components/MapleWordmark";
+import {
+  AgentAcpClient,
+  type PermissionDecision,
+  type PermissionRequestHandle
+} from "@/services/agentAcpClient";
+import {
+  agentRuntimeService,
+  type AgentRuntimeStatus,
+  type RecentProjectRoot
+} from "@/services/agentRuntimeService";
+import {
+  SIDEBAR_GRID_COLUMNS_CLASS,
+  getSidebarLayoutStyle
+} from "@/constants/layout";
+import { cn, useIsLandscapeMobile, useIsMobile } from "@/utils/utils";
+import { isDesktop } from "@/utils/platform";
+
+type AgentMessageRole = "user" | "assistant" | "thought" | "system";
+
+interface AgentMessage {
+  id: string;
+  role: AgentMessageRole;
+  text: string;
+}
+
+interface AgentToolState {
+  id: string;
+  title: string;
+  kind?: string;
+  status?: string;
+  input?: unknown;
+  output?: unknown;
+  content?: ToolCallContent[];
+}
+
+const DEFAULT_MODEL = "auto:powerful";
+
+export function AgentMode() {
+  const isMobile = useIsMobile();
+  const isLandscapeMobile = useIsLandscapeMobile();
+  const isCompactLayout = isMobile || isLandscapeMobile;
+  const [isSidebarOpen, setIsSidebarOpen] = useState(!isCompactLayout);
+  const [runtimeStatus, setRuntimeStatus] = useState<AgentRuntimeStatus | null>(null);
+  const [recentRoots, setRecentRoots] = useState<RecentProjectRoot[]>([]);
+  const [projectRoot, setProjectRoot] = useState("");
+  const [model, setModel] = useState(DEFAULT_MODEL);
+  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [tools, setTools] = useState<AgentToolState[]>([]);
+  const [planEntries, setPlanEntries] = useState<PlanEntry[]>([]);
+  const [usage, setUsage] = useState<UsageUpdate | null>(null);
+  const [pendingPermissions, setPendingPermissions] = useState<PermissionRequestHandle[]>([]);
+  const [input, setInput] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
+  const [isSending, setIsSending] = useState(false);
+  const clientRef = useRef<AgentAcpClient | null>(null);
+  const sessionIdRef = useRef<string | null>(null);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    setIsSidebarOpen(!isCompactLayout);
+  }, [isCompactLayout]);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadInitialState() {
+      if (!isDesktop()) return;
+      try {
+        const [status, config, roots] = await Promise.all([
+          agentRuntimeService.getRuntimeStatus(),
+          agentRuntimeService.loadConfig(),
+          agentRuntimeService.listRecentProjectRoots()
+        ]);
+        if (cancelled) return;
+        setRuntimeStatus(status);
+        setRecentRoots(roots);
+        const root = status.projectRoot || config.defaultProjectRoot || roots[0]?.path || "";
+        setProjectRoot(root);
+        setModel(status.model || config.defaultModel || DEFAULT_MODEL);
+      } catch (loadError) {
+        if (!cancelled) setError(errorMessage(loadError));
+      }
+    }
+    void loadInitialState();
+    return () => {
+      cancelled = true;
+      clientRef.current?.close();
+      clientRef.current = null;
+    };
+  }, []);
+
+  useEffect(() => {
+    sessionIdRef.current = sessionId;
+  }, [sessionId]);
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ block: "end" });
+  }, [messages, tools, pendingPermissions, planEntries]);
+
+  const activeRootLabel = useMemo(() => {
+    if (!projectRoot) return "Select folder";
+    return recentRoots.find((root) => root.path === projectRoot)?.name || basename(projectRoot);
+  }, [projectRoot, recentRoots]);
+
+  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+
+  const handleSessionUpdate = useCallback((notification: SessionNotification) => {
+    const update = notification.update;
+    void agentRuntimeService.appendSessionEvent(notification.sessionId, {
+      type: "sessionUpdate",
+      update
+    });
+
+    switch (update.sessionUpdate) {
+      case "agent_message_chunk":
+        appendMessageChunk("assistant", update.messageId, contentBlockText(update.content));
+        break;
+      case "agent_thought_chunk":
+        appendMessageChunk("thought", update.messageId, contentBlockText(update.content));
+        break;
+      case "tool_call":
+        mergeToolCall(update);
+        break;
+      case "tool_call_update":
+        mergeToolCall(update);
+        break;
+      case "plan":
+        setPlanEntries(update.entries);
+        break;
+      case "usage_update":
+        setUsage(update);
+        break;
+      case "user_message_chunk":
+      case "available_commands_update":
+      case "current_mode_update":
+      case "config_option_update":
+      case "session_info_update":
+        break;
+    }
+  }, []);
+
+  const createClient = useCallback(() => {
+    return new AgentAcpClient({
+      onSessionUpdate: handleSessionUpdate,
+      onPermissionRequest: (request) => {
+        setPendingPermissions((current) => [...current, request]);
+      },
+      onClosed: () => {
+        clientRef.current = null;
+      }
+    });
+  }, [handleSessionUpdate]);
+
+  const refreshRuntimeStatus = useCallback(async () => {
+    if (!isDesktop()) return;
+    const status = await agentRuntimeService.getRuntimeStatus();
+    setRuntimeStatus(status);
+  }, []);
+
+  const chooseProjectRoot = useCallback(async () => {
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const selected = await open({
+        directory: true,
+        multiple: false,
+        title: "Select project folder"
+      });
+      if (typeof selected === "string") {
+        setProjectRoot(selected);
+        const roots = await agentRuntimeService.saveRecentProjectRoot(selected);
+        setRecentRoots(roots);
+      }
+    } catch (chooseError) {
+      setError(errorMessage(chooseError));
+    }
+  }, []);
+
+  const ensureConnectedSession = useCallback(async () => {
+    if (!projectRoot) {
+      throw new Error("Select a project folder first");
+    }
+
+    let status = await agentRuntimeService.getRuntimeStatus();
+    if (!status.running || !status.acpUrl) {
+      setIsStarting(true);
+      status = await agentRuntimeService.startRuntime({
+        projectRoot,
+        model: model || DEFAULT_MODEL,
+        mode: "approve"
+      });
+      setRuntimeStatus(status);
+      setRecentRoots(await agentRuntimeService.listRecentProjectRoots());
+      setIsStarting(false);
+    }
+
+    if (!status.acpUrl) {
+      throw new Error("ACP endpoint is not available");
+    }
+
+    if (!clientRef.current) {
+      const nextClient = createClient();
+      await nextClient.connect(status.acpUrl);
+      clientRef.current = nextClient;
+    }
+
+    let activeSessionId = sessionIdRef.current;
+    if (!activeSessionId) {
+      activeSessionId = await clientRef.current.newSession(projectRoot);
+      setSessionId(activeSessionId);
+      sessionIdRef.current = activeSessionId;
+      await agentRuntimeService.appendSessionEvent(activeSessionId, {
+        type: "sessionStarted",
+        projectRoot,
+        model: model || DEFAULT_MODEL
+      });
+    }
+
+    return { client: clientRef.current, sessionId: activeSessionId };
+  }, [createClient, model, projectRoot]);
+
+  const startRuntime = useCallback(async () => {
+    setError(null);
+    setIsStarting(true);
+    try {
+      if (!projectRoot) {
+        throw new Error("Select a project folder first");
+      }
+      const status = await agentRuntimeService.startRuntime({
+        projectRoot: projectRoot || null,
+        model: model || DEFAULT_MODEL,
+        mode: "approve"
+      });
+      setRuntimeStatus(status);
+      setProjectRoot(status.projectRoot || projectRoot);
+      setModel(status.model || model || DEFAULT_MODEL);
+      setRecentRoots(await agentRuntimeService.listRecentProjectRoots());
+    } catch (startError) {
+      setError(errorMessage(startError));
+    } finally {
+      setIsStarting(false);
+    }
+  }, [model, projectRoot]);
+
+  const restartRuntime = useCallback(async () => {
+    setError(null);
+    setIsStarting(true);
+    clientRef.current?.close();
+    clientRef.current = null;
+    setSessionId(null);
+    setTools([]);
+    setPlanEntries([]);
+    setUsage(null);
+    setPendingPermissions([]);
+    try {
+      const status = await agentRuntimeService.restartRuntime({
+        projectRoot: projectRoot || null,
+        model: model || DEFAULT_MODEL,
+        mode: "approve"
+      });
+      setRuntimeStatus(status);
+      setProjectRoot(status.projectRoot || projectRoot);
+      setModel(status.model || model || DEFAULT_MODEL);
+    } catch (restartError) {
+      setError(errorMessage(restartError));
+    } finally {
+      setIsStarting(false);
+    }
+  }, [model, projectRoot]);
+
+  const stopRuntime = useCallback(async () => {
+    clientRef.current?.close();
+    clientRef.current = null;
+    setSessionId(null);
+    setPendingPermissions([]);
+    setRuntimeStatus(await agentRuntimeService.stopRuntime());
+  }, []);
+
+  const sendMessage = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isSending) return;
+
+    setError(null);
+    setInput("");
+    setIsSending(true);
+    const userMessage: AgentMessage = { id: crypto.randomUUID(), role: "user", text };
+    setMessages((current) => [...current, userMessage]);
+
+    try {
+      const active = await ensureConnectedSession();
+      await agentRuntimeService.appendSessionEvent(active.sessionId, {
+        type: "userPrompt",
+        text
+      });
+      await active.client.prompt(active.sessionId, text);
+    } catch (sendError) {
+      setError(errorMessage(sendError));
+      setMessages((current) => [
+        ...current,
+        { id: crypto.randomUUID(), role: "system", text: errorMessage(sendError) }
+      ]);
+    } finally {
+      setIsSending(false);
+    }
+  }, [ensureConnectedSession, input, isSending]);
+
+  const cancelPrompt = useCallback(async () => {
+    if (!sessionId || !clientRef.current) return;
+    try {
+      await clientRef.current.cancel(sessionId);
+    } catch (cancelError) {
+      setError(errorMessage(cancelError));
+    }
+  }, [sessionId]);
+
+  const respondToPermission = useCallback((id: string, decision: PermissionDecision) => {
+    setPendingPermissions((current) => {
+      const request = current.find((candidate) => candidate.id === id);
+      request?.decide(decision);
+      return current.filter((candidate) => candidate.id !== id);
+    });
+  }, []);
+
+  const cancelPermission = useCallback((id: string) => {
+    setPendingPermissions((current) => {
+      const request = current.find((candidate) => candidate.id === id);
+      request?.cancel();
+      return current.filter((candidate) => candidate.id !== id);
+    });
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.key === "Enter" && !event.shiftKey && !isCompactLayout) {
+        event.preventDefault();
+        void sendMessage();
+      }
+    },
+    [isCompactLayout, sendMessage]
+  );
+
+  const sidebarLayoutStyle = getSidebarLayoutStyle({ offsetContent: isSidebarOpen });
+
+  if (!isDesktop()) {
+    return (
+      <div className="flex h-dvh items-center justify-center bg-background p-6 text-center">
+        <div className="max-w-sm space-y-3">
+          <MapleWordmark className="mx-auto h-4 w-auto" />
+          <p className="text-sm text-muted-foreground">Agent Mode is available in Maple Desktop.</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={sidebarLayoutStyle}
+      className={cn(
+        "grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden bg-background",
+        isSidebarOpen ? SIDEBAR_GRID_COLUMNS_CLASS : ""
+      )}
+    >
+      <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />
+
+      <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+        {!isSidebarOpen && (
+          <div className="fixed left-4 top-[9.5px] z-20 flex items-center gap-1.5">
+            <SidebarToggle onToggle={toggleSidebar} />
+            <MapleWordmark className="h-4 w-auto" aria-hidden />
+          </div>
+        )}
+
+        <header className="flex h-14 shrink-0 items-center justify-between gap-3 border-b border-border/35 px-4">
+          <div className={cn("flex min-w-0 items-center gap-3", !isSidebarOpen && "pl-20")}>
+            <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-md border border-border/50 bg-muted/60">
+              <Bot className="h-4 w-4" />
+            </div>
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <h1 className="truncate text-sm font-medium">Agent Mode</h1>
+                <RuntimeBadge running={runtimeStatus?.running ?? false} />
+              </div>
+              <p className="truncate text-xs text-muted-foreground">
+                {projectRoot ? projectRoot : "No project folder selected"}
+              </p>
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={() => void refreshRuntimeStatus()}
+              aria-label="Refresh agent status"
+            >
+              <RotateCcw className="h-4 w-4" />
+            </Button>
+            {runtimeStatus?.running ? (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => void stopRuntime()}
+                aria-label="Stop agent runtime"
+              >
+                <Square className="h-3.5 w-3.5" />
+              </Button>
+            ) : (
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                onClick={() => void startRuntime()}
+                disabled={isStarting || !projectRoot}
+                aria-label="Start agent runtime"
+              >
+                {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+              </Button>
+            )}
+          </div>
+        </header>
+
+        {error && (
+          <div className="mx-auto mt-3 w-full max-w-4xl px-4">
+            <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm text-destructive">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <span className="min-w-0 break-words">{error}</span>
+            </div>
+          </div>
+        )}
+
+        <main className="flex min-h-0 flex-1 flex-col">
+          <div className="min-h-0 flex-1 overflow-y-auto px-4 py-5">
+            <div className="mx-auto flex w-full max-w-4xl flex-col gap-4">
+              {messages.length === 0 && tools.length === 0 ? (
+                <div className="flex min-h-[42vh] items-center justify-center">
+                  <div className="flex w-full max-w-2xl flex-col items-center gap-5 text-center">
+                    <h2 className="font-displayWide text-3xl font-normal brand-gradient-text">
+                      Work in a folder...
+                    </h2>
+                    <AgentComposer
+                      activeRootLabel={activeRootLabel}
+                      input={input}
+                      isSending={isSending}
+                      isStarting={isStarting}
+                      model={model}
+                      projectRoot={projectRoot}
+                      recentRoots={recentRoots}
+                      onCancelPrompt={cancelPrompt}
+                      onChooseProjectRoot={chooseProjectRoot}
+                      onInputChange={setInput}
+                      onKeyDown={handleKeyDown}
+                      onModelChange={setModel}
+                      onProjectRootChange={setProjectRoot}
+                      onRestartRuntime={restartRuntime}
+                      onSendMessage={sendMessage}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <>
+                  <MessageTranscript messages={messages} />
+                  {planEntries.length > 0 && <PlanList entries={planEntries} />}
+                  {tools.length > 0 && <ToolCallList tools={tools} />}
+                  {pendingPermissions.length > 0 && (
+                    <PermissionList
+                      requests={pendingPermissions}
+                      onCancel={cancelPermission}
+                      onDecision={respondToPermission}
+                    />
+                  )}
+                  {usage && <UsageLine usage={usage} />}
+                </>
+              )}
+              <div ref={messagesEndRef} />
+            </div>
+          </div>
+
+          {messages.length > 0 || tools.length > 0 ? (
+            <div className="shrink-0 border-t border-border/35 bg-background px-4 py-3">
+              <div className="mx-auto max-w-4xl">
+                <AgentComposer
+                  activeRootLabel={activeRootLabel}
+                  input={input}
+                  isSending={isSending}
+                  isStarting={isStarting}
+                  model={model}
+                  projectRoot={projectRoot}
+                  recentRoots={recentRoots}
+                  onCancelPrompt={cancelPrompt}
+                  onChooseProjectRoot={chooseProjectRoot}
+                  onInputChange={setInput}
+                  onKeyDown={handleKeyDown}
+                  onModelChange={setModel}
+                  onProjectRootChange={setProjectRoot}
+                  onRestartRuntime={restartRuntime}
+                  onSendMessage={sendMessage}
+                />
+              </div>
+            </div>
+          ) : null}
+        </main>
+      </div>
+    </div>
+  );
+
+  function appendMessageChunk(role: AgentMessageRole, messageId: string | null | undefined, text: string) {
+    if (!text) return;
+    const id = messageId || `${role}-${crypto.randomUUID()}`;
+    setMessages((current) => {
+      const index = current.findIndex((message) => message.id === id);
+      if (index >= 0) {
+        const next = [...current];
+        next[index] = { ...next[index], text: next[index].text + text };
+        return next;
+      }
+      return [...current, { id, role, text }];
+    });
+  }
+
+  function mergeToolCall(update: (ToolCall | ToolCallUpdate) & { sessionUpdate: string }) {
+    setTools((current) => {
+      const index = current.findIndex((tool) => tool.id === update.toolCallId);
+      const previous = index >= 0 ? current[index] : null;
+      const nextTool: AgentToolState = {
+        id: update.toolCallId,
+        title: update.title ?? previous?.title ?? "Tool call",
+        kind: update.kind ?? previous?.kind,
+        status: update.status ?? previous?.status,
+        input: update.rawInput ?? previous?.input,
+        output: update.rawOutput ?? previous?.output,
+        content: update.content ?? previous?.content
+      };
+
+      if (index >= 0) {
+        const next = [...current];
+        next[index] = nextTool;
+        return next;
+      }
+      return [...current, nextTool];
+    });
+  }
+}
+
+interface AgentComposerProps {
+  activeRootLabel: string;
+  input: string;
+  isSending: boolean;
+  isStarting: boolean;
+  model: string;
+  projectRoot: string;
+  recentRoots: RecentProjectRoot[];
+  onCancelPrompt: () => void;
+  onChooseProjectRoot: () => void;
+  onInputChange: (value: string) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
+  onModelChange: (value: string) => void;
+  onProjectRootChange: (value: string) => void;
+  onRestartRuntime: () => void;
+  onSendMessage: () => void;
+}
+
+function AgentComposer({
+  activeRootLabel,
+  input,
+  isSending,
+  isStarting,
+  model,
+  projectRoot,
+  recentRoots,
+  onCancelPrompt,
+  onChooseProjectRoot,
+  onInputChange,
+  onKeyDown,
+  onModelChange,
+  onProjectRootChange,
+  onRestartRuntime,
+  onSendMessage
+}: AgentComposerProps) {
+  return (
+    <div className="w-full rounded-lg border border-border/45 bg-background shadow-sm">
+      <div className="flex flex-wrap items-center gap-2 border-b border-border/35 px-2 py-2">
+        <Select value={projectRoot || undefined} onValueChange={onProjectRootChange}>
+          <SelectTrigger className="h-8 min-w-[12rem] flex-1 rounded-md border-0 bg-muted/60 px-2">
+            <FolderOpen className="mr-2 h-4 w-4 shrink-0" />
+            <SelectValue placeholder={activeRootLabel} />
+          </SelectTrigger>
+          <SelectContent>
+            {recentRoots.map((root) => (
+              <SelectItem key={root.path} value={root.path}>
+                {root.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={onChooseProjectRoot}
+          aria-label="Choose project folder"
+        >
+          <FolderOpen className="h-4 w-4" />
+        </Button>
+        <Input
+          value={model}
+          onChange={(event) => onModelChange(event.target.value)}
+          className="h-8 w-[11rem] rounded-md border-0 bg-muted/60 text-xs"
+          aria-label="Agent model"
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="icon"
+          className="h-8 w-8 shrink-0"
+          onClick={onRestartRuntime}
+          disabled={isStarting}
+          aria-label="Restart agent runtime"
+        >
+          {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCcw className="h-4 w-4" />}
+        </Button>
+      </div>
+      <div className="flex items-end gap-2 p-2">
+        <Textarea
+          id="agent-message"
+          value={input}
+          onChange={(event) => onInputChange(event.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder="Ask Goose to work in this folder..."
+          className="max-h-44 min-h-[4.5rem] resize-none rounded-md border-0 bg-transparent px-2 py-2 focus-visible:ring-0 focus-visible:ring-offset-0"
+        />
+        {isSending ? (
+          <Button
+            type="button"
+            size="icon"
+            variant="outline"
+            className="h-9 w-9 shrink-0"
+            onClick={onCancelPrompt}
+            aria-label="Cancel prompt"
+          >
+            <Square className="h-3.5 w-3.5" />
+          </Button>
+        ) : (
+          <Button
+            type="button"
+            size="icon"
+            className="h-9 w-9 shrink-0"
+            onClick={onSendMessage}
+            disabled={!input.trim() || isStarting || !projectRoot}
+            aria-label="Send agent message"
+          >
+            {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function MessageTranscript({ messages }: { messages: AgentMessage[] }) {
+  return (
+    <div className="flex flex-col gap-3">
+      {messages.map((message) => (
+        <div
+          key={message.id}
+          className={cn(
+            "flex",
+            message.role === "user" ? "justify-end" : "justify-start",
+            message.role === "thought" && "opacity-80"
+          )}
+        >
+          <div
+            className={cn(
+              "max-w-[82%] rounded-lg px-3 py-2 text-sm leading-6",
+              message.role === "user"
+                ? "bg-[hsl(var(--maple-primary))] text-primary-foreground"
+                : "border border-border/45 bg-muted/45 text-foreground",
+              message.role === "system" && "border-destructive/30 bg-destructive/5 text-destructive",
+              message.role === "thought" && "text-muted-foreground"
+            )}
+          >
+            <div className="whitespace-pre-wrap break-words">{message.text}</div>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ToolCallList({ tools }: { tools: AgentToolState[] }) {
+  return (
+    <div className="space-y-2">
+      {tools.map((tool) => (
+        <div key={tool.id} className="rounded-lg border border-border/45 bg-muted/30 px-3 py-2">
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-2">
+              <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate text-sm font-medium">{tool.title}</span>
+            </div>
+            <Badge variant="secondary" className="shrink-0 capitalize">
+              {tool.status || "pending"}
+            </Badge>
+          </div>
+          {tool.kind && <p className="mt-1 text-xs text-muted-foreground">{tool.kind}</p>}
+          {tool.content?.length ? (
+            <div className="mt-2 whitespace-pre-wrap rounded-md bg-background/70 px-2 py-1.5 text-xs text-muted-foreground">
+              {tool.content.map(toolContentText).filter(Boolean).join("\n")}
+            </div>
+          ) : null}
+          {tool.output !== undefined ? (
+            <pre className="mt-2 max-h-56 overflow-auto rounded-md bg-background/70 px-2 py-1.5 text-xs text-muted-foreground">
+              {formatUnknown(tool.output)}
+            </pre>
+          ) : null}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PermissionList({
+  requests,
+  onCancel,
+  onDecision
+}: {
+  requests: PermissionRequestHandle[];
+  onCancel: (id: string) => void;
+  onDecision: (id: string, decision: PermissionDecision) => void;
+}) {
+  return (
+    <div className="space-y-2">
+      {requests.map((permission) => (
+        <div
+          key={permission.id}
+          className="rounded-lg border border-[hsl(var(--maple-primary)/0.45)] bg-[hsl(var(--maple-primary)/0.06)] px-3 py-3"
+        >
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-sm font-medium">{permission.request.toolCall.title}</p>
+              <p className="mt-1 break-words text-xs text-muted-foreground">
+                {permission.request.toolCall.content?.map(toolContentText).filter(Boolean).join(" ")}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0"
+              onClick={() => onCancel(permission.id)}
+              aria-label="Cancel permission request"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-2">
+            {permission.request.options.map((option) => (
+              <Button
+                key={option.optionId}
+                size="sm"
+                variant={option.kind.startsWith("allow") ? "default" : "outline"}
+                className="h-8"
+                onClick={() => onDecision(permission.id, option.kind)}
+              >
+                {option.kind.startsWith("allow") ? (
+                  <Check className="mr-1 h-4 w-4" />
+                ) : (
+                  <X className="mr-1 h-4 w-4" />
+                )}
+                {formatPermission(option.name)}
+              </Button>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function PlanList({ entries }: { entries: PlanEntry[] }) {
+  return (
+    <div className="rounded-lg border border-border/45 bg-muted/25 px-3 py-2">
+      <div className="space-y-1.5">
+        {entries.map((entry, index) => (
+          <div key={`${entry.content}-${index}`} className="flex items-start gap-2 text-sm">
+            <Circle className="mt-1.5 h-2 w-2 shrink-0 fill-muted-foreground text-muted-foreground" />
+            <span className={entry.status === "completed" ? "text-muted-foreground line-through" : ""}>
+              {entry.content}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function UsageLine({ usage }: { usage: UsageUpdate }) {
+  return (
+    <p className="text-right text-xs text-muted-foreground">
+      {usage.used.toLocaleString()} / {usage.size.toLocaleString()} tokens
+    </p>
+  );
+}
+
+function RuntimeBadge({ running }: { running: boolean }) {
+  return (
+    <Badge variant={running ? "default" : "secondary"} className="h-5 rounded-md px-1.5 text-[11px]">
+      {running ? "running" : "stopped"}
+    </Badge>
+  );
+}
+
+function contentBlockText(block: ContentBlock): string {
+  switch (block.type) {
+    case "text":
+      return block.text;
+    case "resource_link":
+      return block.uri;
+    case "resource":
+      return "resource" in block.resource && "text" in block.resource ? block.resource.text : "";
+    case "image":
+      return "[image]";
+    case "audio":
+      return "[audio]";
+  }
+}
+
+function toolContentText(content: ToolCallContent): string {
+  if (content.type === "diff") {
+    const oldLines = content.oldText?.split("\n").length ?? 0;
+    const newLines = content.newText.split("\n").length;
+    return `${content.path}: ${oldLines} -> ${newLines} lines`;
+  }
+  if (content.type === "terminal") {
+    return content.terminalId;
+  }
+  return contentBlockText(content.content);
+}
+
+function formatUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, null, 2);
+}
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] || path;
+}
+
+function formatPermission(value: string): string {
+  return value.replace(/_/g, " ");
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
+}

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -3,6 +3,7 @@ import { useOpenSecret } from "@opensecret/react";
 import {
   AlertCircle,
   Bot,
+  ChevronRight,
   Check,
   Circle,
   FolderOpen,
@@ -20,6 +21,7 @@ import {
   type SessionNotification,
   type ToolCall,
   type ToolCallContent,
+  type ToolCallLocation,
   type ToolCallUpdate,
   type UsageUpdate
 } from "@agentclientprotocol/sdk";
@@ -67,6 +69,8 @@ interface AgentToolState {
   input?: unknown;
   output?: unknown;
   content?: ToolCallContent[];
+  locations?: ToolCallLocation[];
+  meta?: Record<string, unknown> | null;
 }
 
 const DEFAULT_MODEL = "auto:powerful";
@@ -168,40 +172,54 @@ export function AgentMode() {
     };
   }, [ensureMapleProxyReady]);
 
-  const handleSessionUpdate = useCallback((notification: SessionNotification) => {
-    const update = notification.update;
-    void agentRuntimeService.appendSessionEvent(notification.sessionId, {
-      type: "sessionUpdate",
-      update
-    });
+  const handleSessionUpdate = useCallback(
+    (notification: SessionNotification) => {
+      const update = notification.update;
+      void agentRuntimeService.appendSessionEvent(notification.sessionId, {
+        type: "sessionUpdate",
+        update
+      });
 
-    switch (update.sessionUpdate) {
-      case "agent_message_chunk":
-        appendMessageChunk("assistant", update.messageId, contentBlockText(update.content));
-        break;
-      case "agent_thought_chunk":
-        appendMessageChunk("thought", update.messageId, contentBlockText(update.content));
-        break;
-      case "tool_call":
-        mergeToolCall(update);
-        break;
-      case "tool_call_update":
-        mergeToolCall(update);
-        break;
-      case "plan":
-        setPlanEntries(update.entries);
-        break;
-      case "usage_update":
-        setUsage(update);
-        break;
-      case "user_message_chunk":
-      case "available_commands_update":
-      case "current_mode_update":
-      case "config_option_update":
-      case "session_info_update":
-        break;
-    }
-  }, []);
+      switch (update.sessionUpdate) {
+        case "agent_message_chunk":
+          appendMessageChunk(
+            "assistant",
+            messageIdFromUpdate(update),
+            contentBlockText(update.content)
+          );
+          break;
+        case "agent_thought_chunk":
+          appendMessageChunk(
+            "thought",
+            messageIdFromUpdate(update),
+            contentBlockText(update.content)
+          );
+          break;
+        case "tool_call":
+          mergeToolCall(update);
+          break;
+        case "tool_call_update":
+          mergeToolCall(update);
+          if (update.status === "failed") {
+            appendRuntimeLog(`[ACP tool failed] ${toolFailureSummary(update)}`);
+          }
+          break;
+        case "plan":
+          setPlanEntries(update.entries);
+          break;
+        case "usage_update":
+          setUsage(update);
+          break;
+        case "user_message_chunk":
+        case "available_commands_update":
+        case "current_mode_update":
+        case "config_option_update":
+        case "session_info_update":
+          break;
+      }
+    },
+    [appendRuntimeLog]
+  );
 
   const createClient = useCallback(() => {
     return new AgentAcpClient({
@@ -357,6 +375,10 @@ export function AgentMode() {
     setError(null);
     setInput("");
     setIsSending(true);
+    setTools([]);
+    setPlanEntries([]);
+    setUsage(null);
+    setPendingPermissions([]);
     const userMessage: AgentMessage = { id: crypto.randomUUID(), role: "user", text };
     setMessages((current) => [...current, userMessage]);
 
@@ -588,15 +610,20 @@ export function AgentMode() {
     text: string
   ) {
     if (!text) return;
-    const id = messageId || `${role}-${crypto.randomUUID()}`;
     setMessages((current) => {
-      const index = current.findIndex((message) => message.id === id);
+      const index = messageId
+        ? current.findIndex((message) => message.id === messageId)
+        : current.length - 1;
+      const existing = index >= 0 ? current[index] : null;
+      if (!messageId && existing?.role !== role) {
+        return [...current, { id: `${role}-${crypto.randomUUID()}`, role, text }];
+      }
       if (index >= 0) {
         const next = [...current];
         next[index] = { ...next[index], text: next[index].text + text };
         return next;
       }
-      return [...current, { id, role, text }];
+      return [...current, { id: messageId || `${role}-${crypto.randomUUID()}`, role, text }];
     });
   }
 
@@ -611,7 +638,9 @@ export function AgentMode() {
         status: update.status ?? previous?.status,
         input: update.rawInput ?? previous?.input,
         output: update.rawOutput ?? previous?.output,
-        content: update.content ?? previous?.content
+        content: update.content ?? previous?.content,
+        locations: update.locations ?? previous?.locations,
+        meta: update._meta ?? previous?.meta
       };
 
       if (index >= 0) {
@@ -751,31 +780,42 @@ function AgentComposer({
 function MessageTranscript({ messages }: { messages: AgentMessage[] }) {
   return (
     <div className="flex flex-col gap-3">
-      {messages.map((message) => (
-        <div
-          key={message.id}
-          className={cn(
-            "flex",
-            message.role === "user" ? "justify-end" : "justify-start",
-            message.role === "thought" && "opacity-80"
-          )}
-        >
+      {messages.map((message) =>
+        message.role === "thought" ? (
+          <ThinkingMessage key={message.id} text={message.text} />
+        ) : (
           <div
-            className={cn(
-              "max-w-[82%] rounded-lg px-3 py-2 text-sm leading-6",
-              message.role === "user"
-                ? "bg-[hsl(var(--maple-primary))] text-primary-foreground"
-                : "border border-border/45 bg-muted/45 text-foreground",
-              message.role === "system" &&
-                "border-destructive/30 bg-destructive/5 text-destructive",
-              message.role === "thought" && "text-muted-foreground"
-            )}
+            key={message.id}
+            className={cn("flex", message.role === "user" ? "justify-end" : "justify-start")}
           >
-            <div className="whitespace-pre-wrap break-words">{message.text}</div>
+            <div
+              className={cn(
+                "max-w-[82%] rounded-lg px-3 py-2 text-sm leading-6",
+                message.role === "user"
+                  ? "bg-[hsl(var(--maple-primary))] text-primary-foreground"
+                  : "border border-border/45 bg-muted/45 text-foreground",
+                message.role === "system" &&
+                  "border-destructive/30 bg-destructive/5 text-destructive"
+              )}
+            >
+              <div className="whitespace-pre-wrap break-words">{message.text}</div>
+            </div>
           </div>
-        </div>
-      ))}
+        )
+      )}
     </div>
+  );
+}
+
+function ThinkingMessage({ text }: { text: string }) {
+  return (
+    <details className="group max-w-[82%] rounded-lg border border-border/35 bg-muted/25 px-3 py-2 text-sm text-muted-foreground">
+      <summary className="flex cursor-pointer list-none items-center gap-2 font-medium text-foreground/80">
+        <ChevronRight className="h-4 w-4 transition-transform group-open:rotate-90" />
+        Thinking
+      </summary>
+      <div className="mt-2 whitespace-pre-wrap break-words text-xs leading-5">{text}</div>
+    </details>
   );
 }
 
@@ -783,29 +823,63 @@ function ToolCallList({ tools }: { tools: AgentToolState[] }) {
   return (
     <div className="space-y-2">
       {tools.map((tool) => (
-        <div key={tool.id} className="rounded-lg border border-border/45 bg-muted/30 px-3 py-2">
-          <div className="flex items-center justify-between gap-3">
+        <details
+          key={tool.id}
+          open={tool.status === "failed"}
+          className={cn(
+            "group rounded-lg border bg-muted/30 px-3 py-2",
+            tool.status === "failed" ? "border-destructive/35" : "border-border/45"
+          )}
+        >
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3">
             <div className="flex min-w-0 items-center gap-2">
+              <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform group-open:rotate-90" />
               <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
               <span className="truncate text-sm font-medium">{tool.title}</span>
             </div>
-            <Badge variant="secondary" className="shrink-0 capitalize">
+            <Badge
+              variant={tool.status === "failed" ? "destructive" : "secondary"}
+              className="shrink-0 capitalize"
+            >
               {tool.status || "pending"}
             </Badge>
+          </summary>
+          <div className="mt-2 space-y-2 pl-6">
+            {tool.kind && <p className="text-xs text-muted-foreground">{tool.kind}</p>}
+            {tool.locations?.length ? (
+              <ToolDetail
+                label="Locations"
+                value={tool.locations.map((item) => item.path).join("\n")}
+              />
+            ) : null}
+            {tool.content?.length ? (
+              <ToolDetail
+                label="Content"
+                value={tool.content.map(toolContentText).filter(Boolean).join("\n")}
+              />
+            ) : null}
+            {tool.input !== undefined ? (
+              <ToolDetail label="Input" value={formatUnknown(tool.input)} />
+            ) : null}
+            {tool.output !== undefined ? (
+              <ToolDetail label="Output" value={formatUnknown(tool.output)} />
+            ) : null}
+            {tool.meta ? <ToolDetail label="Metadata" value={formatUnknown(tool.meta)} /> : null}
           </div>
-          {tool.kind && <p className="mt-1 text-xs text-muted-foreground">{tool.kind}</p>}
-          {tool.content?.length ? (
-            <div className="mt-2 whitespace-pre-wrap rounded-md bg-background/70 px-2 py-1.5 text-xs text-muted-foreground">
-              {tool.content.map(toolContentText).filter(Boolean).join("\n")}
-            </div>
-          ) : null}
-          {tool.output !== undefined ? (
-            <pre className="mt-2 max-h-56 overflow-auto rounded-md bg-background/70 px-2 py-1.5 text-xs text-muted-foreground">
-              {formatUnknown(tool.output)}
-            </pre>
-          ) : null}
-        </div>
+        </details>
       ))}
+    </div>
+  );
+}
+
+function ToolDetail({ label, value }: { label: string; value: string }) {
+  if (!value.trim()) return null;
+  return (
+    <div>
+      <p className="mb-1 text-[11px] font-medium uppercase text-muted-foreground">{label}</p>
+      <pre className="max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-background/70 px-2 py-1.5 text-xs text-muted-foreground">
+        {value}
+      </pre>
     </div>
   );
 }
@@ -952,4 +1026,35 @@ function formatPermission(value: string): string {
 function errorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   return String(error);
+}
+
+function messageIdFromUpdate(update: { messageId?: string | null; _meta?: unknown }) {
+  if (update.messageId) return update.messageId;
+  const goose = gooseMeta(update);
+  return typeof goose?.messageId === "string" ? goose.messageId : undefined;
+}
+
+function toolFailureSummary(update: ToolCallUpdate): string {
+  const output =
+    typeof update.rawOutput === "string" && update.rawOutput.trim()
+      ? update.rawOutput.trim()
+      : update.content?.map(toolContentText).filter(Boolean).join(" ").trim() || "";
+  return [
+    `id=${update.toolCallId}`,
+    update.title ? `title=${update.title}` : null,
+    update.kind ? `kind=${update.kind}` : null,
+    output ? `output=${truncate(output, 500)}` : null
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+function gooseMeta(update: { _meta?: unknown }): Record<string, unknown> | null {
+  if (!update._meta || typeof update._meta !== "object") return null;
+  const goose = (update._meta as Record<string, unknown>).goose;
+  return goose && typeof goose === "object" ? (goose as Record<string, unknown>) : null;
+}
+
+function truncate(value: string, maxLength: number): string {
+  return value.length > maxLength ? `${value.slice(0, maxLength)}...` : value;
 }

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -45,12 +45,9 @@ import {
   type AgentRuntimeStatus,
   type RecentProjectRoot
 } from "@/services/agentRuntimeService";
-import {
-  SIDEBAR_GRID_COLUMNS_CLASS,
-  getSidebarLayoutStyle
-} from "@/constants/layout";
+import { SIDEBAR_GRID_COLUMNS_CLASS, getSidebarLayoutStyle } from "@/constants/layout";
 import { cn, useIsLandscapeMobile, useIsMobile } from "@/utils/utils";
-import { isDesktop } from "@/utils/platform";
+import { isTauriDesktop } from "@/utils/platform";
 
 type AgentMessageRole = "user" | "assistant" | "thought" | "system";
 
@@ -102,7 +99,7 @@ export function AgentMode() {
   useEffect(() => {
     let cancelled = false;
     async function loadInitialState() {
-      if (!isDesktop()) return;
+      if (!isTauriDesktop()) return;
       try {
         const [status, config, roots] = await Promise.all([
           agentRuntimeService.getRuntimeStatus(),
@@ -190,12 +187,13 @@ export function AgentMode() {
   }, [handleSessionUpdate]);
 
   const refreshRuntimeStatus = useCallback(async () => {
-    if (!isDesktop()) return;
+    if (!isTauriDesktop()) return;
     const status = await agentRuntimeService.getRuntimeStatus();
     setRuntimeStatus(status);
   }, []);
 
   const chooseProjectRoot = useCallback(async () => {
+    if (!isTauriDesktop()) return;
     try {
       const { open } = await import("@tauri-apps/plugin-dialog");
       const selected = await open({
@@ -378,7 +376,7 @@ export function AgentMode() {
 
   const sidebarLayoutStyle = getSidebarLayoutStyle({ offsetContent: isSidebarOpen });
 
-  if (!isDesktop()) {
+  if (!isTauriDesktop()) {
     return (
       <div className="flex h-dvh items-center justify-center bg-background p-6 text-center">
         <div className="max-w-sm space-y-3">
@@ -451,7 +449,11 @@ export function AgentMode() {
                 disabled={isStarting || !projectRoot}
                 aria-label="Start agent runtime"
               >
-                {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Play className="h-4 w-4" />}
+                {isStarting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="h-4 w-4" />
+                )}
               </Button>
             )}
           </div>
@@ -541,7 +543,11 @@ export function AgentMode() {
     </div>
   );
 
-  function appendMessageChunk(role: AgentMessageRole, messageId: string | null | undefined, text: string) {
+  function appendMessageChunk(
+    role: AgentMessageRole,
+    messageId: string | null | undefined,
+    text: string
+  ) {
     if (!text) return;
     const id = messageId || `${role}-${crypto.randomUUID()}`;
     setMessages((current) => {
@@ -655,7 +661,11 @@ function AgentComposer({
           disabled={isStarting}
           aria-label="Restart agent runtime"
         >
-          {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <RotateCcw className="h-4 w-4" />}
+          {isStarting ? (
+            <Loader2 className="h-4 w-4 animate-spin" />
+          ) : (
+            <RotateCcw className="h-4 w-4" />
+          )}
         </Button>
       </div>
       <div className="flex items-end gap-2 p-2">
@@ -687,7 +697,11 @@ function AgentComposer({
             disabled={!input.trim() || isStarting || !projectRoot}
             aria-label="Send agent message"
           >
-            {isStarting ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+            {isStarting ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Send className="h-4 w-4" />
+            )}
           </Button>
         )}
       </div>
@@ -713,7 +727,8 @@ function MessageTranscript({ messages }: { messages: AgentMessage[] }) {
               message.role === "user"
                 ? "bg-[hsl(var(--maple-primary))] text-primary-foreground"
                 : "border border-border/45 bg-muted/45 text-foreground",
-              message.role === "system" && "border-destructive/30 bg-destructive/5 text-destructive",
+              message.role === "system" &&
+                "border-destructive/30 bg-destructive/5 text-destructive",
               message.role === "thought" && "text-muted-foreground"
             )}
           >
@@ -776,7 +791,10 @@ function PermissionList({
             <div className="min-w-0">
               <p className="text-sm font-medium">{permission.request.toolCall.title}</p>
               <p className="mt-1 break-words text-xs text-muted-foreground">
-                {permission.request.toolCall.content?.map(toolContentText).filter(Boolean).join(" ")}
+                {permission.request.toolCall.content
+                  ?.map(toolContentText)
+                  .filter(Boolean)
+                  .join(" ")}
               </p>
             </div>
             <Button
@@ -820,7 +838,9 @@ function PlanList({ entries }: { entries: PlanEntry[] }) {
         {entries.map((entry, index) => (
           <div key={`${entry.content}-${index}`} className="flex items-start gap-2 text-sm">
             <Circle className="mt-1.5 h-2 w-2 shrink-0 fill-muted-foreground text-muted-foreground" />
-            <span className={entry.status === "completed" ? "text-muted-foreground line-through" : ""}>
+            <span
+              className={entry.status === "completed" ? "text-muted-foreground line-through" : ""}
+            >
               {entry.content}
             </span>
           </div>
@@ -840,7 +860,10 @@ function UsageLine({ usage }: { usage: UsageUpdate }) {
 
 function RuntimeBadge({ running }: { running: boolean }) {
   return (
-    <Badge variant={running ? "default" : "secondary"} className="h-5 rounded-md px-1.5 text-[11px]">
+    <Badge
+      variant={running ? "default" : "secondary"}
+      className="h-5 rounded-md px-1.5 text-[11px]"
+    >
       {running ? "running" : "stopped"}
     </Badge>
   );

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -6,7 +6,8 @@ import {
   XCircle,
   Trash2,
   X,
-  FolderInput
+  FolderInput,
+  Bot
 } from "lucide-react";
 import { Button } from "./ui/button";
 import { useLocation, useRouter } from "@tanstack/react-router";
@@ -108,6 +109,18 @@ export function Sidebar({
       } catch (error) {
         console.error("Navigation failed:", error);
       }
+    }
+  }
+
+  async function openAgentMode() {
+    if (isOpen && isCompactLayout) {
+      onToggle();
+    }
+
+    try {
+      await router.navigate({ to: "/agent" });
+    } catch (error) {
+      console.error("Navigation failed:", error);
     }
   }
 
@@ -242,6 +255,19 @@ export function Sidebar({
             >
               <Search className="h-4 w-4" />
               Search
+            </button>
+            <button
+              type="button"
+              className={cn(
+                "flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm transition-colors",
+                location.pathname === "/agent"
+                  ? "text-[hsl(var(--maple-primary-strong))] dark:text-[hsl(var(--maple-primary))]"
+                  : "text-foreground hover:text-foreground/70"
+              )}
+              onClick={openAgentMode}
+            >
+              <Bot className="h-4 w-4" />
+              Agent Mode
             </button>
           </div>
         </div>

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -24,6 +24,7 @@ import {
   SIDEBAR_MAX_WIDTH_CLASS,
   SIDEBAR_WIDTH_CLASS
 } from "@/constants/layout";
+import { isTauriDesktop } from "@/utils/platform";
 
 export function Sidebar({
   chatId,
@@ -153,6 +154,7 @@ export function Sidebar({
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
+  const showAgentMode = isTauriDesktop();
 
   // Modified click outside handler to ignore clicks in dropdowns and dialogs
   // Only applies on mobile - desktop users use the toggle button
@@ -256,19 +258,21 @@ export function Sidebar({
               <Search className="h-4 w-4" />
               Search
             </button>
-            <button
-              type="button"
-              className={cn(
-                "flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm transition-colors",
-                location.pathname === "/agent"
-                  ? "text-[hsl(var(--maple-primary-strong))] dark:text-[hsl(var(--maple-primary))]"
-                  : "text-foreground hover:text-foreground/70"
-              )}
-              onClick={openAgentMode}
-            >
-              <Bot className="h-4 w-4" />
-              Agent Mode
-            </button>
+            {showAgentMode && (
+              <button
+                type="button"
+                className={cn(
+                  "flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm transition-colors",
+                  location.pathname === "/agent"
+                    ? "text-[hsl(var(--maple-primary-strong))] dark:text-[hsl(var(--maple-primary))]"
+                    : "text-foreground hover:text-foreground/70"
+                )}
+                onClick={openAgentMode}
+              >
+                <Bot className="h-4 w-4" />
+                Agent Mode
+              </button>
+            )}
           </div>
         </div>
         {isSelectionMode && (

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -21,6 +21,7 @@ import { Route as PasswordResetRouteImport } from './routes/password-reset'
 import { Route as LoginRouteImport } from './routes/login'
 import { Route as DownloadsRouteImport } from './routes/downloads'
 import { Route as DesktopAuthRouteImport } from './routes/desktop-auth'
+import { Route as AgentRouteImport } from './routes/agent'
 import { Route as AboutRouteImport } from './routes/about'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as VerifyCodeRouteImport } from './routes/verify.$code'
@@ -88,6 +89,11 @@ const DesktopAuthRoute = DesktopAuthRouteImport.update({
   path: '/desktop-auth',
   getParentRoute: () => rootRouteImport,
 } as any)
+const AgentRoute = AgentRouteImport.update({
+  id: '/agent',
+  path: '/agent',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const AboutRoute = AboutRouteImport.update({
   id: '/about',
   path: '/about',
@@ -122,6 +128,7 @@ const AuthProviderCallbackRoute = AuthProviderCallbackRouteImport.update({
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/agent': typeof AgentRoute
   '/desktop-auth': typeof DesktopAuthRoute
   '/downloads': typeof DownloadsRoute
   '/login': typeof LoginRoute
@@ -142,6 +149,7 @@ export interface FileRoutesByFullPath {
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/agent': typeof AgentRoute
   '/desktop-auth': typeof DesktopAuthRoute
   '/downloads': typeof DownloadsRoute
   '/login': typeof LoginRoute
@@ -163,6 +171,7 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/about': typeof AboutRoute
+  '/agent': typeof AgentRoute
   '/desktop-auth': typeof DesktopAuthRoute
   '/downloads': typeof DownloadsRoute
   '/login': typeof LoginRoute
@@ -185,6 +194,7 @@ export interface FileRouteTypes {
   fullPaths:
     | '/'
     | '/about'
+    | '/agent'
     | '/desktop-auth'
     | '/downloads'
     | '/login'
@@ -205,6 +215,7 @@ export interface FileRouteTypes {
   to:
     | '/'
     | '/about'
+    | '/agent'
     | '/desktop-auth'
     | '/downloads'
     | '/login'
@@ -225,6 +236,7 @@ export interface FileRouteTypes {
     | '__root__'
     | '/'
     | '/about'
+    | '/agent'
     | '/desktop-auth'
     | '/downloads'
     | '/login'
@@ -246,6 +258,7 @@ export interface FileRouteTypes {
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AboutRoute: typeof AboutRoute
+  AgentRoute: typeof AgentRoute
   DesktopAuthRoute: typeof DesktopAuthRoute
   DownloadsRoute: typeof DownloadsRoute
   LoginRoute: typeof LoginRoute
@@ -349,6 +362,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof DesktopAuthRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/agent': {
+      id: '/agent'
+      path: '/agent'
+      fullPath: '/agent'
+      preLoaderRoute: typeof AgentRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/about': {
       id: '/about'
       path: '/about'
@@ -409,6 +429,7 @@ const PasswordResetRouteWithChildren = PasswordResetRoute._addFileChildren(
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   AboutRoute: AboutRoute,
+  AgentRoute: AgentRoute,
   DesktopAuthRoute: DesktopAuthRoute,
   DownloadsRoute: DownloadsRoute,
   LoginRoute: LoginRoute,

--- a/frontend/src/routes/agent.tsx
+++ b/frontend/src/routes/agent.tsx
@@ -1,0 +1,26 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { useOpenSecret } from "@opensecret/react";
+import { AgentMode } from "@/components/AgentMode";
+import { AppEntryPage } from "@/components/AppEntryPage";
+import { useRouteMeta } from "@/utils/routeMeta";
+import { appUrl } from "@/config/domains";
+
+export const Route = createFileRoute("/agent")({
+  component: AgentRoute
+});
+
+function AgentRoute() {
+  const os = useOpenSecret();
+
+  useRouteMeta({
+    title: os.auth.user ? "Maple Agent Mode" : "Maple Research | Private AI Workspace",
+    description: "Maple Agent Mode.",
+    canonicalUrl: appUrl("/agent")
+  });
+
+  if (!os.auth.user) {
+    return <AppEntryPage />;
+  }
+
+  return <AgentMode />;
+}

--- a/frontend/src/routes/agent.tsx
+++ b/frontend/src/routes/agent.tsx
@@ -1,9 +1,14 @@
-import { createFileRoute } from "@tanstack/react-router";
+import { lazy, Suspense } from "react";
+import { Navigate, createFileRoute } from "@tanstack/react-router";
 import { useOpenSecret } from "@opensecret/react";
-import { AgentMode } from "@/components/AgentMode";
 import { AppEntryPage } from "@/components/AppEntryPage";
 import { useRouteMeta } from "@/utils/routeMeta";
 import { appUrl } from "@/config/domains";
+import { isTauriDesktop } from "@/utils/platform";
+
+const AgentMode = lazy(() =>
+  import("@/components/AgentMode").then((module) => ({ default: module.AgentMode }))
+);
 
 export const Route = createFileRoute("/agent")({
   component: AgentRoute
@@ -11,16 +16,28 @@ export const Route = createFileRoute("/agent")({
 
 function AgentRoute() {
   const os = useOpenSecret();
+  const agentModeAvailable = isTauriDesktop();
 
   useRouteMeta({
-    title: os.auth.user ? "Maple Agent Mode" : "Maple Research | Private AI Workspace",
+    title:
+      agentModeAvailable && os.auth.user
+        ? "Maple Agent Mode"
+        : "Maple Research | Private AI Workspace",
     description: "Maple Agent Mode.",
     canonicalUrl: appUrl("/agent")
   });
+
+  if (!agentModeAvailable) {
+    return <Navigate to="/" replace />;
+  }
 
   if (!os.auth.user) {
     return <AppEntryPage />;
   }
 
-  return <AgentMode />;
+  return (
+    <Suspense fallback={null}>
+      <AgentMode />
+    </Suspense>
+  );
 }

--- a/frontend/src/services/agentAcpClient.ts
+++ b/frontend/src/services/agentAcpClient.ts
@@ -19,9 +19,26 @@ export interface PermissionRequestHandle {
   cancel: () => void;
 }
 
+export interface AgentAcpDiagnostic {
+  phase:
+    | "connect:start"
+    | "connect:open"
+    | "connect:initialized"
+    | "connect:error"
+    | "connect:close"
+    | "message:malformed";
+  message: string;
+  url?: string;
+  readyState?: number;
+  closeCode?: number;
+  closeReason?: string;
+  wasClean?: boolean;
+}
+
 export interface AgentAcpClientCallbacks {
   onSessionUpdate: (notification: SessionNotification) => void;
   onPermissionRequest: (request: PermissionRequestHandle) => void;
+  onDiagnostic?: (diagnostic: AgentAcpDiagnostic) => void;
   onExtensionNotification?: (method: string, params: Record<string, unknown>) => void;
   onClosed?: () => void;
 }
@@ -47,7 +64,16 @@ export class AgentAcpClient {
   async connect(acpUrl: string): Promise<ConnectedAgentAcpClient> {
     this.close();
 
-    const stream = createWebSocketStream(acpUrl);
+    const redactedUrl = redactAcpUrl(acpUrl);
+    this.callbacks.onDiagnostic?.({
+      phase: "connect:start",
+      message: `Opening ACP WebSocket ${redactedUrl}`,
+      url: redactedUrl
+    });
+
+    const stream = createWebSocketStream(acpUrl, (diagnostic) => {
+      this.callbacks.onDiagnostic?.(diagnostic);
+    });
     const acpClient = this.createClientCallbacks();
     const connection = new ClientSideConnection(() => acpClient, stream);
     this.stream = stream;
@@ -72,8 +98,19 @@ export class AgentAcpClient {
         }
       });
 
+      this.callbacks.onDiagnostic?.({
+        phase: "connect:initialized",
+        message: `ACP initialize completed for ${redactedUrl}`,
+        url: redactedUrl
+      });
+
       return { initializeResponse, client: this };
     } catch (error) {
+      this.callbacks.onDiagnostic?.({
+        phase: "connect:error",
+        message: `ACP initialize failed for ${redactedUrl}: ${errorMessage(error)}`,
+        url: redactedUrl
+      });
       this.close();
       throw error;
     }
@@ -157,8 +194,12 @@ function isSessionNotification(value: unknown): value is SessionNotification {
   return typeof candidate.sessionId === "string" && typeof candidate.update === "object";
 }
 
-function createWebSocketStream(wsUrl: string): ClosableAcpStream {
+function createWebSocketStream(
+  wsUrl: string,
+  onDiagnostic: (diagnostic: AgentAcpDiagnostic) => void
+): ClosableAcpStream {
   const ws = new WebSocket(wsUrl);
+  const redactedUrl = redactAcpUrl(wsUrl);
   const incoming: unknown[] = [];
   const waiters: Array<() => void> = [];
   let closed = false;
@@ -171,10 +212,32 @@ function createWebSocketStream(wsUrl: string): ClosableAcpStream {
   };
 
   const openPromise = new Promise<void>((resolve, reject) => {
-    ws.addEventListener("open", () => resolve(), { once: true });
-    ws.addEventListener("error", () => reject(new Error("ACP WebSocket connection failed")), {
-      once: true
-    });
+    ws.addEventListener(
+      "open",
+      () => {
+        onDiagnostic({
+          phase: "connect:open",
+          message: `ACP WebSocket opened ${redactedUrl}`,
+          url: redactedUrl,
+          readyState: ws.readyState
+        });
+        resolve();
+      },
+      { once: true }
+    );
+    ws.addEventListener(
+      "error",
+      () => {
+        onDiagnostic({
+          phase: "connect:error",
+          message: `ACP WebSocket error for ${redactedUrl}`,
+          url: redactedUrl,
+          readyState: ws.readyState
+        });
+        reject(new Error(`ACP WebSocket connection failed for ${redactedUrl}`));
+      },
+      { once: true }
+    );
   });
 
   const wakeWaiters = () => {
@@ -189,10 +252,26 @@ function createWebSocketStream(wsUrl: string): ClosableAcpStream {
       incoming.push(JSON.parse(event.data));
       waiters.shift()?.();
     } catch {
-      // Ignore malformed transport messages.
+      onDiagnostic({
+        phase: "message:malformed",
+        message: "Ignored malformed ACP transport message",
+        url: redactedUrl,
+        readyState: ws.readyState
+      });
     }
   });
-  ws.addEventListener("close", wakeWaiters);
+  ws.addEventListener("close", (event) => {
+    onDiagnostic({
+      phase: "connect:close",
+      message: `ACP WebSocket closed for ${redactedUrl} code=${event.code} clean=${event.wasClean}`,
+      url: redactedUrl,
+      readyState: ws.readyState,
+      closeCode: event.code,
+      closeReason: event.reason || undefined,
+      wasClean: event.wasClean
+    });
+    wakeWaiters();
+  });
   ws.addEventListener("error", wakeWaiters);
 
   const readable = new ReadableStream({
@@ -225,4 +304,21 @@ function createWebSocketStream(wsUrl: string): ClosableAcpStream {
     writable,
     close: () => ws.close()
   };
+}
+
+function redactAcpUrl(wsUrl: string): string {
+  try {
+    const url = new URL(wsUrl);
+    if (url.searchParams.has("token")) {
+      url.searchParams.set("token", "REDACTED");
+    }
+    return url.toString();
+  } catch {
+    return wsUrl.replace(/([?&]token=)[^&]+/i, "$1REDACTED");
+  }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  return String(error);
 }

--- a/frontend/src/services/agentAcpClient.ts
+++ b/frontend/src/services/agentAcpClient.ts
@@ -26,6 +26,7 @@ export interface AgentAcpDiagnostic {
     | "connect:initialized"
     | "connect:error"
     | "connect:close"
+    | "request:error"
     | "message:malformed";
   message: string;
   url?: string;
@@ -118,18 +119,34 @@ export class AgentAcpClient {
 
   async newSession(cwd: string): Promise<string> {
     const connection = this.requireConnection();
-    const response = await connection.newSession({ cwd, mcpServers: [] });
-    return response.sessionId;
+    try {
+      const response = await connection.newSession({ cwd, mcpServers: [] });
+      return response.sessionId;
+    } catch (error) {
+      this.callbacks.onDiagnostic?.({
+        phase: "request:error",
+        message: `ACP session/new failed: ${errorMessage(error)}`
+      });
+      throw error;
+    }
   }
 
   async prompt(sessionId: string, text: string): Promise<void> {
     const connection = this.requireConnection();
     const prompt: ContentBlock[] = [{ type: "text", text }];
-    await connection.prompt({
-      sessionId,
-      messageId: crypto.randomUUID(),
-      prompt
-    });
+    try {
+      await connection.prompt({
+        sessionId,
+        messageId: crypto.randomUUID(),
+        prompt
+      });
+    } catch (error) {
+      this.callbacks.onDiagnostic?.({
+        phase: "request:error",
+        message: `ACP session/prompt failed: ${errorMessage(error)}`
+      });
+      throw error;
+    }
   }
 
   async cancel(sessionId: string): Promise<void> {
@@ -310,6 +327,29 @@ function redactAcpUrl(wsUrl: string): string {
 }
 
 function errorMessage(error: unknown): string {
-  if (error instanceof Error) return error.message;
-  return String(error);
+  const message = error instanceof Error ? error.message : String(error);
+  const details = errorDetails(error);
+  return details ? `${message}: ${details}` : message;
+}
+
+function errorDetails(error: unknown): string | null {
+  if (!error || typeof error !== "object") return null;
+  const record = error as Record<string, unknown>;
+  const parts: string[] = [];
+  if (typeof record.code === "number") {
+    parts.push(`code=${record.code}`);
+  }
+  if ("data" in record && record.data !== undefined) {
+    parts.push(`data=${formatUnknown(record.data)}`);
+  }
+  return parts.join(" ");
+}
+
+function formatUnknown(value: unknown): string {
+  if (typeof value === "string") return value;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return String(value);
+  }
 }

--- a/frontend/src/services/agentAcpClient.ts
+++ b/frontend/src/services/agentAcpClient.ts
@@ -1,0 +1,228 @@
+import {
+  ClientSideConnection,
+  PROTOCOL_VERSION,
+  type Client,
+  type ContentBlock,
+  type InitializeResponse,
+  type RequestPermissionRequest,
+  type RequestPermissionResponse,
+  type SessionNotification,
+  type Stream
+} from "@agentclientprotocol/sdk";
+
+export type PermissionDecision = "allow_once" | "allow_always" | "reject_once" | "reject_always";
+
+export interface PermissionRequestHandle {
+  id: string;
+  request: RequestPermissionRequest;
+  decide: (decision: PermissionDecision) => void;
+  cancel: () => void;
+}
+
+export interface AgentAcpClientCallbacks {
+  onSessionUpdate: (notification: SessionNotification) => void;
+  onPermissionRequest: (request: PermissionRequestHandle) => void;
+  onExtensionNotification?: (method: string, params: Record<string, unknown>) => void;
+  onClosed?: () => void;
+}
+
+export interface ConnectedAgentAcpClient {
+  initializeResponse: InitializeResponse;
+  client: AgentAcpClient;
+}
+
+type ClosableAcpStream = Stream & {
+  close: () => void;
+};
+
+export class AgentAcpClient {
+  private connection: ClientSideConnection | null = null;
+  private stream: ClosableAcpStream | null = null;
+  private readonly callbacks: AgentAcpClientCallbacks;
+
+  constructor(callbacks: AgentAcpClientCallbacks) {
+    this.callbacks = callbacks;
+  }
+
+  async connect(acpUrl: string): Promise<ConnectedAgentAcpClient> {
+    this.close();
+
+    const stream = createWebSocketStream(acpUrl);
+    const acpClient = this.createClientCallbacks();
+    const connection = new ClientSideConnection(() => acpClient, stream);
+    this.stream = stream;
+    this.connection = connection;
+
+    connection.closed
+      .then(() => this.callbacks.onClosed?.())
+      .catch(() => this.callbacks.onClosed?.());
+
+    try {
+      const initializeResponse = await connection.initialize({
+        protocolVersion: PROTOCOL_VERSION,
+        clientCapabilities: {
+          _meta: {
+            maple: { agentMode: true },
+            goose: { customNotifications: true }
+          }
+        },
+        clientInfo: {
+          name: "Maple Agent Mode",
+          version: "0.1.0"
+        }
+      });
+
+      return { initializeResponse, client: this };
+    } catch (error) {
+      this.close();
+      throw error;
+    }
+  }
+
+  async newSession(cwd: string): Promise<string> {
+    const connection = this.requireConnection();
+    const response = await connection.newSession({ cwd, mcpServers: [] });
+    return response.sessionId;
+  }
+
+  async prompt(sessionId: string, text: string): Promise<void> {
+    const connection = this.requireConnection();
+    const prompt: ContentBlock[] = [{ type: "text", text }];
+    await connection.prompt({
+      sessionId,
+      messageId: crypto.randomUUID(),
+      prompt
+    });
+  }
+
+  async cancel(sessionId: string): Promise<void> {
+    await this.requireConnection().cancel({ sessionId });
+  }
+
+  close(): void {
+    this.stream?.close();
+    this.stream = null;
+    this.connection = null;
+  }
+
+  private requireConnection(): ClientSideConnection {
+    if (!this.connection) {
+      throw new Error("ACP client is not connected");
+    }
+    return this.connection;
+  }
+
+  private createClientCallbacks(): Client {
+    return {
+      requestPermission: (request) => this.handlePermissionRequest(request),
+      sessionUpdate: async (notification) => {
+        this.callbacks.onSessionUpdate(notification);
+      },
+      extNotification: async (method, params) => {
+        this.callbacks.onExtensionNotification?.(method, params);
+        if (method === "_goose/unstable/session/update" && isSessionNotification(params)) {
+          this.callbacks.onSessionUpdate(params);
+        }
+      }
+    };
+  }
+
+  private async handlePermissionRequest(
+    request: RequestPermissionRequest
+  ): Promise<RequestPermissionResponse> {
+    return await new Promise<RequestPermissionResponse>((resolve) => {
+      const id = crypto.randomUUID();
+      const finish = (response: RequestPermissionResponse) => resolve(response);
+
+      this.callbacks.onPermissionRequest({
+        id,
+        request,
+        decide: (decision) => {
+          const option = request.options.find((candidate) => candidate.kind === decision);
+          finish({
+            outcome: option
+              ? { outcome: "selected", optionId: option.optionId }
+              : { outcome: "cancelled" }
+          });
+        },
+        cancel: () => finish({ outcome: { outcome: "cancelled" } })
+      });
+    });
+  }
+}
+
+function isSessionNotification(value: unknown): value is SessionNotification {
+  if (!value || typeof value !== "object") return false;
+  const candidate = value as { sessionId?: unknown; update?: unknown };
+  return typeof candidate.sessionId === "string" && typeof candidate.update === "object";
+}
+
+function createWebSocketStream(wsUrl: string): ClosableAcpStream {
+  const ws = new WebSocket(wsUrl);
+  const incoming: unknown[] = [];
+  const waiters: Array<() => void> = [];
+  let closed = false;
+
+  const waitForMessage = (): Promise<void> => {
+    if (incoming.length > 0 || closed) {
+      return Promise.resolve();
+    }
+    return new Promise<void>((resolve) => waiters.push(resolve));
+  };
+
+  const openPromise = new Promise<void>((resolve, reject) => {
+    ws.addEventListener("open", () => resolve(), { once: true });
+    ws.addEventListener("error", () => reject(new Error("ACP WebSocket connection failed")), {
+      once: true
+    });
+  });
+
+  const wakeWaiters = () => {
+    closed = true;
+    for (const waiter of waiters) waiter();
+    waiters.length = 0;
+  };
+
+  ws.addEventListener("message", (event) => {
+    if (typeof event.data !== "string") return;
+    try {
+      incoming.push(JSON.parse(event.data));
+      waiters.shift()?.();
+    } catch {
+      // Ignore malformed transport messages.
+    }
+  });
+  ws.addEventListener("close", wakeWaiters);
+  ws.addEventListener("error", wakeWaiters);
+
+  const readable = new ReadableStream({
+    async pull(controller) {
+      await waitForMessage();
+      while (incoming.length > 0) {
+        controller.enqueue(incoming.shift());
+      }
+      if (closed && incoming.length === 0) {
+        controller.close();
+      }
+    }
+  });
+
+  const writable = new WritableStream({
+    async write(message) {
+      await openPromise;
+      ws.send(JSON.stringify(message));
+    },
+    close() {
+      ws.close();
+    },
+    abort() {
+      ws.close();
+    }
+  });
+
+  return {
+    readable,
+    writable,
+    close: () => ws.close()
+  };
+}

--- a/frontend/src/services/agentAcpClient.ts
+++ b/frontend/src/services/agentAcpClient.ts
@@ -157,9 +157,6 @@ export class AgentAcpClient {
       },
       extNotification: async (method, params) => {
         this.callbacks.onExtensionNotification?.(method, params);
-        if (method === "_goose/unstable/session/update" && isSessionNotification(params)) {
-          this.callbacks.onSessionUpdate(params);
-        }
       }
     };
   }
@@ -186,12 +183,6 @@ export class AgentAcpClient {
       });
     });
   }
-}
-
-function isSessionNotification(value: unknown): value is SessionNotification {
-  if (!value || typeof value !== "object") return false;
-  const candidate = value as { sessionId?: unknown; update?: unknown };
-  return typeof candidate.sessionId === "string" && typeof candidate.update === "object";
 }
 
 function createWebSocketStream(

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -29,6 +29,8 @@ export interface AgentRuntimeStatus {
   configDir: string;
   goosePathRoot?: string | null;
   logPath?: string | null;
+  llmLogDir?: string | null;
+  latestLlmLogPath?: string | null;
   error?: string | null;
 }
 

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -31,6 +31,8 @@ export interface AgentRuntimeStatus {
   logPath?: string | null;
   llmLogDir?: string | null;
   latestLlmLogPath?: string | null;
+  proxyLlmLogDir?: string | null;
+  latestProxyLlmLogPath?: string | null;
   error?: string | null;
 }
 

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -1,4 +1,4 @@
-import { invoke } from "@tauri-apps/api/core";
+import { isTauriDesktop } from "@/utils/platform";
 
 export interface AgentConfig {
   defaultProjectRoot?: string | null;
@@ -40,40 +40,52 @@ export interface RecentProjectRoot {
 
 class AgentRuntimeService {
   async getRuntimeStatus(): Promise<AgentRuntimeStatus> {
-    return await invoke<AgentRuntimeStatus>("agent_get_runtime_status");
+    return await invokeAgent<AgentRuntimeStatus>("agent_get_runtime_status");
   }
 
   async startRuntime(request?: AgentStartRequest): Promise<AgentRuntimeStatus> {
-    return await invoke<AgentRuntimeStatus>("agent_start_runtime", { request: request ?? null });
+    return await invokeAgent<AgentRuntimeStatus>("agent_start_runtime", {
+      request: request ?? null
+    });
   }
 
   async stopRuntime(): Promise<AgentRuntimeStatus> {
-    return await invoke<AgentRuntimeStatus>("agent_stop_runtime");
+    return await invokeAgent<AgentRuntimeStatus>("agent_stop_runtime");
   }
 
   async restartRuntime(request?: AgentStartRequest): Promise<AgentRuntimeStatus> {
-    return await invoke<AgentRuntimeStatus>("agent_restart_runtime", { request: request ?? null });
+    return await invokeAgent<AgentRuntimeStatus>("agent_restart_runtime", {
+      request: request ?? null
+    });
   }
 
   async loadConfig(): Promise<AgentConfig> {
-    return await invoke<AgentConfig>("agent_load_config");
+    return await invokeAgent<AgentConfig>("agent_load_config");
   }
 
   async saveConfig(config: AgentConfig): Promise<void> {
-    await invoke("agent_save_config", { config });
+    await invokeAgent("agent_save_config", { config });
   }
 
   async listRecentProjectRoots(): Promise<RecentProjectRoot[]> {
-    return await invoke<RecentProjectRoot[]>("agent_list_recent_project_roots");
+    return await invokeAgent<RecentProjectRoot[]>("agent_list_recent_project_roots");
   }
 
   async saveRecentProjectRoot(path: string): Promise<RecentProjectRoot[]> {
-    return await invoke<RecentProjectRoot[]>("agent_save_recent_project_root", { path });
+    return await invokeAgent<RecentProjectRoot[]>("agent_save_recent_project_root", { path });
   }
 
   async appendSessionEvent(sessionId: string, event: unknown): Promise<void> {
-    await invoke("agent_append_session_event", { sessionId, event });
+    await invokeAgent("agent_append_session_event", { sessionId, event });
   }
+}
+
+async function invokeAgent<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  if (!isTauriDesktop()) {
+    throw new Error("Agent Mode is available in Maple Desktop.");
+  }
+  const { invoke } = await import("@tauri-apps/api/core");
+  return await invoke<T>(command, args);
 }
 
 export const agentRuntimeService = new AgentRuntimeService();

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -1,0 +1,79 @@
+import { invoke } from "@tauri-apps/api/core";
+
+export interface AgentConfig {
+  defaultProjectRoot?: string | null;
+  defaultModel: string;
+  runtimeKind: string;
+  externalAcpUrl?: string | null;
+}
+
+export interface AgentStartRequest {
+  projectRoot?: string | null;
+  model?: string | null;
+  gooseBinary?: string | null;
+  mode?: string | null;
+}
+
+export interface AgentRuntimeStatus {
+  running: boolean;
+  acpUrl?: string | null;
+  redactedAcpUrl?: string | null;
+  httpBaseUrl?: string | null;
+  statusUrl?: string | null;
+  projectRoot?: string | null;
+  gooseBinary?: string | null;
+  pid?: number | null;
+  model?: string | null;
+  mode?: string | null;
+  mapleProxyBaseUrl?: string | null;
+  configDir: string;
+  goosePathRoot?: string | null;
+  logPath?: string | null;
+  error?: string | null;
+}
+
+export interface RecentProjectRoot {
+  path: string;
+  name: string;
+  lastUsedMs: number;
+}
+
+class AgentRuntimeService {
+  async getRuntimeStatus(): Promise<AgentRuntimeStatus> {
+    return await invoke<AgentRuntimeStatus>("agent_get_runtime_status");
+  }
+
+  async startRuntime(request?: AgentStartRequest): Promise<AgentRuntimeStatus> {
+    return await invoke<AgentRuntimeStatus>("agent_start_runtime", { request: request ?? null });
+  }
+
+  async stopRuntime(): Promise<AgentRuntimeStatus> {
+    return await invoke<AgentRuntimeStatus>("agent_stop_runtime");
+  }
+
+  async restartRuntime(request?: AgentStartRequest): Promise<AgentRuntimeStatus> {
+    return await invoke<AgentRuntimeStatus>("agent_restart_runtime", { request: request ?? null });
+  }
+
+  async loadConfig(): Promise<AgentConfig> {
+    return await invoke<AgentConfig>("agent_load_config");
+  }
+
+  async saveConfig(config: AgentConfig): Promise<void> {
+    await invoke("agent_save_config", { config });
+  }
+
+  async listRecentProjectRoots(): Promise<RecentProjectRoot[]> {
+    return await invoke<RecentProjectRoot[]>("agent_list_recent_project_roots");
+  }
+
+  async saveRecentProjectRoot(path: string): Promise<RecentProjectRoot[]> {
+    return await invoke<RecentProjectRoot[]>("agent_save_recent_project_root", { path });
+  }
+
+  async appendSessionEvent(sessionId: string, event: unknown): Promise<void> {
+    await invoke("agent_append_session_event", { sessionId, event });
+  }
+}
+
+export const agentRuntimeService = new AgentRuntimeService();

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -78,6 +78,10 @@ class AgentRuntimeService {
   async appendSessionEvent(sessionId: string, event: unknown): Promise<void> {
     await invokeAgent("agent_append_session_event", { sessionId, event });
   }
+
+  async appendRuntimeLog(message: string): Promise<void> {
+    await invokeAgent("agent_append_runtime_log", { message });
+  }
 }
 
 async function invokeAgent<T>(command: string, args?: Record<string, unknown>): Promise<T> {

--- a/frontend/src/services/proxyService.ts
+++ b/frontend/src/services/proxyService.ts
@@ -98,19 +98,45 @@ class ProxyService {
 
   private async ensureProxyReadyInner(createApiKey: CreateProxyApiKey): Promise<ProxyStatus> {
     const status = await this.getProxyStatus();
-    if (status.running && status.config.api_key.trim()) {
-      return status;
-    }
-
     const savedConfig = status.running ? status.config : await this.loadProxyConfig();
     let apiKey = savedConfig.api_key.trim();
-    let createdApiKey = false;
 
     if (!apiKey) {
       apiKey = await createApiKey(createAgentProxyKeyName());
-      createdApiKey = true;
     }
 
+    let nextConfig = this.buildAgentProxyConfig(savedConfig, apiKey);
+    let readyStatus = status;
+
+    if (!status.running || !status.config.api_key.trim()) {
+      if (status.running) {
+        await this.stopProxy();
+      } else if (!savedConfig.api_key.trim()) {
+        await this.saveProxySettings({ ...nextConfig, enabled: false });
+      }
+
+      readyStatus = await this.startProxy(nextConfig);
+    }
+
+    if ((await this.checkProxyBackendAuth(readyStatus)) === "auth_error") {
+      apiKey = await createApiKey(createAgentProxyKeyName());
+      nextConfig = this.buildAgentProxyConfig(readyStatus.config, apiKey);
+
+      if (readyStatus.running) {
+        await this.stopProxy();
+      }
+
+      readyStatus = await this.startProxy(nextConfig);
+
+      if ((await this.checkProxyBackendAuth(readyStatus)) === "auth_error") {
+        throw new Error("Maple proxy API key was refreshed but the backend still returned 401");
+      }
+    }
+
+    return readyStatus;
+  }
+
+  private buildAgentProxyConfig(savedConfig: ProxyConfig, apiKey: string): ProxyConfig {
     const backendUrl =
       savedConfig.backend_url ||
       import.meta.env.VITE_OPEN_SECRET_API_URL ||
@@ -118,7 +144,7 @@ class ProxyService {
     const port = Number(savedConfig.port || 8080);
     this.validateAgentPort(port);
 
-    const nextConfig: ProxyConfig = {
+    return {
       ...savedConfig,
       host: savedConfig.host || "127.0.0.1",
       port,
@@ -128,14 +154,33 @@ class ProxyService {
       backend_url: backendUrl,
       auto_start: savedConfig.auto_start ?? false
     };
+  }
 
-    if (status.running) {
-      await this.stopProxy();
-    } else if (createdApiKey) {
-      await this.saveProxySettings({ ...nextConfig, enabled: false });
+  private async checkProxyBackendAuth(
+    status: ProxyStatus
+  ): Promise<"ok" | "auth_error" | "unknown_error"> {
+    if (!status.running || !status.config.api_key.trim()) {
+      return "auth_error";
     }
 
-    return await this.startProxy(nextConfig);
+    const host = status.config.host === "0.0.0.0" ? "127.0.0.1" : status.config.host;
+    try {
+      const response = await fetch(`http://${host}:${status.config.port}/v1/models`);
+      if (response.ok) return "ok";
+
+      const body = await response.text();
+      if (
+        response.status === 401 ||
+        body.includes('"status":401') ||
+        body.toLowerCase().includes("unauthorized")
+      ) {
+        return "auth_error";
+      }
+
+      return "unknown_error";
+    } catch {
+      return "unknown_error";
+    }
   }
 
   async testProxyPort(host: string, port: number): Promise<boolean> {

--- a/frontend/src/services/proxyService.ts
+++ b/frontend/src/services/proxyService.ts
@@ -16,10 +16,20 @@ export interface ProxyStatus {
   error?: string;
 }
 
+export type CreateProxyApiKey = (name: string) => Promise<string>;
+
 class ProxyService {
+  private ensureReadyPromise: Promise<ProxyStatus> | null = null;
+
   private validatePort(port: number): void {
     if (!Number.isInteger(port) || port < 0 || port > 65535) {
       throw new Error(`Port must be a valid u16 integer (0-65535), got: ${port}`);
+    }
+  }
+
+  private validateAgentPort(port: number): void {
+    if (!Number.isInteger(port) || port < 1 || port > 65535) {
+      throw new Error(`Port must be a valid TCP port (1-65535), got: ${port}`);
     }
   }
 
@@ -74,6 +84,58 @@ class ProxyService {
       console.error("Failed to save proxy settings:", error);
       throw error;
     }
+  }
+
+  async ensureProxyReady(createApiKey: CreateProxyApiKey): Promise<ProxyStatus> {
+    if (!this.ensureReadyPromise) {
+      this.ensureReadyPromise = this.ensureProxyReadyInner(createApiKey).finally(() => {
+        this.ensureReadyPromise = null;
+      });
+    }
+
+    return await this.ensureReadyPromise;
+  }
+
+  private async ensureProxyReadyInner(createApiKey: CreateProxyApiKey): Promise<ProxyStatus> {
+    const status = await this.getProxyStatus();
+    if (status.running && status.config.api_key.trim()) {
+      return status;
+    }
+
+    const savedConfig = status.running ? status.config : await this.loadProxyConfig();
+    let apiKey = savedConfig.api_key.trim();
+    let createdApiKey = false;
+
+    if (!apiKey) {
+      apiKey = await createApiKey(createAgentProxyKeyName());
+      createdApiKey = true;
+    }
+
+    const backendUrl =
+      savedConfig.backend_url ||
+      import.meta.env.VITE_OPEN_SECRET_API_URL ||
+      "https://enclave.trymaple.ai";
+    const port = Number(savedConfig.port || 8080);
+    this.validateAgentPort(port);
+
+    const nextConfig: ProxyConfig = {
+      ...savedConfig,
+      host: savedConfig.host || "127.0.0.1",
+      port,
+      api_key: apiKey,
+      enabled: true,
+      enable_cors: savedConfig.enable_cors ?? true,
+      backend_url: backendUrl,
+      auto_start: savedConfig.auto_start ?? false
+    };
+
+    if (status.running) {
+      await this.stopProxy();
+    } else if (createdApiKey) {
+      await this.saveProxySettings({ ...nextConfig, enabled: false });
+    }
+
+    return await this.startProxy(nextConfig);
   }
 
   async testProxyPort(host: string, port: number): Promise<boolean> {
@@ -131,6 +193,15 @@ class ProxyService {
       return false;
     }
   }
+}
+
+function createAgentProxyKeyName(): string {
+  const date = new Date().toISOString().slice(0, 10).replace(/-/g, "");
+  const random =
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+      ? crypto.randomUUID().slice(0, 8)
+      : Math.random().toString(36).slice(2, 10);
+  return `maple-agent-${date}-${random}`;
 }
 
 export const proxyService = new ProxyService();

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -2391,6 +2391,32 @@ remove_generated_ios_cargo_config() {
   fi
 }
 
+DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP=""
+
+disable_desktop_goose_cargo_dependencies() {
+  local manifest="${TAURI_DIR}/Cargo.toml"
+
+  if ! grep -q "# BEGIN MAPLE_DESKTOP_GOOSE_DEPENDENCIES" "${manifest}"; then
+    return 0
+  fi
+
+  if [ -z "${DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP}" ]; then
+    DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP="$(mktemp)"
+    cp "${manifest}" "${DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP}"
+  fi
+
+  perl -0pi -e 's/\n# BEGIN MAPLE_DESKTOP_GOOSE_DEPENDENCIES\n.*?\n# END MAPLE_DESKTOP_GOOSE_DEPENDENCIES\n/\n/s' "${manifest}"
+  echo "disabled-desktop-goose-cargo-dependencies  $(repo_relative_path "${manifest}")"
+}
+
+restore_desktop_goose_cargo_dependencies() {
+  if [ -n "${DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP}" ] && [ -f "${DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP}" ]; then
+    cp "${DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP}" "${TAURI_DIR}/Cargo.toml"
+    rm -f "${DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP}"
+    DESKTOP_GOOSE_CARGO_MANIFEST_BACKUP=""
+  fi
+}
+
 archive_tree_as_root_tar_gz() {
   local root="$1"
   local out="$2"

--- a/scripts/ci/android-pr.sh
+++ b/scripts/ci/android-pr.sh
@@ -56,7 +56,11 @@ fi
 export PATH="${toolchain_prebuilt}/bin:${PATH}"
 
 tmp_toolchain_bin="$(mktemp -d)"
-trap 'rm -rf "${tmp_toolchain_bin}"' EXIT
+cleanup_android_pr() {
+  rm -rf "${tmp_toolchain_bin}"
+  restore_desktop_goose_cargo_dependencies
+}
+trap cleanup_android_pr EXIT
 
 ln -sf "${toolchain_prebuilt}/bin/llvm-ranlib" "${tmp_toolchain_bin}/aarch64-linux-android-ranlib"
 ln -sf "${toolchain_prebuilt}/bin/llvm-ranlib" "${tmp_toolchain_bin}/armv7a-linux-androideabi-ranlib"
@@ -100,6 +104,7 @@ tauri.android.versionCode=${version_code}
 EOF
 
 cd "${FRONTEND_DIR}"
+disable_desktop_goose_cargo_dependencies
 bun tauri android build --debug --apk --config '{"build":{"beforeBuildCommand":null}}'
 
 android_artifacts=()

--- a/scripts/ci/android-release.sh
+++ b/scripts/ci/android-release.sh
@@ -55,6 +55,8 @@ cleanup_android_release() {
   if [ -n "${fake_android_keystore_dir:-}" ]; then
     rm -rf "${fake_android_keystore_dir}"
   fi
+
+  restore_desktop_goose_cargo_dependencies
 }
 trap cleanup_android_release EXIT
 
@@ -186,6 +188,7 @@ remove_android_outputs() {
 
 build_android_release_outputs() {
   cd "${FRONTEND_DIR}"
+  disable_desktop_goose_cargo_dependencies
   bun tauri android build --apk --aab --ci --config "${android_build_config}"
 }
 

--- a/scripts/ci/ios-pr.sh
+++ b/scripts/ci/ios-pr.sh
@@ -34,6 +34,7 @@ ios_info_plist_present=0
 ios_entitlements_present=0
 restore_ios_build_state() {
   remove_generated_ios_cargo_config
+  restore_desktop_goose_cargo_dependencies
 
   if [ -n "${ios_project_state_dir}" ] && [ -d "${ios_project_state_dir}" ]; then
     if [ -f "${ios_project_state_dir}/Info.plist" ]; then
@@ -72,6 +73,7 @@ export IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-16.0}"
 rm -rf "${TAURI_DIR}/gen/apple/build/arm64-sim" "${TAURI_DIR}/gen/apple/build/maple_iOS.xcarchive"
 
 cd "${FRONTEND_DIR}"
+disable_desktop_goose_cargo_dependencies
 bun tauri ios build --debug --target aarch64-sim --ci --config '{"build":{"beforeBuildCommand":null}}'
 strip_apple_debug_symbols "${TAURI_DIR}/gen/apple/build/arm64-sim/Maple.app"
 adhoc_resign_apple_bundle "${TAURI_DIR}/gen/apple/build/arm64-sim/Maple.app"

--- a/scripts/ci/ios-release.sh
+++ b/scripts/ci/ios-release.sh
@@ -39,6 +39,7 @@ ios_info_plist_present=0
 ios_entitlements_present=0
 restore_ios_build_state() {
   remove_generated_ios_cargo_config
+  restore_desktop_goose_cargo_dependencies
 
   if [ -n "${ios_project_state_dir}" ] && [ -d "${ios_project_state_dir}" ]; then
     if [ -f "${ios_project_state_dir}/Info.plist" ]; then
@@ -97,6 +98,7 @@ remove_ios_release_outputs() {
 
 build_ios_release() {
   cd "${FRONTEND_DIR}"
+  disable_desktop_goose_cargo_dependencies
   bun tauri ios build --target aarch64 --ci --config "${ios_build_config}" "$@"
 }
 


### PR DESCRIPTION
## Summary
- add a desktop Agent Mode route and chat surface backed by ACP
- add a Tauri-managed Goose runtime that starts bundled `goose serve`, configures Goose for Maple's local OpenAI-compatible proxy, and exposes project-root/config/session-log commands to the frontend
- stage the Goose binary at build time via `MAPLE_GOOSE_BINARY` or the `@aaif/goose-binary-*` platform packages
- add ACP client/runtime services, route/sidebar wiring, and required Tauri dialog capability/dependencies

## Validation
- `nix develop -c bun run typecheck`
- `nix develop -c cargo check`
- `nix develop -c bun run build`
- `VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000 VITE_MAPLE_BILLING_API_URL=http://127.0.0.1:36503 nix develop -c bun tauri build --bundles app --config '{"bundle":{"createUpdaterArtifacts":false}}'`
- launched packaged `Maple.app` and confirmed it spawned bundled `goose serve`
- completed ACP smoke through the packaged app with Maple's local proxy: prompt requested `Maple Goose smoke test response` and Goose returned exactly that
- parsed generated JSONL session log successfully and confirmed Goose config/log/session files are written with `0600` permissions

Draft because this is ready for hands-on product/runtime testing today.
