### PR TITLE
chore: use pinned Nix tools for local workflows

### DIFF
--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -20,7 +20,7 @@ Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing 
    ```
 
 2. If `current_version` is newer than `released_version`, keep the existing version. Never bump it again merely because a release was requested.
-3. If they are equal, prepare the intended next version through the repository helpers. Proceed directly only when the user's current request explicitly names the version or patch/minor/major level. Otherwise stop and ask the user which version to stage; never infer SemVer intent from the commit list. After the user answers, run exactly one of:
+3. If they are equal, prepare the intended next version through the repository helpers. Proceed directly only when the user's current request explicitly names the version or patch/minor/major level. Otherwise ask which version to stage and recommend a patch bump. If the user explicitly delegates the choice, use patch; never infer a minor or major bump from the commit list. After the choice is established, run exactly one of:
 
    ```bash
    nix develop .#ci -c just update-version X.Y.Z

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -1,11 +1,36 @@
 ---
 name: release-maple
-description: Publish and verify a Maple GitHub release from master. Use when asked to cut, create, publish, monitor, or finish a Maple release, including checking whether the version was bumped after the previous release, generating GitHub release notes, creating the release tag, monitoring release CI, retrying genuinely transient failures, verifying artifacts, and confirming Zapstore publication.
+description: Prepare, publish, and verify a Maple GitHub release from master. Use when asked to cut, create, publish, monitor, or finish a Maple release, including preparing a missing version bump through the pinned Nix and just workflow, generating GitHub release notes, creating the release tag, monitoring release CI, retrying genuinely transient failures, verifying artifacts, and confirming Zapstore publication.
 ---
 
 # Release Maple
 
 Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing a release as a production action: report the intended tag and commit before creating it, then stay with all workflows until they succeed or a real defect is identified.
+
+## Prepare Version
+
+1. Start from a clean, current `master`. Compare `just get-version` with the latest published release:
+
+   ```bash
+   git switch master
+   git pull --ff-only origin master
+   current_version="$(nix develop .#ci -c just get-version | tail -n 1)"
+   released_version="$(gh api repos/OpenSecretCloud/Maple/releases/latest --jq '.tag_name | ltrimstr("v")')"
+   printf 'current=%s released=%s\n' "$current_version" "$released_version"
+   ```
+
+2. If `current_version` is newer than `released_version`, keep the existing version. Never bump it again merely because a release was requested.
+3. If they are equal, prepare the intended next version through the repository helpers. Use an explicitly requested version or release level; otherwise ask which version to stage. Run exactly one of:
+
+   ```bash
+   nix develop .#ci -c just update-version X.Y.Z
+   nix develop .#ci -c just bump-patch
+   nix develop .#ci -c just bump-minor
+   nix develop .#ci -c just bump-major
+   ```
+
+4. Review the generated manifest and lockfile diff, then commit it on a focused branch, push it, and open a PR. Do not use `just release`; it creates a local tag before the reviewed GitHub release flow.
+5. Wait for required PR checks, merge the bump, switch back to `master`, pull with `--ff-only`, and wait for every required master workflow to succeed. Then continue with preflight. Never release from the bump branch or before the merged commit's CI is green.
 
 ## Preflight
 

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -20,7 +20,7 @@ Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing 
    ```
 
 2. If `current_version` is newer than `released_version`, keep the existing version. Never bump it again merely because a release was requested.
-3. If they are equal, prepare the intended next version through the repository helpers. Use an explicitly requested version or release level; otherwise ask which version to stage. Run exactly one of:
+3. If they are equal, prepare the intended next version through the repository helpers. Proceed directly only when the user's current request explicitly names the version or patch/minor/major level. Otherwise stop and ask the user which version to stage; never infer SemVer intent from the commit list. After the user answers, run exactly one of:
 
    ```bash
    nix develop .#ci -c just update-version X.Y.Z

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -6,6 +6,33 @@ REPO_ROOT=$(git rev-parse --show-toplevel)
 STAGED_FILES=$(git diff --cached --name-only)
 NEEDS_TOOLCHAIN=0
 
+find_nix() {
+    if command -v nix >/dev/null 2>&1; then
+        command -v nix
+        return
+    fi
+
+    for candidate in /nix/var/nix/profiles/default/bin/nix "$HOME/.nix-profile/bin/nix"; do
+        if [ -x "$candidate" ]; then
+            printf '%s\n' "$candidate"
+            return
+        fi
+    done
+}
+
+# Prefer the pinned toolchain whenever Nix is available. GUI applications on
+# macOS may not inherit the shell PATH, so also check the standard Nix paths.
+if [ "${MAPLE_HOOK_NIX_BOOTSTRAPPED:-0}" != "1" ] \
+    && [ -z "${IN_NIX_SHELL:-}" ] \
+    && [ -f "$REPO_ROOT/flake.nix" ]; then
+    NIX_BIN=$(find_nix)
+    if [ -n "$NIX_BIN" ]; then
+        echo "Entering the Maple Nix CI shell for pinned hook tools..."
+        exec "$NIX_BIN" develop "$REPO_ROOT#ci" -c env MAPLE_HOOK_NIX_BOOTSTRAPPED=1 \
+            "$REPO_ROOT/.githooks/pre-commit"
+    fi
+fi
+
 if ! command -v bun >/dev/null 2>&1; then
     NEEDS_TOOLCHAIN=1
 fi
@@ -21,9 +48,10 @@ if [ "$NEEDS_TOOLCHAIN" -eq 1 ]; then
         exit 1
     fi
 
-    if command -v nix >/dev/null 2>&1 && [ -f "$REPO_ROOT/flake.nix" ]; then
+    NIX_BIN=$(find_nix)
+    if [ -n "$NIX_BIN" ] && [ -f "$REPO_ROOT/flake.nix" ]; then
         echo "Required tools are not on PATH; entering the Maple Nix development shell..."
-        exec nix develop "$REPO_ROOT" -c env MAPLE_HOOK_NIX_BOOTSTRAPPED=1 \
+        exec "$NIX_BIN" develop "$REPO_ROOT#ci" -c env MAPLE_HOOK_NIX_BOOTSTRAPPED=1 \
             "$REPO_ROOT/.githooks/pre-commit"
     fi
 

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -23,7 +23,6 @@ find_nix() {
 # Prefer the pinned toolchain whenever Nix is available. GUI applications on
 # macOS may not inherit the shell PATH, so also check the standard Nix paths.
 if [ "${MAPLE_HOOK_NIX_BOOTSTRAPPED:-0}" != "1" ] \
-    && [ -z "${IN_NIX_SHELL:-}" ] \
     && [ -f "$REPO_ROOT/flake.nix" ]; then
     NIX_BIN=$(find_nix)
     if [ -n "$NIX_BIN" ]; then

--- a/README.md
+++ b/README.md
@@ -54,8 +54,10 @@ rustup target add aarch64-apple-darwin x86_64-apple-darwin
 This configures Git to use the project's pre-commit hook. Managed
 `opensecret-workspaces` checkouts enable the same hook automatically. The hook
 checks formatting, builds the frontend, runs frontend tests, and runs Rust tests
-when Tauri files are staged. If Bun or Cargo is not already available and Nix
-is installed, the hook enters this repository's Nix development shell.
+when Tauri files are staged. When Nix is installed, the hook enters the pinned
+CI development shell automatically, including from macOS GUI environments that
+do not inherit the user's shell `PATH`. Without Nix, it uses compatible Bun and
+Cargo tools already available on `PATH`.
 
 ## Development
 


### PR DESCRIPTION
## Summary

- prefer the flake-pinned `.#ci` toolchain for Git hooks whenever Nix is available
- discover Determinate Nix from its standard path when macOS GUI apps omit Nix from `PATH`
- retain the existing host-tool fallback for developers without Nix
- teach the checked-in release skill to inspect and prepare missing version bumps through `nix develop .#ci` and the repository `just` helpers
- preserve already-staged versions and prohibit `just release`, which would create a tag before the reviewed GitHub release flow

## Motivation

A version bump from macOS found host Rust 1.92.0 and failed after Maple moved to pinned Rust 1.94.1, even though Determinate Nix was installed. The hook previously entered Nix only when Cargo was entirely absent. The release skill also treated version preparation as an external prerequisite instead of using Maple’s reproducible bump helpers.

## Validation

- `sh -n .githooks/pre-commit`
- `git diff --check`
- skill validation via `quick_validate.py`
- `env PATH=/usr/bin:/bin ./.githooks/pre-commit`
  - discovered `/nix/var/nix/profiles/default/bin/nix`
  - entered `.#ci` with Bun 1.3.5 and Rust 1.94.1
  - frontend build passed
  - 212 frontend tests passed