### PR TITLE
Fix browser image paste in Linux desktop app

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -2279,12 +2279,12 @@ export function UnifiedChat() {
         return;
       }
 
-      // WebKitGTK 2.50.3+ hides file-backed images from the paste DataTransfer.
-      // Keep the async fallback scoped to the reporter's zero-item symptom.
-      if (!isLinuxTauriEnv || items.length !== 0) return;
+      // WebKitGTK can hide a clipboard image from the paste DataTransfer while
+      // exposing either no items (screenshots) or one HTML item (browser Copy Image).
+      if (!isLinuxTauriEnv) return;
 
       const fallback = maybeReadLinuxTauriClipboardImages({
-        eventItemCount: items.length,
+        eventItemTypes: Array.from(items, (item) => item.type),
         isTauri: isTauriEnv,
         isLinux: isLinuxEnv,
         readClipboard: () => {

--- a/frontend/src/utils/imagePaste.test.ts
+++ b/frontend/src/utils/imagePaste.test.ts
@@ -8,7 +8,7 @@ describe("image paste", () => {
     let readCalls = 0;
 
     const fallback = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 1,
+      eventItemTypes: ["image/png"],
       isTauri: true,
       isLinux: true,
       readClipboard: () => {
@@ -27,7 +27,7 @@ describe("image paste", () => {
     let readCalls = 0;
 
     const fallback = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 1,
+      eventItemTypes: ["text/plain"],
       isTauri: true,
       isLinux: true,
       readClipboard: () => {
@@ -44,7 +44,7 @@ describe("image paste", () => {
   it("starts an async image read immediately for an empty Linux Tauri paste event", async () => {
     let readCalls = 0;
     const fallback = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 0,
+      eventItemTypes: [],
       isTauri: true,
       isLinux: true,
       readClipboard: () => {
@@ -68,6 +68,48 @@ describe("image paste", () => {
     expect(await files[0].text()).toBe("png data");
   });
 
+  it("reads an image from an HTML-only browser Copy Image paste", async () => {
+    let readCalls = 0;
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemTypes: ["text/html"],
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () => {
+        readCalls++;
+        return Promise.resolve([
+          {
+            types: ["text/html", "image/png"],
+            getType: (type) => Promise.resolve(new Blob([type], { type }))
+          }
+        ]);
+      }
+    });
+
+    expect(readCalls).toBe(1);
+    expect(fallback).toBeDefined();
+
+    const files = await fallback!;
+    expect(files).toHaveLength(1);
+    expect(files[0].name).toBe("pasted-image.png");
+    expect(files[0].type).toBe("image/png");
+  });
+
+  it("does not inspect a paste that includes an ordinary text representation", () => {
+    let readCalls = 0;
+    const fallback = maybeReadLinuxTauriClipboardImages({
+      eventItemTypes: ["text/html", "text/plain"],
+      isTauri: true,
+      isLinux: true,
+      readClipboard: () => {
+        readCalls++;
+        return Promise.resolve([]);
+      }
+    });
+
+    expect(fallback).toBeUndefined();
+    expect(readCalls).toBe(0);
+  });
+
   it.each([
     ["web", false, false],
     ["non-Tauri Linux", false, true],
@@ -79,7 +121,7 @@ describe("image paste", () => {
     let readCalls = 0;
 
     const fallback = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 0,
+      eventItemTypes: [],
       isTauri,
       isLinux,
       readClipboard: () => {
@@ -95,7 +137,7 @@ describe("image paste", () => {
   it("uses one supported representation per clipboard item", async () => {
     const requestedTypes: string[] = [];
     const fallback = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 0,
+      eventItemTypes: [],
       isTauri: true,
       isLinux: true,
       readClipboard: () =>
@@ -117,7 +159,7 @@ describe("image paste", () => {
 
   it("skips an unreadable item without dropping other clipboard images", async () => {
     const fallback = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 0,
+      eventItemTypes: [],
       isTauri: true,
       isLinux: true,
       readClipboard: () =>
@@ -141,12 +183,12 @@ describe("image paste", () => {
 
   it("silently skips unavailable or rejected clipboard reads", async () => {
     const unavailable = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 0,
+      eventItemTypes: [],
       isTauri: true,
       isLinux: true
     });
     const rejected = maybeReadLinuxTauriClipboardImages({
-      eventItemCount: 0,
+      eventItemTypes: [],
       isTauri: true,
       isLinux: true,
       readClipboard: () => Promise.reject(new Error("clipboard access rejected"))

--- a/frontend/src/utils/imagePaste.ts
+++ b/frontend/src/utils/imagePaste.ts
@@ -13,7 +13,7 @@ interface AsyncClipboardItemLike {
 type ClipboardReader = () => Promise<readonly AsyncClipboardItemLike[]> | undefined;
 
 interface LinuxTauriClipboardFallbackOptions {
-  eventItemCount: number;
+  eventItemTypes: readonly string[];
   isTauri: boolean;
   isLinux: boolean;
   readClipboard?: ClipboardReader;
@@ -38,12 +38,19 @@ export function getImageFilesFromClipboardItems(items: ArrayLike<ClipboardEventI
  * the paste gesture. Returning undefined means the fallback was not attempted.
  */
 export function maybeReadLinuxTauriClipboardImages({
-  eventItemCount,
+  eventItemTypes,
   isTauri,
   isLinux,
   readClipboard
 }: LinuxTauriClipboardFallbackOptions): Promise<File[]> | undefined {
-  if (eventItemCount !== 0 || !isTauri || !isLinux || !readClipboard) return undefined;
+  const normalizedEventTypes = eventItemTypes.map((type) => type.toLowerCase());
+  const isEmptyImagePaste = normalizedEventTypes.length === 0;
+  const isHtmlOnlyImagePaste =
+    normalizedEventTypes.length === 1 && normalizedEventTypes[0] === "text/html";
+
+  if ((!isEmptyImagePaste && !isHtmlOnlyImagePaste) || !isTauri || !isLinux || !readClipboard) {
+    return undefined;
+  }
 
   let clipboardItemsPromise: ReturnType<ClipboardReader>;
   try {


### PR DESCRIPTION
## Summary

- reuse the existing Linux async clipboard fallback when WebKitGTK exposes Chromium Copy Image as one HTML item
- keep zero-item screenshot paste behavior unchanged
- leave ordinary text paste, other platforms, dependencies, native capabilities, and packaging unchanged

This intentionally does not add native file-manager clipboard support. Copied files still use the attachment picker because supporting file references would require new native filesystem or portal plumbing.

Follow-up to #616.

## Validation

- nix develop .#ci -c ./scripts/ci/frontend.sh
- MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh
- pre-commit build and test hook
- 107 frontend tests passed

The remaining validation is an Ubuntu field test with Chromium Copy Image, so this starts as a draft.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved image pasting on Linux desktop app installations, including cases where clipboard content appears as empty or HTML-only.
  * Preserved ordinary text paste behavior without unnecessary clipboard inspection.
  * Added coverage for browser “Copy Image” pastes and related clipboard scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->