### PR TITLE
Remove sidebar search underlay

### DIFF
--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -418,16 +418,7 @@ export function Sidebar({
             {/* Real empty tail so the last row sits in clear space — no overlay on hit targets */}
             <div aria-hidden className="min-h-[7.5rem] shrink-0 bg-transparent" />
           </nav>
-          {/* Fades sit over the scrollport; spacer above keeps last rows out of the bottom band */}
-          <div
-            aria-hidden
-            className={cn(
-              "pointer-events-none absolute left-0 top-0 z-[8] h-8 w-[calc(100%-10px)] max-w-full bg-gradient-to-b to-transparent",
-              !isAgentMode && isSearchVisible
-                ? "from-background/75 dark:from-background/75"
-                : "from-muted/75 dark:from-[hsl(var(--sidebar)/0.75)]"
-            )}
-          />
+          {/* Bottom scroll fade */}
           <div
             aria-hidden
             className="pointer-events-none absolute bottom-0 left-0 z-[8] h-8 w-[calc(100%-10px)] max-w-full bg-gradient-to-b from-transparent to-muted/75 dark:to-[hsl(var(--sidebar)/0.75)]"


### PR DESCRIPTION
## Summary

- remove the sidebar history's top scroll-fade overlay
- preserve the existing bottom fade, scroll spacing, and footer layout

## Why

With Search expanded in dark mode, the top fade used the page background over the lighter sidebar and stopped short of the right edge. That produced the sharp black band shown beneath the search field.

## Validation

- `nix develop .#ci -c ./scripts/ci/frontend.sh` (formatting, lint with 0 errors, typecheck, 58 tests)
- `nix develop -c just build`
- Maple pre-commit hook
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the sidebar’s bottom scroll fade display by removing a redundant overlay that could affect visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->