### PR TITLE
Add Chat and Agent mode switch

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -122,6 +122,10 @@ import {
 } from "@/utils/utils";
 import { isTauriDesktop } from "@/utils/platform";
 import { useLocalState } from "@/state/useLocalState";
+import {
+  usePersistentHomeNavigation,
+  usePersistentSidebarState
+} from "@/contexts/PersistentHomeNavigationContext";
 import type {
   ModelAccessTier,
   OpenSecretModel,
@@ -137,6 +141,9 @@ const MAX_STABLE_SESSION_LOAD_ATTEMPTS = 3;
 const AUTO_SCROLL_BOTTOM_THRESHOLD_PX = 100;
 const SIDEBAR_REORDER_ANIMATION_MS = 150;
 const SIDEBAR_ICON_STROKE = 2;
+const AGENT_SESSION_DELETED_EVENT = "maple:agent-session-deleted";
+// Mode switches remount AgentMode, so project-root mutations must be ordered outside it.
+const projectRootPersistenceQueues = new Map<string, Promise<void>>();
 const AGENT_SIDEBAR_ELLIPSIS_FADE =
   "pointer-events-none w-4 shrink-0 self-stretch bg-gradient-to-r from-transparent to-[hsl(var(--muted))] dark:to-[hsl(var(--sidebar))]";
 const AGENT_SIDEBAR_ELLIPSIS_TRIGGER_ROW_BASE =
@@ -248,10 +255,11 @@ export function AgentMode({ userId }: { userId: string }) {
   const os = useOpenSecret();
   const { createApiKey, deleteApiKey } = os;
   const { availableModels, modelAliases } = useLocalState();
+  const { agentSessionSelection } = usePersistentHomeNavigation();
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
-  const [isSidebarOpen, setIsSidebarOpen] = useState(!isCompactLayout);
+  const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
   const [runtimeStatus, setRuntimeStatus] = useState<AgentRuntimeStatus | null>(null);
   const [projectOrderState, dispatchProjectOrder] = useReducer(
     projectOrderReducer<RecentProjectRoot>,
@@ -259,6 +267,7 @@ export function AgentMode({ userId }: { userId: string }) {
   );
   const recentRoots = projectOrderState.visible;
   const [sessions, setSessions] = useState<AgentSessionSummary[]>([]);
+  const [isSessionHistoryReady, setIsSessionHistoryReady] = useState(false);
   const [sessionToDelete, setSessionToDelete] = useState<AgentSessionSummary | null>(null);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
   const [projectRoot, setProjectRoot] = useState("");
@@ -295,7 +304,6 @@ export function AgentMode({ userId }: { userId: string }) {
   const activeSessionIdRef = useRef(activeSessionId);
   const deletedSessionIdsRef = useRef(new Set<string>());
   const shouldAutoScrollRef = useRef(true);
-  const projectRootPersistenceRef = useRef<Promise<void>>(Promise.resolve());
   const permissionModeUpdateRef = useRef<Promise<void>>(Promise.resolve());
   const permissionModeUpdateGenerationRef = useRef(0);
   const selectedModeRef = useRef<AgentPermissionMode>(mode);
@@ -314,6 +322,9 @@ export function AgentMode({ userId }: { userId: string }) {
   const isAgentModelLockedRef = useRef(false);
   const mcpSessionLoadGenerationRef = useRef(0);
   const mcpToggleGenerationRef = useRef(0);
+  const previousIsCompactLayoutRef = useRef(isCompactLayout);
+  const hasAttemptedSessionRestoreRef = useRef(false);
+  const isAgentModeMountedRef = useRef(true);
   const projectOrderRequestIdRef = useRef(0);
 
   const applyAuthoritativeMode = useCallback((value: AgentPermissionMode) => {
@@ -323,10 +334,19 @@ export function AgentMode({ userId }: { userId: string }) {
   }, []);
 
   useEffect(() => {
-    if (isCompactLayout) {
+    isAgentModeMountedRef.current = true;
+    return () => {
+      isAgentModeMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const wasCompactLayout = previousIsCompactLayoutRef.current;
+    previousIsCompactLayoutRef.current = isCompactLayout;
+    if (isCompactLayout && !wasCompactLayout) {
       setIsSidebarOpen(false);
     }
-  }, [isCompactLayout]);
+  }, [isCompactLayout, setIsSidebarOpen]);
 
   useEffect(() => {
     activeSessionIdRef.current = activeSessionId;
@@ -451,7 +471,7 @@ export function AgentMode({ userId }: { userId: string }) {
     return ids;
   }, [activeRunsBySession, pendingSendSessionIds, pendingSessionSelectionId]);
 
-  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), [setIsSidebarOpen]);
 
   const beginSessionSelection = useCallback((sessionId: string): number => {
     interactionGenerationRef.current += 1;
@@ -625,18 +645,24 @@ export function AgentMode({ userId }: { userId: string }) {
 
   const enqueueProjectRootMutation = useCallback(
     async <T,>(mutation: () => Promise<T>): Promise<T> => {
-      const previousOperation = projectRootPersistenceRef.current;
+      const previousOperation = projectRootPersistenceQueues.get(userId) ?? Promise.resolve();
       const operation = (async () => {
         await previousOperation;
         return await trackAgentWorkflow(mutation);
       })();
-      projectRootPersistenceRef.current = operation.then(
+      const queueTail = operation.then(
         () => undefined,
         () => undefined
       );
+      projectRootPersistenceQueues.set(userId, queueTail);
+      void queueTail.then(() => {
+        if (projectRootPersistenceQueues.get(userId) === queueTail) {
+          projectRootPersistenceQueues.delete(userId);
+        }
+      });
       return await operation;
     },
-    [trackAgentWorkflow]
+    [trackAgentWorkflow, userId]
   );
 
   const persistSelectedProjectRoot = useCallback(
@@ -720,6 +746,7 @@ export function AgentMode({ userId }: { userId: string }) {
       if (!isTauriDesktop()) return;
       const nextSessions = await agentRuntimeService.listSessions(userId, null);
       setSessions(nextSessions.filter((session) => !deletedSessionIdsRef.current.has(session.id)));
+      setIsSessionHistoryReady(true);
     });
   }, [trackAgentWorkflow, userId]);
 
@@ -851,6 +878,13 @@ export function AgentMode({ userId }: { userId: string }) {
     async function loadInitialState() {
       if (!isTauriDesktop()) return;
       try {
+        // A mode switch can remount AgentMode while the previous mount is still saving a selected
+        // root or manual order. Read only after that user-scoped queue reaches its latest tail.
+        await (projectRootPersistenceQueues.get(userId) ?? Promise.resolve());
+        if (cancelled || interactionGenerationRef.current !== initializationGeneration) {
+          return;
+        }
+
         const runStateGeneration = runStateGenerationRef.current;
         const [status, config, roots, savedMcpServers] = await Promise.all([
           agentRuntimeService.getRuntimeStatus(userId),
@@ -958,6 +992,7 @@ export function AgentMode({ userId }: { userId: string }) {
         });
         if (typeof selected === "string") {
           invalidateSessionSelection();
+          agentSessionSelection.forget(userId);
           shouldAutoScrollRef.current = true;
           setProjectRoot(selected);
           activeSessionIdRef.current = null;
@@ -975,11 +1010,18 @@ export function AgentMode({ userId }: { userId: string }) {
     } catch (chooseError) {
       setError(errorMessage(chooseError));
     }
-  }, [invalidateSessionSelection, registerProjectRoot, trackAgentWorkflow]);
+  }, [
+    agentSessionSelection,
+    invalidateSessionSelection,
+    registerProjectRoot,
+    trackAgentWorkflow,
+    userId
+  ]);
 
   const selectProjectRoot = useCallback(
     (value: string) => {
       invalidateSessionSelection();
+      agentSessionSelection.forget(userId);
       const interactionGeneration = interactionGenerationRef.current;
       setProjectRoot(value);
       setActiveSessionId(null);
@@ -999,7 +1041,13 @@ export function AgentMode({ userId }: { userId: string }) {
         }
       })();
     },
-    [invalidateSessionSelection, persistSelectedProjectRoot, refreshSessions]
+    [
+      agentSessionSelection,
+      invalidateSessionSelection,
+      persistSelectedProjectRoot,
+      refreshSessions,
+      userId
+    ]
   );
 
   const selectModel = useCallback((value: string) => {
@@ -1204,6 +1252,7 @@ export function AgentMode({ userId }: { userId: string }) {
         // A send that creates a session may finish after the user selects a
         // different chat. Keep the new chat/run, but never steal focus back.
         if (
+          isAgentModeMountedRef.current &&
           sessionSelectionGenerationRef.current === expectedSelectionGeneration &&
           interactionGenerationRef.current === expectedInteractionGeneration &&
           activeSessionIdRef.current === null
@@ -1211,6 +1260,7 @@ export function AgentMode({ userId }: { userId: string }) {
           shouldAutoScrollRef.current = true;
           activeSessionIdRef.current = sessionId;
           setActiveSessionId(sessionId);
+          agentSessionSelection.remember(userId, sessionId);
           applyAuthoritativeMode(normalizeAgentPermissionMode(detail.session.mode));
           replaceSessionTimeline(sessionId, detail.timeline);
           const mcpError = mcpConnectionErrorMessage(detail.mcpErrors);
@@ -1222,6 +1272,7 @@ export function AgentMode({ userId }: { userId: string }) {
     },
     [
       applyAuthoritativeMode,
+      agentSessionSelection,
       model,
       projectRoot,
       replaceSessionTimeline,
@@ -1257,12 +1308,14 @@ export function AgentMode({ userId }: { userId: string }) {
       replaceSessionTimeline(detail.session.id, detail.timeline);
 
       if (
+        isAgentModeMountedRef.current &&
         sessionSelectionGenerationRef.current === selectionGeneration &&
         interactionGenerationRef.current === interactionGeneration
       ) {
         shouldAutoScrollRef.current = true;
         activeSessionIdRef.current = detail.session.id;
         setActiveSessionId(detail.session.id);
+        agentSessionSelection.remember(userId, detail.session.id);
         applyAuthoritativeMode(normalizeAgentPermissionMode(detail.session.mode));
         replaceSessionTimeline(detail.session.id, detail.timeline);
         const mcpError = mcpConnectionErrorMessage(detail.mcpErrors);
@@ -1270,16 +1323,20 @@ export function AgentMode({ userId }: { userId: string }) {
       }
     } catch (createError) {
       if (
+        isAgentModeMountedRef.current &&
         sessionSelectionGenerationRef.current === selectionGeneration &&
         interactionGenerationRef.current === interactionGeneration
       ) {
         setError(errorMessage(createError));
       }
     } finally {
-      finishSessionSelection(selectionGeneration);
+      if (isAgentModeMountedRef.current) {
+        finishSessionSelection(selectionGeneration);
+      }
     }
   }, [
     applyAuthoritativeMode,
+    agentSessionSelection,
     beginSessionSelection,
     finishSessionSelection,
     model,
@@ -1311,6 +1368,7 @@ export function AgentMode({ userId }: { userId: string }) {
         });
         const { detail, timelineRevision } = loaded;
         if (
+          !isAgentModeMountedRef.current ||
           sessionSelectionGenerationRef.current !== selectionGeneration ||
           interactionGenerationRef.current !== interactionGeneration ||
           deletedSessionIdsRef.current.has(sessionId)
@@ -1331,6 +1389,7 @@ export function AgentMode({ userId }: { userId: string }) {
         shouldAutoScrollRef.current = true;
         activeSessionIdRef.current = detail.session.id;
         setActiveSessionId(detail.session.id);
+        agentSessionSelection.remember(userId, detail.session.id);
         setProjectRoot(detail.session.projectRoot);
         if (detail.session.model) {
           setModel(detail.session.model);
@@ -1345,6 +1404,7 @@ export function AgentMode({ userId }: { userId: string }) {
           await persistSelectedProjectRoot(detail.session.projectRoot);
         } catch (persistError) {
           if (
+            isAgentModeMountedRef.current &&
             sessionSelectionGenerationRef.current === selectionGeneration &&
             interactionGenerationRef.current === interactionGeneration &&
             activeSessionIdRef.current === detail.session.id
@@ -1354,17 +1414,21 @@ export function AgentMode({ userId }: { userId: string }) {
         }
       } catch (loadError) {
         if (
+          isAgentModeMountedRef.current &&
           sessionSelectionGenerationRef.current === selectionGeneration &&
           interactionGenerationRef.current === interactionGeneration
         ) {
           setError(errorMessage(loadError));
         }
       } finally {
-        finishSessionSelection(selectionGeneration);
+        if (isAgentModeMountedRef.current) {
+          finishSessionSelection(selectionGeneration);
+        }
       }
     },
     [
       applyAuthoritativeMode,
+      agentSessionSelection,
       beginSessionSelection,
       clearCompletedUnreadSession,
       finishSessionSelection,
@@ -1374,6 +1438,31 @@ export function AgentMode({ userId }: { userId: string }) {
       userId
     ]
   );
+
+  useEffect(() => {
+    if (
+      hasAttemptedSessionRestoreRef.current ||
+      !isAuthTransitionReady ||
+      isInitializing ||
+      !isSessionHistoryReady
+    ) {
+      return;
+    }
+
+    hasAttemptedSessionRestoreRef.current = true;
+    const rememberedSessionId = agentSessionSelection.resolve(userId, sessions);
+    if (rememberedSessionId) {
+      void loadSession(rememberedSessionId);
+    }
+  }, [
+    agentSessionSelection,
+    isAuthTransitionReady,
+    isInitializing,
+    isSessionHistoryReady,
+    loadSession,
+    sessions,
+    userId
+  ]);
 
   const sendMessage = useCallback(async () => {
     const text = input.trim();
@@ -1548,6 +1637,7 @@ export function AgentMode({ userId }: { userId: string }) {
   const removeSessionFromState = useCallback(
     (sessionId: string) => {
       deletedSessionIdsRef.current.add(sessionId);
+      agentSessionSelection.forget(userId, sessionId);
       timelineRevisionBySessionRef.current.delete(sessionId);
       setSessions((current) => current.filter((session) => session.id !== sessionId));
       setCompletedUnreadSessionIds((current) => {
@@ -1567,7 +1657,7 @@ export function AgentMode({ userId }: { userId: string }) {
         setInput("");
       }
     },
-    [clearActiveRun]
+    [agentSessionSelection, clearActiveRun, userId]
   );
 
   const deleteSession = useCallback(
@@ -1576,12 +1666,32 @@ export function AgentMode({ userId }: { userId: string }) {
       try {
         await agentRuntimeService.deleteSession(userId, sessionId);
         removeSessionFromState(sessionId);
+        // A mode switch can remount AgentMode while native deletion is pending.
+        // Notify the current mount so it cannot keep or restore the deleted session.
+        window.dispatchEvent(
+          new CustomEvent(AGENT_SESSION_DELETED_EVENT, { detail: { userId, sessionId } })
+        );
       } catch (deleteError) {
         setError(errorMessage(deleteError));
       }
     },
     [removeSessionFromState, userId]
   );
+
+  useEffect(() => {
+    const handleSessionDeleted = (event: Event) => {
+      if (!(event instanceof CustomEvent)) return;
+      const detail = event.detail as { userId?: unknown; sessionId?: unknown } | null;
+      if (detail?.userId === userId && typeof detail.sessionId === "string" && detail.sessionId) {
+        removeSessionFromState(detail.sessionId);
+      }
+    };
+
+    window.addEventListener(AGENT_SESSION_DELETED_EVENT, handleSessionDeleted);
+    return () => {
+      window.removeEventListener(AGENT_SESSION_DELETED_EVENT, handleSessionDeleted);
+    };
+  }, [removeSessionFromState, userId]);
 
   const upsertSessionSummary = useCallback((summary: AgentSessionSummary) => {
     if (deletedSessionIdsRef.current.has(summary.id)) return;

--- a/frontend/src/components/AuthenticatedHomeContent.tsx
+++ b/frontend/src/components/AuthenticatedHomeContent.tsx
@@ -8,9 +8,11 @@ import {
   type ReactNode
 } from "react";
 import { useLocation, useRouter } from "@tanstack/react-router";
+import { useOpenSecret } from "@opensecret/react";
 import { ProjectDetailView } from "@/components/ProjectDetailView";
 import { UnifiedChat } from "@/components/UnifiedChat";
 import { PersistentHomeNavigationContext } from "@/contexts/PersistentHomeNavigationContext";
+import { AgentSessionSelectionMemory } from "@/services/agentSessionSelection";
 
 const TRANSIENT_HOME_SEARCH_PARAMS = ["team_setup", "credits_success", "api_settings"];
 
@@ -48,21 +50,38 @@ function readSafeHomeHref(): string {
 export function PersistentHomeNavigationProvider({ children }: { children: ReactNode }) {
   const location = useLocation();
   const router = useRouter();
+  const os = useOpenSecret();
+  const userId = os.auth.user?.user.id ?? null;
   const initialHomeHref = readSafeHomeHref();
   const homeHrefRef = useRef(initialHomeHref);
-  const [homeHref, setHomeHref] = useState(initialHomeHref);
+  const homeHrefUserIdRef = useRef(userId);
+  const skipNextHomeCaptureRef = useRef(false);
+  const [sidebarOpen, setSidebarOpen] = useState<boolean | null>(null);
+  const [agentSessionSelection] = useState(() => new AgentSessionSelectionMemory());
 
   const captureHomeHref = useCallback(() => {
-    if (window.location.pathname !== "/") return;
+    if (!userId || window.location.pathname !== "/") return;
 
     const nextHomeHref = readSafeHomeHref();
     homeHrefRef.current = nextHomeHref;
-    setHomeHref((current) => (current === nextHomeHref ? current : nextHomeHref));
-  }, []);
+  }, [userId]);
+
+  useLayoutEffect(() => {
+    if (homeHrefUserIdRef.current === userId) return;
+
+    // Conversation and project IDs are account-scoped; never carry a home snapshot across users.
+    homeHrefUserIdRef.current = userId;
+    skipNextHomeCaptureRef.current = true;
+    homeHrefRef.current = "/";
+  }, [userId]);
 
   // TanStack navigations update location.href. Maple also updates the home URL with the native
   // History API, so the app events below keep the snapshot exact for those transitions too.
   useLayoutEffect(() => {
+    if (skipNextHomeCaptureRef.current) {
+      skipNextHomeCaptureRef.current = false;
+      return;
+    }
     captureHomeHref();
   }, [captureHomeHref, location.href]);
 
@@ -100,10 +119,12 @@ export function PersistentHomeNavigationProvider({ children }: { children: React
 
   const value = useMemo(
     () => ({
-      homeHref,
-      returnToHome
+      returnToHome,
+      sidebarOpen,
+      setSidebarOpen,
+      agentSessionSelection
     }),
-    [homeHref, returnToHome]
+    [agentSessionSelection, returnToHome, sidebarOpen]
   );
 
   return (

--- a/frontend/src/components/ProjectDetailView.tsx
+++ b/frontend/src/components/ProjectDetailView.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   CheckSquare,
   Folder,
@@ -47,6 +47,7 @@ import { BulkDeleteDialog } from "@/components/BulkDeleteDialog";
 import { MoveChatsDialog } from "@/components/MoveChatsDialog";
 import { listAllConversationProjects } from "@/utils/paginatedLists";
 import { SIDEBAR_GRID_COLUMNS_CLASS, SIDEBAR_LAYOUT_STYLE } from "@/constants/layout";
+import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
 
 const PROJECT_PAGE_SIZE = 20;
 const MAX_SELECTION = 20;
@@ -151,13 +152,16 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
   const { setSelectedProjectId } = useLocalState();
   const hasAuthUser = !!os.auth.user;
 
-  const [isSidebarOpen, setIsSidebarOpen] = useState(!isCompactLayout);
+  const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
+  const wasLandscapeMobileRef = useRef(isLandscapeMobile);
 
   useEffect(() => {
-    if (isLandscapeMobile && isSidebarOpen) {
+    const enteredLandscapeMobile = isLandscapeMobile && !wasLandscapeMobileRef.current;
+    wasLandscapeMobileRef.current = isLandscapeMobile;
+    if (enteredLandscapeMobile && isSidebarOpen) {
       setIsSidebarOpen(false);
     }
-  }, [isLandscapeMobile]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isLandscapeMobile, isSidebarOpen, setIsSidebarOpen]);
 
   const [conversations, setConversations] = useState<Conversation[]>([]);
   const [hasMoreConversations, setHasMoreConversations] = useState(false);
@@ -179,7 +183,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
 
   const toggleSidebar = useCallback(() => {
     setIsSidebarOpen((prev) => !prev);
-  }, []);
+  }, [setIsSidebarOpen]);
 
   useEffect(() => {
     setSelectedProjectId(projectId);

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -6,8 +6,7 @@ import {
   XCircle,
   Trash2,
   X,
-  FolderInput,
-  Bot
+  FolderInput
 } from "lucide-react";
 import { Button } from "./ui/button";
 import { useLocation, useRouter } from "@tanstack/react-router";
@@ -37,6 +36,8 @@ import { useOpenSecret } from "@opensecret/react";
 import { FEATURE_FLAGS, flagsClient } from "@/services/flags";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { hasApiAccess } from "@/billing/billingAccess";
+import { WorkspaceModeSwitch, type WorkspaceMode } from "@/components/WorkspaceModeSwitch";
+import { usePersistentHomeNavigation } from "@/contexts/PersistentHomeNavigationContext";
 
 export function Sidebar({
   chatId,
@@ -47,12 +48,13 @@ export function Sidebar({
 }: {
   chatId?: string;
   isOpen: boolean;
-  mode?: "chat" | "agent";
+  mode?: WorkspaceMode;
   navigationContent?: ReactNode;
   onToggle: () => void;
 }) {
   const router = useRouter();
   const location = useLocation();
+  const { returnToHome } = usePersistentHomeNavigation();
   const os = useOpenSecret();
   const userId = os.auth.user?.user.id;
   const {
@@ -70,6 +72,8 @@ export function Sidebar({
   const [isSelectionMode, setIsSelectionMode] = useState(false);
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
   const [agentModeUpgradeOpen, setAgentModeUpgradeOpen] = useState(false);
+  const [pendingWorkspaceMode, setPendingWorkspaceMode] = useState<WorkspaceMode | null>(null);
+  const workspaceModeNavigationStartedRef = useRef(false);
 
   // Enter selection mode when items are selected (e.g., via long press)
   useEffect(() => {
@@ -133,10 +137,33 @@ export function Sidebar({
     }
   }
 
-  async function toggleAgentMode() {
-    const isLeavingAgentMode = location.pathname === "/agent";
+  async function completeWorkspaceModeChange(nextMode: WorkspaceMode) {
+    if (workspaceModeNavigationStartedRef.current) return;
+    workspaceModeNavigationStartedRef.current = true;
 
-    if (!isLeavingAgentMode) {
+    if (nextMode === "chat") {
+      returnToHome({ replace: false });
+      return;
+    }
+
+    try {
+      await router.navigate({ to: "/agent" });
+    } catch (error) {
+      workspaceModeNavigationStartedRef.current = false;
+      setPendingWorkspaceMode(null);
+      console.error("Navigation failed:", error);
+    }
+  }
+
+  function switchWorkspaceMode(nextMode: WorkspaceMode) {
+    if (pendingWorkspaceMode !== null) {
+      if (nextMode === mode) setPendingWorkspaceMode(null);
+      return;
+    }
+
+    if (nextMode === mode) return;
+
+    if (nextMode === "agent") {
       if (billingStatus === null) return;
 
       if (!hasApiAccess(billingStatus)) {
@@ -145,15 +172,12 @@ export function Sidebar({
       }
     }
 
-    if (isOpen) {
-      onToggle();
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      void completeWorkspaceModeChange(nextMode);
+      return;
     }
 
-    try {
-      await router.navigate({ to: isLeavingAgentMode ? "/" : "/agent" });
-    } catch (error) {
-      console.error("Navigation failed:", error);
-    }
+    setPendingWorkspaceMode(nextMode);
   }
 
   const toggleSearch = () => {
@@ -190,11 +214,16 @@ export function Sidebar({
     userId: string;
     enabled: boolean;
   } | null>(null);
-  const showAgentMode =
-    agentModeAvailable &&
-    billingStatus !== null &&
-    agentModeFlag?.userId === userId &&
-    agentModeFlag?.enabled === true;
+  // Chat and Agent mount separate Sidebar instances. Seed a remount from the existing,
+  // user-scoped flag cache while this instance revalidates in the background.
+  const cachedAgentModeEnabled = userId
+    ? flagsClient.peekIsEnabled(userId, FEATURE_FLAGS.AGENT_MODE)
+    : undefined;
+  const agentModeEnabled =
+    agentModeFlag !== null && agentModeFlag.userId === userId
+      ? agentModeFlag.enabled
+      : cachedAgentModeEnabled;
+  const showAgentMode = agentModeAvailable && billingStatus !== null && agentModeEnabled === true;
   const isAgentMode = mode === "agent";
 
   useEffect(() => {
@@ -256,6 +285,11 @@ export function Sidebar({
         // Prevent updates if component unmounted
         if (!isMountedRef.current) return;
 
+        const resolvedPath = window.location.pathname;
+        const isWorkspaceModeTransition =
+          (isAgentMode && resolvedPath === "/") || (!isAgentMode && resolvedPath === "/agent");
+        if (isWorkspaceModeTransition) return;
+
         // Double-check conditions after async boundary
         if (isOpen && isCompactLayout) {
           onToggle();
@@ -266,7 +300,7 @@ export function Sidebar({
     return () => {
       unsubscribe();
     };
-  }, [router, isOpen, onToggle, isCompactLayout]);
+  }, [router, isOpen, onToggle, isCompactLayout, isAgentMode]);
 
   return (
     <div
@@ -299,6 +333,19 @@ export function Sidebar({
               <ArrowLeftFromLine className="h-4 w-4" />
             </button>
           </div>
+          {(showAgentMode || isAgentMode) && (
+            <div className="mb-2 px-8">
+              <WorkspaceModeSwitch
+                mode={pendingWorkspaceMode ?? mode}
+                onModeChange={switchWorkspaceMode}
+                onModeTransitionEnd={(nextMode) => {
+                  if (nextMode === pendingWorkspaceMode) {
+                    void completeWorkspaceModeChange(nextMode);
+                  }
+                }}
+              />
+            </div>
+          )}
           <div className="flex flex-col gap-2 px-4">
             <button
               type="button"
@@ -308,21 +355,6 @@ export function Sidebar({
               <SquarePenIcon className="h-4 w-4 shrink-0" />
               New Chat
             </button>
-            {showAgentMode && (
-              <button
-                type="button"
-                className={cn(
-                  "flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm transition-colors",
-                  location.pathname === "/agent"
-                    ? "text-[hsl(var(--maple-primary-strong))] dark:text-[hsl(var(--maple-primary))]"
-                    : "text-foreground hover:text-foreground/70"
-                )}
-                onClick={toggleAgentMode}
-              >
-                <Bot className="h-4 w-4" />
-                Agent Mode
-              </button>
-            )}
             {!isAgentMode && (
               <button
                 className="flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm text-foreground hover:text-foreground/70 transition-colors"

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -91,6 +91,7 @@ import type {
   ResponseTextDoneEvent
 } from "openai/resources/responses/responses.js";
 import type { Message as OpenAIMessage } from "openai/resources/conversations/conversations.js";
+import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
 
 const CHAT_ALERT_CLASS = `fixed top-16 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl px-4 ${SIDEBAR_AWARE_FIXED_CENTER_CLASS}`;
 
@@ -1387,7 +1388,7 @@ export function UnifiedChat() {
   const [input, setInput] = useState("");
   const [draftProjectId, setDraftProjectId] = useState<string | null>(() => selectedProjectId);
   const [isGenerating, setIsGenerating] = useState(false);
-  const [isSidebarOpen, setIsSidebarOpen] = useState(!isCompactLayout);
+  const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
   const [error, setError] = useState<string | null>(null);
   const [lastSeenItemId, setLastSeenItemId] = useState<string | undefined>();
   const [isNewConversationJustCreated, setIsNewConversationJustCreated] = useState(false);
@@ -1429,12 +1430,17 @@ export function UnifiedChat() {
   });
   const [isFullscreenAnimating, setIsFullscreenAnimating] = useState(false);
 
-  // Close sidebar when rotating to landscape on a short screen
+  const wasLandscapeMobileRef = useRef(isLandscapeMobile);
+
+  // Close an already-open sidebar when the current view rotates into a short landscape layout.
+  // A route that mounts while already compact keeps the shared sidebar state during a mode switch.
   useEffect(() => {
-    if (isLandscapeMobile && isSidebarOpen) {
+    const enteredLandscapeMobile = isLandscapeMobile && !wasLandscapeMobileRef.current;
+    wasLandscapeMobileRef.current = isLandscapeMobile;
+    if (enteredLandscapeMobile && isSidebarOpen) {
       setIsSidebarOpen(false);
     }
-  }, [isLandscapeMobile]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isLandscapeMobile, isSidebarOpen, setIsSidebarOpen]);
 
   // Save fullscreen preference to localStorage when it changes
   useEffect(() => {
@@ -2158,7 +2164,7 @@ export function UnifiedChat() {
   }, [error]);
 
   // Toggle sidebar
-  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), []);
+  const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), [setIsSidebarOpen]);
 
   const handleNewChatFromHeader = useCallback(() => {
     flushSync(() => {

--- a/frontend/src/components/WorkspaceModeSwitch.test.tsx
+++ b/frontend/src/components/WorkspaceModeSwitch.test.tsx
@@ -1,0 +1,43 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { WorkspaceModeSwitch, type WorkspaceMode } from "./WorkspaceModeSwitch";
+
+function renderSwitch(mode: WorkspaceMode): string {
+  return renderToStaticMarkup(<WorkspaceModeSwitch mode={mode} onModeChange={() => {}} />);
+}
+
+function radioMarkup(markup: string, mode: WorkspaceMode): string {
+  const match = markup.match(new RegExp(`<input[^>]*id="workspace-mode-${mode}"[^>]*>`));
+  if (!match) throw new Error(`Missing ${mode} radio`);
+  return match[0];
+}
+
+describe("WorkspaceModeSwitch", () => {
+  test("renders an accessible radio group with persistent Chat and Agent options", () => {
+    const markup = renderSwitch("chat");
+
+    expect(markup).toContain("<fieldset");
+    expect(markup).toContain('<legend class="sr-only">Workspace mode</legend>');
+    expect(markup.match(/type="radio"/g)).toHaveLength(2);
+    expect(markup.match(/name="workspace-mode"/g)).toHaveLength(2);
+
+    for (const mode of ["chat", "agent"] as const) {
+      expect(radioMarkup(markup, mode)).toContain(`value="${mode}"`);
+      expect(markup).toContain(`<label for="workspace-mode-${mode}"`);
+    }
+
+    expect(markup).toContain(">Chat</span>");
+    expect(markup).toContain(">Agent</span>");
+    expect(markup).toContain("lucide-message-circle");
+    expect(markup).toContain("lucide-bot");
+  });
+
+  test.each(["chat", "agent"] as const)("marks only %s as selected", (activeMode) => {
+    const markup = renderSwitch(activeMode);
+    const inactiveMode: WorkspaceMode = activeMode === "chat" ? "agent" : "chat";
+
+    expect(radioMarkup(markup, activeMode)).toContain('checked=""');
+    expect(radioMarkup(markup, inactiveMode)).not.toContain("checked");
+  });
+});

--- a/frontend/src/components/WorkspaceModeSwitch.tsx
+++ b/frontend/src/components/WorkspaceModeSwitch.tsx
@@ -1,0 +1,112 @@
+import { Bot, MessageCircle, type LucideIcon } from "lucide-react";
+
+import { cn } from "@/utils/utils";
+
+export type WorkspaceMode = "chat" | "agent";
+
+type WorkspaceModeOption = {
+  mode: WorkspaceMode;
+  label: string;
+  icon: LucideIcon;
+  iconClassName?: string;
+  selectedIconClassName: string;
+};
+
+const WORKSPACE_MODE_OPTIONS: WorkspaceModeOption[] = [
+  {
+    mode: "chat",
+    label: "Chat",
+    icon: MessageCircle,
+    selectedIconClassName:
+      "fill-[hsl(var(--maple-primary))] text-[hsl(var(--maple-primary-strong))]"
+  },
+  {
+    mode: "agent",
+    label: "Agent",
+    icon: Bot,
+    iconClassName:
+      "[&>rect]:fill-transparent [&>rect]:transition-[fill] [&>rect]:duration-200 motion-reduce:[&>rect]:transition-none",
+    selectedIconClassName:
+      "text-[hsl(var(--maple-primary-strong))] [&>rect]:fill-[hsl(var(--maple-primary))]"
+  }
+];
+
+export function WorkspaceModeSwitch({
+  mode,
+  onModeChange,
+  onModeTransitionEnd
+}: {
+  mode: WorkspaceMode;
+  onModeChange: (mode: WorkspaceMode) => void;
+  onModeTransitionEnd?: (mode: WorkspaceMode) => void;
+}) {
+  return (
+    <fieldset className="m-0 min-w-0 border-0 p-0">
+      <legend className="sr-only">Workspace mode</legend>
+      {/* Keep both segments even-width so their centered icons land on whole CSS pixels. */}
+      <div className="relative grid w-[calc(100%-1px)] grid-cols-2 gap-1 rounded-[10px] border border-foreground/10 bg-foreground/5 px-0.5 py-px shadow-inner dark:border-transparent dark:bg-foreground/[0.07] dark:shadow-none">
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute inset-y-px left-0.5 w-[calc(50%-0.25rem)] rounded-lg bg-[hsl(var(--sidebar-chrome))] shadow-sm transition-transform duration-200 ease-out motion-reduce:transition-none",
+            mode === "agent" ? "translate-x-[calc(100%+0.25rem)]" : "translate-x-0"
+          )}
+          onTransitionEnd={(event) => {
+            if (event.propertyName === "transform") onModeTransitionEnd?.(mode);
+          }}
+        />
+        {WORKSPACE_MODE_OPTIONS.map((option) => {
+          const isSelected = option.mode === mode;
+          const Icon = option.icon;
+          const id = `workspace-mode-${option.mode}`;
+
+          return (
+            <div key={option.mode} className="relative z-10 min-w-0">
+              <input
+                id={id}
+                type="radio"
+                name="workspace-mode"
+                value={option.mode}
+                checked={isSelected}
+                className="peer sr-only"
+                onChange={() => {
+                  if (!isSelected) onModeChange(option.mode);
+                }}
+              />
+              <label
+                htmlFor={id}
+                className={cn(
+                  "group flex h-8 w-full cursor-pointer items-center justify-center gap-2 rounded-lg px-2 text-sm peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-1 peer-focus-visible:ring-offset-muted",
+                  isSelected ? "font-semibold" : "font-medium"
+                )}
+              >
+                <Icon
+                  aria-hidden="true"
+                  className={cn(
+                    "h-4 w-4 shrink-0 duration-200 motion-reduce:transition-none",
+                    option.mode === "agent" ? "transition-[color]" : "transition-colors",
+                    option.iconClassName,
+                    isSelected
+                      ? option.selectedIconClassName
+                      : "text-muted-foreground group-hover:text-foreground"
+                  )}
+                  strokeWidth={2}
+                />
+                <span
+                  className={cn(
+                    "w-10 shrink-0 text-left transition-colors duration-200 motion-reduce:transition-none",
+                    isSelected
+                      ? "text-foreground"
+                      : "text-muted-foreground group-hover:text-foreground"
+                  )}
+                >
+                  {option.label}
+                </span>
+              </label>
+            </div>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/frontend/src/contexts/PersistentHomeNavigationContext.ts
+++ b/frontend/src/contexts/PersistentHomeNavigationContext.ts
@@ -1,8 +1,11 @@
-import { createContext, useContext } from "react";
+import { createContext, useCallback, useContext, type Dispatch, type SetStateAction } from "react";
+import type { AgentSessionSelectionMemory } from "@/services/agentSessionSelection";
 
 export type PersistentHomeNavigation = {
-  homeHref: string;
   returnToHome: (options?: { replace?: boolean }) => void;
+  sidebarOpen: boolean | null;
+  setSidebarOpen: Dispatch<SetStateAction<boolean | null>>;
+  agentSessionSelection: AgentSessionSelectionMemory;
 };
 
 export const PersistentHomeNavigationContext = createContext<PersistentHomeNavigation | null>(null);
@@ -15,4 +18,22 @@ export function usePersistentHomeNavigation() {
     );
   }
   return context;
+}
+
+export function usePersistentSidebarState(
+  isCompactLayout: boolean
+): readonly [boolean, Dispatch<SetStateAction<boolean>>] {
+  const { sidebarOpen, setSidebarOpen } = usePersistentHomeNavigation();
+  const isOpen = sidebarOpen ?? !isCompactLayout;
+  const setIsOpen = useCallback<Dispatch<SetStateAction<boolean>>>(
+    (nextValue) => {
+      setSidebarOpen((currentValue) => {
+        const currentIsOpen = currentValue ?? !isCompactLayout;
+        return typeof nextValue === "function" ? nextValue(currentIsOpen) : nextValue;
+      });
+    },
+    [isCompactLayout, setSidebarOpen]
+  );
+
+  return [isOpen, setIsOpen] as const;
 }

--- a/frontend/src/services/agentSessionSelection.test.ts
+++ b/frontend/src/services/agentSessionSelection.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { AgentSessionSelectionMemory } from "./agentSessionSelection";
+
+describe("AgentSessionSelectionMemory", () => {
+  test("restores a remembered session that is still available", () => {
+    const memory = new AgentSessionSelectionMemory();
+    memory.remember("user-a", "session-b");
+
+    expect(memory.resolve("user-a", [{ id: "session-a" }, { id: "session-b" }])).toBe("session-b");
+  });
+
+  test("clears a remembered session that is no longer available", () => {
+    const memory = new AgentSessionSelectionMemory();
+    memory.remember("user-a", "deleted-session");
+
+    expect(memory.resolve("user-a", [{ id: "session-a" }])).toBeNull();
+    expect(memory.resolve("user-a", [{ id: "deleted-session" }])).toBeNull();
+  });
+
+  test("forgets conditionally when an expected session is supplied", () => {
+    const memory = new AgentSessionSelectionMemory();
+    memory.remember("user-a", "session-a");
+
+    memory.forget("user-a", "session-b");
+    expect(memory.resolve("user-a", [{ id: "session-a" }])).toBe("session-a");
+
+    memory.forget("user-a", "session-a");
+    expect(memory.resolve("user-a", [{ id: "session-a" }])).toBeNull();
+
+    memory.remember("user-a", "session-b");
+    memory.forget("user-a");
+    expect(memory.resolve("user-a", [{ id: "session-b" }])).toBeNull();
+  });
+
+  test("isolates remembered selections by user", () => {
+    const memory = new AgentSessionSelectionMemory();
+    memory.remember("user-a", "session-a");
+    memory.remember("user-b", "session-b");
+
+    expect(memory.resolve("user-a", [{ id: "session-a" }])).toBe("session-a");
+    expect(memory.resolve("user-b", [{ id: "session-b" }])).toBe("session-b");
+
+    memory.forget("user-a");
+    expect(memory.resolve("user-b", [{ id: "session-b" }])).toBe("session-b");
+  });
+});

--- a/frontend/src/services/agentSessionSelection.ts
+++ b/frontend/src/services/agentSessionSelection.ts
@@ -1,0 +1,30 @@
+export class AgentSessionSelectionMemory {
+  private readonly sessionIdsByUser = new Map<string, string>();
+
+  remember(userId: string, sessionId: string): void {
+    this.sessionIdsByUser.set(userId, sessionId);
+  }
+
+  forget(userId: string, expectedSessionId?: string): void {
+    if (
+      expectedSessionId !== undefined &&
+      this.sessionIdsByUser.get(userId) !== expectedSessionId
+    ) {
+      return;
+    }
+
+    this.sessionIdsByUser.delete(userId);
+  }
+
+  resolve(userId: string, sessions: readonly { id: string }[]): string | null {
+    const rememberedSessionId = this.sessionIdsByUser.get(userId);
+    if (rememberedSessionId === undefined) return null;
+
+    if (sessions.some((session) => session.id === rememberedSessionId)) {
+      return rememberedSessionId;
+    }
+
+    this.sessionIdsByUser.delete(userId);
+    return null;
+  }
+}

--- a/frontend/src/services/flags.test.ts
+++ b/frontend/src/services/flags.test.ts
@@ -43,7 +43,26 @@ describe("FlagsClient", () => {
 
   test("treats a missing flag as disabled", async () => {
     const flags = client(async () => jsonResponse(USER_A, {}));
+    expect(flags.peekIsEnabled(USER_A, "missing")).toBeUndefined();
     await expect(flags.isEnabled(USER_A, "missing")).resolves.toBe(false);
+    expect(flags.peekIsEnabled(USER_A, "missing")).toBe(false);
+  });
+
+  test("only exposes settled cached values synchronously", async () => {
+    let resolveRequest: ((response: Response) => void) | undefined;
+    const flags = client(
+      () =>
+        new Promise<Response>((resolve) => {
+          resolveRequest = resolve;
+        })
+    );
+
+    const pending = flags.isEnabled(USER_A, " enabled ");
+    expect(flags.peekIsEnabled(USER_A, "enabled")).toBeUndefined();
+
+    resolveRequest?.(jsonResponse(USER_A, { enabled: true }));
+    await expect(pending).resolves.toBe(true);
+    expect(flags.peekIsEnabled(` ${USER_A} `, " enabled ")).toBe(true);
   });
 
   test("coalesces concurrent and normalized equivalent lookups", async () => {
@@ -80,11 +99,14 @@ describe("FlagsClient", () => {
 
     await expect(flags.isEnabled(USER_A, "enabled")).resolves.toBe(true);
     now = 600_999;
+    expect(flags.peekIsEnabled(USER_A, "enabled")).toBe(true);
     await expect(flags.isEnabled(USER_A, "enabled")).resolves.toBe(true);
     expect(calls).toBe(1);
 
     now = 601_000;
+    expect(flags.peekIsEnabled(USER_A, "enabled")).toBeUndefined();
     await expect(flags.isEnabled(USER_A, "enabled")).resolves.toBe(false);
+    expect(flags.peekIsEnabled(USER_A, "enabled")).toBe(false);
     expect(calls).toBe(2);
   });
 
@@ -97,7 +119,10 @@ describe("FlagsClient", () => {
     });
 
     await expect(flags.isEnabled(USER_A, "enabled")).resolves.toBe(true);
+    expect(flags.peekIsEnabled(USER_A, "enabled")).toBe(true);
+    expect(flags.peekIsEnabled(USER_B, "enabled")).toBeUndefined();
     await expect(flags.isEnabled(USER_B, "enabled")).resolves.toBe(false);
+    expect(flags.peekIsEnabled(USER_B, "enabled")).toBe(false);
     expect(calls).toBe(2);
   });
 
@@ -110,6 +135,7 @@ describe("FlagsClient", () => {
     });
 
     await expect(flags.isEnabled(USER_A, "enabled")).rejects.toThrow("status 503");
+    expect(flags.peekIsEnabled(USER_A, "enabled")).toBeUndefined();
     await expect(flags.isEnabled(USER_A, "enabled")).resolves.toBe(true);
     expect(calls).toBe(2);
   });

--- a/frontend/src/services/flags.ts
+++ b/frontend/src/services/flags.ts
@@ -24,6 +24,7 @@ interface CacheEntry {
   settled: boolean;
   promise: Promise<FlagValues>;
   token: object;
+  values?: FlagValues;
 }
 
 function defaultBaseUrl(): string {
@@ -117,6 +118,7 @@ export class FlagsClient {
         if (current?.token === token) {
           current.settled = true;
           current.expiresAt = this.now() + this.cacheTtlMs;
+          current.values = flags;
         }
         return flags;
       },
@@ -133,6 +135,17 @@ export class FlagsClient {
   async isEnabled(userId: string, key: string): Promise<boolean> {
     const flags = await this.getFlags(userId, [key]);
     return flags[key.trim()] === true;
+  }
+
+  peekIsEnabled(userId: string, key: string): boolean | undefined {
+    const normalizedUserId = userId.trim();
+    const [normalizedKey] = normalizeKeys([key]);
+    if (!normalizedUserId || !normalizedKey) return undefined;
+
+    this.evictExpired(this.now());
+    const entry = this.cache.get(cacheKey(normalizedUserId, [normalizedKey]));
+    if (!entry?.settled || !entry.values) return undefined;
+    return entry.values[normalizedKey] === true;
   }
 
   private evictExpired(now: number): void {


### PR DESCRIPTION
## Summary

- add an accessible Chat/Agent mode switch below the Maple logo, replacing the standalone Agent Mode action
- animate the selected surface while keeping hover, focus, light/dark, and reduced-motion behavior consistent
- preserve the exact Chat location and sidebar state, and restore the last Agent session when switching modes
- keep feature availability stable and guard Agent async state across route remounts

https://github.com/user-attachments/assets/08130c37-279a-4909-944a-96f9112ea443


## Testing

- `bun test` — 131 passing
- `bun run typecheck`
- `bun run lint` — 0 errors (12 existing warnings)
- `bun run build`
- `git diff --check`

Closes #638


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined switch between Chat and Agent modes.
  * Agent sessions now remember and restore the most recently selected session when available.
  * Sidebar open/closed state persists across navigation and mode changes.
  * Added smoother workspace transitions, including reduced-motion support.
  * Improved mobile and landscape layouts by automatically closing the sidebar when appropriate.

* **Bug Fixes**
  * Prevented deleted sessions from being restored.
  * Reduced duplicate navigation and stale state during workspace transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->