### PR TITLE
Prevent Markdown image loading

### DIFF
--- a/frontend/src/components/markdown.test.ts
+++ b/frontend/src/components/markdown.test.ts
@@ -36,4 +36,12 @@ describe("MarkdownContent images", () => {
     expect(rendered).toContain('href="https://trymaple.ai"');
     expect(rendered).toContain(">Maple</a>");
   });
+
+  it("omits images without alt text", () => {
+    const rendered = renderMarkdown("![](https://example.com/hidden.png)");
+
+    expect(rendered).not.toContain("<img");
+    expect(rendered).not.toContain("hidden.png");
+    expect(rendered).not.toContain("<span");
+  });
 });

--- a/frontend/src/components/markdown.test.ts
+++ b/frontend/src/components/markdown.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { MarkdownContent } from "./markdown";
+
+function renderMarkdown(content: string): string {
+  return renderToStaticMarkup(React.createElement(MarkdownContent, { content }));
+}
+
+describe("MarkdownContent images", () => {
+  it("renders image alt text without loading remote or local URL schemes", () => {
+    const rendered = renderMarkdown(
+      [
+        "![remote](https://example.com/tracker.png)",
+        "![relative](/local-image.png)",
+        "![data](data:image/png;base64,abc)",
+        "![blob](blob:https://trymaple.ai/image-id)"
+      ].join("\n\n")
+    );
+
+    expect(rendered).not.toContain("<img");
+    expect(rendered).not.toContain("tracker.png");
+    expect(rendered).not.toContain("local-image.png");
+    expect(rendered).not.toContain("data:image");
+    expect(rendered).not.toContain("blob:");
+    expect(rendered).toContain("remote");
+    expect(rendered).toContain("relative");
+    expect(rendered).toContain("data");
+    expect(rendered).toContain("blob");
+  });
+
+  it("continues to render ordinary links", () => {
+    const rendered = renderMarkdown("[Maple](https://trymaple.ai)");
+
+    expect(rendered).toContain('href="https://trymaple.ai"');
+    expect(rendered).toContain(">Maple</a>");
+  });
+});

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -435,6 +435,9 @@ function MarkDownContentToMemo(props: { content: string }) {
         ]
       ]}
       components={{
+        // Uploaded images use structured input_image parts outside Markdown. Preserve
+        // useful alt text here without creating an image element or loading its URL.
+        img: ({ alt }) => (alt ? <span>{alt}</span> : null),
         pre: (props: JSX.IntrinsicElements["pre"]) => <PreCode {...props} />,
         code: (props: JSX.IntrinsicElements["code"]) => <CustomCode {...props} />,
         table: (props: JSX.IntrinsicElements["table"]) => <ResponsiveTable {...props} />,


### PR DESCRIPTION
## Summary

- render Markdown image nodes as escaped alt text only, so remote, relative, data, and blob URLs in assistant or tool Markdown cannot create image elements or load resources
- keep structured user image attachments unchanged; uploads remain separate input_image parts and continue to render in the attachment and message UI
- add server-rendered regression coverage for image URL schemes, alt-text preservation, empty-alt omission, and ordinary links

Companion backend work: OpenSecretCloud/opensecret#237 sanitizes Kagi-provided Markdown before content budgets and safe truncation.

## Validation

- Maple pre-commit hook passed: formatting, production frontend build, and all 110 Bun tests
- live macOS Maple app used the local Pro fixture with web-search.kagi enabled
- a live Kagi search and open_urls call rendered the Polymarket page as text with no page-result image accessibility nodes or broken placeholders
- uploading the reported screenshot through Maples native attachment picker still showed the preview and sent-message image, and the model received it successfully