### PR TITLE
Add workspace-aware desktop dev command

### DIFF
--- a/justfile
+++ b/justfile
@@ -63,6 +63,10 @@ android-build:
 desktop-build:
     cd frontend && bun tauri build
 
+# Run Tauri desktop development build, using workspace-local config when available
+desktop-dev:
+    cd frontend && if [ -f ../.local/tauri-workspace.json ]; then bun tauri dev --config ../.local/tauri-workspace.json; else bun tauri dev; fi
+
 # Build Tauri desktop debug
 desktop-build-debug:
     cd frontend && bun tauri build --debug


### PR DESCRIPTION
## Summary

- add a `just desktop-dev` entrypoint
- automatically load the ignored `.local/tauri-workspace.json` when a managed workspace provides one
- preserve the normal Tauri development configuration outside managed workspaces

## Why

Managed OpenSecret feature workspaces allocate a dynamic Maple web port and generate a workspace-specific desktop identifier. This gives agents one stable command for launching the desktop app with that generated configuration.

## Validation

- `just --list`
- `just --show desktop-dev`
- `just --dry-run desktop-dev`
- launched Tauri on the allocated workspace port while a Maple debug app from another workspace remained running

## Companion PRs

- OpenSecretCloud/opensecret-workspaces#6 — generates the local Tauri configuration and documents the complete agent workflow
- OpenSecretCloud/maple-billing-server#64 — provides the local Pro and credit fixtures used by that workflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new desktop development command for launching the Tauri app from the frontend workspace.
  * The command now automatically uses a local workspace config when available, and falls back to the default setup otherwise.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->