### PR TITLE
Bump OpenSecret React SDK to 3.2.1

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "3.2.0",
+        "@opensecret/react": "3.2.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -240,7 +240,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opensecret/react": ["@opensecret/react@3.2.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-tmn52THsD3M3vzC2IErHJuAq9zKAXce16Y77YuaqEM9Vfg6u4ZU6lUIiR3Uvb7ObZSjUaJjxqhdEs6lSChW4iQ=="],
+    "@opensecret/react": ["@opensecret/react@3.2.1", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-lxfjO2arSLcCFULBlc8jLGSF7BLH+P17qFfgCAZOQzDDvfkvJt9z2NTRSvCFVbJAYtOh7AY+dKZ07Mk4w8P/1Q=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@opensecret/react": "3.2.0",
+    "@opensecret/react": "3.2.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## Summary
- bump `@opensecret/react` from `3.2.0` to `3.2.1`
- refresh `frontend/bun.lock` with the newly published npm tarball
- picks up OpenSecret-SDK PR #85, which allows dev fake attestation on loopback hosts using any HTTP port

## Verification
- `nix develop -c bash -lc 'bun install --frozen-lockfile --ignore-scripts && node -p "require(\\"./node_modules/@opensecret/react/package.json\\").version"'`\n- `nix develop -c just lint`\n- `nix develop -c just build`\n- checked installed SDK dist no longer contains the old `127.0.0.1:3000` / `localhost:3000` / `0.0.0.0:3000` hardcoded checks
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/609" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a frontend dependency to a newer patch version, which may include minor stability or compatibility improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->