### PR TITLE
Improve Local Proxy setup and model guidance

### DIFF
--- a/frontend/src/components/apikeys/ProxyClientGuides.tsx
+++ b/frontend/src/components/apikeys/ProxyClientGuides.tsx
@@ -1,0 +1,302 @@
+import { Link } from "@tanstack/react-router";
+import { type ReactNode, useState } from "react";
+import {
+  AlertCircle,
+  Check,
+  Copy,
+  KeyRound,
+  Play,
+  ShieldCheck,
+  TerminalSquare
+} from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  buildOpenCodeProviderFields,
+  buildCurlProxyExample,
+  buildPythonProxyExample,
+  getModelDisplayName
+} from "@/services/proxyModels";
+import type { OpenSecretModel } from "@/state/LocalStateContextDef";
+
+type ProxyClientGuidesProps = {
+  baseUrl: string;
+  isRunning: boolean;
+  hasApiKeys: boolean;
+  models: OpenSecretModel[];
+  selectedModelId: string;
+  onSelectModel: (modelId: string) => void;
+};
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 2000);
+    } catch (error) {
+      console.error(`Failed to copy ${label}:`, error);
+      setCopyState("error");
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7 shrink-0"
+      onClick={handleCopy}
+      aria-label={
+        copyState === "copied"
+          ? `${label} copied`
+          : copyState === "error"
+            ? `Copy ${label} failed`
+            : `Copy ${label}`
+      }
+      title={copyState === "error" ? "Copy failed" : undefined}
+    >
+      {copyState === "copied" ? (
+        <Check className="h-3.5 w-3.5 text-maple-success" />
+      ) : copyState === "error" ? (
+        <AlertCircle className="h-3.5 w-3.5 text-destructive" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+      <span className="sr-only" aria-live="polite">
+        {copyState === "copied"
+          ? `${label} copied`
+          : copyState === "error"
+            ? `Copy ${label} failed`
+            : ""}
+      </span>
+    </Button>
+  );
+}
+
+function SetupField({
+  label,
+  value,
+  copyable = true
+}: {
+  label: string;
+  value: string;
+  copyable?: boolean;
+}) {
+  return (
+    <div className="min-w-0 rounded-lg border border-border/70 bg-background/60 p-3">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
+        <code className="min-w-0 break-all text-xs text-foreground">{value}</code>
+        {copyable && <CopyButton value={value} label={label} />}
+      </div>
+    </div>
+  );
+}
+
+function CodeExample({ label, code }: { label: string; code: string }) {
+  return (
+    <div className="relative overflow-hidden rounded-lg border border-border/70 bg-background">
+      <div className="flex items-center justify-between border-b border-border/70 px-3 py-2">
+        <span className="text-xs font-medium">{label}</span>
+        <CopyButton value={code} label={`${label} example`} />
+      </div>
+      <pre className="overflow-x-auto p-3 text-xs leading-relaxed">
+        <code>{code}</code>
+      </pre>
+    </div>
+  );
+}
+
+function Step({ number, children }: { number: number; children: ReactNode }) {
+  return (
+    <li className="flex gap-3 text-sm leading-relaxed">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[hsl(var(--maple-primary-container))] text-[11px] font-semibold text-foreground"
+      >
+        {number}
+      </span>
+      <span>{children}</span>
+    </li>
+  );
+}
+
+export function ProxyClientGuides({
+  baseUrl,
+  isRunning,
+  hasApiKeys,
+  models,
+  selectedModelId,
+  onSelectModel
+}: ProxyClientGuidesProps) {
+  const selectedModel = models.find((model) => model.id === selectedModelId);
+  const exampleModelId = selectedModel?.id ?? "SELECT_A_MODEL";
+  const openCodeFields = buildOpenCodeProviderFields(baseUrl, selectedModel);
+
+  return (
+    <div className="space-y-4">
+      {!isRunning && (
+        <Alert role="note">
+          <Play className="h-4 w-4" />
+          <AlertDescription>
+            Start the proxy above before connecting a client. You can prepare the remaining setup
+            now.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <div className="grid gap-3 sm:grid-cols-[minmax(0,1fr)_auto] sm:items-end">
+        <div className="grid gap-2">
+          <label htmlFor="proxy-guide-model" className="text-sm font-medium">
+            Model used in examples
+          </label>
+          <Select
+            value={selectedModel?.id ?? ""}
+            onValueChange={onSelectModel}
+            disabled={models.length === 0}
+          >
+            <SelectTrigger id="proxy-guide-model">
+              <SelectValue placeholder="Load the current model catalog" />
+            </SelectTrigger>
+            <SelectContent>
+              {models.map((model) => (
+                <SelectItem key={model.id} value={model.id}>
+                  {getModelDisplayName(model)} · {model.id}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <Button asChild variant="outline" className="sm:mb-0">
+          <Link to="/settings/api/keys/new">
+            <KeyRound className="mr-2 h-4 w-4" />
+            Create API key
+          </Link>
+        </Button>
+      </div>
+
+      <Tabs defaultValue="opencode" className="w-full">
+        <TabsList className="grid h-auto w-full grid-cols-3">
+          <TabsTrigger value="opencode">OpenCode</TabsTrigger>
+          <TabsTrigger value="curl">cURL</TabsTrigger>
+          <TabsTrigger value="python">Python</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="opencode" className="space-y-4 pt-2">
+          <ol className="space-y-3">
+            <Step number={1}>
+              In Maple, create a dedicated API key above and copy it. The full key is shown only
+              once. Then return to Local Proxy.
+            </Step>
+            <Step number={2}>
+              In OpenCode, open <strong>Settings → Providers → Custom Provider → Connect</strong>.
+            </Step>
+            <Step number={3}>Enter the values below, then connect and select the model.</Step>
+          </ol>
+
+          {hasApiKeys && (
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              Existing keys cannot be revealed again. If you did not save one, create a new key for
+              OpenCode.
+            </p>
+          )}
+
+          <div className="grid gap-2 sm:grid-cols-2">
+            <SetupField label="Provider ID" value={openCodeFields.providerId} />
+            <SetupField label="Display name" value={openCodeFields.displayName} />
+            <SetupField label="Base URL" value={openCodeFields.baseUrl} />
+            <SetupField label="API key" value={openCodeFields.apiKey} copyable={false} />
+            <SetupField
+              label="Model ID"
+              value={openCodeFields.modelId}
+              copyable={!!selectedModel}
+            />
+            <SetupField
+              label="Model name"
+              value={openCodeFields.modelName}
+              copyable={!!selectedModel}
+            />
+            <SetupField label="Headers" value={openCodeFields.headers} copyable={false} />
+          </div>
+
+          <Alert role="note" className="border-maple-warning/40 bg-maple-warning/10">
+            <ShieldCheck className="h-4 w-4 text-maple-warning" />
+            <AlertDescription className="space-y-1">
+              <p>
+                Use a real Maple key—never a placeholder. An incoming bearer key overrides the key
+                saved by Maple Desktop.
+              </p>
+              <p>
+                When replacing an old key, disconnect and reconnect the provider. OpenCode stores
+                credentials separately from project configuration.
+              </p>
+            </AlertDescription>
+          </Alert>
+        </TabsContent>
+
+        <TabsContent value="curl" className="space-y-3 pt-2">
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Set <code>MAPLE_API_KEY</code> to a real key created in Maple, then run this request.
+          </p>
+          {selectedModel ? (
+            <CodeExample
+              label="Streaming Chat Completions"
+              code={buildCurlProxyExample(baseUrl, exampleModelId)}
+            />
+          ) : (
+            <div
+              role="status"
+              className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground"
+            >
+              Load and select a current model before copying this example.
+            </div>
+          )}
+        </TabsContent>
+
+        <TabsContent value="python" className="space-y-3 pt-2">
+          <p className="text-sm leading-relaxed text-muted-foreground">
+            Install the OpenAI Python package and set <code>MAPLE_API_KEY</code> to a real Maple
+            key.
+          </p>
+          {selectedModel ? (
+            <CodeExample
+              label="OpenAI-compatible Python"
+              code={buildPythonProxyExample(baseUrl, exampleModelId)}
+            />
+          ) : (
+            <div
+              role="status"
+              className="rounded-lg border border-dashed p-4 text-sm text-muted-foreground"
+            >
+              Load and select a current model before copying this example.
+            </div>
+          )}
+        </TabsContent>
+      </Tabs>
+
+      <Card className="border-dashed p-3">
+        <div className="flex gap-2 text-xs leading-relaxed text-muted-foreground">
+          <TerminalSquare className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>
+            A 401 usually means an invalid or stale key; a 400 usually means an old model ID. A 5xx
+            can be a temporary model-provider outage even when this setup is correct.
+          </p>
+        </div>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/components/apikeys/ProxyConfigSection.tsx
+++ b/frontend/src/components/apikeys/ProxyConfigSection.tsx
@@ -1,20 +1,49 @@
-import { useState, useEffect } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  AlertCircle,
+  Check,
+  CheckCircle,
+  Copy,
+  Loader2,
+  Play,
+  Server,
+  ShieldCheck,
+  Square
+} from "lucide-react";
+import { SettingsSection } from "@/components/settings/SettingsPage";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Play, Square, Loader2, AlertCircle, CheckCircle, Server, Copy, Check } from "lucide-react";
-import { proxyService, ProxyConfig, ProxyStatus } from "@/services/proxyService";
+import { Switch } from "@/components/ui/switch";
+import { DEFAULT_AGENT_MODEL } from "@/services/agentModels";
+import { proxyService, type ProxyConfig, type ProxyStatus } from "@/services/proxyService";
+import { getProxyBaseUrl, isCodingAgentModel } from "@/services/proxyModels";
+import type { OpenSecretModel } from "@/state/LocalStateContextDef";
 import { isTauriDesktop } from "@/utils/platform";
-import { QUICK_MODEL_ALIAS } from "@/utils/utils";
+import { ProxyClientGuides } from "./ProxyClientGuides";
+import { ProxyModelList } from "./ProxyModelList";
 
 interface ProxyConfigSectionProps {
   apiKeys: Array<{ name: string; created_at: string }>;
   onRequestNewApiKey: (name: string) => Promise<string>;
+  models: OpenSecretModel[];
+  isModelsLoading: boolean;
+  isModelsError: boolean;
 }
 
-export function ProxyConfigSection({ apiKeys, onRequestNewApiKey }: ProxyConfigSectionProps) {
+function isLoopbackHost(host: string): boolean {
+  return host.trim() === "127.0.0.1";
+}
+
+export function ProxyConfigSection({
+  apiKeys,
+  onRequestNewApiKey,
+  models,
+  isModelsLoading,
+  isModelsError
+}: ProxyConfigSectionProps) {
   const [proxyStatus, setProxyStatus] = useState<ProxyStatus | null>(null);
   const [config, setConfig] = useState<ProxyConfig>({
     host: "127.0.0.1",
@@ -27,14 +56,22 @@ export function ProxyConfigSection({ apiKeys, onRequestNewApiKey }: ProxyConfigS
   const [isLoading, setIsLoading] = useState(false);
   const [message, setMessage] = useState<{ type: "success" | "error"; text: string } | null>(null);
   const [copied, setCopied] = useState(false);
+  const [selectedModelId, setSelectedModelId] = useState("");
   const isTauriDesktopPlatform = isTauriDesktop();
 
-  useEffect(() => {
-    if (!isTauriDesktopPlatform) return;
+  const guideModels = useMemo(() => models.filter(isCodingAgentModel), [models]);
 
-    // Load saved config and status on mount
-    loadProxyState();
-  }, [isTauriDesktopPlatform]);
+  useEffect(() => {
+    if (guideModels.length === 0) {
+      setSelectedModelId("");
+      return;
+    }
+
+    setSelectedModelId((current) => {
+      if (guideModels.some((model) => model.id === current)) return current;
+      return guideModels.find((model) => model.id === DEFAULT_AGENT_MODEL)?.id ?? guideModels[0].id;
+    });
+  }, [guideModels]);
 
   const loadProxyState = async () => {
     try {
@@ -50,70 +87,62 @@ export function ProxyConfigSection({ apiKeys, onRequestNewApiKey }: ProxyConfigS
     }
   };
 
+  useEffect(() => {
+    if (!isTauriDesktopPlatform) return;
+    void loadProxyState();
+  }, [isTauriDesktopPlatform]);
+
   const handleStartProxy = async () => {
     setIsLoading(true);
+    setMessage(null);
 
     try {
-      // If no API key is set, auto-generate one
       let apiKey = config.api_key;
       if (!apiKey) {
         const date = new Date().toISOString().split("T")[0].replace(/-/g, "");
         const keyName = `maple-desktop-${date}`;
-
-        // Check if a key with this name already exists
-        const existingKey = apiKeys.find((k) => k.name === keyName);
+        const existingKey = apiKeys.find((key) => key.name === keyName);
         if (existingKey) {
-          // Use the existing key (we don't have access to the actual key value)
           setMessage({
             type: "error",
             text: "Please select an existing API key or create a new one"
           });
-          setIsLoading(false);
           return;
         }
 
-        // Request a new API key
         try {
           apiKey = await onRequestNewApiKey(keyName);
-          setConfig((prev) => ({ ...prev, api_key: apiKey }));
+          setConfig((previous) => ({ ...previous, api_key: apiKey }));
         } catch {
           setMessage({
             type: "error",
             text: "Failed to create API key. Please create an API key manually first"
           });
-          setIsLoading(false);
           return;
         }
       }
 
-      // Validate port range (1-65535)
       const port = Number(config.port);
       if (!Number.isInteger(port) || port < 1 || port > 65535) {
         setMessage({
           type: "error",
           text: `Invalid port: ${config.port}. Port must be between 1 and 65535.`
         });
-        setIsLoading(false);
         return;
       }
 
-      // Get the backend URL from environment
       const backendUrl = import.meta.env.VITE_OPEN_SECRET_API_URL || "https://enclave.trymaple.ai";
-
       const updatedConfig = {
         ...config,
         api_key: apiKey,
         enabled: true,
         backend_url: backendUrl,
-        auto_start: config.auto_start // Preserve auto_start setting
+        auto_start: config.auto_start
       };
-      // The user is explicitly taking control of the shared proxy. The service
-      // detaches the active Agent association only after the native start
-      // succeeds, while retaining its exact key name for later revocation.
+
       const status = await proxyService.startManualProxy(updatedConfig);
       setProxyStatus(status);
       setConfig(updatedConfig);
-
       setMessage({
         type: "success",
         text: `Proxy is now running on ${config.host}:${config.port}`
@@ -127,13 +156,13 @@ export function ProxyConfigSection({ apiKeys, onRequestNewApiKey }: ProxyConfigS
 
   const handleStopProxy = async () => {
     setIsLoading(true);
+    setMessage(null);
 
     try {
       const status = await proxyService.stopManualProxy();
       setProxyStatus(status);
-      setConfig((prev) => ({ ...prev, enabled: false }));
-
-      setMessage({ type: "success", text: "The proxy server has been stopped" });
+      setConfig((previous) => ({ ...previous, enabled: false }));
+      setMessage({ type: "success", text: "The proxy has stopped" });
     } catch (error) {
       setMessage({ type: "error", text: `Failed to stop proxy: ${error}` });
     } finally {
@@ -142,236 +171,278 @@ export function ProxyConfigSection({ apiKeys, onRequestNewApiKey }: ProxyConfigS
   };
 
   const handleConfigChange = (field: keyof ProxyConfig, value: string | number | boolean) => {
-    setConfig((prev) => ({ ...prev, [field]: value }));
+    setConfig((previous) => ({ ...previous, [field]: value }));
   };
 
-  const copyProxyUrl = () => {
-    const url = `http://${config.host}:${config.port}/v1`;
-    navigator.clipboard.writeText(url);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+  const handleAutoStartChange = async (checked: boolean) => {
+    const updatedConfig = { ...config, auto_start: checked };
+    setConfig(updatedConfig);
+    try {
+      await proxyService.saveManualProxySettings(updatedConfig);
+      setMessage({
+        type: "success",
+        text: checked ? "Auto-start enabled" : "Auto-start disabled"
+      });
+    } catch {
+      setMessage({ type: "error", text: "Failed to save the auto-start setting" });
+    }
   };
 
-  if (!isTauriDesktopPlatform) {
-    return null; // Don't show proxy config on non-desktop platforms (includes mobile)
-  }
-
+  const proxyBaseUrl = getProxyBaseUrl(config.host, config.port);
   const isRunning = proxyStatus?.running || false;
+
+  const copyProxyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(proxyBaseUrl);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch (error) {
+      console.error("Failed to copy proxy URL:", error);
+      setMessage({ type: "error", text: "Failed to copy the proxy URL" });
+    }
+  };
+
+  if (!isTauriDesktopPlatform) return null;
 
   return (
     <>
-      {/* Show message alerts */}
-      {message && (
-        <Alert
-          className={`${
-            message.type === "error" ? "border-destructive/50" : "border-maple-success/40"
-          } mb-3`}
-        >
-          <div className="flex items-start gap-2">
-            {message.type === "error" ? (
-              <AlertCircle className="h-4 w-4 flex-shrink-0" />
-            ) : (
-              <CheckCircle className="h-4 w-4 flex-shrink-0 text-maple-success" />
-            )}
-            <AlertDescription className="text-xs">{message.text}</AlertDescription>
-          </div>
-        </Alert>
-      )}
+      <SettingsSection
+        title="Local OpenAI proxy"
+        description="Run a local, OpenAI-compatible Chat Completions endpoint from Maple Desktop."
+      >
+        <div className="space-y-4">
+          {message && (
+            <Alert
+              className={
+                message.type === "error" ? "border-destructive/50" : "border-maple-success/40"
+              }
+            >
+              <div className="flex items-start gap-2">
+                {message.type === "error" ? (
+                  <AlertCircle className="h-4 w-4 shrink-0" />
+                ) : (
+                  <CheckCircle className="h-4 w-4 shrink-0 text-maple-success" />
+                )}
+                <AlertDescription>{message.text}</AlertDescription>
+              </div>
+            </Alert>
+          )}
 
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-medium flex items-center gap-2">
-          <Server className="h-4 w-4" />
-          Local OpenAI Proxy
-        </h3>
-        <div className="flex items-center gap-2">
-          <span className="text-xs text-muted-foreground">{isRunning ? "Running" : "Stopped"}</span>
           <div
-            className={`h-2 w-2 rounded-full ${isRunning ? "bg-maple-success" : "bg-muted-foreground/50"}`}
-          />
-        </div>
-      </div>
-
-      <Card className="p-4 space-y-4">
-        {/* Configuration */}
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <Label htmlFor="proxy-host" className="text-xs">
-              Host
-            </Label>
-            <Input
-              id="proxy-host"
-              value={config.host}
-              onChange={(e) => handleConfigChange("host", e.target.value)}
-              placeholder="127.0.0.1"
-              disabled={isRunning}
-              className="h-8 text-sm"
-            />
-          </div>
-          <div>
-            <Label htmlFor="proxy-port" className="text-xs">
-              Port
-            </Label>
-            <div className="flex gap-2">
-              <Input
-                id="proxy-port"
-                type="number"
-                value={config.port}
-                onChange={(e) => handleConfigChange("port", parseInt(e.target.value) || 8080)}
-                placeholder="8080"
-                disabled={isRunning}
-                className="h-8 text-sm"
-              />
+            className="flex flex-col gap-4 rounded-xl border border-border/70 bg-background/40 p-4 sm:flex-row sm:items-center sm:justify-between"
+            aria-busy={isLoading}
+          >
+            <div className="flex min-w-0 items-start gap-3">
+              <div className="rounded-lg bg-[hsl(var(--maple-primary-container))] p-2 text-[hsl(var(--maple-primary-strong))]">
+                <Server className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium">{isRunning ? "Proxy running" : "Proxy stopped"}</p>
+                  <Badge variant={isRunning ? "secondary" : "outline"}>
+                    {isRunning ? "Online" : "Offline"}
+                  </Badge>
+                </div>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  {isRunning
+                    ? "Keep Maple open while connected tools are using this endpoint."
+                    : "Start the proxy when you are ready to connect an app or coding agent."}
+                </p>
+              </div>
             </div>
+            {!isRunning ? (
+              <Button onClick={handleStartProxy} disabled={isLoading} className="shrink-0">
+                {isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Play className="mr-2 h-4 w-4" />
+                )}
+                {isLoading ? "Starting proxy..." : "Start proxy"}
+              </Button>
+            ) : (
+              <Button
+                onClick={handleStopProxy}
+                disabled={isLoading}
+                variant="destructive"
+                className="shrink-0"
+              >
+                {isLoading ? (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                ) : (
+                  <Square className="mr-2 h-4 w-4" />
+                )}
+                {isLoading ? "Stopping proxy..." : "Stop proxy"}
+              </Button>
+            )}
           </div>
-        </div>
 
-        {/* API Key Info */}
-        {config.api_key && (
           <div>
-            <Label className="text-xs">API Key Status</Label>
-            <p className="text-xs text-muted-foreground mt-1">API key configured</p>
-          </div>
-        )}
-
-        {/* Proxy URL */}
-        {isRunning && (
-          <div>
-            <Label className="text-xs">Proxy URL</Label>
-            <div className="flex gap-2">
-              <Input
-                value={`http://${config.host}:${config.port}/v1`}
-                readOnly
-                className="h-8 text-sm font-mono"
-              />
-              <Button size="sm" variant="outline" onClick={copyProxyUrl} className="h-8">
-                {copied ? <Check className="h-3 w-3" /> : <Copy className="h-3 w-3" />}
+            <Label htmlFor="proxy-url" className="text-xs">
+              OpenAI-compatible base URL
+            </Label>
+            <div className="mt-1 flex gap-2">
+              <Input id="proxy-url" value={proxyBaseUrl} readOnly className="font-mono text-xs" />
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={copyProxyUrl}
+                aria-label={copied ? "Proxy URL copied" : "Copy proxy URL"}
+              >
+                {copied ? (
+                  <Check className="h-4 w-4 text-maple-success" />
+                ) : (
+                  <Copy className="h-4 w-4" />
+                )}
               </Button>
             </div>
-            <p className="text-xs text-muted-foreground mt-1">
-              Use this URL as your OpenAI base URL in any client
+            <p className="mt-1.5 text-xs text-muted-foreground">
+              Compatible with clients that use OpenAI Chat Completions.
             </p>
           </div>
-        )}
 
-        {/* Control Buttons */}
-        <div className="flex gap-2">
-          {!isRunning ? (
-            <Button onClick={handleStartProxy} disabled={isLoading} size="sm" className="flex-1">
-              {isLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Play className="mr-2 h-4 w-4" />
-              )}
-              Start Proxy
-            </Button>
-          ) : (
-            <Button
-              onClick={handleStopProxy}
-              disabled={isLoading}
-              variant="destructive"
-              size="sm"
-              className="flex-1"
-            >
-              {isLoading ? (
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-              ) : (
-                <Square className="mr-2 h-4 w-4" />
-              )}
-              Stop Proxy
-            </Button>
+          <Alert role="note">
+            <ShieldCheck className="h-4 w-4" />
+            <AlertDescription>
+              Local processes can use Maple&apos;s saved proxy credential without supplying their
+              own key. Keep the proxy on loopback, run only trusted clients, and remember that proxy
+              usage counts toward your Maple account.
+            </AlertDescription>
+          </Alert>
+
+          {config.enable_cors && (
+            <Alert role="note" className="border-maple-warning/40 bg-maple-warning/10">
+              <AlertCircle className="h-4 w-4 text-maple-warning" />
+              <AlertDescription>
+                CORS is enabled, so browser pages may be able to reach this proxy while it is
+                running. Turn CORS off unless a browser client specifically requires it.
+              </AlertDescription>
+            </Alert>
           )}
-        </div>
 
-        {/* CORS Toggle */}
-        <div className="flex items-center justify-between pt-2 border-t">
-          <Label htmlFor="enable-cors" className="text-xs">
-            Enable CORS (for web clients)
-          </Label>
-          <input
-            id="enable-cors"
-            type="checkbox"
-            checked={config.enable_cors ?? true}
-            onChange={(e) => handleConfigChange("enable_cors", e.target.checked)}
-            disabled={isRunning}
-            className="h-4 w-4"
-          />
-        </div>
+          {!isLoopbackHost(config.host) && (
+            <Alert role="note" className="border-maple-warning/40 bg-maple-warning/10">
+              <AlertCircle className="h-4 w-4 text-maple-warning" />
+              <AlertDescription>
+                This host may expose the proxy beyond your device. Use 127.0.0.1 unless you fully
+                understand the network and billing risk.
+              </AlertDescription>
+            </Alert>
+          )}
 
-        {/* Auto-start Toggle */}
-        <div className="flex items-center justify-between">
-          <div className="flex-1">
-            <Label htmlFor="auto-start" className="text-xs">
-              Auto-start proxy when app launches
-            </Label>
-            <p className="text-xs text-muted-foreground mt-0.5">
-              Proxy will start automatically on app launch if configured
-            </p>
-          </div>
-          <input
-            id="auto-start"
-            type="checkbox"
-            checked={config.auto_start ?? false}
-            onChange={async (e) => {
-              const newConfig = { ...config, auto_start: e.target.checked };
-              setConfig(newConfig);
-              // Save immediately when toggling auto-start
-              try {
-                await proxyService.saveManualProxySettings(newConfig);
-                setMessage({
-                  type: "success",
-                  text: e.target.checked ? "Auto-start enabled" : "Auto-start disabled"
-                });
-              } catch {
-                setMessage({ type: "error", text: "Failed to save auto-start setting" });
-              }
-            }}
-            disabled={!config.api_key} // Only enable if we have an API key
-            className="h-4 w-4"
-          />
-        </div>
-      </Card>
+          <details className="group rounded-lg border border-border/70">
+            <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
+              Advanced settings
+            </summary>
+            <div className="space-y-4 border-t border-border/70 p-4">
+              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+                <div className="grid gap-1.5">
+                  <Label htmlFor="proxy-host" className="text-xs">
+                    Host
+                  </Label>
+                  <Input
+                    id="proxy-host"
+                    value={config.host}
+                    onChange={(event) => handleConfigChange("host", event.target.value)}
+                    placeholder="127.0.0.1"
+                    disabled={isRunning}
+                    aria-describedby="proxy-host-description"
+                  />
+                  <p id="proxy-host-description" className="text-xs text-muted-foreground">
+                    Use a numeric IPv4 address. 127.0.0.1 is recommended.
+                  </p>
+                </div>
+                <div className="grid gap-1.5">
+                  <Label htmlFor="proxy-port" className="text-xs">
+                    Port
+                  </Label>
+                  <Input
+                    id="proxy-port"
+                    type="number"
+                    value={config.port}
+                    onChange={(event) =>
+                      handleConfigChange("port", Number.parseInt(event.target.value, 10) || 8080)
+                    }
+                    placeholder="8080"
+                    disabled={isRunning}
+                  />
+                </div>
+              </div>
 
-      {/* Usage Examples */}
-      {isRunning && (
-        <div className="space-y-3">
-          <Card className="p-3">
-            <div className="text-xs">
-              <strong>Python Example:</strong>
-              <pre className="mt-2 text-xs bg-background p-2 rounded border overflow-x-auto">
-                <code>{`from openai import OpenAI
-client = OpenAI(
-  base_url="http://${config.host}:${config.port}/v1",
-  api_key="anything"  # API key handled by proxy
-)
+              <div className="flex items-start justify-between gap-4 border-t border-border/70 pt-4">
+                <div>
+                  <Label htmlFor="enable-cors" className="text-xs">
+                    Enable CORS for browser clients
+                  </Label>
+                  <p
+                    id="enable-cors-description"
+                    className="mt-1 text-xs leading-relaxed text-muted-foreground"
+                  >
+                    Desktop clients such as OpenCode do not need CORS. Turn this off unless a
+                    browser app specifically requires it.
+                  </p>
+                </div>
+                <Switch
+                  id="enable-cors"
+                  checked={config.enable_cors ?? true}
+                  onCheckedChange={(checked) => handleConfigChange("enable_cors", checked)}
+                  disabled={isRunning}
+                  aria-describedby="enable-cors-description"
+                />
+              </div>
 
-response = client.chat.completions.create(
-  model="${QUICK_MODEL_ALIAS}",
-  messages=[{"role": "user", "content": "Hello!"}],
-  stream=True
-)
+              <div className="flex items-start justify-between gap-4 border-t border-border/70 pt-4">
+                <div>
+                  <Label htmlFor="auto-start" className="text-xs">
+                    Auto-start when Maple launches
+                  </Label>
+                  <p
+                    id="auto-start-description"
+                    className="mt-1 text-xs leading-relaxed text-muted-foreground"
+                  >
+                    Available after Maple has created and saved the proxy credential.
+                  </p>
+                </div>
+                <Switch
+                  id="auto-start"
+                  checked={config.auto_start ?? false}
+                  onCheckedChange={handleAutoStartChange}
+                  disabled={!config.api_key}
+                  aria-describedby="auto-start-description"
+                />
+              </div>
 
-for chunk in response:
-    print(chunk.choices[0].delta.content or "", end="")`}</code>
-              </pre>
+              {config.api_key && (
+                <div className="flex items-center gap-2 text-xs text-muted-foreground">
+                  <ShieldCheck className="h-4 w-4 text-maple-success" />
+                  Maple has saved its proxy credential.
+                </div>
+              )}
             </div>
-          </Card>
-
-          <Card className="p-3">
-            <div className="text-xs">
-              <strong>cURL Example:</strong>
-              <pre className="mt-2 text-xs bg-background p-2 rounded border overflow-x-auto">
-                <code>{`curl -N http://${config.host}:${config.port}/v1/chat/completions \\
-  -H "Content-Type: application/json" \\
-  -d '{
-    "model": "${QUICK_MODEL_ALIAS}",
-    "messages": [{"role": "user", "content": "Hello!"}],
-    "stream": true
-  }'`}</code>
-              </pre>
-            </div>
-          </Card>
+          </details>
         </div>
-      )}
+      </SettingsSection>
+
+      <SettingsSection
+        title="Connect your tools"
+        description="Follow a built-in setup guide using this proxy URL and Maple's current model catalog."
+      >
+        <ProxyClientGuides
+          baseUrl={proxyBaseUrl}
+          isRunning={isRunning}
+          hasApiKeys={apiKeys.length > 0}
+          models={guideModels}
+          selectedModelId={selectedModelId}
+          onSelectModel={setSelectedModelId}
+        />
+      </SettingsSection>
+
+      <SettingsSection
+        title="Current Maple models"
+        description="Browse current chat model IDs recommended for Local Proxy clients."
+      >
+        <ProxyModelList models={models} isLoading={isModelsLoading} isError={isModelsError} />
+      </SettingsSection>
     </>
   );
 }

--- a/frontend/src/components/apikeys/ProxyModelList.tsx
+++ b/frontend/src/components/apikeys/ProxyModelList.tsx
@@ -1,0 +1,144 @@
+import { useState } from "react";
+import { AlertCircle, Check, Copy, Loader2 } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { formatModelContext, getModelDisplayName } from "@/services/proxyModels";
+import type { OpenSecretModel } from "@/state/LocalStateContextDef";
+
+type ProxyModelListProps = {
+  models: OpenSecretModel[];
+  isLoading: boolean;
+  isError: boolean;
+};
+
+function ModelId({ modelId }: { modelId: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(modelId);
+      setCopyState("copied");
+      setTimeout(() => setCopyState("idle"), 2000);
+    } catch (error) {
+      console.error("Failed to copy model ID:", error);
+      setCopyState("error");
+    }
+  };
+
+  return (
+    <div className="mt-1 flex min-w-0 items-center gap-1">
+      <code className="min-w-0 break-all text-xs text-foreground">{modelId}</code>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-6 w-6 shrink-0"
+        onClick={handleCopy}
+        aria-label={
+          copyState === "copied"
+            ? `Model ID ${modelId} copied`
+            : copyState === "error"
+              ? `Copy model ID ${modelId} failed`
+              : `Copy model ID ${modelId}`
+        }
+      >
+        {copyState === "copied" ? (
+          <Check className="h-3 w-3 text-maple-success" />
+        ) : copyState === "error" ? (
+          <AlertCircle className="h-3 w-3 text-destructive" />
+        ) : (
+          <Copy className="h-3 w-3" />
+        )}
+        <span className="sr-only" aria-live="polite">
+          {copyState === "copied"
+            ? `Model ID ${modelId} copied`
+            : copyState === "error"
+              ? `Copy model ID ${modelId} failed`
+              : ""}
+        </span>
+      </Button>
+    </div>
+  );
+}
+
+function capabilityLabels(model: OpenSecretModel): string[] {
+  const labels: string[] = [];
+  if (model.capabilities?.reasoning) labels.push("Reasoning");
+  if (model.capabilities?.tool_use) labels.push("Tools");
+  if (model.capabilities?.vision) labels.push("Vision");
+  if (model.capabilities?.tool_use === false) labels.push("No tools");
+  return labels;
+}
+
+export function ProxyModelList({ models, isLoading, isError }: ProxyModelListProps) {
+  return (
+    <div className="space-y-4" aria-busy={isLoading}>
+      <div>
+        <p className="text-sm font-medium">
+          {models.length > 0 ? `${models.length} chat model IDs` : "Chat model IDs"}
+        </p>
+        <p className="mt-1 max-w-2xl text-xs leading-relaxed text-muted-foreground">
+          Fetched from Maple&apos;s current client catalog. This confirms configured support, not
+          real-time provider uptime or every API-only model.
+        </p>
+      </div>
+
+      {isLoading && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="flex items-center gap-2 rounded-lg border border-dashed p-5 text-sm text-muted-foreground"
+        >
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Loading the current Maple model catalog...
+        </div>
+      )}
+
+      {isError && (
+        <Alert variant="destructive">
+          <AlertCircle className="h-4 w-4" />
+          <AlertDescription>
+            Maple could not load the current model catalog. Restart Maple once you are back online.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {!isLoading && !isError && models.length === 0 && (
+        <div className="rounded-lg border border-dashed p-5 text-sm text-muted-foreground">
+          No chat models are currently listed. Restart Maple if this persists.
+        </div>
+      )}
+
+      {models.length > 0 && (
+        <ul className="divide-y overflow-hidden rounded-lg border border-border/70">
+          {models.map((model) => {
+            const context = formatModelContext(model);
+
+            return (
+              <li key={model.id} className="bg-background/40 p-3 sm:p-4">
+                <div className="min-w-0">
+                  <div className="flex flex-wrap items-center gap-2">
+                    <p className="text-sm font-medium">{getModelDisplayName(model)}</p>
+                    {(model.badges ?? []).map((badge) => (
+                      <Badge key={badge} variant="secondary">
+                        {badge}
+                      </Badge>
+                    ))}
+                  </div>
+                  <ModelId modelId={model.id} />
+                  <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-muted-foreground">
+                    {context && <span>{context}</span>}
+                    {capabilityLabels(model).map((capability) => (
+                      <span key={capability}>{capability}</span>
+                    ))}
+                  </div>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/settings/api/ApiSettingsLayout.tsx
+++ b/frontend/src/components/settings/api/ApiSettingsLayout.tsx
@@ -14,7 +14,6 @@ import { getBillingService } from "@/billing/billingService";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import { useLocalState } from "@/state/useLocalState";
-import { openExternalUrl } from "@/utils/openUrl";
 import { isIOS, isTauriDesktop } from "@/utils/platform";
 import { cn } from "@/utils/utils";
 import { SettingsPage, SettingsSection } from "../SettingsPage";
@@ -196,17 +195,6 @@ export function ApiSettingsLayout() {
     <SettingsPage
       title="API & credits"
       description="Manage API keys and configure access to Maple services."
-      actions={
-        <button
-          type="button"
-          onClick={() =>
-            void openExternalUrl("https://blog.trymaple.ai/maple-proxy-documentation/")
-          }
-          className="text-sm font-medium text-[hsl(var(--maple-primary-strong))] underline underline-offset-4 hover:text-[hsl(var(--maple-primary))]"
-        >
-          API documentation
-        </button>
-      }
     >
       <nav aria-label="API settings" className={cn("grid gap-2", navColumnClass)}>
         <ApiNavLink to="/settings/api" label="Credits" icon={CreditCard} exact />

--- a/frontend/src/components/settings/api/LocalProxySettings.tsx
+++ b/frontend/src/components/settings/api/LocalProxySettings.tsx
@@ -4,10 +4,12 @@ import { ProxyConfigSection } from "@/components/apikeys/ProxyConfigSection";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { SettingsSection } from "../SettingsPage";
 import { useApiKeys } from "./useApiKeys";
+import { useProxyModels } from "./useProxyModels";
 
 export function LocalProxySettings() {
   const { createApiKey } = useOpenSecret();
   const { data: apiKeys, isLoading, error, refetch } = useApiKeys();
+  const { data: models, isLoading: modelsLoading, isError: modelsError } = useProxyModels();
 
   const handleRequestNewApiKey = async (name: string) => {
     try {
@@ -20,24 +22,41 @@ export function LocalProxySettings() {
     }
   };
 
-  return (
-    <SettingsSection
-      title="Local OpenAI proxy"
-      description="Run an OpenAI-compatible endpoint from the Maple desktop app."
-    >
-      {isLoading ? (
+  if (isLoading) {
+    return (
+      <SettingsSection
+        title="Local OpenAI proxy"
+        description="Run an OpenAI-compatible endpoint from the Maple desktop app."
+      >
         <div className="flex items-center gap-2 py-6 text-sm text-muted-foreground">
           <Loader2 className="h-4 w-4 animate-spin" />
           Loading proxy settings...
         </div>
-      ) : error ? (
+      </SettingsSection>
+    );
+  }
+
+  if (error) {
+    return (
+      <SettingsSection
+        title="Local OpenAI proxy"
+        description="Run an OpenAI-compatible endpoint from the Maple desktop app."
+      >
         <Alert variant="destructive">
           <AlertCircle className="h-4 w-4" />
           <AlertDescription>Failed to load API keys. Please try again.</AlertDescription>
         </Alert>
-      ) : (
-        <ProxyConfigSection apiKeys={apiKeys ?? []} onRequestNewApiKey={handleRequestNewApiKey} />
-      )}
-    </SettingsSection>
+      </SettingsSection>
+    );
+  }
+
+  return (
+    <ProxyConfigSection
+      apiKeys={apiKeys ?? []}
+      onRequestNewApiKey={handleRequestNewApiKey}
+      models={models ?? []}
+      isModelsLoading={modelsLoading}
+      isModelsError={modelsError}
+    />
   );
 }

--- a/frontend/src/components/settings/api/useProxyModels.ts
+++ b/frontend/src/components/settings/api/useProxyModels.ts
@@ -1,0 +1,20 @@
+import { useQuery } from "@tanstack/react-query";
+import { useOpenSecret } from "@opensecret/react";
+import { fetchProxyChatModels } from "@/services/proxyModels";
+import type { OpenSecretModel, OpenSecretModelCatalog } from "@/state/LocalStateContextDef";
+
+export function useProxyModels() {
+  const { auth, fetchModelCatalog, fetchModels } = useOpenSecret();
+
+  return useQuery<OpenSecretModel[]>({
+    queryKey: ["proxy-chat-model-catalog"],
+    queryFn: () =>
+      fetchProxyChatModels({
+        fetchModelCatalog: async () =>
+          (await fetchModelCatalog()) as unknown as OpenSecretModelCatalog,
+        fetchModels: async () => (await fetchModels()) as OpenSecretModel[]
+      }),
+    enabled: !!auth.user && !auth.loading,
+    staleTime: 5 * 60 * 1000
+  });
+}

--- a/frontend/src/services/proxyModels.test.ts
+++ b/frontend/src/services/proxyModels.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, test } from "bun:test";
+import type { OpenSecretModel } from "@/state/LocalStateContextDef";
+import {
+  buildOpenCodeProviderFields,
+  buildCurlProxyExample,
+  buildPythonProxyExample,
+  fetchProxyChatModels,
+  formatModelContext,
+  getProxyBaseUrl,
+  isCodingAgentModel,
+  normalizeProxyChatModels
+} from "./proxyModels";
+
+function model(id: string, overrides: Partial<OpenSecretModel> = {}): OpenSecretModel {
+  return { id, object: "model", created: 0, owned_by: "opensecret", ...overrides };
+}
+
+describe("normalizeProxyChatModels", () => {
+  test("keeps current generation models and filters unsupported utility entries", () => {
+    const models = normalizeProxyChatModels([
+      model("glm-current", { tasks: ["generate"], capabilities: { chat: true } }),
+      model("embedding", { tasks: ["embed"] }),
+      model("speech", { tasks: ["speech"] }),
+      model("disabled", { tasks: ["generate"], enabled: false }),
+      model("deprecated", { tasks: ["generate"], deprecated: true })
+    ]);
+
+    expect(models.map((candidate) => candidate.id)).toEqual(["glm-current"]);
+  });
+
+  test("deduplicates IDs and respects catalog ordering metadata", () => {
+    const models = normalizeProxyChatModels([
+      model("later", { tasks: ["generate"], sort_order: 20 }),
+      model("first", { tasks: ["generate"], sort_order: 10 }),
+      model("first", { tasks: ["generate"], sort_order: 1 })
+    ]);
+
+    expect(models.map((candidate) => candidate.id)).toEqual(["first", "later"]);
+  });
+});
+
+describe("fetchProxyChatModels", () => {
+  test("uses the richer catalog when it is available", async () => {
+    const models = await fetchProxyChatModels({
+      fetchModelCatalog: async () => ({
+        object: "list",
+        aliases: [],
+        data: [model("catalog-model", { tasks: ["generate"] })]
+      }),
+      fetchModels: async () => [model("fallback-model", { tasks: ["generate"] })]
+    });
+
+    expect(models.map((candidate) => candidate.id)).toEqual(["catalog-model"]);
+  });
+
+  test("falls back to the basic model list when catalog loading fails", async () => {
+    const models = await fetchProxyChatModels({
+      fetchModelCatalog: async () => {
+        throw new Error("catalog unavailable");
+      },
+      fetchModels: async () => [model("fallback-model", { tasks: ["generate"] })]
+    });
+
+    expect(models.map((candidate) => candidate.id)).toEqual(["fallback-model"]);
+  });
+});
+
+describe("proxy guide values", () => {
+  test("builds a reachable base URL for loopback and wildcard binds", () => {
+    expect(getProxyBaseUrl("127.0.0.1", 8080)).toBe("http://127.0.0.1:8080/v1");
+    expect(getProxyBaseUrl("0.0.0.0", 9000)).toBe("http://127.0.0.1:9000/v1");
+  });
+
+  test("uses a real-key environment variable and the selected current model", () => {
+    const curl = buildCurlProxyExample("http://127.0.0.1:8080/v1", "current-model");
+    const python = buildPythonProxyExample("http://127.0.0.1:8080/v1", "current-model");
+
+    expect(curl).toContain("Bearer $MAPLE_API_KEY");
+    expect(curl).toContain('"model":"current-model"');
+    expect(python).toContain('os.environ["MAPLE_API_KEY"]');
+    expect(python).toContain('model="current-model"');
+    const retiredPlaceholderExample = ["api_key", '"anything"'].join("=");
+    expect(`${curl}\n${python}`).not.toContain(retiredPlaceholderExample);
+  });
+
+  test("builds the verified OpenCode provider fields without placeholder credentials", () => {
+    const fields = buildOpenCodeProviderFields(
+      "http://127.0.0.1:8080/v1",
+      model("current-model", { display_name: "Current Model" })
+    );
+
+    expect(fields).toEqual({
+      providerId: "maple-local",
+      displayName: "Maple (local proxy)",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      apiKey: "Paste the real Maple key you created",
+      modelId: "current-model",
+      modelName: "Current Model",
+      headers: "Leave blank"
+    });
+    expect(Object.values(fields).join("\n")).not.toContain("anything");
+  });
+
+  test("only recommends models that explicitly support coding tools", () => {
+    expect(
+      isCodingAgentModel(
+        model("tools", { tasks: ["generate"], capabilities: { chat: true, tool_use: true } })
+      )
+    ).toBe(true);
+    expect(isCodingAgentModel(model("unknown", { tasks: ["generate"] }))).toBe(false);
+    expect(
+      isCodingAgentModel(
+        model("no-tools", { tasks: ["generate"], capabilities: { chat: true, tool_use: false } })
+      )
+    ).toBe(false);
+  });
+
+  test("formats context windows without inventing metadata", () => {
+    expect(formatModelContext(model("large", { context_window: 384_000 }))).toBe("384K context");
+    expect(formatModelContext(model("unknown"))).toBeNull();
+  });
+});

--- a/frontend/src/services/proxyModels.ts
+++ b/frontend/src/services/proxyModels.ts
@@ -1,0 +1,114 @@
+import type { OpenSecretModel, OpenSecretModelCatalog } from "@/state/LocalStateContextDef";
+
+export type ProxyModelClient = {
+  fetchModelCatalog: () => Promise<OpenSecretModelCatalog>;
+  fetchModels: () => Promise<OpenSecretModel[]>;
+};
+
+export function isProxyChatModel(model: OpenSecretModel): boolean {
+  if (!model.id.trim() || model.enabled === false || model.deprecated === true) return false;
+  if (model.capabilities?.chat === false) return false;
+
+  const tasks = model.tasks ?? [];
+  if (tasks.length > 0) return tasks.includes("generate");
+
+  const normalizedId = model.id.toLowerCase();
+  return !["whisper", "transcri", "embed", "speech", "tts"].some((part) =>
+    normalizedId.includes(part)
+  );
+}
+
+export function normalizeProxyChatModels(models: OpenSecretModel[]): OpenSecretModel[] {
+  const deduplicated = new Map<string, { model: OpenSecretModel; originalIndex: number }>();
+
+  models.forEach((model, originalIndex) => {
+    if (!isProxyChatModel(model) || deduplicated.has(model.id)) return;
+    deduplicated.set(model.id, { model, originalIndex });
+  });
+
+  return [...deduplicated.values()]
+    .sort((left, right) => {
+      const leftOrder = left.model.sort_order ?? Number.MAX_SAFE_INTEGER;
+      const rightOrder = right.model.sort_order ?? Number.MAX_SAFE_INTEGER;
+      return leftOrder - rightOrder || left.originalIndex - right.originalIndex;
+    })
+    .map(({ model }) => model);
+}
+
+export function isCodingAgentModel(model: OpenSecretModel): boolean {
+  return isProxyChatModel(model) && model.capabilities?.tool_use === true;
+}
+
+export async function fetchProxyChatModels(client: ProxyModelClient): Promise<OpenSecretModel[]> {
+  try {
+    const catalog = await client.fetchModelCatalog();
+    return normalizeProxyChatModels(catalog.data);
+  } catch (catalogError) {
+    try {
+      return normalizeProxyChatModels(await client.fetchModels());
+    } catch {
+      throw catalogError;
+    }
+  }
+}
+
+export function getProxyBaseUrl(host: string, port: number): string {
+  const trimmedHost = host.trim() || "127.0.0.1";
+  const clientHost = trimmedHost === "0.0.0.0" || trimmedHost === "::" ? "127.0.0.1" : trimmedHost;
+  const formattedHost = clientHost.includes(":") ? `[${clientHost}]` : clientHost;
+  return `http://${formattedHost}:${port}/v1`;
+}
+
+export function getModelDisplayName(model: OpenSecretModel): string {
+  return model.display_name || model.short_name || model.id;
+}
+
+export function buildOpenCodeProviderFields(baseUrl: string, model?: OpenSecretModel) {
+  return {
+    providerId: "maple-local",
+    displayName: "Maple (local proxy)",
+    baseUrl,
+    apiKey: "Paste the real Maple key you created",
+    modelId: model?.id ?? "SELECT_A_MODEL",
+    modelName: model ? getModelDisplayName(model) : "Select a model",
+    headers: "Leave blank"
+  };
+}
+
+export function formatModelContext(model: OpenSecretModel): string | null {
+  const context = model.context_window ?? model.max_context_tokens;
+  if (!context) return null;
+  if (context >= 1_000_000) return `${Math.round(context / 100_000) / 10}M context`;
+  if (context >= 1_000) return `${Math.round(context / 1_000)}K context`;
+  return `${context.toLocaleString()} context`;
+}
+
+export function buildCurlProxyExample(baseUrl: string, modelId: string): string {
+  return `curl --fail-with-body -N ${baseUrl}/chat/completions \\
+  -H "Authorization: Bearer $MAPLE_API_KEY" \\
+  -H "Content-Type: application/json" \\
+  -d '${JSON.stringify({
+    model: modelId,
+    messages: [{ role: "user", content: "Hello!" }],
+    stream: true
+  })}'`;
+}
+
+export function buildPythonProxyExample(baseUrl: string, modelId: string): string {
+  return `import os
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="${baseUrl}",
+    api_key=os.environ["MAPLE_API_KEY"],
+)
+
+stream = client.chat.completions.create(
+    model="${modelId}",
+    messages=[{"role": "user", "content": "Hello!"}],
+    stream=True,
+)
+
+for chunk in stream:
+    print(chunk.choices[0].delta.content or "", end="")`;
+}


### PR DESCRIPTION
## Summary

- add built-in OpenCode, cURL, and Python setup guides using real Maple API keys
- load and display current chat model IDs from the Maple catalog, with fallback and capability metadata
- reorganize Local Proxy status, controls, security warnings, and troubleshooting, and remove the stale external documentation link
- preserve the existing Local Proxy runtime, configuration defaults, credential lifecycle, and load/start/stop behavior

## Validation

- repository pre-commit frontend build passed
- full frontend suite passed (140 tests)
- repository pre-commit Rust suite passed (123 tests)
- TypeScript, ESLint, Prettier, and diff checks passed
- workspace-scoped macOS debug app rebuilt and visually inspected
- verified the workspace proxy on port 37915 while preserving the independent port 8080 instance

## Separate follow-ups

Potential proxy behavior changes are deliberately excluded from this documentation and UI PR:

- #654 — harden the credential-backed Local Proxy against arbitrary browser origins
- #655 — fence manual proxy startup against logout and account transitions
- #656 — recover manual Local Proxy setup after logout without orphaning API keys

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned local proxy setup on Tauri desktop with start/stop controls, base URL copy, safety alerts, advanced settings, and connect-your-tools guidance.
  * Added proxy connection guides with tabbed OpenCode/cURL/Python examples and clipboard-friendly copy buttons.
  * Introduced a model catalog list with badges, capability chips, context info, and per-row model ID copy.
  * Automatically loads proxy models and creates an API key when starting without one (when needed).

* **Bug Fixes**
  * Improved proxy model normalization, filtering, deduplication, and example generation (including correct API key handling and model selection).
  * Added robust fallback behavior when model catalog data isn’t available.

* **Documentation**
  * Added troubleshooting guidance for common proxy HTTP error meanings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->