### PR TITLE
Show Agent waiting indicator after tool results

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -46,6 +46,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Markdown, ThinkingBlock } from "@/components/markdown";
 import {
   CHAT_COMPOSER_TEXTAREA_CLASS,
+  ChatAssistantPendingIndicator,
   ChatAssistantPendingTurn,
   ChatAssistantTurn,
   ChatComposerSurface,
@@ -3882,6 +3883,9 @@ function AgentTimeline({
   const turns = groupAgentTimelineItems(visibleItems);
   const activeThinkingItemId = activeAgentThinkingItemId(visibleItems, isRunActive);
   const showAssistantLoader = shouldShowAgentAssistantLoader(turns, isResponsePending);
+  const trailingTurn = turns[turns.length - 1];
+  const pendingIndicatorTurnId =
+    showAssistantLoader && trailingTurn?.type === "assistant" ? trailingTurn.id : null;
 
   return (
     <div className="space-y-1">
@@ -3928,10 +3932,11 @@ function AgentTimeline({
                 onPermissionDecision={onPermissionDecision}
               />
             ))}
+            {pendingIndicatorTurnId === turn.id ? <ChatAssistantPendingIndicator /> : null}
           </ChatAssistantTurn>
         );
       })}
-      {showAssistantLoader ? <ChatAssistantPendingTurn /> : null}
+      {showAssistantLoader && pendingIndicatorTurnId === null ? <ChatAssistantPendingTurn /> : null}
     </div>
   );
 }

--- a/frontend/src/components/chat/ChatTurn.tsx
+++ b/frontend/src/components/chat/ChatTurn.tsx
@@ -71,14 +71,20 @@ export function ChatAssistantTurn({ children, actions, containerRef, className }
   );
 }
 
+export function ChatAssistantPendingIndicator() {
+  return (
+    <div className="flex items-center gap-1" role="status" aria-label="Maple is responding">
+      <div className="h-2 w-2 animate-pulse rounded-full bg-foreground/60" />
+      <div className="h-2 w-2 animate-pulse rounded-full bg-foreground/60 delay-75" />
+      <div className="h-2 w-2 animate-pulse rounded-full bg-foreground/60 delay-150" />
+    </div>
+  );
+}
+
 export function ChatAssistantPendingTurn() {
   return (
     <ChatAssistantTurn>
-      <div className="flex items-center gap-1" role="status" aria-label="Maple is responding">
-        <div className="h-2 w-2 animate-pulse rounded-full bg-foreground/60" />
-        <div className="h-2 w-2 animate-pulse rounded-full bg-foreground/60 delay-75" />
-        <div className="h-2 w-2 animate-pulse rounded-full bg-foreground/60 delay-150" />
-      </div>
+      <ChatAssistantPendingIndicator />
     </ChatAssistantTurn>
   );
 }

--- a/frontend/src/services/agentTimeline.test.ts
+++ b/frontend/src/services/agentTimeline.test.ts
@@ -516,6 +516,19 @@ describe("shouldShowAgentAssistantLoader", () => {
     items: [thinking("thought", "Working")]
   };
 
+  function toolTurn(status: string, permissionStatus?: string) {
+    return {
+      type: "assistant" as const,
+      id: "assistant-after-user",
+      items: [
+        { ...item("tool", "tool", "assistant"), status },
+        ...(permissionStatus
+          ? [{ ...item("permission", "permission", "system"), status: permissionStatus }]
+          : [])
+      ]
+    };
+  }
+
   test("shows while a sent user turn is waiting for its first assistant activity", () => {
     expect(shouldShowAgentAssistantLoader([userTurn], true)).toBe(true);
   });
@@ -523,6 +536,36 @@ describe("shouldShowAgentAssistantLoader", () => {
   test("hides when the response is no longer pending or assistant activity has arrived", () => {
     expect(shouldShowAgentAssistantLoader([userTurn], false)).toBe(false);
     expect(shouldShowAgentAssistantLoader([userTurn, assistantTurn], true)).toBe(false);
+  });
+
+  test("shows after a tool result while the agent waits for its next response", () => {
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("completed")], true)).toBe(true);
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("failed")], true)).toBe(true);
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("error")], true)).toBe(true);
+  });
+
+  test("shows after a permissioned tool result whose decision row remains last", () => {
+    expect(
+      shouldShowAgentAssistantLoader([userTurn, toolTurn("completed", "allow_once")], true)
+    ).toBe(true);
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("failed", "allow_once")], true)).toBe(
+      true
+    );
+  });
+
+  test("keeps the tool status as the only activity while the tool is still running", () => {
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("running")], true)).toBe(false);
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("pending")], true)).toBe(false);
+    expect(
+      shouldShowAgentAssistantLoader([userTurn, toolTurn("running", "allow_once")], true)
+    ).toBe(false);
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("running", "pending")], true)).toBe(
+      false
+    );
+  });
+
+  test("hides after a settled tool result once the run finishes", () => {
+    expect(shouldShowAgentAssistantLoader([userTurn, toolTurn("completed")], false)).toBe(false);
   });
 
   test("does not invent an assistant turn without a user message", () => {

--- a/frontend/src/services/agentTimeline.ts
+++ b/frontend/src/services/agentTimeline.ts
@@ -363,5 +363,23 @@ export function shouldShowAgentAssistantLoader(
   turns: AgentTimelineTurn[],
   isResponsePending: boolean
 ): boolean {
-  return isResponsePending && turns[turns.length - 1]?.type === "user";
+  if (!isResponsePending) return false;
+
+  const trailingTurn = turns[turns.length - 1];
+  if (trailingTurn?.type === "user") return true;
+  if (trailingTurn?.type !== "assistant" || turns[turns.length - 2]?.type !== "user") return false;
+
+  let trailingItemIndex = trailingTurn.items.length - 1;
+  while (trailingItemIndex >= 0) {
+    const item = trailingTurn.items[trailingItemIndex];
+    if (item.itemType !== "permission" || !item.status || item.status === "pending") break;
+    // Permission decisions update their original row in place, so a resolved
+    // card can remain after the tool row whose result arrived later.
+    trailingItemIndex -= 1;
+  }
+  const trailingItem = trailingTurn.items[trailingItemIndex];
+  return (
+    trailingItem?.itemType === "tool" &&
+    ["completed", "failed", "error"].includes(trailingItem.status ?? "")
+  );
 }


### PR DESCRIPTION
## Summary

- reuse the existing Maple three-dot response indicator while an Agent run waits for the model after a completed or failed tool result
- keep the indicator inline with the current assistant turn so tool loops do not duplicate the Maple avatar or header
- handle permissioned tools whose resolved permission row remains after the tool row
- preserve the existing spinner for running tools and the existing reasoning indicator once reasoning text arrives

## Validation

- 209 frontend tests passed
- TypeScript check passed
- production Vite build passed
- Prettier check passed
- ESLint passed with 0 errors and 12 pre-existing warnings
- three independent review passes covered run-state correctness, React/UX/accessibility, and regression/test coverage
