### PR TITLE
TEST PR: DO NOT MERGE

### DIFF
--- a/frontend/src/components/AppEntryPage.tsx
+++ b/frontend/src/components/AppEntryPage.tsx
@@ -11,7 +11,7 @@ export function AppEntryPage() {
       <main className="flex flex-1 items-center justify-center px-4 pb-16 pt-8 sm:px-6">
         <section className="w-full max-w-md rounded-lg border border-neutral-900/10 bg-white/75 p-5 text-center shadow-sm backdrop-blur dark:border-white/10 dark:bg-neutral-900/70 sm:p-6">
           <img src="/maple-research-icon.svg" alt="" className="mx-auto mb-4 h-14 w-14" />
-          <h1 className="text-2xl font-semibold leading-tight text-[#221a18] dark:text-foreground">
+          <h1 className="text-2xl font-semibold leading-tight text-green-600 dark:text-green-400">
             Maple Research
           </h1>
           <p className="mt-2 text-sm leading-6 text-[#747474] dark:text-muted-foreground">


### PR DESCRIPTION
## What changed

- Changed only the text color of the prominent “Maple Research” heading on Maple’s initial unauthenticated screen.
- Kept the heading text and behavior unchanged.

## Why

This is a disposable end-to-end test of a small, user-facing UI change.

## Impact

The initial-screen heading now uses green text in both light and dark themes. No behavior or content changes are included.

## Validation

- Prettier formatting check passed.
- Production frontend build passed.
- Frontend test suite passed: 205 tests.
- Computer Use visual verification was attempted, but the Mac was locked at verification time.
