### PR TITLE
fix(ios): enable background audio playback

### DIFF
--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -64,5 +64,9 @@
 	<string>Maple needs access to your camera to take photos for your AI conversations.</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>Maple needs access to your microphone to record voice messages for your AI conversations.</string>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
 </dict>
 </plist>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -42,6 +42,7 @@ targets:
       properties:
         LSRequiresIPhoneOS: true
         UILaunchStoryboardName: LaunchScreen
+        UIBackgroundModes: [audio]
         UIRequiredDeviceCapabilities: [arm64, metal]
         UISupportedInterfaceOrientations:
           - UIInterfaceOrientationPortrait


### PR DESCRIPTION
## Summary

- declare the iOS `audio` background mode in both the XcodeGen source and checked-in plist
- keep the Supertonic 3 chunked player, ORT integration, and Nix configuration unchanged

## Why

The exact TestFlight 3.3.0 build 5 app bundle did not declare `UIBackgroundModes`. Maple already selects the iOS playback audio-session type, but the missing background mode means continued lock-screen audio execution is not supported by the packaged app.

This is the narrow first fix for the reported behavior where TTS stops after roughly 50 seconds with the screen locked and reopening Maple shows a reloaded interface. A physical-device TestFlight run is still required to confirm that this was the complete cause.

## Validation

- `plutil` validation of the source plist
- parsed `UIBackgroundModes` from `project.yml`
- reproducibly built pinned ONNX Runtime device and simulator artifacts
- `./scripts/ci/ios-pr.sh`
- verified the built `Maple.app/Info.plist` contains exactly `["audio"]`
- pre-commit frontend build and 212 tests passed
- focused independent review found no issues

## TestFlight verification

1. Play a TTS response long enough to exceed two minutes.
2. Lock the device shortly after playback starts.
3. Confirm playback continues past the previous approximately 50-second cutoff.
4. Reopen Maple and confirm it remains in the same chat.

If this still reproduces, collect a matching Maple `.ips` or `JetsamEvent` from the device before changing the player. The next contained fallback would be synthesizing or buffering the complete response before playback.