### PR TITLE
Bump Maple version to 3.3.1

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.0",
+  "version": "3.3.1",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4585,7 +4585,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.0"
+version = "3.3.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.0"
+version = "3.3.1"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>3.3.1</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.0</string>
+	<string>3.3.1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.0
-        CFBundleVersion: 3.3.0
+        CFBundleShortVersionString: 3.3.1
+        CFBundleVersion: 3.3.1
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -99,7 +99,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028011
+      "versionCode": 2000028012
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- bump Maple from 3.3.0 to 3.3.1 across frontend, Rust/Tauri, and generated Apple version sources
- increment the Android version code once, from 2000028011 to 2000028012
- keep the bump as a standalone release-preparation commit

## Validation
- pinned Nix `just update-version 3.3.1`
- pinned Nix `cargo check`
- Prettier check
- frontend production build
- Bun tests
- Rust tests: 204 passed, 0 failed, 1 model-backed OCR test intentionally ignored
- cross-file version consistency assertions
- `git diff --check`

## Scope
- does **not** include the Android 16 KB page-size fix
- does **not** create a tag, publish a release, or upload store artifacts