### PR TITLE
chore: update maple-proxy to 0.1.11

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4071,9 +4071,9 @@ dependencies = [
 
 [[package]]
 name = "maple-proxy"
-version = "0.1.10"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29ac117843d081e34ed1bbaf386e4975c2c93af4649668fe86282737007ae922"
+checksum = "88573e251e75ff45858962256de59394793e33df1d06b19e2f1ce44dad5ae430"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4833,9 +4833,9 @@ dependencies = [
 
 [[package]]
 name = "opensecret"
-version = "3.1.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2782b2ff33589206bb6418bd7adbc1f064d3aef9e4a92aef93c41174ac5f686b"
+checksum = "92ce94955ead29ea33002f32d19b94420582e15e0b2c8b7c8e66e64dae6ff48a"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -5566,9 +5566,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ tauri-plugin-os = "2.3.2"
 tauri-plugin-sign-in-with-apple = "1.0.2"
 tokio = { version = "1.0", features = ["net", "sync", "rt-multi-thread", "macros", "time"] }
 once_cell = "1.18.0"
-maple-proxy = "0.1.10"
+maple-proxy = "0.1.11"
 tauri-plugin-fs = "2.5.1"
 anyhow = "1.0"
 axum = "0.8"


### PR DESCRIPTION
## Summary

- update the embedded `maple-proxy` dependency from `0.1.10` to `0.1.11`
- update the required OpenSecret SDK lock entry from `3.1.1` to `3.3.0`
- update `quinn-proto` from `0.11.14` to `0.11.15` so Maple receives the security fix included in the proxy release

## Why

Maple Proxy `0.1.11` carries OpenSecret SDK `3.3.0`, enabling both float and base64 embedding responses through Maple’s embedded proxy. Registry crates do not propagate the publisher’s lockfile, so the transitive `quinn-proto` lock entry is advanced explicitly here as well.

Release: https://github.com/OpenSecretCloud/maple-proxy/releases/tag/v0.1.11

## Testing

- `nix develop -c just rust-lint`
- `nix develop .#ci -c ./scripts/ci/rust.sh` (60 Rust tests)
- managed pre-commit gate
  - Prettier check
  - frontend production build
  - 72 frontend tests
  - 60 Rust tests

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/617" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal networking component to its latest patch version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->