### PR TITLE
Update Agent Mode empty state heading to "Work on anything..."

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -2489,7 +2489,7 @@ function EmptyAgentState(props: AgentComposerProps) {
       <div className="flex w-full flex-col items-center gap-6 text-center landscape-short:gap-3">
         {!isExpanded ? (
           <h1 className="mb-6 overflow-visible pb-1 font-displayWide text-4xl font-normal leading-relaxed brand-gradient-text landscape-short:mb-2 landscape-short:text-2xl">
-            Work in a folder...
+            Work on anything...
           </h1>
         ) : null}
         <AgentComposer {...props} />


### PR DESCRIPTION
## Summary

Updates the Agent Mode empty-state heading from **"Work in a folder..."** to **"Work on anything..."**, aligning it with the **"Research anything..."** heading already used for normal chat in `UnifiedChat`.

## Why

The previous wording ("Work in a folder...") emphasized the folder/project-root aspect of Agent Mode, which undersells what the mode is for. "Work on anything..." mirrors the parallel "Research anything..." phrasing used in unified chat, giving the two modes a consistent voice while still leaving the folder/project controls directly below to convey the project-scoped nature of Agent Mode.

## Change

- `frontend/src/components/AgentMode.tsx`: updated the `<h1>` text in `EmptyAgentState` from `Work in a folder...` to `Work on anything...`.

## Verification

- Pre-commit hooks ran successfully (Prettier, `tsc -b && vite build`, and the full `bun test` suite: 205 pass / 0 fail).
- Confirmed there are no other source occurrences of the old string and no tests referencing it.