### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.1.5",
+  "version": "3.2.0",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4012,7 +4012,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.1.5"
+version = "3.2.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.1.5"
+version = "3.2.0"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.1.5</string>
+	<string>3.2.0</string>
 	<key>CFBundleVersion</key>
-	<string>3.1.5</string>
+	<string>3.2.0</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -52,8 +52,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.1.5
-        CFBundleVersion: 3.1.5
+        CFBundleShortVersionString: 3.2.0
+        CFBundleVersion: 3.2.0
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.1.5",
+  "version": "3.2.0",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -97,7 +97,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028009
+      "versionCode": 2000028010
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
Bumps version from 3.1.5 → 3.2.0 across all version files:

- `frontend/package.json`
- `frontend/src-tauri/tauri.conf.json` (including Android versionCode bump)
- `frontend/src-tauri/Cargo.toml` + `Cargo.lock`
- `frontend/src-tauri/gen/apple/project.yml`
- `frontend/src-tauri/gen/apple/maple_iOS/Info.plist`

Prepares for the v3.2.0 release.