### PR TITLE
Add reusable Maple release skill

### DIFF
--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -25,7 +25,7 @@ Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing 
    ```bash
    gh api --method POST repos/OpenSecretCloud/Maple/releases/generate-notes \
      -f tag_name="$tag" \
-     -f target_commitish=master \
+     -f target_commitish="$head_sha" \
      -f previous_tag_name="$previous_tag" | jq -r '.name, .body'
    ```
 
@@ -38,7 +38,7 @@ Create and publish the release exactly once. This creates the tag, matching the 
 ```bash
 gh release create "$tag" \
   --repo OpenSecretCloud/Maple \
-  --target master \
+  --target "$head_sha" \
   --title "$tag" \
   --generate-notes
 ```

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: release-maple
+description: Publish and verify a Maple GitHub release from master. Use when asked to cut, create, publish, monitor, or finish a Maple release, including checking whether the version was bumped after the previous release, generating GitHub release notes, creating the release tag, monitoring release CI, retrying genuinely transient failures, verifying artifacts, and confirming Zapstore publication.
+---
+
+# Release Maple
+
+Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing a release as a production action: report the intended tag and commit before creating it, then stay with all workflows until they succeed or a real defect is identified.
+
+## Preflight
+
+1. Run the bundled preflight from the repository root:
+
+   ```bash
+   preflight="$(.agents/skills/release-maple/scripts/preflight.sh)"
+   printf '%s\n' "$preflight" | jq .
+   tag="$(printf '%s' "$preflight" | jq -r .tag)"
+   previous_tag="$(printf '%s' "$preflight" | jq -r .previous_tag)"
+   head_sha="$(printf '%s' "$preflight" | jq -r .head_sha)"
+   ```
+
+2. Stop if preflight fails. Fix the branch/version/CI issue through the normal PR process before releasing. Never overwrite a tag or release.
+3. Preview GitHub's generated title and notes:
+
+   ```bash
+   gh api --method POST repos/OpenSecretCloud/Maple/releases/generate-notes \
+     -f tag_name="$tag" \
+     -f target_commitish=master \
+     -f previous_tag_name="$previous_tag" | jq -r '.name, .body'
+   ```
+
+4. Confirm the notes span the intended changes and the reported commit is still `origin/master`.
+
+## Publish
+
+Create and publish the release exactly once. This creates the tag, matching the standard GitHub release GUI flow:
+
+```bash
+gh release create "$tag" \
+  --repo OpenSecretCloud/Maple \
+  --target master \
+  --title "$tag" \
+  --generate-notes
+```
+
+Do not create or push a separate local tag first. Record the release URL and confirm the resulting release and workflow point to `head_sha`.
+
+## Monitor Release CI
+
+1. Find the new `Release` run for the tag and commit:
+
+   ```bash
+   gh run list --repo OpenSecretCloud/Maple --workflow Release --event release \
+     --commit "$head_sha" --limit 10 \
+     --json databaseId,displayTitle,headSha,status,conclusion,url
+   ```
+
+2. Watch it through every platform build, artifact upload, reproducibility verifier, `latest.json`, full release verification, and verification-guide publication:
+
+   ```bash
+   gh run watch RELEASE_RUN_ID --repo OpenSecretCloud/Maple --exit-status --compact
+   ```
+
+3. If it fails, inspect the failed job logs before acting:
+
+   ```bash
+   gh run view RELEASE_RUN_ID --repo OpenSecretCloud/Maple --log-failed
+   ```
+
+4. Retry only failures proven to be transient infrastructure problems, such as interrupted cache/network downloads. Wait for the run to become terminal, then use:
+
+   ```bash
+   gh run rerun RELEASE_RUN_ID --repo OpenSecretCloud/Maple --failed
+   ```
+
+5. Do not retry version mismatches, proof mismatches, signing failures, missing credentials, or deterministic build failures as if they were transient. Diagnose and report them. Do not delete or recreate the published release without explicit user direction.
+6. Continue watching the same run until its latest attempt concludes `success`. A failed attempt may create a skipped Zapstore workflow; this is expected and is not the final Zapstore result.
+
+## Verify Zapstore
+
+`Publish to Zapstore` starts only after the `Release` workflow completes successfully. Find the newest non-skipped workflow for `head_sha`, then watch it through `Verify and install zsp` and `Publish to Zapstore`:
+
+```bash
+gh run list --repo OpenSecretCloud/Maple --workflow 'Publish to Zapstore' \
+  --commit "$head_sha" --limit 10 \
+  --json databaseId,status,conclusion,headSha,createdAt,url
+
+gh run watch ZAPSTORE_RUN_ID --repo OpenSecretCloud/Maple --exit-status --compact
+```
+
+Treat pinned Go/zsp verification failures as integrity failures unless logs clearly show transient transport trouble.
+
+## Final Verification
+
+Confirm the release is published, targets the intended commit/tag, and has artifacts:
+
+```bash
+gh release view "$tag" --repo OpenSecretCloud/Maple \
+  --json tagName,name,isDraft,isPrerelease,publishedAt,targetCommitish,url,assets
+```
+
+Report the release URL, tag, commit SHA, main workflow URL and attempt count, Zapstore workflow URL, any retry and its evidence, and final success. Do not call the release complete while any required workflow is queued or running.

--- a/.agents/skills/release-maple/agents/openai.yaml
+++ b/.agents/skills/release-maple/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Release Maple"
+  short_description: "Publish and verify a Maple GitHub release"
+  default_prompt: "Use $release-maple to publish and verify the next Maple release."

--- a/.agents/skills/release-maple/scripts/preflight.sh
+++ b/.agents/skills/release-maple/scripts/preflight.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly expected_repo="OpenSecretCloud/Maple"
+readonly remote_url="https://github.com/OpenSecretCloud/Maple.git"
+
+fail() {
+  printf 'release preflight: %s\n' "$*" >&2
+  exit 1
+}
+
+for command_name in git gh jq python3; do
+  command -v "${command_name}" >/dev/null 2>&1 || fail "missing required command: ${command_name}"
+done
+
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null)" || fail "run from the Maple repository"
+cd "${repo_root}"
+
+repo="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+[[ "${repo}" == "${expected_repo}" ]] || fail "expected ${expected_repo}, found ${repo}"
+
+branch="$(git branch --show-current)"
+[[ "${branch}" == "master" ]] || fail "release from master, not ${branch:-detached HEAD}"
+
+if [[ -n "$(git status --porcelain --untracked-files=no)" ]]; then
+  fail "tracked worktree changes are present"
+fi
+
+git fetch --no-tags "${remote_url}" refs/heads/master:refs/remotes/origin/master >/dev/null
+
+head_sha="$(git rev-parse HEAD)"
+remote_sha="$(git rev-parse refs/remotes/origin/master)"
+[[ "${head_sha}" == "${remote_sha}" ]] || fail "HEAD ${head_sha} does not match origin/master ${remote_sha}"
+
+package_version="$(jq -er .version frontend/package.json)"
+tauri_version="$(jq -er .version frontend/src-tauri/tauri.conf.json)"
+cargo_version="$(awk '
+  /^\[package\]$/ { in_package = 1; next }
+  /^\[/ && in_package { exit }
+  in_package && /^version[[:space:]]*=/ {
+    value = $0
+    sub(/^[^=]*=[[:space:]]*"/, "", value)
+    sub(/"[[:space:]]*$/, "", value)
+    print value
+    exit
+  }
+' frontend/src-tauri/Cargo.toml)"
+
+[[ -n "${cargo_version}" ]] || fail "could not read Cargo package version"
+[[ "${package_version}" == "${tauri_version}" ]] || fail "package.json ${package_version} != tauri.conf.json ${tauri_version}"
+[[ "${package_version}" == "${cargo_version}" ]] || fail "package.json ${package_version} != Cargo.toml ${cargo_version}"
+
+tag="v${package_version}"
+validated_version="$(./scripts/ci/validate-release-version.sh "${tag}")"
+[[ "${validated_version}" == "${package_version}" ]] || fail "release validator returned ${validated_version}"
+
+previous_tag="$(gh api "repos/${repo}/releases/latest" --jq .tag_name)"
+[[ -n "${previous_tag}" ]] || fail "could not determine the latest published release"
+[[ "${tag}" != "${previous_tag}" ]] || fail "${tag} is already the latest published release"
+
+previous_version="$(gh api \
+  -H 'Accept: application/vnd.github.raw+json' \
+  "repos/${repo}/contents/frontend/package.json?ref=${previous_tag}" | jq -er .version)"
+
+python3 - "${previous_version}" "${package_version}" <<'PY'
+import re
+import sys
+
+
+def semver(value: str):
+    match = re.fullmatch(
+        r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+        r"(?:-([0-9A-Za-z.-]+))?(?:\+[0-9A-Za-z.-]+)?",
+        value,
+    )
+    if not match:
+        raise SystemExit(f"release preflight: invalid semantic version: {value}")
+    core = tuple(int(match.group(index)) for index in range(1, 4))
+    prerelease = match.group(4)
+    identifiers = prerelease.split(".") if prerelease else None
+    return core, identifiers
+
+
+def compare(left, right):
+    if left[0] != right[0]:
+        return (left[0] > right[0]) - (left[0] < right[0])
+    left_pre, right_pre = left[1], right[1]
+    if left_pre is None or right_pre is None:
+        return (left_pre is None) - (right_pre is None)
+    for left_id, right_id in zip(left_pre, right_pre):
+        if left_id == right_id:
+            continue
+        left_num, right_num = left_id.isdigit(), right_id.isdigit()
+        if left_num and right_num:
+            return (int(left_id) > int(right_id)) - (int(left_id) < int(right_id))
+        if left_num != right_num:
+            return -1 if left_num else 1
+        return (left_id > right_id) - (left_id < right_id)
+    return (len(left_pre) > len(right_pre)) - (len(left_pre) < len(right_pre))
+
+
+previous, current = map(semver, sys.argv[1:3])
+if compare(current, previous) <= 0:
+    raise SystemExit(
+        f"release preflight: current version {sys.argv[2]} is not newer than {sys.argv[1]}"
+    )
+PY
+
+compare_status="$(gh api "repos/${repo}/compare/${previous_tag}...${head_sha}" --jq .status)"
+[[ "${compare_status}" == "ahead" ]] || fail "master is not ahead of ${previous_tag} (status: ${compare_status})"
+
+if gh release view "${tag}" --repo "${repo}" >/dev/null 2>&1; then
+  fail "GitHub release ${tag} already exists"
+fi
+
+if git ls-remote --exit-code --tags "${remote_url}" "refs/tags/${tag}" "refs/tags/${tag}^{}" >/dev/null 2>&1; then
+  fail "remote tag ${tag} already exists"
+fi
+
+runs="$(gh run list --repo "${repo}" --commit "${head_sha}" --limit 50 \
+  --json workflowName,status,conclusion,createdAt,url)"
+
+required_workflows=(
+  "Frontend Tests"
+  "Rust Unit Tests"
+  "Web App Build"
+  "Desktop App CI"
+  "Android App CI"
+  "Mobile App CI"
+  "CodeQL"
+)
+
+for workflow in "${required_workflows[@]}"; do
+  latest="$(printf '%s' "${runs}" | jq -c --arg workflow "${workflow}" \
+    '[.[] | select(.workflowName == $workflow)] | sort_by(.createdAt) | reverse | .[0] // empty')"
+  [[ -n "${latest}" ]] || fail "no ${workflow} run found for ${head_sha}"
+  run_status="$(printf '%s' "${latest}" | jq -r .status)"
+  run_conclusion="$(printf '%s' "${latest}" | jq -r .conclusion)"
+  [[ "${run_status}" == "completed" && "${run_conclusion}" == "success" ]] || \
+    fail "${workflow} is ${run_status}/${run_conclusion} for ${head_sha}"
+done
+
+jq -n \
+  --arg repo "${repo}" \
+  --arg branch "${branch}" \
+  --arg head_sha "${head_sha}" \
+  --arg previous_tag "${previous_tag}" \
+  --arg previous_version "${previous_version}" \
+  --arg version "${package_version}" \
+  --arg tag "${tag}" \
+  '{
+    repo: $repo,
+    branch: $branch,
+    head_sha: $head_sha,
+    previous_tag: $previous_tag,
+    previous_version: $previous_version,
+    version: $version,
+    tag: $tag,
+    ci: "passed"
+  }'

--- a/.agents/skills/release-maple/scripts/preflight.sh
+++ b/.agents/skills/release-maple/scripts/preflight.sh
@@ -59,8 +59,10 @@ previous_tag="$(gh api "repos/${repo}/releases/latest" --jq .tag_name)"
 [[ "${tag}" != "${previous_tag}" ]] || fail "${tag} is already the latest published release"
 
 previous_version="$(gh api \
+  --method GET \
   -H 'Accept: application/vnd.github.raw+json' \
-  "repos/${repo}/contents/frontend/package.json?ref=${previous_tag}" | jq -er .version)"
+  "repos/${repo}/contents/frontend/package.json" \
+  -f ref="${previous_tag}" | jq -er .version)"
 
 python3 - "${previous_version}" "${package_version}" <<'PY'
 import re


### PR DESCRIPTION
## Summary
- add a repo-local `release-maple` skill for the full GitHub release workflow
- add a deterministic preflight for version bumps, clean/current `master`, existing tags/releases, and required CI
- document generated notes, release monitoring, evidence-based retries, artifact verification, and Zapstore confirmation

## Validation
- cut and verified `v3.1.5` end to end
- Release workflow passed on attempt 2 after retrying a proven transient Nix cache download failure
- Zapstore publication passed with pinned Go/zsp verification
- skill schema validator passed
- `bash -n` and `shellcheck` passed
- live guard test correctly refused the already-published `v3.1.5`
- repo pre-commit hook passed frontend build and 107 tests
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/opensecretcloud/maple/pull/636" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a guided release workflow for publishing and verifying Maple releases.
  * Added automated preflight checks for branch status, version consistency, release tags, and required CI results.
  * Added release verification steps covering GitHub release metadata, workflow completion, and published artifacts.
  * Added configuration and prompts for invoking the Maple release workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->