### PR TITLE
CI: retain macOS artifacts after build failures

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -83,6 +83,7 @@ jobs:
           subject-checksums: desktop-macos-artifacts.sha256
 
       - name: Upload macOS Build
+        if: always()
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # was v4
         with:
           name: maple-macos-universal
@@ -92,6 +93,7 @@ jobs:
             frontend/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz
             frontend/src-tauri/target/universal-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
             frontend/src-tauri/target/reproducibility/*.sha256
+          if-no-files-found: warn
           retention-days: 5
 
   build-linux:


### PR DESCRIPTION
## Summary

- run the existing macOS artifact upload step even when the build/reproducibility step fails
- warn instead of masking the original failure when an early failure leaves no files to upload
- preserve the signed app updater archive and any other completed macOS outputs for byte-level diagnosis

The original build result still controls the job conclusion; this does not weaken or bypass the reproducibility gate.

## Validation

- `nix build .#checks.aarch64-darwin.workflows --no-link`
- `git diff --check`
- Maple pre-commit hook (Prettier, frontend build, 209 frontend tests)
