### PR TITLE
Increase chat history page size to 20

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -2063,7 +2063,7 @@ export function UnifiedChat() {
           (error) => ({ ok: false as const, error })
         );
         const itemsPromise = openai.conversations.items.list(conversationId, {
-          limit: 10,
+          limit: 20,
           order: "desc"
         });
 
@@ -2153,9 +2153,9 @@ export function UnifiedChat() {
     setIsLoadingOlderMessages(true);
 
     try {
-      // Fetch next 10 older items using the oldest item ID we have
+      // Fetch next 20 older items using the oldest item ID we have
       const itemsResponse = await openai.conversations.items.list(conversation.id, {
-        limit: 10,
+        limit: 20,
         order: "desc",
         after: oldestItemId
       });


### PR DESCRIPTION
## Summary
- load 20 raw conversation timeline items for the initial chat-history page
- load 20 raw items for each deliberate older-history page

Keeps existing pagination behavior, grouping, and scroll logic unchanged.

Closes #688.