### PR TITLE
Add a Linux desktop fallback for image paste

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -28,6 +28,10 @@ import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { MapleWordmark } from "@/components/MapleWordmark";
 import { useIsMobile, useIsLandscapeMobile } from "@/utils/utils";
 import { fileToDataURL } from "@/utils/file";
+import {
+  getImageFilesFromClipboardItems,
+  maybeReadLinuxTauriClipboardImages
+} from "@/utils/imagePaste";
 import { truncateMarkdownPreservingLinks } from "@/utils/markdown";
 import { useOpenAI } from "@/ai/useOpenAi";
 import { DEFAULT_MODEL_ID, getInitialWebSearchEnabled } from "@/state/LocalStateContext";
@@ -56,7 +60,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { isTauri } from "@/utils/platform";
+import { isLinux, isTauri } from "@/utils/platform";
 import { ConversationProjectPicker } from "@/components/ConversationProjectPicker";
 import {
   getSidebarLayoutStyle,
@@ -1412,6 +1416,8 @@ export function UnifiedChat() {
   const { selectedProjectId, setSelectedProjectId } = localState;
   const os = useOpenSecret();
   const isTauriEnv = isTauri();
+  const isLinuxEnv = isLinux();
+  const isLinuxTauriEnv = isTauriEnv && isLinuxEnv;
   const queryClient = useQueryClient();
   const { playbackError, clearPlaybackError } = useTTS();
 
@@ -1503,6 +1509,7 @@ export function UnifiedChat() {
   const billingRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
   const documentInputRef = useRef<HTMLInputElement>(null);
+  const imagePasteGenerationRef = useRef(0);
 
   // Refs
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -1513,6 +1520,7 @@ export function UnifiedChat() {
 
   // Attachment cleanup function - defined early to avoid reference errors
   const clearAllAttachments = useCallback(() => {
+    imagePasteGenerationRef.current += 1;
     // Clean up image URLs
     imageUrls.forEach((url) => URL.revokeObjectURL(url));
     setImageUrls(new Map());
@@ -1521,6 +1529,14 @@ export function UnifiedChat() {
     setDocumentName("");
     setAttachmentError(null);
   }, [imageUrls]);
+
+  // Invalidate delayed clipboard reads when switching conversations or unmounting.
+  useEffect(() => {
+    imagePasteGenerationRef.current += 1;
+    return () => {
+      imagePasteGenerationRef.current += 1;
+    };
+  }, [chatId]);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -2261,24 +2277,8 @@ export function UnifiedChat() {
     [imageUrls, localState]
   );
 
-  const handlePaste = useCallback(
-    (e: React.ClipboardEvent) => {
-      const items = e.clipboardData?.items;
-      if (!items) return;
-
-      const imageFiles: File[] = [];
-      for (let i = 0; i < items.length; i++) {
-        if (items[i].type.startsWith("image/")) {
-          const file = items[i].getAsFile();
-          if (file) imageFiles.push(file);
-        }
-      }
-
-      if (imageFiles.length === 0) return;
-
-      // Prevent the default paste behavior for images
-      e.preventDefault();
-
+  const attachPastedImages = useCallback(
+    (imageFiles: File[]) => {
       if (!canUseImages) {
         setUpgradeFeature("image");
         setUpgradeDialogOpen(true);
@@ -2304,16 +2304,54 @@ export function UnifiedChat() {
 
       if (validFiles.length === 0) return;
 
-      const newUrlMap = new Map(imageUrls);
-      validFiles.forEach((file) => {
-        if (!newUrlMap.has(file)) {
-          newUrlMap.set(file, URL.createObjectURL(file));
-        }
-      });
-      setImageUrls(newUrlMap);
+      const newUrls = validFiles.map((file) => [file, URL.createObjectURL(file)] as const);
+      setImageUrls((currentUrls) => new Map([...currentUrls, ...newUrls]));
       setDraftImages((prev) => [...prev, ...validFiles]);
     },
-    [canUseImages, imageUrls]
+    [canUseImages]
+  );
+
+  const handlePaste = useCallback(
+    (e: React.ClipboardEvent) => {
+      const pasteGeneration = ++imagePasteGenerationRef.current;
+      const items = e.clipboardData?.items;
+      if (!items) return;
+
+      const imageFiles = getImageFilesFromClipboardItems(items);
+      if (imageFiles.length > 0) {
+        // Preserve the existing DOM clipboard path whenever WebKit exposes the image.
+        e.preventDefault();
+        attachPastedImages(imageFiles);
+        return;
+      }
+
+      // WebKitGTK 2.50.3+ hides file-backed images from the paste DataTransfer.
+      // Keep the async fallback scoped to the reporter's zero-item symptom.
+      if (!isLinuxTauriEnv || items.length !== 0) return;
+
+      const fallback = maybeReadLinuxTauriClipboardImages({
+        eventItemCount: items.length,
+        isTauri: isTauriEnv,
+        isLinux: isLinuxEnv,
+        readClipboard: () => {
+          if (typeof navigator === "undefined") return undefined;
+
+          const clipboard = navigator.clipboard;
+          if (typeof clipboard?.read !== "function") return undefined;
+          return clipboard.read();
+        }
+      });
+
+      // Do not prevent the native paste while an async read is pending. An
+      // image-only clipboard has no useful textarea default, and this keeps
+      // ordinary text paste intact if clipboard access is unavailable.
+      void fallback?.then((fallbackFiles) => {
+        if (fallbackFiles.length > 0 && pasteGeneration === imagePasteGenerationRef.current) {
+          attachPastedImages(fallbackFiles);
+        }
+      });
+    },
+    [attachPastedImages, isLinuxEnv, isLinuxTauriEnv, isTauriEnv]
   );
 
   const removeImage = useCallback(

--- a/frontend/src/utils/imagePaste.test.ts
+++ b/frontend/src/utils/imagePaste.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, it } from "bun:test";
+import { getImageFilesFromClipboardItems, maybeReadLinuxTauriClipboardImages } from "./imagePaste";
+
+describe("image paste", () => {
+  it("keeps the DOM image path authoritative", () => {
+    const image = new File(["png"], "clipboard.png", { type: "image/png" });
+    const files = getImageFilesFromClipboardItems([{ type: "image/png", getAsFile: () => image }]);
+    let readCalls = 0;
+
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 1,
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () => {
+        readCalls++;
+        return Promise.resolve([]);
+      }
+    });
+
+    expect(files).toEqual([image]);
+    expect(fallback).toBeUndefined();
+    expect(readCalls).toBe(0);
+  });
+
+  it("does not inspect the async clipboard for ordinary text paste", () => {
+    const files = getImageFilesFromClipboardItems([{ type: "text/plain", getAsFile: () => null }]);
+    let readCalls = 0;
+
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 1,
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () => {
+        readCalls++;
+        return Promise.resolve([]);
+      }
+    });
+
+    expect(files).toEqual([]);
+    expect(fallback).toBeUndefined();
+    expect(readCalls).toBe(0);
+  });
+
+  it("starts an async image read immediately for an empty Linux Tauri paste event", async () => {
+    let readCalls = 0;
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 0,
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () => {
+        readCalls++;
+        return Promise.resolve([
+          {
+            types: ["image/png"],
+            getType: () => Promise.resolve(new Blob(["png data"], { type: "image/png" }))
+          }
+        ]);
+      }
+    });
+
+    expect(readCalls).toBe(1);
+    expect(fallback).toBeDefined();
+
+    const files = await fallback!;
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("pasted-image.png");
+    expect(files[0].type).toBe("image/png");
+    expect(await files[0].text()).toBe("png data");
+  });
+
+  it.each([
+    ["web", false, false],
+    ["non-Tauri Linux", false, true],
+    ["Tauri macOS", true, false],
+    ["Tauri Windows", true, false],
+    ["Tauri iOS", true, false],
+    ["Tauri Android", true, false]
+  ])("is a no-op on %s", (_platform, isTauri, isLinux) => {
+    let readCalls = 0;
+
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 0,
+      isTauri,
+      isLinux,
+      readClipboard: () => {
+        readCalls++;
+        return Promise.resolve([]);
+      }
+    });
+
+    expect(fallback).toBeUndefined();
+    expect(readCalls).toBe(0);
+  });
+
+  it("uses one supported representation per clipboard item", async () => {
+    const requestedTypes: string[] = [];
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 0,
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () =>
+        Promise.resolve([
+          {
+            types: ["image/png", "image/jpeg"],
+            getType: (type) => {
+              requestedTypes.push(type);
+              return Promise.resolve(new Blob(["image"], { type }));
+            }
+          }
+        ])
+    });
+
+    const files = await fallback!;
+    expect(requestedTypes).toEqual(["image/png"]);
+    expect(files).toHaveLength(1);
+  });
+
+  it("skips an unreadable item without dropping other clipboard images", async () => {
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 0,
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () =>
+        Promise.resolve([
+          {
+            types: ["image/png"],
+            getType: () => Promise.reject(new Error("clipboard item disappeared"))
+          },
+          {
+            types: ["image/webp"],
+            getType: () => Promise.resolve(new Blob(["webp"], { type: "image/webp" }))
+          }
+        ])
+    });
+
+    const files = await fallback!;
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("pasted-image.webp");
+    expect(files[0].type).toBe("image/webp");
+  });
+
+  it("silently skips unavailable or rejected clipboard reads", async () => {
+    const unavailable = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 0,
+      isTauri: true,
+      isLinux: true
+    });
+    const rejected = maybeReadLinuxTauriClipboardImages({
+      eventItemCount: 0,
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () => Promise.reject(new Error("clipboard access rejected"))
+    });
+
+    expect(unavailable).toBeUndefined();
+    expect(await rejected!).toEqual([]);
+  });
+});

--- a/frontend/src/utils/imagePaste.ts
+++ b/frontend/src/utils/imagePaste.ts
@@ -1,0 +1,84 @@
+const SUPPORTED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/jpg", "image/webp"] as const;
+
+interface ClipboardEventItemLike {
+  type: string;
+  getAsFile(): File | null;
+}
+
+interface AsyncClipboardItemLike {
+  readonly types: readonly string[];
+  getType(type: string): Promise<Blob>;
+}
+
+type ClipboardReader = () => Promise<readonly AsyncClipboardItemLike[]> | undefined;
+
+interface LinuxTauriClipboardFallbackOptions {
+  eventItemCount: number;
+  isTauri: boolean;
+  isLinux: boolean;
+  readClipboard?: ClipboardReader;
+}
+
+export function getImageFilesFromClipboardItems(items: ArrayLike<ClipboardEventItemLike>): File[] {
+  const imageFiles: File[] = [];
+
+  for (let index = 0; index < items.length; index++) {
+    const item = items[index];
+    if (!item.type.startsWith("image/")) continue;
+
+    const file = item.getAsFile();
+    if (file) imageFiles.push(file);
+  }
+
+  return imageFiles;
+}
+
+/**
+ * Starts the async clipboard read synchronously so WebKit can associate it with
+ * the paste gesture. Returning undefined means the fallback was not attempted.
+ */
+export function maybeReadLinuxTauriClipboardImages({
+  eventItemCount,
+  isTauri,
+  isLinux,
+  readClipboard
+}: LinuxTauriClipboardFallbackOptions): Promise<File[]> | undefined {
+  if (eventItemCount !== 0 || !isTauri || !isLinux || !readClipboard) return undefined;
+
+  let clipboardItemsPromise: ReturnType<ClipboardReader>;
+  try {
+    clipboardItemsPromise = readClipboard();
+  } catch {
+    return Promise.resolve([]);
+  }
+
+  if (!clipboardItemsPromise) return undefined;
+
+  return clipboardItemsPromise
+    .then(async (clipboardItems) => {
+      const imageFiles: File[] = [];
+
+      for (const item of clipboardItems) {
+        const imageType = SUPPORTED_IMAGE_TYPES.find((type) => item.types.includes(type));
+        if (!imageType) continue;
+
+        try {
+          const blob = await item.getType(imageType);
+          const extension =
+            imageType === "image/jpeg" || imageType === "image/jpg"
+              ? "jpg"
+              : imageType.split("/")[1];
+          imageFiles.push(
+            new File([blob], `pasted-image.${extension}`, {
+              type: blob.type || imageType
+            })
+          );
+        } catch {
+          // A clipboard item can disappear or become unreadable before getType resolves.
+        }
+      }
+
+      return imageFiles;
+    })
+    .catch(() => []);
+}


### PR DESCRIPTION
## Summary

- Preserve the existing `ClipboardEvent.clipboardData.items` image path on every platform.
- Only in Tauri on Linux, and only for the reported zero-item WebKitGTK paste event, start `navigator.clipboard.read()` directly inside the paste gesture.
- Convert one supported image representation per clipboard item into the existing attachment path.
- Silently no-op when async clipboard access is unavailable/rejected and discard delayed results after another paste, attachment clear, chat switch, or unmount.

## Why

WebKitGTK 2.50.3+ intentionally prevents file-backed clipboard images from reaching JavaScript through `DataTransfer` on non-Cocoa platforms. The reporter reproduced that behavior with current WebKitGTK 2.52.3: native editable paste can see the screenshot, but `clipboardData.items` and `.files` are both empty.

The async Clipboard API uses a separate WebKit path, so this PR tests it as the lowest-risk workaround before adding a native Tauri clipboard plugin.

## Safety boundaries

- The existing synchronous DOM path still wins whenever it exposes an image.
- A non-empty text paste never invokes `navigator.clipboard.read()`.
- Web, non-Tauri Linux, macOS, Windows, iOS, and Android are explicit no-ops in the unit matrix.
- The fallback does not call `preventDefault()`, preserving normal text paste if no image can be read.
- There are no Rust, Cargo, Tauri plugin/capability, dependency-lock, Nix, or packaging changes. The same frontend fallback is therefore present in both the .deb and AppImage without changing either runtime closure.

## Validation

- `nix develop .#ci -c ./scripts/ci/frontend.sh` — formatting, ESLint, TypeScript, and 89 tests pass.
- `MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh` — reproducible production frontend payload builds.
- Maple pre-commit hook — production build and 89 tests pass.
- Independent code review found one delayed-read race; the generation guard fix was re-reviewed with no remaining blocker.

This is intentionally a draft until the PR-built .deb and AppImage can be tried on Ubuntu. GitHub PR CI will build and validate the Linux AppImage, .deb, and RPM artifacts, plus the other desktop/mobile targets, but it still cannot prove clipboard runtime behavior.

Refs #616

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image pasting in Linux/Tauri environments, including cases where pasted images are not immediately exposed by the clipboard.
  * Preserved normal text paste behavior while reliably attaching valid clipboard images.
  * Prevented delayed clipboard results from appearing in the wrong conversation.

* **Tests**
  * Added comprehensive coverage for clipboard image handling, platform-specific fallbacks, invalid content, and read failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->