### PR TITLE
fix(ios): prebuffer TTS before background playback

### DIFF
--- a/frontend/src/services/tts/TTSContext.tsx
+++ b/frontend/src/services/tts/TTSContext.tsx
@@ -10,6 +10,7 @@ import {
 import { isTauriDesktop, isIOS, isTauri } from "@/utils/platform";
 import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
+import { prepareAndScheduleTTSChunks } from "./ttsPlayback";
 
 export type TTSStatus =
   | "not_available"
@@ -573,8 +574,14 @@ export function TTSProvider({ children }: { children: ReactNode }) {
           );
         }
 
+        const prebufferBeforePlayback = isIOS();
+
         try {
-          if (isIOS() && "mediaSession" in navigator && typeof MediaMetadata !== "undefined") {
+          if (
+            prebufferBeforePlayback &&
+            "mediaSession" in navigator &&
+            typeof MediaMetadata !== "undefined"
+          ) {
             if (!mediaSessionPrevStateRef.current) {
               mediaSessionPrevStateRef.current = {
                 metadata: navigator.mediaSession.metadata,
@@ -652,15 +659,7 @@ export function TTSProvider({ children }: { children: ReactNode }) {
         let lastPlaybackEnded: Promise<void> | null = null;
         let startedPlayback = false;
 
-        for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex += 1) {
-          const decoded = await synthesizeAndDecodeChunk(chunkIndex);
-          if (!isActiveRequest()) {
-            return;
-          }
-          if (!decoded) {
-            continue;
-          }
-
+        const scheduleDecodedChunk = (decoded: DecodedTTSChunk) => {
           const source = audioContext.createBufferSource();
           source.buffer = decoded.audioBuffer;
           source.connect(audioContext.destination);
@@ -688,6 +687,22 @@ export function TTSProvider({ children }: { children: ReactNode }) {
             setIsPreparing(false);
             setIsPlaying(true);
           }
+        };
+
+        const completedPreparation = await prepareAndScheduleTTSChunks({
+          chunkCount: chunks.length,
+          prebufferBeforePlayback,
+          prepareChunk: synthesizeAndDecodeChunk,
+          scheduleChunk: scheduleDecodedChunk,
+          isActive: isActiveRequest,
+          beforeBufferedSchedule: async () => {
+            if (audioContext.state === "suspended") {
+              await audioContext.resume();
+            }
+          }
+        });
+        if (!completedPreparation || !isActiveRequest()) {
+          return;
         }
 
         if (!lastPlaybackEnded) {

--- a/frontend/src/services/tts/ttsPlayback.test.ts
+++ b/frontend/src/services/tts/ttsPlayback.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from "bun:test";
+import { prepareAndScheduleTTSChunks } from "./ttsPlayback";
+
+describe("prepareAndScheduleTTSChunks", () => {
+  test("progressive playback schedules each chunk as soon as it is ready", async () => {
+    const events: string[] = [];
+
+    const completed = await prepareAndScheduleTTSChunks({
+      chunkCount: 2,
+      prebufferBeforePlayback: false,
+      prepareChunk: async (chunkIndex) => {
+        events.push(`prepare ${chunkIndex}`);
+        return chunkIndex;
+      },
+      scheduleChunk: (chunkIndex) => {
+        events.push(`schedule ${chunkIndex}`);
+      },
+      isActive: () => true
+    });
+
+    expect(completed).toBe(true);
+    expect(events).toEqual(["prepare 0", "schedule 0", "prepare 1", "schedule 1"]);
+  });
+
+  test("buffered playback prepares every chunk before scheduling any audio", async () => {
+    const events: string[] = [];
+
+    const completed = await prepareAndScheduleTTSChunks({
+      chunkCount: 3,
+      prebufferBeforePlayback: true,
+      prepareChunk: async (chunkIndex) => {
+        events.push(`prepare ${chunkIndex}`);
+        return chunkIndex === 1 ? null : chunkIndex;
+      },
+      beforeBufferedSchedule: async () => {
+        events.push("resume");
+      },
+      scheduleChunk: (chunkIndex) => {
+        events.push(`schedule ${chunkIndex}`);
+      },
+      isActive: () => true
+    });
+
+    expect(completed).toBe(true);
+    expect(events).toEqual([
+      "prepare 0",
+      "prepare 1",
+      "prepare 2",
+      "resume",
+      "schedule 0",
+      "schedule 2"
+    ]);
+  });
+
+  test("cancellation during buffered preparation schedules nothing", async () => {
+    const scheduledChunks: number[] = [];
+    let active = true;
+
+    const completed = await prepareAndScheduleTTSChunks({
+      chunkCount: 3,
+      prebufferBeforePlayback: true,
+      prepareChunk: async (chunkIndex) => {
+        if (chunkIndex === 1) {
+          active = false;
+        }
+        return chunkIndex;
+      },
+      scheduleChunk: (chunkIndex) => {
+        scheduledChunks.push(chunkIndex);
+      },
+      isActive: () => active
+    });
+
+    expect(completed).toBe(false);
+    expect(scheduledChunks).toEqual([]);
+  });
+
+  test("a later preparation error schedules nothing in buffered mode", async () => {
+    const scheduledChunks: number[] = [];
+
+    const playback = prepareAndScheduleTTSChunks({
+      chunkCount: 3,
+      prebufferBeforePlayback: true,
+      prepareChunk: async (chunkIndex) => {
+        if (chunkIndex === 1) {
+          throw new Error("inference failed");
+        }
+        return chunkIndex;
+      },
+      scheduleChunk: (chunkIndex) => {
+        scheduledChunks.push(chunkIndex);
+      },
+      isActive: () => true
+    });
+
+    await expect(playback).rejects.toThrow("inference failed");
+    expect(scheduledChunks).toEqual([]);
+  });
+});

--- a/frontend/src/services/tts/ttsPlayback.ts
+++ b/frontend/src/services/tts/ttsPlayback.ts
@@ -1,0 +1,58 @@
+interface TTSChunkPlaybackOptions<T> {
+  chunkCount: number;
+  prebufferBeforePlayback: boolean;
+  prepareChunk: (chunkIndex: number) => Promise<T | null>;
+  scheduleChunk: (chunk: T) => void;
+  isActive: () => boolean;
+  beforeBufferedSchedule?: () => Promise<void>;
+}
+
+/**
+ * Prepares chunks sequentially and either schedules each one immediately or
+ * waits until every chunk is ready. iOS uses the buffered mode so locking the
+ * device after playback starts cannot suspend later inference or audio decoding.
+ */
+export async function prepareAndScheduleTTSChunks<T>({
+  chunkCount,
+  prebufferBeforePlayback,
+  prepareChunk,
+  scheduleChunk,
+  isActive,
+  beforeBufferedSchedule
+}: TTSChunkPlaybackOptions<T>): Promise<boolean> {
+  const bufferedChunks: T[] = [];
+
+  for (let chunkIndex = 0; chunkIndex < chunkCount; chunkIndex += 1) {
+    const chunk = await prepareChunk(chunkIndex);
+    if (!isActive()) {
+      return false;
+    }
+    if (chunk === null) {
+      continue;
+    }
+
+    if (prebufferBeforePlayback) {
+      bufferedChunks.push(chunk);
+    } else {
+      scheduleChunk(chunk);
+    }
+  }
+
+  if (!prebufferBeforePlayback || bufferedChunks.length === 0) {
+    return true;
+  }
+
+  if (beforeBufferedSchedule) {
+    await beforeBufferedSchedule();
+    if (!isActive()) {
+      return false;
+    }
+  }
+
+  for (const chunk of bufferedChunks) {
+    scheduleChunk(chunk);
+  }
+  bufferedChunks.length = 0;
+
+  return true;
+}


### PR DESCRIPTION
## Summary

- on iOS, synthesize and decode every TTS chunk before starting playback
- schedule all decoded audio buffers up front so lock-screen playback no longer depends on later ONNX inference, Tauri IPC, JavaScript, or audio decoding
- preserve progressive chunk playback on desktop for faster startup
- add focused tests for progressive and prebuffered ordering, skipped chunks, cancellation, and preparation failures

## Why

TestFlight build 6 still stopped after roughly 30 to 50 seconds with the screen locked even after PR #680 added the iOS audio background mode. The Supertonic 3 player currently begins playing its first chunk while later chunks are still synthesized and decoded. iOS background audio permits already-scheduled playback, but does not guarantee continued ONNX inference and WebView execution after the app is suspended.

This restores the important sequencing property of the pre-Supertonic 3 player on iOS: once audio starts, all expensive preparation is already complete. It keeps the current per-chunk native API instead of returning one monolithic WAV/base64 payload, which bounds transient bridge and decoding memory to one chunk at a time. The intentional UX tradeoff is a longer preparing phase before the first sound on iOS.

No Rust, model, ONNX Runtime, linking, or background-mode configuration changes are included.

## Validation

- 216 frontend tests passed
- TypeScript typecheck and production frontend build passed
- focused ESLint check passed with only the existing component-export warning
- Prettier and git diff checks passed
- reproducibly rebuilt pinned ONNX Runtime 1.23.2 device and simulator artifacts and verified their hashes
- full scripts/ci/ios-pr.sh build passed, including Rust/Tauri compilation, Xcode link/sign, and Maple.app packaging
- verified both source and built Info.plist contain UIBackgroundModes = [audio]
- two narrow independent reviews found no major issues

## TestFlight verification

1. Start a TTS response long enough to play for more than two minutes.
2. Wait for the preparing indicator to finish and for audio to begin.
3. Lock the device immediately after playback starts.
4. Confirm playback continues well beyond the previous 30 to 50 second cutoff.
5. Reopen Maple and confirm it remains in the same chat.
6. Also verify foreground playback and stopping during preparation still behave normally.

If this still reproduces after all audio has been prepared, background inference is effectively ruled out and iOS memory pressure becomes the next focused hypothesis. At that point, collect the matching JetsamEvent before attempting model-memory changes.