### PR TITLE
feat(agent): use Gemma 4 for shell approvals

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -3134,16 +3134,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hdrhistogram"
-version = "7.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "765c9198f173dd59ce26ff9f95ef0aafd0a0fe01fb9d72841bc5066a4c06511d"
-dependencies = [
- "byteorder",
- "num-traits",
-]
-
-[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4075,9 +4065,9 @@ dependencies = [
 
 [[package]]
 name = "maple-proxy"
-version = "0.1.11"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88573e251e75ff45858962256de59394793e33df1d06b19e2f1ce44dad5ae430"
+checksum = "4a1167df860d322880d1bacf48f57505244f4d805b3fa492e57e8a4a355d93cf"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -4837,12 +4827,13 @@ dependencies = [
 
 [[package]]
 name = "opensecret"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ce94955ead29ea33002f32d19b94420582e15e0b2c8b7c8e66e64dae6ff48a"
+checksum = "a7652ddb1661444ea0cbacacbc62c13f5073f1687a2e765e0195ebf29d3e394d"
 dependencies = [
  "aes-gcm",
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64 0.22.1",
  "bytes",
@@ -4853,6 +4844,7 @@ dependencies = [
  "futures",
  "hex",
  "hkdf",
+ "http",
  "p256",
  "percent-encoding",
  "pin-project",
@@ -8119,13 +8111,9 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "hdrhistogram",
- "indexmap 2.12.0",
  "pin-project-lite",
- "slab",
  "sync_wrapper",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ tauri-plugin-os = "2.3.2"
 tauri-plugin-sign-in-with-apple = "1.0.2"
 tokio = { version = "1.0", features = ["io-util", "net", "process", "sync", "rt-multi-thread", "macros", "time"] }
 once_cell = "1.18.0"
-maple-proxy = "0.1.11"
+maple-proxy = "0.2.0"
 tauri-plugin-fs = "2.5.1"
 anyhow = "1.0"
 axum = "0.8"

--- a/frontend/src-tauri/src/agent/shell_permission.rs
+++ b/frontend/src-tauri/src/agent/shell_permission.rs
@@ -3,11 +3,15 @@ use goose::conversation::message::{ActionRequired, ActionRequiredData, Message, 
 use rmcp::model::Tool;
 use rmcp::object;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 const READ_ONLY_MODE: &str = "smart_approve";
+const CLASSIFIER_MODEL: &str = "gemma4-31b";
+const CLASSIFIER_TEMPERATURE: f32 = 0.0;
+const CLASSIFIER_MAX_TOKENS: i32 = 256;
 const CLASSIFIER_TOOL_NAME: &str = "maple__classify_shell_permission";
 const CLASSIFIER_TIMEOUT: Duration = Duration::from_secs(10);
 const MAX_COMMAND_CHARS: usize = 32_000;
@@ -32,8 +36,11 @@ output to /dev/null is also observational.
 Return requires_approval for file/output redirection that writes durable state; tee; mutating flags
 such as sed -i or find -delete; git mutations; package managers; builds or tests; interpreters,
 scripts, project executables, or arbitrary code execution; network operations; process management;
-permission or system configuration changes; unknown commands or aliases; obfuscation; or any
-ambiguity. User intent never makes a mutating command read-only.
+permission or system configuration changes; reads likely to expose secrets, credentials, private
+keys, access tokens, or process environments (for example non-template .env files, SSH or cloud
+credential files, keychains, env, or printenv); unknown commands or aliases; obfuscation; or any
+ambiguity. Obvious example, sample, and template environment files are not secret merely because of
+their filename. User intent never makes a mutating command read-only.
 
 Respond only by calling maple__classify_shell_permission exactly once."#;
 
@@ -205,13 +212,28 @@ impl ShellPermissionClassifier {
                 return ShellPermissionOutcome::RequiresApproval;
             }
         };
-        let model_config = match agent.model_config_for_session(session_id).await {
-            Ok(model_config) => model_config,
-            Err(error) => {
-                log::warn!("Read-only shell classifier could not resolve model: {error}");
-                return ShellPermissionOutcome::RequiresApproval;
-            }
-        };
+        let mut model_config =
+            match goose::model_config::model_config_from_user_config_with_session_settings(
+                provider.get_name(),
+                CLASSIFIER_MODEL,
+                None,
+                Some(classifier_request_params()),
+                None,
+            ) {
+                Ok(model_config) => model_config,
+                Err(error) => {
+                    log::warn!("Read-only shell classifier could not configure {CLASSIFIER_MODEL}: {error}");
+                    return ShellPermissionOutcome::RequiresApproval;
+                }
+            };
+        // The classifier is intentionally isolated from session-level reasoning
+        // and request settings. In particular, Goose may otherwise inherit a
+        // global thinking effort after applying the explicit request params.
+        model_config.request_params = Some(classifier_request_params());
+        model_config.reasoning = Some(false);
+        let model_config = model_config
+            .with_temperature(Some(CLASSIFIER_TEMPERATURE))
+            .with_max_tokens(Some(CLASSIFIER_MAX_TOKENS));
         let input = match serde_json::to_string(request) {
             Ok(input) => input,
             Err(error) => {
@@ -221,13 +243,9 @@ impl ShellPermissionClassifier {
         };
         let messages = [Message::user().with_text(input)];
         let tools = [classifier_tool()];
-        let completion = goose::model_config::complete_fast(
-            provider.as_ref(),
-            &model_config,
-            session_id,
-            CLASSIFIER_SYSTEM_PROMPT,
-            &messages,
-            &tools,
+        let completion = goose::session_context::with_session_id(
+            Some(session_id.to_string()),
+            provider.complete(&model_config, CLASSIFIER_SYSTEM_PROMPT, &messages, &tools),
         );
 
         let result = tokio::select! {
@@ -252,6 +270,16 @@ impl ShellPermissionClassifier {
             ShellPermissionOutcome::RequiresApproval
         })
     }
+}
+
+fn classifier_request_params() -> HashMap<String, serde_json::Value> {
+    HashMap::from([
+        ("include_reasoning".to_string(), serde_json::json!(false)),
+        (
+            "chat_template_kwargs".to_string(),
+            serde_json::json!({ "enable_thinking": false }),
+        ),
+    ])
 }
 
 fn classifier_tool() -> Tool {
@@ -312,7 +340,9 @@ fn parse_classifier_response(message: &Message) -> Option<ShellPermissionOutcome
 mod tests {
     use super::*;
     use goose::conversation::message::MessageContent;
+    use goose::providers::base::Provider;
     use rmcp::model::CallToolRequestParams;
+    use std::sync::{Arc, Mutex as StdMutex};
 
     fn action(
         tool_name: &str,
@@ -498,5 +528,125 @@ mod tests {
             tool.input_schema["properties"]["reason"]["maxLength"],
             MAX_REASON_CHARS
         );
+    }
+
+    #[test]
+    fn classifier_uses_gemma_with_thinking_disabled() {
+        assert_eq!(CLASSIFIER_MODEL, "gemma4-31b");
+
+        let params = classifier_request_params();
+        assert_eq!(
+            params.get("include_reasoning"),
+            Some(&serde_json::json!(false))
+        );
+        assert_eq!(
+            params.get("chat_template_kwargs"),
+            Some(&serde_json::json!({ "enable_thinking": false }))
+        );
+
+        let mut model_config =
+            goose::model_config::model_config_from_user_config_with_session_settings(
+                "openai",
+                CLASSIFIER_MODEL,
+                None,
+                Some(params),
+                None,
+            )
+            .unwrap();
+        model_config.request_params = Some(classifier_request_params());
+        model_config.reasoning = Some(false);
+        let model_config = model_config
+            .with_temperature(Some(CLASSIFIER_TEMPERATURE))
+            .with_max_tokens(Some(CLASSIFIER_MAX_TOKENS));
+        assert_eq!(model_config.model_name, CLASSIFIER_MODEL);
+        assert_eq!(model_config.temperature, Some(CLASSIFIER_TEMPERATURE));
+        assert_eq!(model_config.max_tokens, Some(CLASSIFIER_MAX_TOKENS));
+        assert_eq!(model_config.reasoning, Some(false));
+        let request_params = model_config.request_params.unwrap();
+        assert_eq!(
+            request_params.get("include_reasoning"),
+            Some(&serde_json::json!(false))
+        );
+        assert_eq!(
+            request_params.get("chat_template_kwargs"),
+            Some(&serde_json::json!({ "enable_thinking": false }))
+        );
+        assert!(request_params.get("thinking_effort").is_none());
+    }
+
+    #[tokio::test]
+    async fn goose_serializes_classifier_model_and_thinking_controls() {
+        let captured = Arc::new(StdMutex::new(None));
+        let handler_capture = Arc::clone(&captured);
+        let app = axum::Router::new().route(
+            "/v1/chat/completions",
+            axum::routing::post(move |axum::Json(payload): axum::Json<serde_json::Value>| {
+                let handler_capture = Arc::clone(&handler_capture);
+                async move {
+                    *handler_capture.lock().unwrap() = Some(payload);
+                    (
+                        [(axum::http::header::CONTENT_TYPE, "text/event-stream")],
+                        concat!(
+                            "data: {\"id\":\"chatcmpl-classifier\",",
+                            "\"object\":\"chat.completion.chunk\",\"created\":1,",
+                            "\"model\":\"test\",\"choices\":[{\"index\":0,",
+                            "\"delta\":{\"role\":\"assistant\",\"content\":\"ok\"},",
+                            "\"finish_reason\":\"stop\"}]}\n\n",
+                            "data: [DONE]\n\n"
+                        ),
+                    )
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let api_client = goose::providers::api_client::ApiClient::new_with_tls(
+            format!("http://{address}"),
+            goose::providers::api_client::AuthMethod::NoAuth,
+            None,
+        )
+        .unwrap();
+        let provider = goose::providers::openai::OpenAiProvider::new(api_client);
+        let mut model_config =
+            goose::model_config::model_config_from_user_config_with_session_settings(
+                provider.get_name(),
+                CLASSIFIER_MODEL,
+                None,
+                Some(classifier_request_params()),
+                None,
+            )
+            .unwrap();
+        model_config.request_params = Some(classifier_request_params());
+        model_config.reasoning = Some(false);
+        let model_config = model_config
+            .with_temperature(Some(CLASSIFIER_TEMPERATURE))
+            .with_max_tokens(Some(CLASSIFIER_MAX_TOKENS));
+
+        provider
+            .complete(
+                &model_config,
+                CLASSIFIER_SYSTEM_PROMPT,
+                &[Message::user().with_text("request")],
+                &[classifier_tool()],
+            )
+            .await
+            .unwrap();
+        server.abort();
+
+        let payload = captured.lock().unwrap().take().unwrap();
+        assert_eq!(payload["model"], CLASSIFIER_MODEL);
+        assert_eq!(payload["temperature"], CLASSIFIER_TEMPERATURE);
+        assert_eq!(payload["max_tokens"], CLASSIFIER_MAX_TOKENS);
+        assert_eq!(payload["stream"], true);
+        assert_eq!(payload["stream_options"]["include_usage"], true);
+        assert_eq!(payload["include_reasoning"], false);
+        assert_eq!(payload["chat_template_kwargs"]["enable_thinking"], false);
+        assert_eq!(
+            payload["tools"][0]["function"]["name"],
+            CLASSIFIER_TOOL_NAME
+        );
+        assert!(payload.get("thinking_effort").is_none());
     }
 }

--- a/frontend/src-tauri/src/proxy.rs
+++ b/frontend/src-tauri/src/proxy.rs
@@ -380,11 +380,6 @@ pub async fn test_proxy_port(host: String, port: u16) -> Result<bool, String> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn proxy_request_body_limit_remains_50_mib() {
-        assert_eq!(maple_proxy::MAX_PROXY_REQUEST_BODY_BYTES, 50 * 1024 * 1024);
-    }
-
     #[tokio::test]
     async fn stop_waits_for_aborted_server_task() {
         struct DropFlag(Arc<std::sync::atomic::AtomicBool>);


### PR DESCRIPTION
## Summary

- run the Read only shell permission classifier on gemma4-31b instead of the active session model
- disable Gemma thinking explicitly with chat_template_kwargs.enable_thinking=false, include_reasoning=false, and Goose reasoning=false
- call the existing Goose provider directly with a classifier-only ModelConfig so session thinking and request settings cannot leak into approval decisions
- keep the structured one-tool response contract, timeout, cancellation, and fail-closed fallback
- make secret-bearing reads such as non-template .env and credential files explicit manual-approval cases
- consume the published maple-proxy 0.2.0 and transitive opensecret 3.4.0 registry releases

## Why

The shell reviewer is a small classification workload and should not inherit the user-selected agent model or reasoning settings. Gemma 4 is the dedicated classifier model, but its Tinfoil thinking control must survive Goose, Maple Proxy, the OpenSecret SDK, and the backend unchanged.

maple-proxy 0.2.0 and opensecret 3.4.0 provide the lossless encrypted transport needed for those provider-specific fields. No Goose fork or global fast-model setting is required.

## Security behavior

- any provider lookup, model configuration, serialization, request, timeout, cancellation, or response-parse failure falls back to manual approval
- the model must call maple__classify_shell_permission exactly once with the closed decision schema
- mutating, executable, networked, ambiguous, and secret-bearing reads require user approval
- only fully observational command chains are automatically approved
- classifier settings are isolated from session-level model, reasoning, and thinking effort

## Dependency contract

- maple-proxy 0.2.0 resolves from crates.io with checksum 4a1167df860d322880d1bacf48f57505244f4d805b3fa492e57e8a4a355d93cf
- opensecret 3.4.0 resolves transitively from crates.io with checksum a7652ddb1661444ea0cbacacbc62c13f5073f1687a2e765e0195ebf29d3e394d
- the stale Maple unit test that depended on the removed maple-proxy implementation constant is deleted; the body-limit behavior remains owned and tested by maple-proxy

## Validation

- Goose serialization test proves model=gemma4-31b, temperature=0, max_tokens=256, stream=true, include_reasoning=false, enable_thinking=false, and no thinking_effort
- live published chain: Goose -> maple-proxy 0.2.0 -> OpenSecret 3.4.0 -> local OpenSecret -> Tinfoil
  - chained pwd/grep/head command: read_only
  - cat .env: requires_approval
  - cat README.md followed by touch: requires_approval
  - no thinking or redacted-thinking blocks returned
- cargo fmt check, focused classifier tests, and cargo check --locked --all-targets
- full pre-commit gate passed:
  - Prettier
  - TypeScript/Vite production build
  - 72 frontend tests
  - 94 Rust tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/621" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->