### PR TITLE
Keep Chat streams alive across conversation switches

### DIFF
--- a/frontend/src/components/AuthenticatedHomeContent.tsx
+++ b/frontend/src/components/AuthenticatedHomeContent.tsx
@@ -13,6 +13,7 @@ import { ProjectDetailView } from "@/components/ProjectDetailView";
 import { UnifiedChat } from "@/components/UnifiedChat";
 import { PersistentHomeNavigationContext } from "@/contexts/PersistentHomeNavigationContext";
 import { AgentSessionSelectionMemory } from "@/services/agentSessionSelection";
+import { ChatRuntimeProvider } from "@/contexts/ChatRuntimeContext";
 
 const TRANSIENT_HOME_SEARCH_PARAMS = ["team_setup", "credits_success", "api_settings"];
 
@@ -129,7 +130,7 @@ export function PersistentHomeNavigationProvider({ children }: { children: React
 
   return (
     <PersistentHomeNavigationContext.Provider value={value}>
-      {children}
+      <ChatRuntimeProvider key={userId ?? "signed-out"}>{children}</ChatRuntimeProvider>
     </PersistentHomeNavigationContext.Provider>
   );
 }

--- a/frontend/src/components/AuthenticatedHomeContent.tsx
+++ b/frontend/src/components/AuthenticatedHomeContent.tsx
@@ -178,5 +178,5 @@ export function AuthenticatedHomeContent({
     return <ProjectDetailView projectId={selection.projectId} />;
   }
 
-  return <UnifiedChat />;
+  return <UnifiedChat isVisible={homeLocationHref !== null} />;
 }

--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -114,7 +114,29 @@ export function ChatHistoryList({
     runtimeStore.getActiveRunKeys,
     runtimeStore.getActiveRunKeys
   );
+  const completedUnreadKeys = useSyncExternalStore(
+    runtimeStore.subscribeCompletedUnread,
+    runtimeStore.getCompletedUnreadKeys,
+    runtimeStore.getCompletedUnreadKeys
+  );
   const activeRunKeySet = useMemo(() => new Set(activeRunKeys), [activeRunKeys]);
+  const completedUnreadKeySet = useMemo(() => new Set(completedUnreadKeys), [completedUnreadKeys]);
+  const activeRunProjectIds = useMemo(() => {
+    const projectIds = new Set<string>();
+    for (const key of activeRunKeys) {
+      const projectId = runtimeStore.getActiveRunGroupId(key);
+      if (projectId) projectIds.add(projectId);
+    }
+    return projectIds;
+  }, [activeRunKeys, runtimeStore]);
+  const completedUnreadProjectIds = useMemo(() => {
+    const projectIds = new Set<string>();
+    for (const key of completedUnreadKeys) {
+      const projectId = runtimeStore.getCompletedUnreadGroupId(key);
+      if (projectId) projectIds.add(projectId);
+    }
+    return projectIds;
+  }, [completedUnreadKeys, runtimeStore]);
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isBulkDeleteDialogOpen, setIsBulkDeleteDialogOpen] = useState(false);
@@ -646,13 +668,27 @@ export function ChatHistoryList({
     []
   );
 
+  const updateRuntimeConversationProject = useCallback(
+    (conversationId: string, projectId: string | null) => {
+      const key = createConversationChatKey(conversationId);
+      if (runtimeStore.get(key)) {
+        runtimeStore.update(key, (snapshot) => ({
+          ...snapshot,
+          conversation: snapshot.conversation
+            ? { ...snapshot.conversation, project_id: projectId }
+            : null
+        }));
+      }
+      runtimeStore.updateActivityGroup(key, projectId);
+    },
+    [runtimeStore]
+  );
+
   // Handle conversation deletion via API
   const handleDeleteConversation = useCallback(
     async (conversationId: string) => {
       try {
         await opensecret.deleteConversation(conversationId);
-        setConversations((prev) => prev.filter((conv) => conv.id !== conversationId));
-        await invalidateConversationData();
 
         if (conversationId === currentChatId) {
           const params = new URLSearchParams(window.location.search);
@@ -660,11 +696,20 @@ export function ChatHistoryList({
           window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
           window.dispatchEvent(new Event("newchat"));
         }
+
+        setConversations((prev) => prev.filter((conv) => conv.id !== conversationId));
+        try {
+          await invalidateConversationData();
+        } finally {
+          // Let the replacement draft commit before removing a runtime that
+          // UnifiedChat may still be subscribed to during this event turn.
+          runtimeStore.delete(createConversationChatKey(conversationId));
+        }
       } catch (error) {
         console.error("Error deleting conversation:", error);
       }
     },
-    [currentChatId, invalidateConversationData, opensecret]
+    [currentChatId, invalidateConversationData, opensecret, runtimeStore]
   );
 
   const MAX_SELECTION = 20;
@@ -700,16 +745,23 @@ export function ChatHistoryList({
         const result = await opensecret.batchDeleteConversations(idsToDelete);
 
         result.data.filter((item) => item.deleted).forEach((item) => deletedIds.add(item.id));
-        setConversations((prev) => prev.filter((conv) => !deletedIds.has(conv.id)));
-        await invalidateConversationData();
-      }
+        // If current chat was deleted, project a replacement before the old
+        // runtime is removed so useSyncExternalStore never observes a gap.
+        if (currentChatId && deletedIds.has(currentChatId)) {
+          const params = new URLSearchParams(window.location.search);
+          params.delete("conversation_id");
+          window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
+          window.dispatchEvent(new Event("newchat"));
+        }
 
-      // If current chat was deleted, navigate to home
-      if (currentChatId && deletedIds.has(currentChatId)) {
-        const params = new URLSearchParams(window.location.search);
-        params.delete("conversation_id");
-        window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
-        window.dispatchEvent(new Event("newchat"));
+        setConversations((prev) => prev.filter((conv) => !deletedIds.has(conv.id)));
+        try {
+          await invalidateConversationData();
+        } finally {
+          for (const id of deletedIds) {
+            runtimeStore.delete(createConversationChatKey(id));
+          }
+        }
       }
 
       // Clear selection and exit selection mode
@@ -727,7 +779,8 @@ export function ChatHistoryList({
     invalidateConversationData,
     currentChatId,
     onSelectionChange,
-    onExitSelectionMode
+    onExitSelectionMode,
+    runtimeStore
   ]);
 
   // Long press handlers for mobile selection mode activation
@@ -793,6 +846,7 @@ export function ChatHistoryList({
     async (conversation: Conversation, projectId: string | null) => {
       try {
         await opensecret.batchUpdateConversationProject([conversation.id], projectId);
+        updateRuntimeConversationProject(conversation.id, projectId);
         await invalidateConversationData();
 
         if (conversation.id === currentChatId) {
@@ -811,7 +865,8 @@ export function ChatHistoryList({
       dispatchConversationMetadataUpdated,
       invalidateConversationData,
       opensecret,
-      setSelectedProjectId
+      setSelectedProjectId,
+      updateRuntimeConversationProject
     ]
   );
 
@@ -840,6 +895,7 @@ export function ChatHistoryList({
       try {
         const ids = Array.from(selectedIds);
         await opensecret.batchUpdateConversationProject(ids, projectId);
+        for (const id of ids) updateRuntimeConversationProject(id, projectId);
         await invalidateConversationData();
 
         if (currentChatId && selectedIds.has(currentChatId)) {
@@ -862,7 +918,8 @@ export function ChatHistoryList({
       onSelectionChange,
       opensecret,
       selectedIds,
-      setSelectedProjectId
+      setSelectedProjectId,
+      updateRuntimeConversationProject
     ]
   );
 
@@ -929,34 +986,57 @@ export function ChatHistoryList({
 
   const handleDeleteProject = useCallback(async () => {
     if (!selectedProject) return;
+    let replacementDispatched = false;
+    const projectAwayFromDeletedProject = () => {
+      if (replacementDispatched) return;
+      const deletingProjectedChat =
+        selectedProjectId === selectedProject.id ||
+        (currentChatId
+          ? runtimeStore.getActivityGroupId(createConversationChatKey(currentChatId)) ===
+            selectedProject.id
+          : false);
+      if (!deletingProjectedChat) return;
+
+      replacementDispatched = true;
+      setSelectedProjectId(null);
+      const params = new URLSearchParams(window.location.search);
+      params.delete("conversation_id");
+      params.delete("project_id");
+      window.history.replaceState({}, "", params.toString() ? `/?${params.toString()}` : "/");
+      window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
+      window.dispatchEvent(new Event("projectselected"));
+    };
 
     try {
       await opensecret.deleteConversationProject(selectedProject.id);
-      await invalidateConversationData();
+      projectAwayFromDeletedProject();
 
       if (expandedProjectId === selectedProject.id) {
         setExpandedProjectId(null);
       }
 
-      if (selectedProjectId === selectedProject.id) {
-        setSelectedProjectId(null);
-        const params = new URLSearchParams(window.location.search);
-        params.delete("conversation_id");
-        params.delete("project_id");
-        window.history.replaceState({}, "", params.toString() ? `/?${params.toString()}` : "/");
-        window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
-        window.dispatchEvent(new Event("projectselected"));
+      try {
+        await invalidateConversationData();
+      } finally {
+        // Metadata can finish loading while the delete request/refetch is in
+        // flight, so re-check membership immediately before grouped cleanup.
+        projectAwayFromDeletedProject();
+        // A selected chat in this project has now committed its replacement;
+        // grouped background runtimes can be aborted and discarded safely.
+        runtimeStore.deleteActivityGroup(selectedProject.id);
       }
     } catch (error) {
       console.error("Error deleting project:", error);
       throw error;
     }
   }, [
+    currentChatId,
     expandedProjectId,
     invalidateConversationData,
     opensecret,
     selectedProject,
     selectedProjectId,
+    runtimeStore,
     setSelectedProjectId
   ]);
 
@@ -1020,6 +1100,7 @@ export function ChatHistoryList({
   // Handle conversation selection
   const handleSelectConversation = useCallback(
     async (conversation: Conversation) => {
+      runtimeStore.markCompletionRead(createConversationChatKey(conversation.id));
       setSelectedProjectId(conversation.project_id ?? null);
 
       if (window.location.pathname !== "/") {
@@ -1037,7 +1118,7 @@ export function ChatHistoryList({
         })
       );
     },
-    [router, setSelectedProjectId]
+    [router, runtimeStore, setSelectedProjectId]
   );
 
   // Listen for conversation created event to refresh the list
@@ -1080,7 +1161,9 @@ export function ChatHistoryList({
     const title = getConversationTitle(conversation);
     const isActive = conversation.id === currentChatId;
     const isSelected = selectedIds.has(conversation.id);
-    const isRunning = activeRunKeySet.has(createConversationChatKey(conversation.id));
+    const runtimeKey = createConversationChatKey(conversation.id);
+    const isRunning = activeRunKeySet.has(runtimeKey);
+    const isUnreadCompleted = !isRunning && completedUnreadKeySet.has(runtimeKey);
     const titlePaddingClass = "pr-8";
 
     const isBoldState = (isActive && !isSelectionMode) || (isSelectionMode && isSelected);
@@ -1099,8 +1182,15 @@ export function ChatHistoryList({
           data-testid="conversation-row"
           data-conversation-id={conversation.id}
           data-running={isRunning || undefined}
+          data-unread={isUnreadCompleted || undefined}
           aria-current={isActive ? "page" : undefined}
-          aria-label={isRunning ? `${title}, running` : title}
+          aria-label={
+            isRunning
+              ? `${title}, running`
+              : isUnreadCompleted
+                ? `${title}, completed, unread`
+                : title
+          }
           onClick={() => {
             if (isSelectionMode) {
               toggleSelection(conversation.id);
@@ -1129,6 +1219,11 @@ export function ChatHistoryList({
                   />
                   <span className="sr-only">Response in progress</span>
                 </>
+              ) : isUnreadCompleted ? (
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full bg-maple-success"
+                  aria-hidden="true"
+                />
               ) : null}
               {conversation.pinned ? (
                 <Pin
@@ -1288,12 +1383,36 @@ export function ChatHistoryList({
           {filteredProjects.map((project) => {
             const isProjectExpanded = expandedProjectId === project.id;
             const isProjectSelected = selectedProjectId === project.id;
+            const showProjectRunningIndicator =
+              !isProjectExpanded && activeRunProjectIds.has(project.id);
+            const showProjectUnreadIndicator =
+              !isProjectExpanded &&
+              !showProjectRunningIndicator &&
+              completedUnreadProjectIds.has(project.id);
+            const projectAccessibleStatus = showProjectRunningIndicator
+              ? "running"
+              : showProjectUnreadIndicator
+                ? "completed, unread"
+                : null;
             return (
-              <div key={project.id} className="relative">
+              <div
+                key={project.id}
+                data-testid="project-row"
+                data-project-id={project.id}
+                data-running={showProjectRunningIndicator || undefined}
+                data-unread={showProjectUnreadIndicator || undefined}
+                className="relative"
+              >
                 <div className="relative isolate group w-full min-w-0">
                   <button
                     type="button"
                     onClick={() => handleToggleProjectExpanded(project.id)}
+                    aria-expanded={isProjectExpanded}
+                    aria-label={
+                      projectAccessibleStatus
+                        ? `${project.name}, ${projectAccessibleStatus}`
+                        : project.name
+                    }
                     className={`relative ${ROW_CONTENT_Z} w-full rounded-2xl py-1 text-left ${
                       isProjectExpanded || isProjectSelected
                         ? "font-bold text-foreground"
@@ -1306,7 +1425,18 @@ export function ChatHistoryList({
                       ) : (
                         <ChevronRight className="h-4 w-4 shrink-0" strokeWidth={ICON_STROKE} />
                       )}
-                      <span className="truncate">{project.name}</span>
+                      <span className="min-w-0 flex-1 truncate">{project.name}</span>
+                      {showProjectRunningIndicator ? (
+                        <Loader2
+                          className="h-3.5 w-3.5 shrink-0 animate-spin text-[hsl(var(--maple-primary))]"
+                          aria-hidden="true"
+                        />
+                      ) : showProjectUnreadIndicator ? (
+                        <span
+                          className="h-2 w-2 shrink-0 rounded-full bg-maple-success"
+                          aria-hidden="true"
+                        />
+                      ) : null}
                     </div>
                   </button>
                   <div className={sidebarEllipsisTriggerRowClass(isMobile)}>

--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -41,6 +41,10 @@ import { ConversationProjectDialog } from "@/components/ConversationProjectDialo
 import { DeleteConversationProjectDialog } from "@/components/DeleteConversationProjectDialog";
 import { MoveChatsDialog } from "@/components/MoveChatsDialog";
 import { listAllConversationProjects, listAllConversations } from "@/utils/paginatedLists";
+import {
+  pushFreshChatHistoryEntry,
+  type NewChatNavigationDetail
+} from "@/services/chatRuntimeNavigation";
 
 const MAX_PROJECTS = 10;
 /** Lucide default; keep sidebar list icons visually consistent. */
@@ -874,8 +878,9 @@ export function ChatHistoryList({
       const params = new URLSearchParams(window.location.search);
       params.delete("conversation_id");
       params.delete("project_id");
-      window.history.replaceState({}, "", params.toString() ? `/?${params.toString()}` : "/");
-      window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId } }));
+      const url = params.toString() ? `/?${params.toString()}` : "/";
+      const detail = pushFreshChatHistoryEntry(window.history, url, projectId);
+      window.dispatchEvent(new CustomEvent<NewChatNavigationDetail>("newchat", { detail }));
       setTimeout(() => document.getElementById("message")?.focus(), 0);
     },
     [router, setSelectedProjectId]
@@ -1066,6 +1071,9 @@ export function ChatHistoryList({
         onContextMenu={(event) => event.preventDefault()}
       >
         <div
+          data-testid="conversation-row"
+          data-conversation-id={conversation.id}
+          aria-current={isActive ? "page" : undefined}
           onClick={() => {
             if (isSelectionMode) {
               toggleSelection(conversation.id);

--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -1,4 +1,12 @@
-import { useState, useMemo, useCallback, useEffect, useRef, useContext } from "react";
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useEffect,
+  useRef,
+  useContext,
+  useSyncExternalStore
+} from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   MoreHorizontal,
@@ -13,7 +21,8 @@ import {
   FolderInput,
   Pin,
   PinOff,
-  SquarePen
+  SquarePen,
+  Loader2
 } from "lucide-react";
 import {
   DropdownMenu,
@@ -45,6 +54,14 @@ import {
   pushFreshChatHistoryEntry,
   type NewChatNavigationDetail
 } from "@/services/chatRuntimeNavigation";
+import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
+import { createConversationChatKey } from "@/services/chatRuntimeStore";
+import {
+  INITIAL_CHAT_HISTORY_RETRY_COUNT,
+  conversationHistoryQueryKey,
+  initialChatHistoryPage,
+  shouldLoadConversationHistory
+} from "@/services/chatHistoryAccountScope";
 
 const MAX_PROJECTS = 10;
 /** Lucide default; keep sidebar list icons visually consistent. */
@@ -91,6 +108,13 @@ export function ChatHistoryList({
   const localState = useContext(LocalStateContext);
   const { selectedProjectId, setSelectedProjectId } = localState;
   const userId = opensecret.auth.user?.user.id;
+  const runtimeStore = useChatRuntimeStore<Conversation, unknown>();
+  const activeRunKeys = useSyncExternalStore(
+    runtimeStore.subscribeActiveRuns,
+    runtimeStore.getActiveRunKeys,
+    runtimeStore.getActiveRunKeys
+  );
+  const activeRunKeySet = useMemo(() => new Set(activeRunKeys), [activeRunKeys]);
   const [isRenameDialogOpen, setIsRenameDialogOpen] = useState(false);
   const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
   const [isBulkDeleteDialogOpen, setIsBulkDeleteDialogOpen] = useState(false);
@@ -112,6 +136,14 @@ export function ChatHistoryList({
   const isLoadingMoreRef = useRef(false);
   const lastConversationRef = useRef<HTMLDivElement>(null);
   const [conversations, setConversations] = useState<Conversation[]>([]);
+
+  useEffect(() => {
+    setConversations([]);
+    setOldestConversationId(undefined);
+    setHasMoreConversations(false);
+    setIsLoadingMore(false);
+    isLoadingMoreRef.current = false;
+  }, [userId]);
 
   // Pull-to-refresh (imperative updates to avoid reflow/re-render jank on iOS)
   const [isPullRefreshing, setIsPullRefreshing] = useState(false);
@@ -193,48 +225,39 @@ export function ChatHistoryList({
   }, [setPullDistancePx]);
 
   // Fetch initial conversations from API using the OpenSecret SDK
-  const { isPending, error } = useQuery({
-    queryKey: ["conversations"],
+  const {
+    data: initialConversations,
+    isPending,
+    error
+  } = useQuery({
+    queryKey: conversationHistoryQueryKey(userId),
     queryFn: async () => {
-      if (!opensecret) return [];
-
-      try {
-        // Load initial 20 conversations (newest first by default)
-        const response = await opensecret.listConversations({
-          limit: 20,
-          unassigned_project: true
-        });
-
-        const loadedConversations = response.data || [];
-
-        // Set initial state only on first load
-        setConversations(loadedConversations);
-
-        // Set pagination state
-        if (loadedConversations.length > 0) {
-          // Last conversation in the array is the oldest (for pagination)
-          const oldestId = loadedConversations[loadedConversations.length - 1].id;
-          setOldestConversationId(oldestId);
-          // If we got a full page, there might be more
-          setHasMoreConversations(loadedConversations.length === 20);
-        } else {
-          setOldestConversationId(undefined);
-          setHasMoreConversations(false);
-        }
-
-        return loadedConversations;
-      } catch (error) {
-        console.error("Failed to load conversations:", error);
-        return [];
-      }
+      const response = await opensecret.listConversations({
+        limit: 20,
+        unassigned_project: true
+      });
+      return response.data || [];
     },
-    enabled: !!opensecret
+    enabled: shouldLoadConversationHistory(userId),
+    retry: INITIAL_CHAT_HISTORY_RETRY_COUNT,
+    retryDelay: 250
     // No refetchInterval - we'll use manual polling instead
   });
 
+  // Query data is authoritative across remounts and request deduplication. Keeping
+  // setState outside queryFn ensures a newly mounted sidebar consumes a request
+  // that may have been started by the previous authenticated surface.
+  useEffect(() => {
+    if (!userId || initialConversations === undefined) return;
+    const page = initialChatHistoryPage(initialConversations);
+    setConversations([...page.conversations]);
+    setOldestConversationId(page.oldestConversationId);
+    setHasMoreConversations(page.hasMoreConversations);
+  }, [initialConversations, userId]);
+
   // Smart polling function - only fetches NEW conversations using the same pattern as UnifiedChat
   const pollForUpdates = useCallback(async () => {
-    if (!opensecret) return;
+    if (!userId) return;
 
     try {
       // Fetch latest conversations to detect new ones or metadata changes
@@ -286,7 +309,7 @@ export function ChatHistoryList({
       console.error("Polling error:", error);
       // Fail silently - don't disrupt the UI
     }
-  }, [opensecret]);
+  }, [opensecret, userId]);
 
   // Pull-to-refresh handler
   const handleRefresh = useCallback(async () => {
@@ -422,7 +445,7 @@ export function ChatHistoryList({
 
   // Set up polling every 60 seconds
   useEffect(() => {
-    if (!opensecret || conversations.length === 0) return;
+    if (!userId) return;
 
     const intervalId = setInterval(() => {
       pollForUpdates();
@@ -431,7 +454,7 @@ export function ChatHistoryList({
     return () => {
       clearInterval(intervalId);
     };
-  }, [opensecret, pollForUpdates, conversations.length]);
+  }, [pollForUpdates, userId]);
 
   // Load more older conversations for pagination
   const loadMoreConversations = useCallback(async () => {
@@ -1029,7 +1052,7 @@ export function ChatHistoryList({
     return () => window.removeEventListener("conversationcreated", handleConversationCreated);
   }, [pollForUpdates, queryClient]);
 
-  if (error) {
+  if (error && conversations.length === 0) {
     return <div>{error.message}</div>;
   }
 
@@ -1057,6 +1080,7 @@ export function ChatHistoryList({
     const title = getConversationTitle(conversation);
     const isActive = conversation.id === currentChatId;
     const isSelected = selectedIds.has(conversation.id);
+    const isRunning = activeRunKeySet.has(createConversationChatKey(conversation.id));
     const titlePaddingClass = "pr-8";
 
     const isBoldState = (isActive && !isSelectionMode) || (isSelectionMode && isSelected);
@@ -1070,10 +1094,13 @@ export function ChatHistoryList({
         className="group relative isolate flex w-full min-w-0 select-none items-stretch gap-0.5 rounded-2xl"
         onContextMenu={(event) => event.preventDefault()}
       >
-        <div
+        <button
+          type="button"
           data-testid="conversation-row"
           data-conversation-id={conversation.id}
+          data-running={isRunning || undefined}
           aria-current={isActive ? "page" : undefined}
+          aria-label={isRunning ? `${title}, running` : title}
           onClick={() => {
             if (isSelectionMode) {
               toggleSelection(conversation.id);
@@ -1088,12 +1115,21 @@ export function ChatHistoryList({
           onTouchMove={handleLongPressMove}
           onTouchEnd={handleLongPressEnd}
           onTouchCancel={handleLongPressEnd}
-          className={`relative ${ROW_CONTENT_Z} min-w-0 flex-1 py-1 pr-2 ${rowTextClass} ${
+          className={`relative ${ROW_CONTENT_Z} min-w-0 flex-1 py-1 pr-2 text-left ${rowTextClass} ${
             isSelectionMode ? "pl-8" : "pl-0"
           } cursor-pointer`}
         >
           <div className={titlePaddingClass}>
             <div className="relative z-0 flex min-w-0 items-center gap-1.5">
+              {isRunning ? (
+                <>
+                  <Loader2
+                    className="h-3 w-3 shrink-0 animate-spin text-[hsl(var(--maple-primary))]"
+                    aria-hidden="true"
+                  />
+                  <span className="sr-only">Response in progress</span>
+                </>
+              ) : null}
               {conversation.pinned ? (
                 <Pin
                   className="h-3.5 w-3.5 shrink-0 fill-none text-foreground"
@@ -1107,7 +1143,7 @@ export function ChatHistoryList({
               {new Date(conversation.last_activity_at * 1000).toLocaleDateString()}
             </div>
           </div>
-        </div>
+        </button>
         {isSelectionMode ? (
           <div
             className={`absolute left-1.5 top-1/2 ${ROW_CHECKBOX_Z} -translate-y-1/2`}

--- a/frontend/src/components/ProjectDetailView.tsx
+++ b/frontend/src/components/ProjectDetailView.tsx
@@ -48,6 +48,8 @@ import { MoveChatsDialog } from "@/components/MoveChatsDialog";
 import { listAllConversationProjects } from "@/utils/paginatedLists";
 import { SIDEBAR_GRID_COLUMNS_CLASS, SIDEBAR_LAYOUT_STYLE } from "@/constants/layout";
 import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
+import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
+import { createConversationChatKey } from "@/services/chatRuntimeStore";
 
 const PROJECT_PAGE_SIZE = 20;
 const MAX_SELECTION = 20;
@@ -151,6 +153,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
   const isCompactLayout = isMobile || isLandscapeMobile;
   const { setSelectedProjectId } = useLocalState();
   const hasAuthUser = !!os.auth.user;
+  const runtimeStore = useChatRuntimeStore<Conversation, unknown>();
 
   const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
   const wasLandscapeMobileRef = useRef(isLandscapeMobile);
@@ -304,6 +307,22 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
     await loadConversations();
   }, [invalidateConversationData, loadConversations]);
 
+  const updateRuntimeConversationProject = useCallback(
+    (conversationId: string, targetProjectId: string | null) => {
+      const key = createConversationChatKey(conversationId);
+      if (runtimeStore.get(key)) {
+        runtimeStore.update(key, (snapshot) => ({
+          ...snapshot,
+          conversation: snapshot.conversation
+            ? { ...snapshot.conversation, project_id: targetProjectId }
+            : null
+        }));
+      }
+      runtimeStore.updateActivityGroup(key, targetProjectId);
+    },
+    [runtimeStore]
+  );
+
   const handleStartNewChat = useCallback(() => {
     setSelectedProjectId(projectId);
     const params = new URLSearchParams(window.location.search);
@@ -316,6 +335,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
 
   const handleSelectConversation = useCallback(
     (conversation: Conversation) => {
+      runtimeStore.markCompletionRead(createConversationChatKey(conversation.id));
       setSelectedProjectId(conversation.project_id ?? null);
       const params = new URLSearchParams(window.location.search);
       params.delete("project_id");
@@ -327,7 +347,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
         })
       );
     },
-    [setSelectedProjectId]
+    [runtimeStore, setSelectedProjectId]
   );
 
   const handleSaveProjectInstructions = useCallback(
@@ -348,12 +368,13 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
 
   const handleDeleteProject = useCallback(async () => {
     await os.deleteConversationProject(projectId);
+    runtimeStore.deleteActivityGroup(projectId);
     await invalidateConversationData();
     setSelectedProjectId(null);
     window.history.replaceState({}, "", "/");
     window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
     window.dispatchEvent(new Event("projectselected"));
-  }, [invalidateConversationData, os, projectId, setSelectedProjectId]);
+  }, [invalidateConversationData, os, projectId, runtimeStore, setSelectedProjectId]);
 
   const handleRenameConversation = useCallback(
     async (conversationId: string, newTitle: string) => {
@@ -366,6 +387,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
   const handleDeleteConversation = useCallback(
     async (conversationId: string) => {
       await os.deleteConversation(conversationId);
+      runtimeStore.delete(createConversationChatKey(conversationId));
       setSelectedIds((prev) => {
         const next = new Set(prev);
         next.delete(conversationId);
@@ -373,7 +395,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
       });
       await refreshProjectPage();
     },
-    [os, refreshProjectPage]
+    [os, refreshProjectPage, runtimeStore]
   );
 
   const handleToggleConversationPin = useCallback(
@@ -389,6 +411,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
   const handleMoveConversationToProject = useCallback(
     async (conversation: Conversation, targetProjectId: string | null) => {
       await os.batchUpdateConversationProject([conversation.id], targetProjectId);
+      updateRuntimeConversationProject(conversation.id, targetProjectId);
       setSelectedIds((prev) => {
         const next = new Set(prev);
         next.delete(conversation.id);
@@ -396,7 +419,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
       });
       await refreshProjectPage();
     },
-    [os, refreshProjectPage]
+    [os, refreshProjectPage, updateRuntimeConversationProject]
   );
 
   const handleBulkDelete = useCallback(async () => {
@@ -405,7 +428,10 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
     setIsBulkDeleting(true);
     setError(null);
     try {
-      await os.batchDeleteConversations(Array.from(selectedIds));
+      const result = await os.batchDeleteConversations(Array.from(selectedIds));
+      for (const item of result.data) {
+        if (item.deleted) runtimeStore.delete(createConversationChatKey(item.id));
+      }
       setSelectedIds(new Set());
       setIsBulkDeleteDialogOpen(false);
       await refreshProjectPage();
@@ -415,7 +441,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
     } finally {
       setIsBulkDeleting(false);
     }
-  }, [os, refreshProjectPage, selectedIds]);
+  }, [os, refreshProjectPage, runtimeStore, selectedIds]);
 
   const handleMoveSelectedConversations = useCallback(
     async (targetProjectId: string | null) => {
@@ -423,7 +449,9 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
 
       setIsBulkMoving(true);
       try {
-        await os.batchUpdateConversationProject(Array.from(selectedIds), targetProjectId);
+        const ids = Array.from(selectedIds);
+        await os.batchUpdateConversationProject(ids, targetProjectId);
+        for (const id of ids) updateRuntimeConversationProject(id, targetProjectId);
         setSelectedIds(new Set());
         await refreshProjectPage();
       } catch (error) {
@@ -433,7 +461,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
         setIsBulkMoving(false);
       }
     },
-    [os, refreshProjectPage, selectedIds]
+    [os, refreshProjectPage, selectedIds, updateRuntimeConversationProject]
   );
 
   const toggleSelection = useCallback((conversationId: string) => {

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -39,6 +39,10 @@ import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { hasApiAccess } from "@/billing/billingAccess";
 import { WorkspaceModeSwitch, type WorkspaceMode } from "@/components/WorkspaceModeSwitch";
 import { usePersistentHomeNavigation } from "@/contexts/PersistentHomeNavigationContext";
+import {
+  createFreshChatHistoryEntry,
+  type NewChatNavigationDetail
+} from "@/services/chatRuntimeNavigation";
 
 export function Sidebar({
   chatId,
@@ -65,7 +69,6 @@ export function Sidebar({
     setSearchQuery,
     isSearchVisible,
     setIsSearchVisible,
-    selectedProjectId,
     setSelectedProjectId,
     billingStatus
   } = useLocalState();
@@ -112,22 +115,15 @@ export function Sidebar({
       setSelectedProjectId(null);
     });
 
-    if (
-      location.pathname === "/" &&
-      (window.location.search.includes("conversation_id") ||
-        window.location.search.includes("project_id"))
-    ) {
-      // Just clear the query params without navigation
-      window.history.replaceState(null, "", "/");
-      // Clear messages by triggering a re-render
-      window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
-      document.getElementById("message")?.focus();
-    } else if (location.pathname === "/") {
-      // Already on home with no conversation_id, just focus
-      if (selectedProjectId) {
-        window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
-      }
-      document.getElementById("message")?.focus();
+    if (location.pathname === "/") {
+      const freshChat = createFreshChatHistoryEntry();
+      window.history.pushState(freshChat.historyState, "", "/");
+      window.dispatchEvent(
+        new CustomEvent<NewChatNavigationDetail>("newchat", {
+          detail: { projectId: null, draftRuntimeKey: freshChat.draftRuntimeKey }
+        })
+      );
+      setTimeout(() => document.getElementById("message")?.focus(), 0);
     } else {
       try {
         // Navigate to home without any query params
@@ -497,6 +493,7 @@ export function SidebarToggle({ onToggle }: { onToggle: () => void }) {
     <button
       className="h-9 w-9 flex items-center justify-center text-foreground hover:text-foreground/70 transition-colors"
       onClick={onToggle}
+      aria-label="Open sidebar"
     >
       <Menu className="h-4 w-4" />
     </button>

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -89,6 +89,12 @@ import {
   type ChatHistoryScrollSnapshot
 } from "@/components/chatHistoryPagination";
 import {
+  ChatProjectionScrollCoordinator,
+  chatProjectionScrollTarget,
+  projectedUserTurnScrollTop,
+  type ChatProjectionScrollLease
+} from "@/components/chatProjectionScroll";
+import {
   getSidebarLayoutStyle,
   SIDEBAR_AWARE_FIXED_CENTER_CLASS,
   SIDEBAR_GRID_COLUMNS_CLASS
@@ -1911,8 +1917,10 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   // Scroll state
   const [isUserScrolling, setIsUserScrolling] = useState(false);
   const isUserScrollingRef = useRef(false);
-  const prevMessageCountRef = useRef(0);
   const prevStreamingRef = useRef(false);
+  const projectionScrollCoordinatorRef = useRef(
+    new ChatProjectionScrollCoordinator<ChatRuntimeKey>()
+  );
   const historyPaginationGateRef = useRef(new ChatHistoryPaginationGate());
   const pendingHistoryScrollRestoreRef = useRef<ChatHistoryScrollSnapshot | null>(null);
   const pendingHistoryScrollRestoreKeyRef = useRef<ChatRuntimeKey | null>(null);
@@ -1924,7 +1932,9 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const pointerHistoryGestureActiveRef = useRef(false);
   const previousPointerScrollTopRef = useRef(0);
   const suppressedHistoryScrollEndsRef = useRef(0);
-  const [hasNewPolledMessages, setHasNewPolledMessages] = useState(false);
+  const [newPolledMessagesOwnerKey, setNewPolledMessagesOwnerKey] = useState<ChatRuntimeKey | null>(
+    null
+  );
   const recorderRef = useRef<RecordRTC | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
   const billingRefreshTimeoutsRef = useRef(new Set<ReturnType<typeof setTimeout>>());
@@ -2021,7 +2031,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   useLayoutEffect(() => {
     clearHistoryBottomCompensation();
-  }, [chatId, clearHistoryBottomCompensation]);
+  }, [renderedRuntimeKey, clearHistoryBottomCompensation]);
 
   useEffect(() => {
     historyPaginationGateRef.current.resetIntent();
@@ -2060,7 +2070,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         touchGestureEndTimeoutRef.current = null;
       }
     };
-  }, [chatId]);
+  }, [renderedRuntimeKey]);
 
   // Auto-resize textarea
   useEffect(() => {
@@ -2131,6 +2141,34 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       }
     },
     [clearHistoryBottomCompensation]
+  );
+
+  const resolveScrollProjectionKey = useCallback(
+    (key: ChatRuntimeKey) => runtimeStore.resolveKey(key),
+    [runtimeStore]
+  );
+
+  const runForProjectedRuntime = useCallback(
+    (lease: ChatProjectionScrollLease<ChatRuntimeKey> | null, action: () => void) => {
+      if (
+        !lease ||
+        !isRuntimeSelected(lease.ownerKey) ||
+        !projectionScrollCoordinatorRef.current.ownsLease(lease, resolveScrollProjectionKey)
+      ) {
+        return false;
+      }
+
+      action();
+      return true;
+    },
+    [isRuntimeSelected, resolveScrollProjectionKey]
+  );
+
+  const lastMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
+  const prevLastMessageId = useRef(lastMessageId);
+  const hasStreamingMessage = messages.some(
+    (message) =>
+      message.type === "message" && (message as { status?: string }).status === "streaming"
   );
 
   const getScrollDebugSnapshot = useCallback(() => {
@@ -2252,25 +2290,88 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     }
   }, [isLoadingOlderMessages, isRuntimeSelected, messages]);
 
-  // Initial load - scroll to bottom instantly
-  useEffect(() => {
-    if (messages.length > 0 && prevMessageCountRef.current === 0 && !isLoadingOlderMessages) {
-      // First load of messages - scroll instantly to bottom
-      setTimeout(() => {
-        scrollToBottom("instant");
-      }, 0);
+  // The message runtime changes independently from this shared DOM scroller.
+  // Position each newly projected runtime explicitly instead of inheriting the
+  // previous chat's numeric scrollTop. A growing stream is anchored to its
+  // newest user turn so later deltas cannot turn a one-time bottom scroll into
+  // an arbitrary midpoint.
+  useLayoutEffect(() => {
+    const coordinator = projectionScrollCoordinatorRef.current;
+
+    if (!isVisible) {
+      coordinator.deactivate();
+      return;
     }
-    // Don't update count when loading older messages, to avoid triggering scroll
-    if (!isLoadingOlderMessages) {
-      prevMessageCountRef.current = messages.length;
+
+    const projectionChanged = coordinator.activate(renderedRuntimeKey, resolveScrollProjectionKey);
+
+    if (projectionChanged) {
+      clearHistoryBottomCompensation();
+      historyPaginationGateRef.current.resetIntent();
+      pendingHistoryScrollRestoreRef.current = null;
+      pendingHistoryScrollRestoreKeyRef.current = null;
+      isUserScrollingRef.current = false;
+      setIsUserScrolling(false);
+      prevLastMessageId.current = lastMessageId;
+      prevStreamingRef.current = hasStreamingMessage;
     }
-  }, [messages.length, scrollToBottom, isLoadingOlderMessages]);
+
+    const container = chatContainerRef.current;
+    const canonicalKey = runtimeStore.resolveKey(renderedRuntimeKey);
+    const isFreshDraft = isDraftChatRuntimeKey(canonicalKey);
+    const projectionReady = Boolean(
+      container &&
+      !isLoadingOlderMessages &&
+      (messages.length > 0 || activeRuntime.historyLoaded || isFreshDraft)
+    );
+
+    if (
+      !container ||
+      !coordinator.takePositionRequest(
+        renderedRuntimeKey,
+        projectionReady,
+        resolveScrollProjectionKey
+      )
+    ) {
+      return;
+    }
+
+    const target = chatProjectionScrollTarget(messages, isGenerating);
+
+    if (target.type === "latest-user") {
+      const userTurn = Array.from(
+        container.querySelectorAll<HTMLElement>("[data-history-anchor-ids]")
+      ).find((candidate) =>
+        candidate.dataset.historyAnchorIds?.split(" ").includes(target.messageId)
+      );
+
+      if (userTurn) {
+        container.scrollTop = projectedUserTurnScrollTop({
+          currentScrollTop: container.scrollTop,
+          containerTop: container.getBoundingClientRect().top,
+          userTurnTop: userTurn.getBoundingClientRect().top
+        });
+        return;
+      }
+    }
+
+    container.scrollTop = container.scrollHeight;
+  }, [
+    activeRuntime.historyLoaded,
+    clearHistoryBottomCompensation,
+    hasStreamingMessage,
+    isGenerating,
+    isLoadingOlderMessages,
+    isVisible,
+    lastMessageId,
+    messages,
+    renderedRuntimeKey,
+    resolveScrollProjectionKey,
+    runtimeStore
+  ]);
 
   // Auto-scroll when user sends a message
   // Track the LAST message ID (at the end of the array), not the count
-  const lastMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
-  const prevLastMessageId = useRef(lastMessageId);
-
   useEffect(() => {
     // Only scroll if the LAST message changed, which means an item was added to the END
     // (not prepended while loading older history).
@@ -2282,28 +2383,42 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         isAssistantConversationItem(lastItem) && !isUserScrolling;
 
       if (isUserMessage || shouldAutoScrollAssistantItem) {
+        const projectionLease = projectionScrollCoordinatorRef.current.captureLease(
+          renderedRuntimeKey,
+          resolveScrollProjectionKey
+        );
         setTimeout(
           () => {
-            scrollToBottom("smooth");
+            runForProjectedRuntime(projectionLease, () => scrollToBottom("smooth"));
           },
           isUserMessage ? 50 : 0
         );
       }
     }
     prevLastMessageId.current = lastMessageId;
-  }, [isUserScrolling, lastMessageId, messages, scrollToBottom]);
+  }, [
+    isUserScrolling,
+    lastMessageId,
+    messages,
+    renderedRuntimeKey,
+    resolveScrollProjectionKey,
+    runForProjectedRuntime,
+    scrollToBottom
+  ]);
 
   // Auto-scroll when assistant starts streaming (but not while streaming)
   useEffect(() => {
-    const hasStreamingMessage = messages.some(
-      (m) => m.type === "message" && (m as { status?: string }).status === "streaming"
-    );
-
     if (hasStreamingMessage && !prevStreamingRef.current && !isUserScrolling) {
       // Just started streaming - scroll slightly to show the loading indicator
+      const projectionLease = projectionScrollCoordinatorRef.current.captureLease(
+        renderedRuntimeKey,
+        resolveScrollProjectionKey
+      );
       setTimeout(() => {
-        const container = chatContainerRef.current;
-        if (container) {
+        runForProjectedRuntime(projectionLease, () => {
+          const container = chatContainerRef.current;
+          if (!container) return;
+
           // Scroll just enough to show the streaming message started
           const currentScroll = container.scrollTop;
           const maxScroll = container.scrollHeight - container.clientHeight;
@@ -2313,25 +2428,40 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
             top: targetScroll,
             behavior: "smooth"
           });
-        }
+        });
       }, 100);
     }
 
     prevStreamingRef.current = hasStreamingMessage;
-  }, [messages, isUserScrolling]);
+  }, [
+    hasStreamingMessage,
+    isUserScrolling,
+    renderedRuntimeKey,
+    resolveScrollProjectionKey,
+    runForProjectedRuntime
+  ]);
 
   // Auto-scroll when new messages arrive from polling
   useEffect(() => {
-    if (hasNewPolledMessages) {
+    if (newPolledMessagesOwnerKey) {
       // New messages arrived from polling - scroll to bottom to show them
+      const projectionLease = projectionScrollCoordinatorRef.current.captureLease(
+        newPolledMessagesOwnerKey,
+        resolveScrollProjectionKey
+      );
       setTimeout(() => {
-        scrollToBottom("smooth");
+        runForProjectedRuntime(projectionLease, () => scrollToBottom("smooth"));
       }, 100);
 
       // Reset the flag
-      setHasNewPolledMessages(false);
+      setNewPolledMessagesOwnerKey(null);
     }
-  }, [hasNewPolledMessages, scrollToBottom]);
+  }, [
+    newPolledMessagesOwnerKey,
+    resolveScrollProjectionKey,
+    runForProjectedRuntime,
+    scrollToBottom
+  ]);
 
   const selectConversationRuntime = useCallback(
     (conversationId: string) => {
@@ -2341,7 +2471,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       activeRuntimeKeyRef.current = key;
       setActiveRuntimeKey(key);
       setChatId(conversationId);
-      prevMessageCountRef.current = 0;
       return key;
     },
     [runtimeStore, stopRecordingForNavigation]
@@ -2357,7 +2486,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       activeRuntimeKeyRef.current = key;
       setActiveRuntimeKey(key);
       setChatId(undefined);
-      prevMessageCountRef.current = 0;
       window.history.replaceState(
         historyStateWithDraftRuntimeKey(window.history.state, key),
         "",
@@ -2491,9 +2619,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       const isStaleRequest = () =>
         !runtimeStore.get(runtimeKey) ||
         activeConversationLoadRef.current.get(runtimeStore.resolveKey(runtimeKey)) !== requestId;
-
-      // Reset message count before loading new conversation
-      prevMessageCountRef.current = 0;
 
       try {
         // Start both fetches immediately in parallel
@@ -2760,7 +2885,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
               // Mark that we have new polled messages for scrolling
               if (trulyNewMessages.length > 0 && isRuntimeSelected(runtimeKey)) {
-                setHasNewPolledMessages(true);
+                setNewPolledMessagesOwnerKey(runtimeKey);
               }
 
               return {

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -968,6 +968,7 @@ interface Conversation {
   id: string;
   object: "conversation";
   created_at: number;
+  project_id?: string | null;
   metadata?: {
     title?: string;
     [key: string]: unknown;
@@ -1649,7 +1650,7 @@ const MessageList = memo(
 
 MessageList.displayName = "MessageList";
 
-export function UnifiedChat() {
+export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
@@ -1664,6 +1665,7 @@ export function UnifiedChat() {
   const { playbackError, clearPlaybackError } = useTTS();
   const runtimeStore = useChatRuntimeStore<Conversation, Message>();
   const runtimeInstanceId = useId();
+  const visibleChatOwner = useRef<object>({}).current;
 
   const [initialRuntimeSelection] = useState(() => {
     const params = new URLSearchParams(window.location.search);
@@ -1681,22 +1683,27 @@ export function UnifiedChat() {
   const [activeRuntimeKey, setActiveRuntimeKey] = useState<ChatRuntimeKey>(
     initialRuntimeSelection.runtimeKey
   );
-  runtimeStore.ensure(activeRuntimeKey, {
+  // Runtime selection is updated synchronously before the matching React state
+  // update commits. If the old chat is deleted in that gap, render the store's
+  // selected replacement instead of recreating the deleted runtime.
+  const renderedRuntimeKey = runtimeStore.get(activeRuntimeKey)
+    ? activeRuntimeKey
+    : (runtimeStore.getActiveKey() ?? activeRuntimeKey);
+  runtimeStore.ensure(renderedRuntimeKey, {
     composer: createChatComposerState(selectedProjectId ?? null)
   });
-  const activeRuntimeKeyRef = useRef(activeRuntimeKey);
-  const isUnifiedChatMountedRef = useRef(true);
-  activeRuntimeKeyRef.current = runtimeStore.resolveKey(activeRuntimeKey);
+  const activeRuntimeKeyRef = useRef(renderedRuntimeKey);
+  activeRuntimeKeyRef.current = runtimeStore.resolveKey(renderedRuntimeKey);
 
   const subscribeToActiveRuntime = useCallback(
-    (listener: () => void) => runtimeStore.subscribeKey(activeRuntimeKey, listener),
-    [activeRuntimeKey, runtimeStore]
+    (listener: () => void) => runtimeStore.subscribeKey(renderedRuntimeKey, listener),
+    [renderedRuntimeKey, runtimeStore]
   );
   const getActiveRuntimeSnapshot = useCallback(() => {
-    const snapshot = runtimeStore.get(activeRuntimeKey);
-    if (!snapshot) throw new Error(`Missing chat runtime for ${activeRuntimeKey}`);
+    const snapshot = runtimeStore.get(renderedRuntimeKey);
+    if (!snapshot) throw new Error(`Missing chat runtime for ${renderedRuntimeKey}`);
     return snapshot;
-  }, [activeRuntimeKey, runtimeStore]);
+  }, [renderedRuntimeKey, runtimeStore]);
   const activeRuntime = useSyncExternalStore(
     subscribeToActiveRuntime,
     getActiveRuntimeSnapshot,
@@ -1704,11 +1711,14 @@ export function UnifiedChat() {
   );
 
   useLayoutEffect(() => {
-    runtimeStore.select(activeRuntimeKey);
-  }, [activeRuntimeKey, runtimeStore]);
+    if (!isVisible) return;
+    runtimeStore.select(renderedRuntimeKey);
+    const lease = runtimeStore.claimVisibleChat(visibleChatOwner, renderedRuntimeKey);
+    return () => runtimeStore.releaseVisibleChat(lease);
+  }, [isVisible, renderedRuntimeKey, runtimeStore, visibleChatOwner]);
 
   useLayoutEffect(() => {
-    const canonicalKey = runtimeStore.resolveKey(activeRuntimeKey);
+    const canonicalKey = runtimeStore.resolveKey(renderedRuntimeKey);
     const canonicalConversationId = conversationIdFromChatRuntimeKey(canonicalKey);
     if (canonicalConversationId) {
       canonicalizeConversationHistoryEntry(canonicalConversationId);
@@ -1722,19 +1732,10 @@ export function UnifiedChat() {
       "",
       window.location.href
     );
-  }, [activeRuntimeKey, runtimeStore]);
-
-  useEffect(() => {
-    isUnifiedChatMountedRef.current = true;
-    return () => {
-      isUnifiedChatMountedRef.current = false;
-    };
-  }, []);
+  }, [renderedRuntimeKey, runtimeStore]);
 
   const isRuntimeSelected = useCallback(
-    (key: ChatRuntimeKey) =>
-      isUnifiedChatMountedRef.current &&
-      runtimeStore.resolveKey(activeRuntimeKeyRef.current) === runtimeStore.resolveKey(key),
+    (key: ChatRuntimeKey) => runtimeStore.isChatVisible(key),
     [runtimeStore]
   );
 
@@ -2554,10 +2555,12 @@ export function UnifiedChat() {
         if (!conv.ok) {
           throw conv.error;
         }
+        const conversation = conv.value as Conversation;
         runtimeStore.update(runtimeKey, (snapshot) => ({
           ...snapshot,
-          conversation: conv.value as Conversation
+          conversation
         }));
+        runtimeStore.updateActivityGroup(runtimeKey, conversation.project_id ?? null);
       } catch (error) {
         if (isStaleRequest()) return;
 
@@ -2565,13 +2568,18 @@ export function UnifiedChat() {
         if (err.status === 404) {
           // Conversation doesn't exist - clear and start fresh
           // Conversation not found, starting new
-          runtimeStore.delete(runtimeKey);
-          if (isRuntimeSelected(runtimeKey)) {
-            const params = new URLSearchParams(window.location.search);
-            params.delete("conversation_id");
-            window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
+          const projectedRuntimeWasDeleted =
+            runtimeStore.resolveKey(activeRuntimeKeyRef.current) ===
+            runtimeStore.resolveKey(runtimeKey);
+          if (projectedRuntimeWasDeleted) {
+            if (isRuntimeSelected(runtimeKey)) {
+              const params = new URLSearchParams(window.location.search);
+              params.delete("conversation_id");
+              window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
+            }
             selectFreshDraftRuntime(selectedProjectId ?? null);
           }
+          runtimeStore.delete(runtimeKey);
         } else {
           console.error("Failed to load conversation:", error);
           setErrorForKey(runtimeKey, err.message || "Failed to load conversation");
@@ -3893,7 +3901,7 @@ export function UnifiedChat() {
       runToken: number,
       optimisticMessageId: string,
       discardOwnedItemsOnError: boolean
-    ) => {
+    ): Promise<ChatStreamTerminalState> => {
       const messageTextBuffers = new Map<string, Map<number, string>>();
       const reasoningTextBuffers = new Map<string, Map<number, string>>();
       const ownedItemIds = new Set<string>();
@@ -4249,6 +4257,8 @@ export function UnifiedChat() {
         deltaCoalescer.finish();
         unregisterChatStreamDeltaCoalescer(runtimeStore, runToken, deltaCoalescer);
       }
+
+      return terminalState;
     },
     [logStreamEvent, runtimeStore]
   );
@@ -4281,11 +4291,18 @@ export function UnifiedChat() {
         startSnapshot.conversation?.id ?? conversationIdFromChatRuntimeKey(runtimeKey);
       const isFollowUpConversation =
         Boolean(existingConversationId) && startSnapshot.messages.length > 1;
-      const run = runtimeStore.beginRun(runtimeKey);
+      const run = runtimeStore.beginRun(runtimeKey, {
+        groupId:
+          startSnapshot.conversation?.project_id ??
+          originalComposer.draftProjectId ??
+          selectedProjectId ??
+          null
+      });
       const localMessageId = uuidv4();
       let conversationId = existingConversationId;
       let composerRestored = false;
       let adoptedExistingDestination = false;
+      let completedSuccessfully = false;
 
       const restoreOriginComposer = (message: string) => {
         if (composerRestored) return true;
@@ -4361,9 +4378,9 @@ export function UnifiedChat() {
           { signal: run.signal }
         );
 
-        if (!runtimeStore.setAssistantStreaming(runtimeKey, run.token, true)) return;
+        if (!runtimeStore.setAssistantStreaming(runtimeKey, run.token, true)) return null;
         try {
-          await processStreamingResponse(
+          return await processStreamingResponse(
             stream,
             runtimeKey,
             run.token,
@@ -4525,7 +4542,7 @@ export function UnifiedChat() {
           }));
 
           const keepSelection = shouldProjectMigratedConversation(
-            isUnifiedChatMountedRef.current,
+            runtimeStore.isChatVisible(runtimeKey),
             sourceWasSelected,
             migration.destinationWasSelected
           );
@@ -4538,7 +4555,8 @@ export function UnifiedChat() {
           window.dispatchEvent(new Event("conversationcreated"));
         }
 
-        await createResponseStream(conversationId, isFollowUpConversation);
+        const terminalState = await createResponseStream(conversationId, isFollowUpConversation);
+        completedSuccessfully = terminalState === "completed";
         scheduleBillingRefresh();
       } catch (error) {
         console.error("Failed to send message:", error);
@@ -4613,7 +4631,8 @@ export function UnifiedChat() {
               if (!runtimeStore.isRunCurrent(runtimeKey, run.token)) return;
 
               console.log("Retrying request once...");
-              await createResponseStream(conversationId, false);
+              const terminalState = await createResponseStream(conversationId, false);
+              completedSuccessfully = terminalState === "completed";
               scheduleBillingRefresh();
               console.log("Retry completed successfully");
               return;
@@ -4655,7 +4674,11 @@ export function UnifiedChat() {
         }
       } finally {
         unregisterChatOptimisticMessage(runtimeStore, run.token, localMessageId);
-        runtimeStore.finishRun(runtimeKey, run.token);
+        if (completedSuccessfully) {
+          runtimeStore.completeRun(runtimeKey, run.token);
+        } else {
+          runtimeStore.finishRun(runtimeKey, run.token);
+        }
       }
     },
     [
@@ -4666,7 +4689,8 @@ export function UnifiedChat() {
       openai,
       processStreamingResponse,
       queryClient,
-      runtimeStore
+      runtimeStore,
+      selectedProjectId
     ]
   );
 

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -1,4 +1,14 @@
-import { useState, useRef, useEffect, useLayoutEffect, useCallback, memo, useMemo } from "react";
+import {
+  useState,
+  useRef,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useSyncExternalStore,
+  memo,
+  useMemo,
+  useId
+} from "react";
 import { flushSync } from "react-dom";
 import {
   ArrowUp,
@@ -107,8 +117,84 @@ import type {
 } from "openai/resources/responses/responses.js";
 import type { Message as OpenAIMessage } from "openai/resources/conversations/conversations.js";
 import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
+import {
+  createChatComposerState,
+  useChatRuntimeStore,
+  type ChatComposerState
+} from "@/contexts/ChatRuntimeContext";
+import {
+  createChatDraftKey,
+  createConversationChatKey,
+  type ChatRuntimeKey,
+  type DraftChatRuntimeKey
+} from "@/services/chatRuntimeStore";
+import {
+  canonicalConversationHistoryHref,
+  conversationIdFromChatRuntimeKey,
+  createFreshChatHistoryEntry,
+  draftRuntimeKeyFromHistoryState,
+  historyStateWithDraftRuntimeKey,
+  isDraftChatRuntimeKey,
+  runtimeKeyForChatLocation,
+  shouldProjectMigratedConversation,
+  type NewChatNavigationDetail
+} from "@/services/chatRuntimeNavigation";
+import {
+  canAdoptRecordingDestination,
+  cleanupRecordingForNavigation,
+  cleanupRecordingForTeardown,
+  isRecordingOwnershipCurrent
+} from "@/services/chatRecordingNavigation";
+import {
+  canAdoptAttachmentDestination,
+  mutateAttachmentComposerWhenIdle,
+  planRestoredImageUrls
+} from "@/services/chatAttachmentOwnership";
+import {
+  classifyChatStreamEof,
+  createChatStreamDeltaCoalescer,
+  flushRegisteredChatStreamDeltas,
+  isTerminalChatStreamErrorEvent,
+  registerChatStreamDeltaCoalescer,
+  removeOwnedChatStreamAttemptItems,
+  unregisterChatStreamDeltaCoalescer,
+  type ChatStreamTerminalState
+} from "@/services/chatStreamDeltaCoalescer";
+import { recoverFailedSendAfterDestinationAdoption } from "@/services/chatSendFailureRecovery";
+import {
+  getRegisteredChatOptimisticMessage,
+  markOptimisticMessageIncomplete,
+  registerChatOptimisticMessage,
+  unregisterChatOptimisticMessage
+} from "@/services/chatOptimisticMessageOwnership";
 
 const CHAT_ALERT_CLASS = `fixed top-16 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl px-4 ${SIDEBAR_AWARE_FIXED_CENTER_CLASS}`;
+const STREAM_EVENT_DEBUG_STORAGE_KEY = "maple:sse-debug";
+
+function isStreamEventDebugLoggingEnabled(): boolean {
+  if (!import.meta.env.DEV || typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(STREAM_EVENT_DEBUG_STORAGE_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+type StateUpdate<T> = T | ((previous: T) => T);
+
+function resolveStateUpdate<T>(previous: T, update: StateUpdate<T>): T {
+  return typeof update === "function" ? (update as (value: T) => T)(previous) : update;
+}
+
+function canonicalizeConversationHistoryEntry(
+  conversationId: string,
+  state: unknown = window.history.state
+): void {
+  const href = canonicalConversationHistoryHref(window.location, conversationId);
+  const currentHref = `${window.location.pathname}${window.location.search}${window.location.hash}`;
+  if (href === currentHref) return;
+  window.history.replaceState(state, "", href);
+}
 
 type ConversationContent =
   | InputTextContent
@@ -579,9 +665,14 @@ function summarizeStreamEventForLog(eventType: string, event: unknown): Record<s
   }
 }
 
-function updateActiveItemStatuses(messages: Message[], status: "error" | "incomplete"): Message[] {
+function updateActiveItemStatuses(
+  messages: Message[],
+  status: "error" | "incomplete",
+  ownedItemIds?: ReadonlySet<string>
+): Message[] {
   const updatedMessages = messages
     .filter((message) => {
+      if (ownedItemIds && !ownedItemIds.has(message.id)) return false;
       const currentStatus = (message as { status?: string }).status;
       return (
         currentStatus === "in_progress" ||
@@ -684,6 +775,44 @@ function mergeStreamingConversationItem(messages: Message[], item: Message): Mes
   }
 
   return mergeMessagesById(messages, [item]);
+}
+
+function reconcileLoadedMessage(serverMessage: Message, localMessage: Message): Message {
+  const merged = mergeStreamingConversationItem([serverMessage], localMessage)[0];
+  const serverStatus = (serverMessage as { status?: string }).status;
+  if (serverStatus === "completed" || serverStatus === "incomplete" || serverStatus === "error") {
+    return { ...merged, status: serverStatus } as Message;
+  }
+  return merged;
+}
+
+function mergeLoadedMessagesWithRuntime(loaded: Message[], cached: readonly Message[]): Message[] {
+  if (cached.length === 0) return loaded;
+
+  const cachedById = new Map(cached.map((message) => [message.id, message]));
+  const loadedIds = new Set(loaded.map((message) => message.id));
+  const reconciledLoaded = loaded.map((serverMessage) => {
+    const localMessage = cachedById.get(serverMessage.id);
+    if (!localMessage) return serverMessage;
+
+    return reconcileLoadedMessage(serverMessage, localMessage);
+  });
+
+  // Optimistic and live SSE items may not be checkpointed by the server until
+  // terminal events. Keep them in their existing order after the loaded page.
+  return [...reconciledLoaded, ...cached.filter((message) => !loadedIds.has(message.id))];
+}
+
+function mergePolledMessagesWithRuntime(cached: readonly Message[], polled: Message[]): Message[] {
+  if (cached.length === 0) return polled;
+  const polledById = new Map(polled.map((message) => [message.id, message]));
+  const cachedIds = new Set(cached.map((message) => message.id));
+  const reconciledCached = cached.map((localMessage) => {
+    const serverMessage = polledById.get(localMessage.id);
+    return serverMessage ? reconcileLoadedMessage(serverMessage, localMessage) : localMessage;
+  });
+
+  return [...reconciledCached, ...polled.filter((message) => !cachedIds.has(message.id))];
 }
 
 // Helper function to convert conversation items - just returns them as-is (flat, no grouping)
@@ -1533,38 +1662,200 @@ export function UnifiedChat() {
   const isLinuxTauriEnv = isTauriEnv && isLinuxEnv;
   const queryClient = useQueryClient();
   const { playbackError, clearPlaybackError } = useTTS();
+  const runtimeStore = useChatRuntimeStore<Conversation, Message>();
+  const runtimeInstanceId = useId();
 
-  // Track chatId from URL - use state so we can update it
-  const [chatId, setChatId] = useState<string | undefined>(() => {
+  const [initialRuntimeSelection] = useState(() => {
     const params = new URLSearchParams(window.location.search);
-    return params.get("conversation_id") || undefined;
+    const urlConversationId = params.get("conversation_id") || undefined;
+    const runtimeKey = runtimeKeyForChatLocation(urlConversationId, window.history.state, () =>
+      createChatDraftKey(`unified-chat-${runtimeInstanceId}`)
+    );
+    return {
+      runtimeKey,
+      conversationId:
+        urlConversationId ?? conversationIdFromChatRuntimeKey(runtimeStore.resolveKey(runtimeKey))
+    };
   });
+  const [chatId, setChatId] = useState<string | undefined>(initialRuntimeSelection.conversationId);
+  const [activeRuntimeKey, setActiveRuntimeKey] = useState<ChatRuntimeKey>(
+    initialRuntimeSelection.runtimeKey
+  );
+  runtimeStore.ensure(activeRuntimeKey, {
+    composer: createChatComposerState(selectedProjectId ?? null)
+  });
+  const activeRuntimeKeyRef = useRef(activeRuntimeKey);
+  const isUnifiedChatMountedRef = useRef(true);
+  activeRuntimeKeyRef.current = runtimeStore.resolveKey(activeRuntimeKey);
 
-  // State
-  const [conversation, setConversation] = useState<Conversation | null>(null);
-  const [messages, setMessages] = useState<Message[]>([]);
-  const [input, setInput] = useState("");
-  const [draftProjectId, setDraftProjectId] = useState<string | null>(() => selectedProjectId);
-  const [isGenerating, setIsGenerating] = useState(false);
+  const subscribeToActiveRuntime = useCallback(
+    (listener: () => void) => runtimeStore.subscribeKey(activeRuntimeKey, listener),
+    [activeRuntimeKey, runtimeStore]
+  );
+  const getActiveRuntimeSnapshot = useCallback(() => {
+    const snapshot = runtimeStore.get(activeRuntimeKey);
+    if (!snapshot) throw new Error(`Missing chat runtime for ${activeRuntimeKey}`);
+    return snapshot;
+  }, [activeRuntimeKey, runtimeStore]);
+  const activeRuntime = useSyncExternalStore(
+    subscribeToActiveRuntime,
+    getActiveRuntimeSnapshot,
+    getActiveRuntimeSnapshot
+  );
+
+  useLayoutEffect(() => {
+    runtimeStore.select(activeRuntimeKey);
+  }, [activeRuntimeKey, runtimeStore]);
+
+  useLayoutEffect(() => {
+    const canonicalKey = runtimeStore.resolveKey(activeRuntimeKey);
+    const canonicalConversationId = conversationIdFromChatRuntimeKey(canonicalKey);
+    if (canonicalConversationId) {
+      canonicalizeConversationHistoryEntry(canonicalConversationId);
+      return;
+    }
+    if (!isDraftChatRuntimeKey(canonicalKey)) return;
+    if (draftRuntimeKeyFromHistoryState(window.history.state) === canonicalKey) return;
+
+    window.history.replaceState(
+      historyStateWithDraftRuntimeKey(window.history.state, canonicalKey),
+      "",
+      window.location.href
+    );
+  }, [activeRuntimeKey, runtimeStore]);
+
+  useEffect(() => {
+    isUnifiedChatMountedRef.current = true;
+    return () => {
+      isUnifiedChatMountedRef.current = false;
+    };
+  }, []);
+
+  const isRuntimeSelected = useCallback(
+    (key: ChatRuntimeKey) =>
+      isUnifiedChatMountedRef.current &&
+      runtimeStore.resolveKey(activeRuntimeKeyRef.current) === runtimeStore.resolveKey(key),
+    [runtimeStore]
+  );
+
+  const updateComposerForKey = useCallback(
+    (key: ChatRuntimeKey, updater: (composer: ChatComposerState) => ChatComposerState) => {
+      if (!runtimeStore.get(key)) return false;
+      runtimeStore.update(key, (snapshot) => ({
+        ...snapshot,
+        composer: updater(snapshot.composer)
+      }));
+      return true;
+    },
+    [runtimeStore]
+  );
+
+  const updateIdleAttachmentComposerForKey = useCallback(
+    (key: ChatRuntimeKey, updater: (composer: ChatComposerState) => ChatComposerState) => {
+      const startSnapshot = runtimeStore.get(key);
+      if (!startSnapshot || startSnapshot.isGenerating) return false;
+
+      const result = mutateAttachmentComposerWhenIdle(startSnapshot, updater);
+      if (!result.didMutate) return false;
+      runtimeStore.update(key, (snapshot) => ({
+        ...snapshot,
+        composer: result.composer
+      }));
+      return true;
+    },
+    [runtimeStore]
+  );
+
+  const updateActiveComposer = useCallback(
+    (updater: (composer: ChatComposerState) => ChatComposerState) => {
+      updateComposerForKey(activeRuntimeKeyRef.current, updater);
+    },
+    [updateComposerForKey]
+  );
+
+  // The active view is only a projection. Background conversations keep their
+  // own messages, composer, cursors, and run lifecycle in runtimeStore.
+  const conversation = activeRuntime.conversation;
+  const messages = activeRuntime.messages as Message[];
+  const input = activeRuntime.composer.input;
+  const draftProjectId = activeRuntime.composer.draftProjectId;
+  const isGenerating = activeRuntime.isGenerating;
   const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
-  const [error, setError] = useState<string | null>(null);
-  const [lastSeenItemId, setLastSeenItemId] = useState<string | undefined>();
-  const [isNewConversationJustCreated, setIsNewConversationJustCreated] = useState(false);
-  const [currentResponseId, setCurrentResponseId] = useState<string | undefined>();
-  const [titleJustUpdated, setTitleJustUpdated] = useState(false);
+  const error = activeRuntime.error;
+  const [titleJustUpdatedKey, setTitleJustUpdatedKey] = useState<ChatRuntimeKey | null>(null);
+  const titleJustUpdated = Boolean(
+    titleJustUpdatedKey &&
+    runtimeStore.resolveKey(titleJustUpdatedKey) === runtimeStore.resolveKey(activeRuntimeKey)
+  );
 
   // Pagination states
-  const [oldestItemId, setOldestItemId] = useState<string | undefined>();
-  const [isLoadingOlderMessages, setIsLoadingOlderMessages] = useState(false);
-  const [hasMoreOlderMessages, setHasMoreOlderMessages] = useState(false);
+  const { oldestItemId, isLoadingOlderMessages, hasMoreOlderMessages } =
+    activeRuntime.composer.pagination;
 
   // Attachment states
-  const [draftImages, setDraftImages] = useState<File[]>([]);
-  const [imageUrls, setImageUrls] = useState<Map<File, string>>(new Map());
-  const [documentText, setDocumentText] = useState<string>("");
-  const [documentName, setDocumentName] = useState<string>("");
-  const [isProcessingDocument, setIsProcessingDocument] = useState(false);
-  const [attachmentError, setAttachmentError] = useState<string | null>(null);
+  const {
+    draftImages,
+    imageUrls,
+    documentText,
+    documentName,
+    isProcessingDocument,
+    attachmentError,
+    audioError
+  } = activeRuntime.composer;
+
+  const setConversationForKey = useCallback(
+    (key: ChatRuntimeKey, update: StateUpdate<Conversation | null>) => {
+      if (!runtimeStore.get(key)) return false;
+      runtimeStore.update(key, (snapshot) => ({
+        ...snapshot,
+        conversation: resolveStateUpdate(snapshot.conversation, update)
+      }));
+      return true;
+    },
+    [runtimeStore]
+  );
+  const setErrorForKey = useCallback(
+    (key: ChatRuntimeKey, update: StateUpdate<string | null>) => {
+      if (!runtimeStore.get(key)) return false;
+      runtimeStore.update(key, (snapshot) => ({
+        ...snapshot,
+        error: resolveStateUpdate(snapshot.error, update)
+      }));
+      return true;
+    },
+    [runtimeStore]
+  );
+  const setLastSeenItemIdForKey = useCallback(
+    (key: ChatRuntimeKey, update: StateUpdate<string | undefined>) => {
+      if (!runtimeStore.get(key)) return false;
+      runtimeStore.update(key, (snapshot) => ({
+        ...snapshot,
+        lastSeenItemId: resolveStateUpdate(snapshot.lastSeenItemId, update)
+      }));
+      return true;
+    },
+    [runtimeStore]
+  );
+  const setInputForKey = useCallback(
+    (key: ChatRuntimeKey, update: StateUpdate<string>) =>
+      updateComposerForKey(key, (composer) => ({
+        ...composer,
+        input: resolveStateUpdate(composer.input, update)
+      })),
+    [updateComposerForKey]
+  );
+  const setInput = useCallback(
+    (update: StateUpdate<string>) => setInputForKey(activeRuntimeKeyRef.current, update),
+    [setInputForKey]
+  );
+  const setDraftProjectId = useCallback(
+    (update: StateUpdate<string | null>) =>
+      updateActiveComposer((composer) => ({
+        ...composer,
+        draftProjectId: resolveStateUpdate(composer.draftProjectId, update)
+      })),
+    [updateActiveComposer]
+  );
   const [upgradeDialogOpen, setUpgradeDialogOpen] = useState(false);
   const [upgradeFeature, setUpgradeFeature] = useState<
     "image" | "document" | "voice" | "usage" | "tokens"
@@ -1577,7 +1868,10 @@ export function UnifiedChat() {
   const [isRecording, setIsRecording] = useState(false);
   const [isTranscribing, setIsTranscribing] = useState(false);
   const [isProcessingSend, setIsProcessingSend] = useState(false);
-  const [audioError, setAudioError] = useState<string | null>(null);
+  const [recordingOwnerKey, setRecordingOwnerKey] = useState<ChatRuntimeKey | null>(null);
+  const isRecordingForActive = Boolean(
+    isRecording && recordingOwnerKey && isRuntimeSelected(recordingOwnerKey)
+  );
 
   // Web search toggle state - persisted in localStorage, billing-aware initial default
   const [isWebSearchEnabled, setIsWebSearchEnabled] = useState(getInitialWebSearchEnabled);
@@ -1620,6 +1914,7 @@ export function UnifiedChat() {
   const prevStreamingRef = useRef(false);
   const historyPaginationGateRef = useRef(new ChatHistoryPaginationGate());
   const pendingHistoryScrollRestoreRef = useRef<ChatHistoryScrollSnapshot | null>(null);
+  const pendingHistoryScrollRestoreKeyRef = useRef<ChatRuntimeKey | null>(null);
   const wheelGestureEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const touchGestureEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const keyIntentTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -1631,14 +1926,13 @@ export function UnifiedChat() {
   const [hasNewPolledMessages, setHasNewPolledMessages] = useState(false);
   const recorderRef = useRef<RecordRTC | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
-  const assistantStreamingRef = useRef(false);
-
-  const abortControllerRef = useRef<AbortController | null>(null);
-  const billingRefreshTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const billingRefreshTimeoutsRef = useRef(new Set<ReturnType<typeof setTimeout>>());
   const fileInputRef = useRef<HTMLInputElement>(null);
   const documentInputRef = useRef<HTMLInputElement>(null);
-  const imagePasteGenerationRef = useRef(0);
-  const documentUploadGenerationRef = useRef(0);
+  const fileInputOwnerKeyRef = useRef<ChatRuntimeKey | null>(null);
+  const documentInputOwnerKeyRef = useRef<ChatRuntimeKey | null>(null);
+  const recordingOwnerKeyRef = useRef<ChatRuntimeKey | null>(null);
+  const recordingSessionTokenRef = useRef(0);
 
   // Refs
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -1646,7 +1940,77 @@ export function UnifiedChat() {
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const historyTopSentinelRef = useRef<HTMLDivElement>(null);
   const historyBottomCompensationRef = useRef<HTMLDivElement>(null);
-  const activeConversationLoadRef = useRef(0);
+  const activeConversationLoadRef = useRef(new Map<ChatRuntimeKey, number>());
+
+  const stopRecordingForNavigation = useCallback(
+    (destinationKey: ChatRuntimeKey) => {
+      const rawOwnerKey = recordingOwnerKeyRef.current;
+      const ownerKey = rawOwnerKey ? runtimeStore.resolveKey(rawOwnerKey) : null;
+      const ownerSessionToken = recordingSessionTokenRef.current;
+      const recorder = recorderRef.current;
+      const stream = streamRef.current;
+      const result = cleanupRecordingForNavigation({
+        ownerKey,
+        destinationKey: runtimeStore.resolveKey(destinationKey),
+        recorder: recorder
+          ? { stopRecording: (callback) => recorder.stopRecording(callback) }
+          : null,
+        stream,
+        clearOwnership: () => {
+          const currentOwnerKey = recordingOwnerKeyRef.current;
+          if (
+            currentOwnerKey &&
+            runtimeStore.resolveKey(currentOwnerKey) === ownerKey &&
+            recordingSessionTokenRef.current === ownerSessionToken
+          ) {
+            recordingOwnerKeyRef.current = null;
+            recordingSessionTokenRef.current += 1;
+            setRecordingOwnerKey(null);
+            setIsRecording(false);
+            setIsTranscribing(false);
+            setIsProcessingSend(false);
+          }
+        },
+        clearRecorder: () => {
+          if (recorderRef.current === recorder) recorderRef.current = null;
+        },
+        clearStream: () => {
+          if (streamRef.current === stream) streamRef.current = null;
+        }
+      });
+      if (result.errors.length > 0) {
+        console.error("Failed to fully stop recording during chat navigation:", result.errors);
+      }
+    },
+    [runtimeStore]
+  );
+
+  useEffect(
+    () => () => {
+      const recorder = recorderRef.current;
+      const stream = streamRef.current;
+      const result = cleanupRecordingForTeardown({
+        recorder: recorder
+          ? { stopRecording: (callback) => recorder.stopRecording(callback) }
+          : null,
+        stream,
+        clearOwnership: () => {
+          recordingOwnerKeyRef.current = null;
+          recordingSessionTokenRef.current += 1;
+        },
+        clearRecorder: () => {
+          if (recorderRef.current === recorder) recorderRef.current = null;
+        },
+        clearStream: () => {
+          if (streamRef.current === stream) streamRef.current = null;
+        }
+      });
+      if (result.errors.length > 0) {
+        console.error("Failed to fully clean up recording during teardown:", result.errors);
+      }
+    },
+    []
+  );
 
   const clearHistoryBottomCompensation = useCallback(() => {
     if (historyBottomCompensationRef.current) {
@@ -1661,6 +2025,7 @@ export function UnifiedChat() {
   useEffect(() => {
     historyPaginationGateRef.current.resetIntent();
     pendingHistoryScrollRestoreRef.current = null;
+    pendingHistoryScrollRestoreKeyRef.current = null;
     previousTouchYRef.current = null;
     touchHistoryGestureActiveRef.current = false;
     pointerHistoryGestureActiveRef.current = false;
@@ -1696,28 +2061,6 @@ export function UnifiedChat() {
     };
   }, [chatId]);
 
-  // Attachment cleanup function - defined early to avoid reference errors
-  const clearAllAttachments = useCallback(() => {
-    imagePasteGenerationRef.current += 1;
-    documentUploadGenerationRef.current += 1;
-    // Clean up image URLs
-    imageUrls.forEach((url) => URL.revokeObjectURL(url));
-    setImageUrls(new Map());
-    setDraftImages([]);
-    setDocumentText("");
-    setDocumentName("");
-    setIsProcessingDocument(false);
-    setAttachmentError(null);
-  }, [imageUrls]);
-
-  // Invalidate delayed clipboard reads when switching conversations or unmounting.
-  useEffect(() => {
-    imagePasteGenerationRef.current += 1;
-    return () => {
-      imagePasteGenerationRef.current += 1;
-    };
-  }, [chatId]);
-
   // Auto-resize textarea
   useEffect(() => {
     if (textareaRef.current) {
@@ -1729,10 +2072,10 @@ export function UnifiedChat() {
 
   // Cleanup billing refresh timeout on unmount
   useEffect(() => {
+    const billingRefreshTimeouts = billingRefreshTimeoutsRef.current;
     return () => {
-      if (billingRefreshTimeoutRef.current) {
-        clearTimeout(billingRefreshTimeoutRef.current);
-      }
+      for (const timeout of billingRefreshTimeouts) clearTimeout(timeout);
+      billingRefreshTimeouts.clear();
     };
   }, []);
 
@@ -1806,8 +2149,18 @@ export function UnifiedChat() {
     };
   }, []);
 
+  const [streamEventDebugLoggingEnabled] = useState(isStreamEventDebugLoggingEnabled);
   const logStreamEvent = useCallback(
-    (streamStartedAt: number, eventIndex: number, eventType: string, event: unknown) => {
+    (
+      runtimeKey: ChatRuntimeKey,
+      runToken: number,
+      streamStartedAt: number,
+      eventIndex: number,
+      eventType: string,
+      event: unknown
+    ) => {
+      if (!streamEventDebugLoggingEnabled) return;
+
       const includeScrollSnapshot =
         eventType === "response.output_item.added" ||
         eventType === "response.output_item.done" ||
@@ -1817,10 +2170,12 @@ export function UnifiedChat() {
       console.log("🔵 SSE Event", {
         at: new Date().toISOString(),
         elapsedMs: Math.round(performance.now() - streamStartedAt),
+        runtimeKey: runtimeStore.resolveKey(runtimeKey),
+        runToken,
         eventIndex,
         eventType,
         ...summarizeStreamEventForLog(eventType, event),
-        ...(includeScrollSnapshot
+        ...(includeScrollSnapshot && isRuntimeSelected(runtimeKey)
           ? {
               isUserScrolling: isUserScrollingRef.current,
               scroll: getScrollDebugSnapshot()
@@ -1828,7 +2183,7 @@ export function UnifiedChat() {
           : {})
       });
     },
-    [getScrollDebugSnapshot]
+    [getScrollDebugSnapshot, isRuntimeSelected, runtimeStore, streamEventDebugLoggingEnabled]
   );
 
   // Attach scroll listener
@@ -1848,9 +2203,11 @@ export function UnifiedChat() {
 
     const container = chatContainerRef.current;
     const snapshot = pendingHistoryScrollRestoreRef.current;
+    const ownerKey = pendingHistoryScrollRestoreKeyRef.current;
     pendingHistoryScrollRestoreRef.current = null;
+    pendingHistoryScrollRestoreKeyRef.current = null;
 
-    if (!container) return;
+    if (!container || !ownerKey || !isRuntimeSelected(ownerKey)) return;
 
     let restoredScrollTop = restoredChatHistoryScrollTop(snapshot, container.scrollHeight);
 
@@ -1892,7 +2249,7 @@ export function UnifiedChat() {
       // the real gesture end (or the compatibility timer) must release the gate.
       suppressedHistoryScrollEndsRef.current += 1;
     }
-  }, [isLoadingOlderMessages, messages]);
+  }, [isLoadingOlderMessages, isRuntimeSelected, messages]);
 
   // Initial load - scroll to bottom instantly
   useEffect(() => {
@@ -1975,55 +2332,97 @@ export function UnifiedChat() {
     }
   }, [hasNewPolledMessages, scrollToBottom]);
 
-  // Unified event handling for conversation changes
+  const selectConversationRuntime = useCallback(
+    (conversationId: string) => {
+      const key = createConversationChatKey(conversationId);
+      stopRecordingForNavigation(key);
+      runtimeStore.select(key);
+      activeRuntimeKeyRef.current = key;
+      setActiveRuntimeKey(key);
+      setChatId(conversationId);
+      prevMessageCountRef.current = 0;
+      return key;
+    },
+    [runtimeStore, stopRecordingForNavigation]
+  );
+
+  const selectFreshDraftRuntime = useCallback(
+    (projectId: string | null, requestedDraftKey?: DraftChatRuntimeKey) => {
+      const key = requestedDraftKey ?? createChatDraftKey();
+      stopRecordingForNavigation(key);
+      runtimeStore.select(key, {
+        composer: createChatComposerState(projectId)
+      });
+      activeRuntimeKeyRef.current = key;
+      setActiveRuntimeKey(key);
+      setChatId(undefined);
+      prevMessageCountRef.current = 0;
+      window.history.replaceState(
+        historyStateWithDraftRuntimeKey(window.history.state, key),
+        "",
+        window.location.href
+      );
+      return key;
+    },
+    [runtimeStore, stopRecordingForNavigation]
+  );
+
+  // Unified event handling for conversation changes. Selection never clears or
+  // aborts the previous runtime; background streams retain their owning key.
   useEffect(() => {
     // Handle new chat event
     const handleNewChat = (event?: Event) => {
+      const detail =
+        event instanceof CustomEvent && event.detail && typeof event.detail === "object"
+          ? (event.detail as NewChatNavigationDetail)
+          : undefined;
       const nextProjectId =
-        event instanceof CustomEvent && event.detail && "projectId" in event.detail
-          ? (event.detail.projectId ?? null)
-          : (selectedProjectId ?? null);
+        detail && "projectId" in detail ? (detail.projectId ?? null) : (selectedProjectId ?? null);
+      const requestedDraftKey = isDraftChatRuntimeKey(detail?.draftRuntimeKey)
+        ? detail.draftRuntimeKey
+        : undefined;
 
-      activeConversationLoadRef.current += 1;
-      setChatId(undefined);
-      setConversation(null);
-      setMessages([]);
-      setInput("");
-      setDraftProjectId(nextProjectId);
-      setError(null);
-      setLastSeenItemId(undefined);
-      // Clear pagination state
-      setOldestItemId(undefined);
-      setHasMoreOlderMessages(false);
-      setIsLoadingOlderMessages(false);
-      // Clear attachments
-      clearAllAttachments();
-      // Reset scroll tracking
-      prevMessageCountRef.current = 0;
+      selectFreshDraftRuntime(nextProjectId, requestedDraftKey);
     };
 
     // Handle conversation selection from sidebar
     const handleConversationSelected = (event: CustomEvent) => {
       const { conversationId } = event.detail;
       if (conversationId && conversationId !== chatId) {
-        // Reset scroll tracking for new conversation
-        prevMessageCountRef.current = 0;
-        activeConversationLoadRef.current += 1;
-        // Update our local chatId state to trigger load
-        setChatId(conversationId);
-        setError(null);
+        selectConversationRuntime(conversationId);
       }
     };
 
     // Handle browser back/forward navigation
-    const handlePopState = () => {
+    const handlePopState = (event: PopStateEvent) => {
       const params = new URLSearchParams(window.location.search);
       const newChatId = params.get("conversation_id") || undefined;
-      if (newChatId !== chatId) {
-        // Reset scroll tracking for navigation
-        prevMessageCountRef.current = 0;
-        activeConversationLoadRef.current += 1;
-        setChatId(newChatId);
+      if (params.has("project_id")) return;
+
+      if (newChatId) {
+        if (newChatId !== chatId) {
+          selectConversationRuntime(newChatId);
+        }
+        return;
+      }
+
+      const savedDraftKey = draftRuntimeKeyFromHistoryState(event.state);
+      if (savedDraftKey) {
+        const restoredConversationId = conversationIdFromChatRuntimeKey(
+          runtimeStore.resolveKey(savedDraftKey)
+        );
+        if (restoredConversationId) {
+          canonicalizeConversationHistoryEntry(restoredConversationId, event.state);
+          if (restoredConversationId !== chatId) {
+            selectConversationRuntime(restoredConversationId);
+          }
+          return;
+        }
+      }
+
+      const currentKey = runtimeStore.resolveKey(activeRuntimeKeyRef.current);
+      if (!savedDraftKey || currentKey !== runtimeStore.resolveKey(savedDraftKey)) {
+        selectFreshDraftRuntime(selectedProjectId ?? null, savedDraftKey ?? undefined);
       }
     };
 
@@ -2039,34 +2438,58 @@ export function UnifiedChat() {
       );
       window.removeEventListener("popstate", handlePopState);
     };
-  }, [chatId, clearAllAttachments, selectedProjectId]);
+  }, [chatId, runtimeStore, selectConversationRuntime, selectFreshDraftRuntime, selectedProjectId]);
 
   // Cancel the current response
   const handleCancelResponse = useCallback(async () => {
-    if (!currentResponseId || !openai) return;
+    const runtimeKey = activeRuntimeKeyRef.current;
+    const runToken = runtimeStore.get(runtimeKey)?.runToken;
+    if (runToken === null || runToken === undefined) return;
+    const optimisticMessageId = getRegisteredChatOptimisticMessage(runtimeStore, runToken);
+    // Commit the final partial frame while this run still owns its token. Once
+    // cancelRun clears ownership, any delayed callback must fail closed.
+    flushRegisteredChatStreamDeltas(runtimeStore, runToken);
+    const cancelled = runtimeStore.cancelRun(runtimeKey, runToken);
+    if (!cancelled) return;
+
+    runtimeStore.update(runtimeKey, (snapshot) => ({
+      ...snapshot,
+      messages: cancelled.responseId
+        ? updateActiveItemStatuses(snapshot.messages as Message[], "incomplete")
+        : updateActiveItemStatuses(
+            markOptimisticMessageIncomplete(snapshot.messages as Message[], optimisticMessageId),
+            "incomplete"
+          )
+    }));
+    if (optimisticMessageId) {
+      unregisterChatOptimisticMessage(runtimeStore, runToken, optimisticMessageId);
+    }
 
     try {
-      await (openai.responses as { cancel: (id: string) => Promise<unknown> }).cancel(
-        currentResponseId
-      );
-      setIsGenerating(false);
-      setCurrentResponseId(undefined);
-      abortControllerRef.current?.abort();
-      abortControllerRef.current = null;
-      assistantStreamingRef.current = false;
+      if (cancelled.responseId && openai) {
+        await (openai.responses as { cancel: (id: string) => Promise<unknown> }).cancel(
+          cancelled.responseId
+        );
+      }
     } catch (error) {
       console.error("Failed to cancel response:", error);
-      setError("Failed to cancel response. Please try again.");
+      if (runtimeStore.get(runtimeKey)) {
+        setErrorForKey(runtimeKey, "Failed to cancel response. Please try again.");
+      }
     }
-  }, [currentResponseId, openai]);
+  }, [openai, runtimeStore, setErrorForKey]);
 
   // Load conversation from API
   const loadConversation = useCallback(
-    async (conversationId: string) => {
+    async (runtimeKey: ChatRuntimeKey, conversationId: string) => {
       if (!openai) return;
 
-      const requestId = ++activeConversationLoadRef.current;
-      const isStaleRequest = () => requestId !== activeConversationLoadRef.current;
+      const canonicalKey = runtimeStore.resolveKey(runtimeKey);
+      const requestId = (activeConversationLoadRef.current.get(canonicalKey) ?? 0) + 1;
+      activeConversationLoadRef.current.set(canonicalKey, requestId);
+      const isStaleRequest = () =>
+        !runtimeStore.get(runtimeKey) ||
+        activeConversationLoadRef.current.get(runtimeStore.resolveKey(runtimeKey)) !== requestId;
 
       // Reset message count before loading new conversation
       prevMessageCountRef.current = 0;
@@ -2105,26 +2528,25 @@ export function UnifiedChat() {
         // Reverse the array for display (we want oldest first/at top, newest last/at bottom)
         // API returns desc (newest first), but chat UI needs chronological order
         const messagesInChronologicalOrder = loadedMessages.reverse();
-        setMessages(messagesInChronologicalOrder);
-
-        // Use the API's raw-item cursor rather than a normalized rendered-message ID.
         const oldestId = itemsResponse.last_id || itemsResponse.data.at(-1)?.id;
-        if (oldestId) {
-          setOldestItemId(oldestId);
-          setHasMoreOlderMessages(itemsResponse.has_more);
-        } else {
-          setOldestItemId(undefined);
-          setHasMoreOlderMessages(false);
-        }
-
-        // Set last seen ID for polling - use the NEWEST message (first in desc response)
-        // Skip in_progress messages by finding the first completed one
         const newestCompletedItem = itemsResponse.data.find(
           (item) => (item as Message).status !== "in_progress"
         );
-        if (newestCompletedItem) {
-          setLastSeenItemId(newestCompletedItem.id);
-        }
+        runtimeStore.update(runtimeKey, (snapshot) => ({
+          ...snapshot,
+          messages: mergeLoadedMessagesWithRuntime(messagesInChronologicalOrder, snapshot.messages),
+          lastSeenItemId: newestCompletedItem?.id ?? snapshot.lastSeenItemId,
+          historyLoaded: true,
+          composer: {
+            ...snapshot.composer,
+            pagination: {
+              ...snapshot.composer.pagination,
+              oldestItemId: oldestId,
+              hasMoreOlderMessages: oldestId ? itemsResponse.has_more : false,
+              isLoadingOlderMessages: false
+            }
+          }
+        }));
 
         // Then handle conversation metadata when it arrives
         const conv = await convPromise;
@@ -2132,7 +2554,10 @@ export function UnifiedChat() {
         if (!conv.ok) {
           throw conv.error;
         }
-        setConversation(conv.value as Conversation);
+        runtimeStore.update(runtimeKey, (snapshot) => ({
+          ...snapshot,
+          conversation: conv.value as Conversation
+        }));
       } catch (error) {
         if (isStaleRequest()) return;
 
@@ -2140,39 +2565,53 @@ export function UnifiedChat() {
         if (err.status === 404) {
           // Conversation doesn't exist - clear and start fresh
           // Conversation not found, starting new
-          setConversation(null);
-          setMessages([]);
-          setError(null);
-          setOldestItemId(undefined);
-          setHasMoreOlderMessages(false);
-          // Clear the invalid conversation_id from URL
-          const params = new URLSearchParams(window.location.search);
-          params.delete("conversation_id");
-          window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
+          runtimeStore.delete(runtimeKey);
+          if (isRuntimeSelected(runtimeKey)) {
+            const params = new URLSearchParams(window.location.search);
+            params.delete("conversation_id");
+            window.history.replaceState({}, "", params.toString() ? `/?${params}` : "/");
+            selectFreshDraftRuntime(selectedProjectId ?? null);
+          }
         } else {
           console.error("Failed to load conversation:", error);
-          setError(err.message || "Failed to load conversation");
+          setErrorForKey(runtimeKey, err.message || "Failed to load conversation");
         }
       }
     },
-    [openai]
+    [
+      isRuntimeSelected,
+      openai,
+      runtimeStore,
+      selectFreshDraftRuntime,
+      selectedProjectId,
+      setErrorForKey
+    ]
   );
 
   // Load older messages for pagination
   const loadOlderMessages = useCallback(async () => {
-    if (!conversation?.id || !openai || !oldestItemId) {
+    const runtimeKey = activeRuntimeKeyRef.current;
+    const snapshot = runtimeStore.get(runtimeKey);
+    const conversationId =
+      snapshot?.conversation?.id ??
+      conversationIdFromChatRuntimeKey(runtimeStore.resolveKey(runtimeKey));
+    const requestOldestItemId = snapshot?.composer.pagination.oldestItemId;
+    if (!conversationId || !openai || !requestOldestItemId) {
       historyPaginationGateRef.current.finishLoad();
       return;
     }
 
-    setIsLoadingOlderMessages(true);
+    updateComposerForKey(runtimeKey, (composer) => ({
+      ...composer,
+      pagination: { ...composer.pagination, isLoadingOlderMessages: true }
+    }));
 
     try {
       // Fetch next 20 older items using the oldest item ID we have
-      const itemsResponse = await openai.conversations.items.list(conversation.id, {
+      const itemsResponse = await openai.conversations.items.list(conversationId, {
         limit: 20,
         order: "desc",
-        after: oldestItemId
+        after: requestOldestItemId
       });
 
       // Convert items to messages, grouping tool calls with their messages
@@ -2195,16 +2634,16 @@ export function UnifiedChat() {
       const olderMessagesInChronologicalOrder = olderMessages.reverse();
       const newOldestId = itemsResponse.last_id || itemsResponse.data.at(-1)?.id;
 
-      if (!chatHistoryCursorProgressed(oldestItemId, newOldestId)) {
-        setHasMoreOlderMessages(false);
+      if (!chatHistoryCursorProgressed(requestOldestItemId, newOldestId)) {
+        updateComposerForKey(runtimeKey, (composer) => ({
+          ...composer,
+          pagination: { ...composer.pagination, hasMoreOlderMessages: false }
+        }));
         return;
       }
 
-      setOldestItemId(newOldestId);
-      setHasMoreOlderMessages(itemsResponse.has_more);
-
       if (olderMessagesInChronologicalOrder.length > 0) {
-        const container = chatContainerRef.current;
+        const container = isRuntimeSelected(runtimeKey) ? chatContainerRef.current : null;
         if (container) {
           const containerRect = container.getBoundingClientRect();
           const firstVisibleAnchor = Array.from(
@@ -2226,128 +2665,136 @@ export function UnifiedChat() {
             anchorId,
             anchorOffset
           };
+          pendingHistoryScrollRestoreKeyRef.current = runtimeKey;
         }
 
         // Prepend older messages while keeping IDs unique. Restore the pending scroll
         // snapshot after this render commits; the loading overlay does not affect layout.
-        setMessages((prev) => mergeMessagesById(olderMessagesInChronologicalOrder, prev));
+        runtimeStore.update(runtimeKey, (current) => ({
+          ...current,
+          messages: mergeMessagesById(
+            olderMessagesInChronologicalOrder,
+            current.messages as Message[]
+          ),
+          composer: {
+            ...current.composer,
+            pagination: {
+              ...current.composer.pagination,
+              oldestItemId: newOldestId,
+              hasMoreOlderMessages: itemsResponse.has_more
+            }
+          }
+        }));
+      } else {
+        updateComposerForKey(runtimeKey, (composer) => ({
+          ...composer,
+          pagination: {
+            ...composer.pagination,
+            oldestItemId: newOldestId,
+            hasMoreOlderMessages: itemsResponse.has_more
+          }
+        }));
       }
     } catch (error) {
       console.error("Failed to load older messages:", error);
     } finally {
       historyPaginationGateRef.current.finishLoad();
-      setIsLoadingOlderMessages(false);
+      const current = runtimeStore.get(runtimeKey);
+      if (current) {
+        updateComposerForKey(runtimeKey, (composer) => ({
+          ...composer,
+          pagination: { ...composer.pagination, isLoadingOlderMessages: false }
+        }));
+      }
     }
-  }, [conversation?.id, openai, oldestItemId]);
+  }, [isRuntimeSelected, openai, runtimeStore, updateComposerForKey]);
 
   // Polling mechanism for conversation updates
-  const pollForNewItems = useCallback(async () => {
-    if (!conversation?.id || !openai) return;
-    if (assistantStreamingRef.current) return;
+  const pollForNewItems = useCallback(
+    async (runtimeKey: ChatRuntimeKey) => {
+      const snapshot = runtimeStore.get(runtimeKey);
+      const conversationId =
+        snapshot?.conversation?.id ??
+        conversationIdFromChatRuntimeKey(runtimeStore.resolveKey(runtimeKey));
+      if (!snapshot || !conversationId || !openai || snapshot.assistantStreaming) return;
 
-    try {
-      // Fetch NEW items that came after the last seen ID
-      // Use order=asc to get items chronologically after the lastSeenItemId
-      const response = await openai.conversations.items.list(conversation.id, {
-        ...(lastSeenItemId ? { after: lastSeenItemId, order: "asc" } : {}),
-        limit: 20 // Smaller limit since we only expect a few new messages
-      });
+      try {
+        // Fetch NEW items that came after the last seen ID
+        // Use order=asc to get items chronologically after the lastSeenItemId
+        const response = await openai.conversations.items.list(conversationId, {
+          ...(snapshot.lastSeenItemId ? { after: snapshot.lastSeenItemId, order: "asc" } : {}),
+          limit: 20 // Smaller limit since we only expect a few new messages
+        });
 
-      if (response.data.length > 0) {
-        // Convert API items to UI messages, grouping tool calls with their messages
-        const newMessages = convertItemsToMessages(
-          response.data as Array<{
-            id: string;
-            type: string;
-            role?: string;
-            content?: unknown;
-            name?: string;
-            arguments?: string;
-            call_id?: string;
-            output?: string;
-            status?: string;
-            created_at?: number;
-          }>
-        );
+        if (response.data.length > 0) {
+          // Convert API items to UI messages, grouping tool calls with their messages
+          const newMessages = convertItemsToMessages(
+            response.data as Array<{
+              id: string;
+              type: string;
+              role?: string;
+              content?: unknown;
+              name?: string;
+              arguments?: string;
+              call_id?: string;
+              output?: string;
+              status?: string;
+              created_at?: number;
+            }>
+          );
 
-        if (newMessages.length > 0) {
-          // Merge new messages with deduplication using helper
-          setMessages((prev) => {
-            // Check if there are truly new messages (not already in prev)
-            const prevIds = new Set(prev.map((m) => m.id));
-            const trulyNewMessages = newMessages.filter((m) => !prevIds.has(m.id));
+          if (newMessages.length > 0) {
+            // Merge new messages with deduplication using helper
+            runtimeStore.update(runtimeKey, (current) => {
+              // Check if there are truly new messages (not already in prev)
+              const prevIds = new Set(current.messages.map((m) => m.id));
+              const trulyNewMessages = newMessages.filter((m) => !prevIds.has(m.id));
 
-            // Mark that we have new polled messages for scrolling
-            if (trulyNewMessages.length > 0) {
-              setHasNewPolledMessages(true);
+              // Mark that we have new polled messages for scrolling
+              if (trulyNewMessages.length > 0 && isRuntimeSelected(runtimeKey)) {
+                setHasNewPolledMessages(true);
+              }
+
+              return {
+                ...current,
+                messages: mergePolledMessagesWithRuntime(current.messages, newMessages)
+              };
+            });
+
+            // Update last seen item ID for next poll
+            // Since we're using order=asc, the LAST item is the newest
+            // Skip in_progress messages by finding the last completed one
+            const newestCompletedItem = [...response.data]
+              .reverse()
+              .find((item) => (item as Message).status !== "in_progress");
+            if (newestCompletedItem) {
+              setLastSeenItemIdForKey(runtimeKey, newestCompletedItem.id);
             }
-
-            // Use merge helper to combine, which will deduplicate and update existing messages
-            return mergeMessagesById(prev, newMessages);
-          });
-
-          // Update last seen item ID for next poll
-          // Since we're using order=asc, the LAST item is the newest
-          // Skip in_progress messages by finding the last completed one
-          const newestCompletedItem = [...response.data]
-            .reverse()
-            .find((item) => (item as Message).status !== "in_progress");
-          if (newestCompletedItem) {
-            setLastSeenItemId(newestCompletedItem.id);
-          }
-
-          // Check if we're no longer generating
-          // Only stop if assistant message is completed or incomplete, not if still in_progress
-          if (
-            isGenerating &&
-            newMessages.some(
-              (m) =>
-                m.type === "message" &&
-                (m as ExtendedMessage).role === "assistant" &&
-                ((m as ExtendedMessage).status === "completed" ||
-                  (m as ExtendedMessage).status === "incomplete")
-            )
-          ) {
-            setIsGenerating(false);
           }
         }
+      } catch (error) {
+        console.error("Polling error:", error);
+        // Don't throw - polling should fail silently
       }
-    } catch (error) {
-      console.error("Polling error:", error);
-      // Don't throw - polling should fail silently
-    }
-  }, [conversation?.id, lastSeenItemId, isGenerating, openai]);
+    },
+    [isRuntimeSelected, openai, runtimeStore, setLastSeenItemIdForKey]
+  );
 
-  // Load conversation when URL changes or on mount
+  // Load conversation when URL changes or on mount. Cached runtimes—including
+  // active offscreen streams—remain authoritative and do not get reloaded.
   useEffect(() => {
-    // Skip if we just created a new conversation
-    if (isNewConversationJustCreated) {
-      // Reset the flag for next time
-      setIsNewConversationJustCreated(false);
-      return;
-    }
-
     if (chatId && openai) {
-      // Load the conversation from URL
-      loadConversation(chatId);
-    } else if (!chatId) {
-      // Clear if no conversation ID
-      setConversation(null);
-      setMessages([]);
-      setDraftProjectId(selectedProjectId ?? null);
-      setLastSeenItemId(undefined);
-      // Clear pagination state
-      setOldestItemId(undefined);
-      setHasMoreOlderMessages(false);
-      setIsLoadingOlderMessages(false);
-      // Reset scroll tracking
-      prevMessageCountRef.current = 0;
+      const snapshot = runtimeStore.get(activeRuntimeKey);
+      if (!snapshot?.historyLoaded) {
+        void loadConversation(activeRuntimeKey, chatId);
+      }
     }
-  }, [chatId, openai, loadConversation, selectedProjectId]);
+  }, [activeRuntimeKey, chatId, openai, loadConversation, runtimeStore]);
 
   // Set up progressive polling interval
   useEffect(() => {
     if (!conversation?.id || !openai) return;
+    const runtimeKey = activeRuntimeKey;
 
     // Progressive intervals: 2s, 5s, 10s, 15s, 20s, 30s, 60s (then 60s forever)
     const intervals = [2000, 5000, 10000, 15000, 20000, 30000, 60000];
@@ -2359,7 +2806,7 @@ export function UnifiedChat() {
       const currentInterval = intervals[Math.min(currentIntervalIndex, intervals.length - 1)];
 
       timeoutId = setTimeout(() => {
-        pollForNewItems();
+        void pollForNewItems(runtimeKey);
 
         // Move to next interval if not at the end
         if (currentIntervalIndex < intervals.length - 1) {
@@ -2377,11 +2824,12 @@ export function UnifiedChat() {
     return () => {
       if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [conversation?.id, openai, pollForNewItems]);
+  }, [activeRuntimeKey, conversation?.id, openai, pollForNewItems]);
 
   // Poll for title updates when it's "New Conversation" with exponential backoff
   useEffect(() => {
     const currentTitle = conversation?.metadata?.title;
+    const runtimeKey = activeRuntimeKey;
 
     // Only poll if we have a conversation and the title is "New Conversation"
     if (!conversation?.id || !openai || currentTitle !== "New Conversation") {
@@ -2392,20 +2840,29 @@ export function UnifiedChat() {
     let currentDelay = 500; // Start at 0.5s
     const maxDelay = 10000; // Cap at 10s
     let timeoutId: ReturnType<typeof setTimeout>;
+    let cancelled = false;
 
     const checkTitle = async () => {
       try {
         // Fetch updated conversation metadata
         const updatedConv = await openai.conversations.retrieve(conversation.id);
+        if (cancelled || !runtimeStore.get(runtimeKey)) return;
         const newTitle = (updatedConv as Conversation).metadata?.title;
 
         // If title changed from "New Conversation", update local state and sidebar
         if (newTitle && newTitle !== "New Conversation") {
-          setConversation(updatedConv as Conversation);
+          setConversationForKey(runtimeKey, updatedConv as Conversation);
           // Trigger title animation
-          setTitleJustUpdated(true);
+          if (isRuntimeSelected(runtimeKey)) setTitleJustUpdatedKey(runtimeKey);
           // Remove animation class after animation completes (800ms for flash animation)
-          setTimeout(() => setTitleJustUpdated(false), 850);
+          setTimeout(() => {
+            setTitleJustUpdatedKey((currentKey) =>
+              currentKey &&
+              runtimeStore.resolveKey(currentKey) === runtimeStore.resolveKey(runtimeKey)
+                ? null
+                : currentKey
+            );
+          }, 850);
           // Refresh all sidebar conversation lists
           await Promise.all([
             queryClient.invalidateQueries({ queryKey: ["conversations"] }),
@@ -2420,6 +2877,7 @@ export function UnifiedChat() {
         timeoutId = setTimeout(checkTitle, currentDelay);
       } catch (error) {
         console.error("Failed to check title update:", error);
+        if (cancelled) return;
         // Continue polling even on error
         currentDelay = Math.min(currentDelay * 2, maxDelay);
         timeoutId = setTimeout(checkTitle, currentDelay);
@@ -2430,9 +2888,19 @@ export function UnifiedChat() {
     timeoutId = setTimeout(checkTitle, currentDelay);
 
     return () => {
+      cancelled = true;
       if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [conversation?.id, conversation?.metadata?.title, openai, queryClient]);
+  }, [
+    activeRuntimeKey,
+    conversation?.id,
+    conversation?.metadata?.title,
+    isRuntimeSelected,
+    openai,
+    queryClient,
+    runtimeStore,
+    setConversationForKey
+  ]);
 
   const isHistoryTopBoundaryNear = useCallback(() => {
     const container = chatContainerRef.current;
@@ -2746,13 +3214,17 @@ export function UnifiedChat() {
   // Auto-clear error after 3 seconds
   useEffect(() => {
     if (error) {
+      const ownerKey = activeRuntimeKey;
+      const ownerError = error;
       const timeoutId = setTimeout(() => {
-        setError(null);
+        if (runtimeStore.get(ownerKey)?.error === ownerError) {
+          setErrorForKey(ownerKey, null);
+        }
       }, 3000);
 
       return () => clearTimeout(timeoutId);
     }
-  }, [error]);
+  }, [activeRuntimeKey, error, runtimeStore, setErrorForKey]);
 
   // Toggle sidebar
   const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), [setIsSidebarOpen]);
@@ -2768,8 +3240,13 @@ export function UnifiedChat() {
     const newUrl = usp.toString()
       ? `${window.location.pathname}?${usp.toString()}`
       : window.location.pathname;
-    window.history.replaceState(null, "", newUrl);
-    window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
+    const freshChat = createFreshChatHistoryEntry();
+    window.history.pushState(freshChat.historyState, "", newUrl);
+    window.dispatchEvent(
+      new CustomEvent<NewChatNavigationDetail>("newchat", {
+        detail: { projectId: null, draftRuntimeKey: freshChat.draftRuntimeKey }
+      })
+    );
     if (isSidebarOpen) {
       toggleSidebar();
     }
@@ -2791,93 +3268,143 @@ export function UnifiedChat() {
   const canUseDocuments = hasProAccess;
   const canUseVoice = hasProAccess && localState.hasWhisperModel;
 
+  const setComposerErrorForKey = useCallback(
+    (
+      key: ChatRuntimeKey,
+      field: "attachmentError" | "audioError",
+      message: string | null,
+      duration = 5000
+    ) => {
+      if (!updateComposerForKey(key, (composer) => ({ ...composer, [field]: message }))) return;
+      if (!message) return;
+
+      setTimeout(() => {
+        const snapshot = runtimeStore.get(key);
+        if (snapshot?.composer[field] !== message) return;
+        updateComposerForKey(key, (composer) => ({ ...composer, [field]: null }));
+      }, duration);
+    },
+    [runtimeStore, updateComposerForKey]
+  );
+
   const handleAddImages = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      if (!e.target.files) return;
+      const ownerKey = fileInputOwnerKeyRef.current ?? activeRuntimeKeyRef.current;
+      fileInputOwnerKeyRef.current = null;
+      const selectedFiles = Array.from(e.currentTarget.files ?? []);
+      e.currentTarget.value = "";
+      const ownerSnapshot = runtimeStore.get(ownerKey);
+      if (selectedFiles.length === 0 || !ownerSnapshot || ownerSnapshot.isGenerating) return;
 
       const supportedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
-      const maxSizeInBytes = 10 * 1024 * 1024; // 10MB
+      const maxSizeInBytes = 10 * 1024 * 1024;
+      let validationError: string | null = null;
 
-      const validFiles = Array.from(e.target.files).filter((file) => {
+      const validFiles = selectedFiles.filter((file) => {
         if (!supportedTypes.includes(file.type.toLowerCase())) {
-          setAttachmentError("Only JPEG, PNG, and WebP images are supported");
-          setTimeout(() => setAttachmentError(null), 5000);
+          validationError = "Only JPEG, PNG, and WebP images are supported";
           return false;
         }
         if (file.size > maxSizeInBytes) {
-          setAttachmentError(`Image too large (max 10MB)`);
-          setTimeout(() => setAttachmentError(null), 5000);
+          validationError = "Image too large (max 10MB)";
           return false;
         }
         return true;
       });
+      if (validationError) {
+        setComposerErrorForKey(ownerKey, "attachmentError", validationError);
+      }
+      if (validFiles.length === 0) return;
 
-      // Create object URLs for previews
-      const newUrlMap = new Map(imageUrls);
-      validFiles.forEach((file) => {
-        if (!newUrlMap.has(file)) {
-          newUrlMap.set(file, URL.createObjectURL(file));
-        }
-      });
-      setImageUrls(newUrlMap);
-      setDraftImages((prev) => [...prev, ...validFiles]);
-
-      // Clear input to allow re-uploading same file
-      e.target.value = "";
+      const newUrls = validFiles.map((file) => [file, URL.createObjectURL(file)] as const);
+      const attached = updateIdleAttachmentComposerForKey(ownerKey, (composer) => ({
+        ...composer,
+        imageUrls: new Map([...composer.imageUrls, ...newUrls]),
+        draftImages: [...composer.draftImages, ...validFiles]
+      }));
+      if (!attached) for (const [, url] of newUrls) URL.revokeObjectURL(url);
     },
-    [imageUrls, localState]
+    [runtimeStore, setComposerErrorForKey, updateIdleAttachmentComposerForKey]
   );
 
   const attachPastedImages = useCallback(
-    (imageFiles: File[]) => {
+    (imageFiles: File[], ownerKey: ChatRuntimeKey, expectedGeneration: number) => {
+      const ownerSnapshot = runtimeStore.get(ownerKey);
+      if (!ownerSnapshot || ownerSnapshot.isGenerating) return;
+
       if (!canUseImages) {
-        setUpgradeFeature("image");
-        setUpgradeDialogOpen(true);
+        if (isRuntimeSelected(ownerKey)) {
+          setUpgradeFeature("image");
+          setUpgradeDialogOpen(true);
+        }
         return;
       }
 
       const supportedTypes = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
-      const maxSizeInBytes = 10 * 1024 * 1024; // 10MB
+      const maxSizeInBytes = 10 * 1024 * 1024;
+      let validationError: string | null = null;
 
       const validFiles = imageFiles.filter((file) => {
         if (!supportedTypes.includes(file.type.toLowerCase())) {
-          setAttachmentError("Only JPEG, PNG, and WebP images are supported");
-          setTimeout(() => setAttachmentError(null), 5000);
+          validationError = "Only JPEG, PNG, and WebP images are supported";
           return false;
         }
         if (file.size > maxSizeInBytes) {
-          setAttachmentError("Image too large (max 10MB)");
-          setTimeout(() => setAttachmentError(null), 5000);
+          validationError = "Image too large (max 10MB)";
           return false;
         }
         return true;
       });
+      if (validationError) {
+        setComposerErrorForKey(ownerKey, "attachmentError", validationError);
+      }
 
       if (validFiles.length === 0) return;
 
       const newUrls = validFiles.map((file) => [file, URL.createObjectURL(file)] as const);
-      setImageUrls((currentUrls) => new Map([...currentUrls, ...newUrls]));
-      setDraftImages((prev) => [...prev, ...validFiles]);
+      let generationMatched = false;
+      const attached = updateIdleAttachmentComposerForKey(ownerKey, (composer) => {
+        if (composer.imagePasteGeneration !== expectedGeneration) return composer;
+        generationMatched = true;
+        return {
+          ...composer,
+          imageUrls: new Map([...composer.imageUrls, ...newUrls]),
+          draftImages: [...composer.draftImages, ...validFiles]
+        };
+      });
+      if (!attached || !generationMatched) {
+        for (const [, url] of newUrls) URL.revokeObjectURL(url);
+      }
     },
-    [canUseImages]
+    [
+      canUseImages,
+      isRuntimeSelected,
+      runtimeStore,
+      setComposerErrorForKey,
+      updateIdleAttachmentComposerForKey
+    ]
   );
 
   const handlePaste = useCallback(
     (e: React.ClipboardEvent) => {
-      const pasteGeneration = ++imagePasteGenerationRef.current;
+      const ownerKey = activeRuntimeKeyRef.current;
+      const startSnapshot = runtimeStore.get(ownerKey);
+      if (!startSnapshot || startSnapshot.isGenerating) return;
+      const pasteGeneration = startSnapshot.composer.imagePasteGeneration + 1;
+      updateComposerForKey(ownerKey, (composer) => ({
+        ...composer,
+        imagePasteGeneration: pasteGeneration
+      }));
       const items = e.clipboardData?.items;
       if (!items) return;
 
       const imageFiles = getImageFilesFromClipboardItems(items);
       if (imageFiles.length > 0) {
-        // Preserve the existing DOM clipboard path whenever WebKit exposes the image.
         e.preventDefault();
-        attachPastedImages(imageFiles);
+        attachPastedImages(imageFiles, ownerKey, pasteGeneration);
         return;
       }
 
-      // WebKitGTK can hide a clipboard image from the paste DataTransfer while
-      // exposing either no items (screenshots) or one HTML item (browser Copy Image).
       if (!isLinuxTauriEnv) return;
 
       const fallback = maybeReadLinuxTauriClipboardImages({
@@ -2893,72 +3420,110 @@ export function UnifiedChat() {
         }
       });
 
-      // Do not prevent the native paste while an async read is pending. An
-      // image-only clipboard has no useful textarea default, and this keeps
-      // ordinary text paste intact if clipboard access is unavailable.
       void fallback?.then((fallbackFiles) => {
-        if (fallbackFiles.length > 0 && pasteGeneration === imagePasteGenerationRef.current) {
-          attachPastedImages(fallbackFiles);
-        }
+        const snapshot = runtimeStore.get(ownerKey);
+        if (
+          fallbackFiles.length === 0 ||
+          snapshot?.composer.imagePasteGeneration !== pasteGeneration
+        )
+          return;
+        attachPastedImages(fallbackFiles, ownerKey, pasteGeneration);
       });
     },
-    [attachPastedImages, isLinuxEnv, isLinuxTauriEnv, isTauriEnv]
+    [
+      attachPastedImages,
+      isLinuxEnv,
+      isLinuxTauriEnv,
+      isTauriEnv,
+      runtimeStore,
+      updateComposerForKey
+    ]
   );
 
   const removeImage = useCallback(
     (idx: number) => {
-      setDraftImages((prev) => {
-        const fileToRemove = prev[idx];
-        const url = imageUrls.get(fileToRemove);
-        if (url) {
-          URL.revokeObjectURL(url);
-          setImageUrls((prevUrls) => {
-            const newUrls = new Map(prevUrls);
-            newUrls.delete(fileToRemove);
-            return newUrls;
-          });
-        }
-        return prev.filter((_, i) => i !== idx);
+      const ownerKey = activeRuntimeKeyRef.current;
+      const snapshot = runtimeStore.get(ownerKey);
+      if (!snapshot || snapshot.isGenerating) return;
+      const fileToRemove = snapshot?.composer.draftImages[idx];
+      if (!fileToRemove) return;
+      const url = snapshot.composer.imageUrls.get(fileToRemove);
+      const removed = updateIdleAttachmentComposerForKey(ownerKey, (composer) => {
+        const nextUrls = new Map(composer.imageUrls);
+        nextUrls.delete(fileToRemove);
+        return {
+          ...composer,
+          imageUrls: nextUrls,
+          draftImages: composer.draftImages.filter((file) => file !== fileToRemove)
+        };
       });
+      if (removed && url) URL.revokeObjectURL(url);
     },
-    [imageUrls]
+    [runtimeStore, updateIdleAttachmentComposerForKey]
   );
 
   const handleDocumentUpload = useCallback(
     async (e: React.ChangeEvent<HTMLInputElement>) => {
-      const file = e.target.files?.[0];
+      const ownerKey = documentInputOwnerKeyRef.current ?? activeRuntimeKeyRef.current;
+      documentInputOwnerKeyRef.current = null;
+      const inputElement = e.currentTarget;
+      const file = inputElement.files?.[0];
       if (!file) return;
 
-      const maxSizeInBytes = 10 * 1024 * 1024; // 10MB
-      if (file.size > maxSizeInBytes) {
-        setAttachmentError("Document too large (max 10MB)");
-        setTimeout(() => setAttachmentError(null), 5000);
-        e.target.value = "";
+      const startSnapshot = runtimeStore.get(ownerKey);
+      if (!startSnapshot || startSnapshot.isGenerating) {
+        inputElement.value = "";
         return;
       }
 
-      setIsProcessingDocument(true);
-      setAttachmentError(null);
-      const uploadGeneration = ++documentUploadGenerationRef.current;
+      const maxSizeInBytes = 10 * 1024 * 1024;
+      if (file.size > maxSizeInBytes) {
+        setComposerErrorForKey(ownerKey, "attachmentError", "Document too large (max 10MB)");
+        inputElement.value = "";
+        return;
+      }
+
+      const uploadGeneration = startSnapshot.composer.documentUploadGeneration + 1;
+      const started = updateIdleAttachmentComposerForKey(ownerKey, (composer) => ({
+        ...composer,
+        isProcessingDocument: true,
+        attachmentError: null,
+        documentUploadGeneration: uploadGeneration
+      }));
+      if (!started) {
+        inputElement.value = "";
+        return;
+      }
+
+      const updateDocumentIfCurrent = (
+        updater: (composer: ChatComposerState) => ChatComposerState
+      ) => {
+        let generationMatched = false;
+        const updated = updateIdleAttachmentComposerForKey(ownerKey, (composer) => {
+          if (composer.documentUploadGeneration !== uploadGeneration) return composer;
+          generationMatched = true;
+          return updater(composer);
+        });
+        return updated && generationMatched;
+      };
 
       try {
         const documentType = getSupportedDocumentType(file.name);
 
-        // For text files, read directly
         if (documentType === "txt" || documentType === "md") {
           const text = await file.text();
-          if (uploadGeneration !== documentUploadGenerationRef.current) return;
-          // Format as JSON for consistency with PDF handling
           const documentData = {
             document: {
               filename: file.name,
               text_content: text
             }
           };
-          setDocumentText(JSON.stringify(documentData));
-          setDocumentName(file.name);
+          updateDocumentIfCurrent((composer) => ({
+            ...composer,
+            documentText: JSON.stringify(documentData),
+            documentName: file.name
+          }));
         } else if (documentType === "pdf" && isTauriEnv) {
-          // For PDFs in Tauri, use the parseDocument API
           const reader = new FileReader();
           const base64Data = await new Promise<string>((resolve, reject) => {
             reader.onload = () => {
@@ -2969,10 +3534,8 @@ export function UnifiedChat() {
             reader.readAsDataURL(file);
           });
 
-          // Use the Tauri API directly for parsing PDFs
           const { invoke } = await import("@tauri-apps/api/core");
 
-          // Define the response type to match Rust
           interface RustDocumentResponse {
             document: {
               filename: string;
@@ -2986,12 +3549,16 @@ export function UnifiedChat() {
             filename: file.name,
             fileType: "pdf"
           });
-          if (uploadGeneration !== documentUploadGenerationRef.current) return;
+          if (runtimeStore.get(ownerKey)?.composer.documentUploadGeneration !== uploadGeneration)
+            return;
 
           const cleanedText = prepareExtractedPdfText(result.document?.text_content);
           if (cleanedText === null) {
-            setAttachmentError("No readable text was found in this PDF");
-            setTimeout(() => setAttachmentError(null), 5000);
+            setComposerErrorForKey(
+              ownerKey,
+              "attachmentError",
+              "No readable text was found in this PDF"
+            );
             return;
           }
 
@@ -3002,58 +3569,92 @@ export function UnifiedChat() {
             }
           };
 
-          // Store as JSON string for markdown.tsx to parse and display properly
-          setDocumentText(JSON.stringify(cleanedParsed));
-          setDocumentName(file.name);
+          updateDocumentIfCurrent((composer) => ({
+            ...composer,
+            documentText: JSON.stringify(cleanedParsed),
+            documentName: file.name
+          }));
         } else if (documentType === "pdf") {
-          setAttachmentError("PDF files can only be processed in the Maple app");
-          setTimeout(() => setAttachmentError(null), 5000);
+          setComposerErrorForKey(
+            ownerKey,
+            "attachmentError",
+            "PDF files can only be processed in the Maple app"
+          );
         } else {
-          setAttachmentError("Only PDF, TXT, and Markdown files are supported");
-          setTimeout(() => setAttachmentError(null), 5000);
+          setComposerErrorForKey(
+            ownerKey,
+            "attachmentError",
+            "Only PDF, TXT, and Markdown files are supported"
+          );
         }
       } catch (error) {
         console.error("Document processing error:", error);
-        if (uploadGeneration === documentUploadGenerationRef.current) {
-          setAttachmentError(getDocumentProcessingErrorMessage(error));
-          setTimeout(() => setAttachmentError(null), 5000);
+        if (runtimeStore.get(ownerKey)?.composer.documentUploadGeneration === uploadGeneration) {
+          setComposerErrorForKey(
+            ownerKey,
+            "attachmentError",
+            getDocumentProcessingErrorMessage(error)
+          );
         }
       } finally {
-        if (uploadGeneration === documentUploadGenerationRef.current) {
-          setIsProcessingDocument(false);
-        }
-        e.target.value = "";
+        updateDocumentIfCurrent((composer) => ({
+          ...composer,
+          isProcessingDocument: false
+        }));
+        inputElement.value = "";
       }
     },
-    [isTauriEnv]
+    [isTauriEnv, runtimeStore, setComposerErrorForKey, updateIdleAttachmentComposerForKey]
   );
 
   const removeDocument = useCallback(() => {
-    documentUploadGenerationRef.current += 1;
-    setIsProcessingDocument(false);
-    setDocumentText("");
-    setDocumentName("");
-  }, []);
+    const ownerKey = activeRuntimeKeyRef.current;
+    updateIdleAttachmentComposerForKey(ownerKey, (composer) => ({
+      ...composer,
+      isProcessingDocument: false,
+      documentText: "",
+      documentName: "",
+      documentUploadGeneration: composer.documentUploadGeneration + 1
+    }));
+  }, [updateIdleAttachmentComposerForKey]);
 
   // Audio recording functions
   const startRecording = async () => {
-    // Prevent duplicate starts
-    if (isRecording || isTranscribing) return;
+    if (isRecording || isTranscribing || recordingOwnerKeyRef.current) return;
 
-    // Check if user has access
     if (!canUseVoice) {
       setUpgradeFeature("voice");
       setUpgradeDialogOpen(true);
       return;
     }
 
+    const ownerKey = runtimeStore.resolveKey(activeRuntimeKeyRef.current);
+    const ownerSessionToken = recordingSessionTokenRef.current + 1;
+    recordingSessionTokenRef.current = ownerSessionToken;
+    recordingOwnerKeyRef.current = ownerKey;
+    setRecordingOwnerKey(ownerKey);
+
     try {
-      // Check if getUserMedia is available
       if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        setAudioError(
-          "Microphone access is blocked. Please check your browser permissions or disable Lockdown Mode for this site (Settings > Safari > Advanced > Lockdown Mode)."
+        setComposerErrorForKey(
+          ownerKey,
+          "audioError",
+          "Microphone access is blocked. Please check your browser permissions or disable Lockdown Mode for this site (Settings > Safari > Advanced > Lockdown Mode).",
+          8000
         );
-        setTimeout(() => setAudioError(null), 8000);
+        if (
+          isRecordingOwnershipCurrent(
+            ownerKey,
+            ownerSessionToken,
+            recordingOwnerKeyRef.current,
+            recordingSessionTokenRef.current,
+            Boolean(runtimeStore.get(ownerKey))
+          )
+        ) {
+          recordingOwnerKeyRef.current = null;
+          recordingSessionTokenRef.current += 1;
+          setRecordingOwnerKey(null);
+        }
         return;
       }
 
@@ -3065,10 +3666,29 @@ export function UnifiedChat() {
           sampleRate: 16000
         }
       });
+      if (
+        !isRecordingOwnershipCurrent(
+          ownerKey,
+          ownerSessionToken,
+          recordingOwnerKeyRef.current,
+          recordingSessionTokenRef.current,
+          Boolean(runtimeStore.get(ownerKey))
+        )
+      ) {
+        stream.getTracks().forEach((track) => track.stop());
+        if (
+          recordingOwnerKeyRef.current === ownerKey &&
+          recordingSessionTokenRef.current === ownerSessionToken
+        ) {
+          recordingOwnerKeyRef.current = null;
+          recordingSessionTokenRef.current += 1;
+          setRecordingOwnerKey(null);
+        }
+        return;
+      }
 
       streamRef.current = stream;
 
-      // Create RecordRTC instance configured for WAV
       const recorder = new RecordRTC(stream, {
         type: "audio",
         mimeType: "audio/wav",
@@ -3080,60 +3700,130 @@ export function UnifiedChat() {
       recorderRef.current = recorder;
       recorder.startRecording();
       setIsRecording(true);
-      setAudioError(null);
+      setComposerErrorForKey(ownerKey, "audioError", null);
     } catch (error) {
       console.error("Failed to start recording:", error);
-      const err = error as Error & { name?: string };
-
-      // Handle different error types
-      if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
-        setAudioError(
-          "Microphone access denied. Please enable microphone permissions in Settings > Maple."
-        );
-      } else if (err.name === "NotFoundError" || err.name === "DevicesNotFoundError") {
-        setAudioError("No microphone found. Please check your device.");
-      } else if (err.name === "NotReadableError" || err.name === "TrackStartError") {
-        setAudioError("Microphone is already in use by another app.");
-      } else {
-        setAudioError(
-          `Failed to access microphone: ${err.name || "Unknown error"} - ${err.message || "Please try again"}`
-        );
+      if (
+        !isRecordingOwnershipCurrent(
+          ownerKey,
+          ownerSessionToken,
+          recordingOwnerKeyRef.current,
+          recordingSessionTokenRef.current,
+          Boolean(runtimeStore.get(ownerKey))
+        )
+      ) {
+        return;
       }
+      const err = error as Error & { name?: string };
+      let errorMessage: string;
 
-      setTimeout(() => setAudioError(null), 5000);
+      if (err.name === "NotAllowedError" || err.name === "PermissionDeniedError") {
+        errorMessage =
+          "Microphone access denied. Please enable microphone permissions in Settings > Maple.";
+      } else if (err.name === "NotFoundError" || err.name === "DevicesNotFoundError") {
+        errorMessage = "No microphone found. Please check your device.";
+      } else if (err.name === "NotReadableError" || err.name === "TrackStartError") {
+        errorMessage = "Microphone is already in use by another app.";
+      } else {
+        errorMessage = `Failed to access microphone: ${err.name || "Unknown error"} - ${err.message || "Please try again"}`;
+      }
+      const failedRecorder = recorderRef.current;
+      const failedStream = streamRef.current;
+      const cleanupResult = cleanupRecordingForTeardown({
+        recorder: failedRecorder
+          ? { stopRecording: (callback) => failedRecorder.stopRecording(callback) }
+          : null,
+        stream: failedStream,
+        clearOwnership: () => {
+          if (
+            recordingOwnerKeyRef.current === ownerKey &&
+            recordingSessionTokenRef.current === ownerSessionToken
+          ) {
+            recordingOwnerKeyRef.current = null;
+            recordingSessionTokenRef.current += 1;
+            setRecordingOwnerKey(null);
+            setIsRecording(false);
+            setIsTranscribing(false);
+            setIsProcessingSend(false);
+          }
+        },
+        clearRecorder: () => {
+          if (recorderRef.current === failedRecorder) recorderRef.current = null;
+        },
+        clearStream: () => {
+          if (streamRef.current === failedStream) streamRef.current = null;
+        }
+      });
+      if (cleanupResult.errors.length > 0) {
+        console.error("Failed to fully clean up microphone startup:", cleanupResult.errors);
+      }
+      setComposerErrorForKey(ownerKey, "audioError", errorMessage);
     }
   };
 
   const stopRecording = (shouldSend: boolean = false) => {
-    if (recorderRef.current && isRecording) {
-      // Only hide immediately if canceling, keep visible if sending
+    const recorder = recorderRef.current;
+    const ownerKey = recordingOwnerKeyRef.current;
+    const ownerSessionToken = recordingSessionTokenRef.current;
+    if (recorder && ownerKey && isRecording) {
+      const ownedStream = streamRef.current;
       if (!shouldSend) {
         setIsRecording(false);
       } else {
         setIsProcessingSend(true);
       }
 
-      recorderRef.current.stopRecording(async () => {
-        const blob = recorderRef.current?.getBlob();
+      recorder.stopRecording(async () => {
+        let released = false;
 
-        if (!blob || blob.size === 0) {
-          console.error("No audio recorded or empty recording");
-          if (shouldSend) {
-            setAudioError("No audio was recorded. Please try again.");
-            setTimeout(() => setAudioError(null), 5000);
-          }
-          // Clean up
-          if (streamRef.current) {
-            streamRef.current.getTracks().forEach((track) => track.stop());
+        const releaseRecording = () => {
+          if (released) return;
+          released = true;
+          ownedStream?.getTracks().forEach((track) => track.stop());
+          if (streamRef.current === ownedStream) {
             streamRef.current = null;
           }
-          recorderRef.current = null;
-          setIsProcessingSend(false);
-          setIsRecording(false);
+          if (recorderRef.current === recorder) recorderRef.current = null;
+          if (
+            recordingOwnerKeyRef.current === ownerKey &&
+            recordingSessionTokenRef.current === ownerSessionToken
+          ) {
+            recordingOwnerKeyRef.current = null;
+            recordingSessionTokenRef.current += 1;
+            setRecordingOwnerKey((current) => (current === ownerKey ? null : current));
+            setIsProcessingSend(false);
+            setIsTranscribing(false);
+            setIsRecording(false);
+          }
+        };
+
+        if (
+          !isRecordingOwnershipCurrent(
+            ownerKey,
+            ownerSessionToken,
+            recordingOwnerKeyRef.current,
+            recordingSessionTokenRef.current,
+            Boolean(runtimeStore.get(ownerKey))
+          )
+        ) {
+          releaseRecording();
           return;
         }
 
-        // Create a proper WAV file
+        const blob = recorder.getBlob();
+        if (!blob || blob.size === 0) {
+          console.error("No audio recorded or empty recording");
+          if (shouldSend) {
+            setComposerErrorForKey(
+              ownerKey,
+              "audioError",
+              "No audio was recorded. Please try again."
+            );
+          }
+          releaseRecording();
+          return;
+        }
+
         const audioFile = new File([blob], "recording.wav", {
           type: "audio/wav"
         });
@@ -3142,53 +3832,80 @@ export function UnifiedChat() {
           setIsTranscribing(true);
           try {
             const result = await os.transcribeAudio(audioFile, "whisper-large-v3");
+            if (
+              !isRecordingOwnershipCurrent(
+                ownerKey,
+                ownerSessionToken,
+                recordingOwnerKeyRef.current,
+                recordingSessionTokenRef.current,
+                Boolean(runtimeStore.get(ownerKey))
+              )
+            ) {
+              return;
+            }
             const transcribedText = result.text.trim();
 
             if (transcribedText) {
-              // Combine with existing input if any
-              const newValue = input ? `${input} ${transcribedText}` : transcribedText;
-
-              // Clear states before sending
-              setInput("");
-              clearAllAttachments();
-              setIsRecording(false);
-              setIsTranscribing(false);
-              setIsProcessingSend(false);
-
-              // Send the message directly with the transcribed text
-              await handleSendMessage(undefined, newValue);
+              const ownerInput = runtimeStore.get(ownerKey)?.composer.input ?? "";
+              const newValue = ownerInput ? `${ownerInput} ${transcribedText}` : transcribedText;
+              const send = handleSendMessage(undefined, newValue, ownerKey);
+              releaseRecording();
+              await send;
             } else {
-              setAudioError("No speech detected. Please try again.");
-              setTimeout(() => setAudioError(null), 5000);
+              setComposerErrorForKey(
+                ownerKey,
+                "audioError",
+                "No speech detected. Please try again."
+              );
             }
           } catch (error) {
             console.error("Transcription failed:", error);
-            setAudioError("Failed to transcribe audio. Please try again.");
-            setTimeout(() => setAudioError(null), 5000);
+            if (
+              isRecordingOwnershipCurrent(
+                ownerKey,
+                ownerSessionToken,
+                recordingOwnerKeyRef.current,
+                recordingSessionTokenRef.current,
+                Boolean(runtimeStore.get(ownerKey))
+              )
+            ) {
+              setComposerErrorForKey(
+                ownerKey,
+                "audioError",
+                "Failed to transcribe audio. Please try again."
+              );
+            }
           } finally {
-            setIsTranscribing(false);
-            setIsProcessingSend(false);
-            setIsRecording(false);
+            releaseRecording();
           }
+        } else {
+          releaseRecording();
         }
-
-        // Clean up resources
-        if (streamRef.current) {
-          streamRef.current.getTracks().forEach((track) => track.stop());
-          streamRef.current = null;
-        }
-        recorderRef.current = null;
       });
     }
   };
 
   // Helper function to process streaming response - used by both initial request and retry
   const processStreamingResponse = useCallback(
-    async (stream: AsyncIterable<unknown>) => {
+    async (
+      stream: AsyncIterable<unknown>,
+      runtimeKey: ChatRuntimeKey,
+      runToken: number,
+      optimisticMessageId: string,
+      discardOwnedItemsOnError: boolean
+    ) => {
       const messageTextBuffers = new Map<string, Map<number, string>>();
       const reasoningTextBuffers = new Map<string, Map<number, string>>();
+      const ownedItemIds = new Set<string>();
       const streamStartedAt = performance.now();
       let streamEventCount = 0;
+      let terminalState: ChatStreamTerminalState = null;
+
+      const updateRunMessages = (updater: (messages: Message[]) => Message[]) =>
+        runtimeStore.updateForRun(runtimeKey, runToken, (snapshot) => ({
+          ...snapshot,
+          messages: updater(snapshot.messages as Message[])
+        }));
 
       const appendBufferedText = (
         buffers: Map<string, Map<number, string>>,
@@ -3215,632 +3932,741 @@ export function UnifiedChat() {
         return text;
       };
 
-      for await (const event of stream) {
-        const eventType = (event as { type: string }).type;
-        streamEventCount += 1;
-        logStreamEvent(streamStartedAt, streamEventCount, eventType, event);
+      const deltaCoalescer = createChatStreamDeltaCoalescer({
+        isCurrent: () => runtimeStore.isRunCurrent(runtimeKey, runToken),
+        onFlush: (deltas) => {
+          runtimeStore.updateForRun(runtimeKey, runToken, (snapshot) => {
+            let nextMessages = snapshot.messages as Message[];
 
-        if (eventType === "response.created") {
-          const eventWithResponse = event as { response?: { id?: string } };
-          if (eventWithResponse.response?.id) {
-            setCurrentResponseId(eventWithResponse.response.id);
-          }
-        } else if (eventType === "response.output_item.added") {
-          const addedEvent = event as ResponseOutputItemAddedEvent;
-          const item = normalizeConversationItem(addedEvent.item);
-
-          if (item) {
-            setMessages((prev) => mergeStreamingConversationItem(prev, item));
-          }
-        } else if (eventType === "response.web_search_call.in_progress") {
-          const webSearchEvent = event as { item_id?: string };
-          if (webSearchEvent.item_id) {
-            setMessages((prev) =>
-              updateMessageById(prev, webSearchEvent.item_id!, (message) =>
-                message.type === "web_search_call"
-                  ? ({ ...message, status: "in_progress" } as unknown as Message)
-                  : message
-              )
-            );
-          }
-        } else if (eventType === "response.web_search_call.searching") {
-          const webSearchEvent = event as { item_id?: string };
-          if (webSearchEvent.item_id) {
-            setMessages((prev) =>
-              updateMessageById(prev, webSearchEvent.item_id!, (message) =>
-                message.type === "web_search_call"
-                  ? ({ ...message, status: "searching" } as unknown as Message)
-                  : message
-              )
-            );
-          }
-        } else if (eventType === "response.web_search_call.completed") {
-          const webSearchEvent = event as { item_id?: string };
-          if (webSearchEvent.item_id) {
-            setMessages((prev) =>
-              updateMessageById(prev, webSearchEvent.item_id!, (message) =>
-                message.type === "web_search_call"
-                  ? ({ ...message, status: "completed" } as unknown as Message)
-                  : message
-              )
-            );
-          }
-        } else if (eventType === "tool_call.created") {
-          const toolCallEvent = event as {
-            tool_call_id?: string;
-            name?: string;
-            arguments?: { query?: string };
-          };
-          if (toolCallEvent.tool_call_id) {
-            const toolCallItem: ToolCallItem = {
-              id: toolCallEvent.tool_call_id,
-              call_id: toolCallEvent.tool_call_id,
-              type: "tool_call",
-              name: toolCallEvent.name || "function",
-              arguments: JSON.stringify(toolCallEvent.arguments || {}),
-              status: "in_progress"
-            };
-
-            setMessages((prev) => {
-              const existingToolCall = prev.find(
-                (message) => message.id === toolCallEvent.tool_call_id
-              );
-
-              if (existingToolCall && isToolCallItem(existingToolCall)) {
-                return mergeMessagesById(prev, [
-                  {
-                    ...existingToolCall,
-                    ...toolCallItem,
-                    status: existingToolCall.status || toolCallItem.status
-                  }
-                ]);
+            for (const delta of deltas) {
+              if (delta.kind === "reasoning") {
+                const nextText = appendBufferedText(
+                  reasoningTextBuffers,
+                  delta.itemId,
+                  delta.contentIndex,
+                  delta.delta
+                );
+                nextMessages = updateMessageById(nextMessages, delta.itemId, (message) =>
+                  message.type === "reasoning"
+                    ? upsertReasoningTextContent(
+                        message as ReasoningItem,
+                        delta.contentIndex,
+                        nextText,
+                        "streaming"
+                      )
+                    : message
+                );
+              } else {
+                const nextText = appendBufferedText(
+                  messageTextBuffers,
+                  delta.itemId,
+                  delta.contentIndex,
+                  delta.delta
+                );
+                nextMessages = updateMessageById(nextMessages, delta.itemId, (message) =>
+                  message.type === "message"
+                    ? (upsertAssistantTextContent(
+                        message as ExtendedMessage,
+                        delta.contentIndex,
+                        nextText,
+                        "streaming"
+                      ) as unknown as Message)
+                    : message
+                );
               }
+            }
 
-              return mergeMessagesById(prev, [toolCallItem]);
-            });
-          }
-        } else if (eventType === "tool_output.created") {
-          const toolOutputEvent = event as {
-            tool_output_id?: string;
-            tool_call_id?: string;
-            output?: string;
-          };
-          if (toolOutputEvent.tool_output_id && toolOutputEvent.tool_call_id) {
-            const toolOutputItem: ToolOutputItem = {
-              id: toolOutputEvent.tool_output_id,
-              call_id: toolOutputEvent.tool_call_id,
-              type: "tool_output",
-              output: toolOutputEvent.output || "",
-              status: "completed"
-            };
-
-            setMessages((prev) => {
-              const existingToolOutput = prev.find(
-                (message) => message.id === toolOutputEvent.tool_output_id
-              );
-              const withOutput = mergeMessagesById(prev, [
-                existingToolOutput && isToolOutputItem(existingToolOutput)
-                  ? {
-                      ...existingToolOutput,
-                      ...toolOutputItem
-                    }
-                  : toolOutputItem
-              ]);
-
-              return updateMessageById(withOutput, toolOutputEvent.tool_call_id!, (message) =>
-                isToolCallItem(message)
-                  ? ({ ...message, status: "completed" } as unknown as Message)
-                  : message
-              );
-            });
-          }
-        } else if (
-          eventType === "response.reasoning_text.delta" &&
-          (event as { delta?: string }).delta
-        ) {
-          const reasoningEvent = event as ResponseReasoningTextDeltaEvent;
-          const nextText = appendBufferedText(
-            reasoningTextBuffers,
-            reasoningEvent.item_id,
-            reasoningEvent.content_index,
-            reasoningEvent.delta
-          );
-
-          setMessages((prev) =>
-            updateMessageById(prev, reasoningEvent.item_id, (message) =>
-              message.type === "reasoning"
-                ? upsertReasoningTextContent(
-                    message as ReasoningItem,
-                    reasoningEvent.content_index,
-                    nextText,
-                    "streaming"
-                  )
-                : message
-            )
-          );
-        } else if (eventType === "response.reasoning_text.done") {
-          const reasoningEvent = event as ResponseReasoningTextDoneEvent;
-          const nextText = setBufferedText(
-            reasoningTextBuffers,
-            reasoningEvent.item_id,
-            reasoningEvent.content_index,
-            reasoningEvent.text
-          );
-
-          setMessages((prev) =>
-            updateMessageById(prev, reasoningEvent.item_id, (message) =>
-              message.type === "reasoning"
-                ? upsertReasoningTextContent(
-                    message as ReasoningItem,
-                    reasoningEvent.content_index,
-                    nextText,
-                    "completed"
-                  )
-                : message
-            )
-          );
-        } else if (
-          eventType === "response.output_text.delta" &&
-          (event as { delta?: string }).delta
-        ) {
-          const textEvent = event as ResponseTextDeltaEvent;
-          const nextText = appendBufferedText(
-            messageTextBuffers,
-            textEvent.item_id,
-            textEvent.content_index,
-            textEvent.delta
-          );
-
-          setMessages((prev) =>
-            updateMessageById(prev, textEvent.item_id, (message) =>
-              message.type === "message"
-                ? (upsertAssistantTextContent(
-                    message as ExtendedMessage,
-                    textEvent.content_index,
-                    nextText,
-                    "streaming"
-                  ) as unknown as Message)
-                : message
-            )
-          );
-        } else if (eventType === "response.output_text.done") {
-          const textEvent = event as ResponseTextDoneEvent;
-          const nextText = setBufferedText(
-            messageTextBuffers,
-            textEvent.item_id,
-            textEvent.content_index,
-            textEvent.text
-          );
-
-          setMessages((prev) =>
-            updateMessageById(prev, textEvent.item_id, (message) =>
-              message.type === "message"
-                ? (upsertAssistantTextContent(
-                    message as ExtendedMessage,
-                    textEvent.content_index,
-                    nextText,
-                    "completed"
-                  ) as unknown as Message)
-                : message
-            )
-          );
-        } else if (eventType === "response.output_item.done") {
-          const doneEvent = event as ResponseOutputItemDoneEvent;
-          const item = normalizeConversationItem(doneEvent.item);
-
-          if (item) {
-            setMessages((prev) => mergeStreamingConversationItem(prev, item));
-            setLastSeenItemId(item.id);
-          }
-        } else if (eventType === "response.failed" || eventType === "error") {
-          console.error("Streaming error:", event);
-          setMessages((prev) => updateActiveItemStatuses(prev, "error"));
-          setError("Failed to generate response. Please try again.");
-        } else if (eventType === "response.cancelled") {
-          setMessages((prev) => updateActiveItemStatuses(prev, "incomplete"));
-          break;
+            return { ...snapshot, messages: nextMessages };
+          });
         }
-      }
-    },
-    [logStreamEvent]
-  );
-
-  // Send message handler - now accepts optional override text for voice input
-  const handleSendMessage = useCallback(
-    async (e?: React.FormEvent, overrideInput?: string) => {
-      e?.preventDefault();
-
-      // Use override input (from voice) or regular input
-      const textToSend = overrideInput || input;
-      const trimmedInput = textToSend.trim();
-      const hasContent = trimmedInput || draftImages.length > 0 || documentText;
-      if (!hasContent || isGenerating || isProcessingDocument || !openai) return;
-
-      // Clear any previous error
-      setError(null);
-
-      // Build the message content - always as an array
-      // Using the input types since we're building user input
-      const messageContent: (InputTextContent | InputImageContent)[] = [];
-
-      // Combine document text with input if both exist
-      let finalText = trimmedInput;
-      if (documentText) {
-        finalText = documentText + (trimmedInput ? `\n\n${trimmedInput}` : "");
-      }
-
-      // Add text part if exists
-      if (finalText) {
-        const textContent: InputTextContent = {
-          type: "input_text",
-          text: finalText
-        };
-        messageContent.push(textContent);
-      }
-
-      // Add image parts if we have images
-      for (const file of draftImages) {
-        try {
-          const dataUrl = await fileToDataURL(file);
-          const imageContent: InputImageContent = {
-            type: "input_image",
-            image_url: dataUrl,
-            detail: "auto",
-            file_id: null
-          };
-          messageContent.push(imageContent);
-        } catch (error) {
-          console.error("Failed to convert image:", error);
-        }
-      }
-
-      // Add user message immediately with a local UUID
-      const localMessageId = uuidv4();
-      const userMessage = {
-        id: localMessageId,
-        type: "message",
-        role: "user",
-        content: messageContent,
-        status: "completed"
-      } as unknown as Message;
-
-      // Use merge helper to add user message (prevents duplicates)
-      setMessages((prev) => mergeMessagesById(prev, [userMessage]));
-      // Set lastSeenItemId to our local message ID
-      // The backend should map this via internal_message_id
-      setLastSeenItemId(localMessageId);
-
-      // Store the original input and attachments in case we need to restore them
-      const originalInput = trimmedInput;
-      const originalImages = [...draftImages];
-      const originalDocumentText = documentText;
-      const originalDocumentName = documentName;
-
-      // Only clear input if not using override (voice already cleared it)
-      if (!overrideInput) {
-        setInput("");
-        clearAllAttachments();
-      }
-      setIsGenerating(true);
+      });
+      registerChatStreamDeltaCoalescer(runtimeStore, runToken, deltaCoalescer);
 
       try {
-        // Create conversation if we don't have one
-        let conversationId = conversation?.id;
-        if (!conversationId) {
-          const newConv = draftProjectId
-            ? await os.createConversation(
-                {},
-                {
-                  project_id: draftProjectId
+        for await (const event of stream) {
+          const eventType = (event as { type: string }).type;
+          streamEventCount += 1;
+          logStreamEvent(runtimeKey, runToken, streamStartedAt, streamEventCount, eventType, event);
+
+          if (
+            eventType === "response.reasoning_text.delta" &&
+            (event as { delta?: string }).delta
+          ) {
+            const reasoningEvent = event as ResponseReasoningTextDeltaEvent;
+            ownedItemIds.add(reasoningEvent.item_id);
+            deltaCoalescer.enqueue({
+              kind: "reasoning",
+              itemId: reasoningEvent.item_id,
+              contentIndex: reasoningEvent.content_index,
+              delta: reasoningEvent.delta
+            });
+            continue;
+          }
+
+          if (eventType === "response.output_text.delta" && (event as { delta?: string }).delta) {
+            const textEvent = event as ResponseTextDeltaEvent;
+            ownedItemIds.add(textEvent.item_id);
+            deltaCoalescer.enqueue({
+              kind: "message",
+              itemId: textEvent.item_id,
+              contentIndex: textEvent.content_index,
+              delta: textEvent.delta
+            });
+            continue;
+          }
+
+          // Preserve event ordering: lifecycle, tool, terminal, and exact-text
+          // events must observe every text delta that arrived before them.
+          deltaCoalescer.flush();
+
+          if (eventType === "response.created") {
+            unregisterChatOptimisticMessage(runtimeStore, runToken, optimisticMessageId);
+            const eventWithResponse = event as { response?: { id?: string } };
+            if (eventWithResponse.response?.id) {
+              runtimeStore.setCurrentResponseId(
+                runtimeKey,
+                runToken,
+                eventWithResponse.response.id
+              );
+            }
+          } else if (eventType === "response.output_item.added") {
+            const addedEvent = event as ResponseOutputItemAddedEvent;
+            const item = normalizeConversationItem(addedEvent.item);
+
+            if (item) {
+              ownedItemIds.add(item.id);
+              updateRunMessages((messages) => mergeStreamingConversationItem(messages, item));
+            }
+          } else if (eventType === "response.web_search_call.in_progress") {
+            const webSearchEvent = event as { item_id?: string };
+            if (webSearchEvent.item_id) {
+              ownedItemIds.add(webSearchEvent.item_id);
+              updateRunMessages((messages) =>
+                updateMessageById(messages, webSearchEvent.item_id!, (message) =>
+                  message.type === "web_search_call"
+                    ? ({ ...message, status: "in_progress" } as unknown as Message)
+                    : message
+                )
+              );
+            }
+          } else if (eventType === "response.web_search_call.searching") {
+            const webSearchEvent = event as { item_id?: string };
+            if (webSearchEvent.item_id) {
+              ownedItemIds.add(webSearchEvent.item_id);
+              updateRunMessages((messages) =>
+                updateMessageById(messages, webSearchEvent.item_id!, (message) =>
+                  message.type === "web_search_call"
+                    ? ({ ...message, status: "searching" } as unknown as Message)
+                    : message
+                )
+              );
+            }
+          } else if (eventType === "response.web_search_call.completed") {
+            const webSearchEvent = event as { item_id?: string };
+            if (webSearchEvent.item_id) {
+              ownedItemIds.add(webSearchEvent.item_id);
+              updateRunMessages((messages) =>
+                updateMessageById(messages, webSearchEvent.item_id!, (message) =>
+                  message.type === "web_search_call"
+                    ? ({ ...message, status: "completed" } as unknown as Message)
+                    : message
+                )
+              );
+            }
+          } else if (eventType === "tool_call.created") {
+            const toolCallEvent = event as {
+              tool_call_id?: string;
+              name?: string;
+              arguments?: { query?: string };
+            };
+            if (toolCallEvent.tool_call_id) {
+              ownedItemIds.add(toolCallEvent.tool_call_id);
+              const toolCallItem: ToolCallItem = {
+                id: toolCallEvent.tool_call_id,
+                call_id: toolCallEvent.tool_call_id,
+                type: "tool_call",
+                name: toolCallEvent.name || "function",
+                arguments: JSON.stringify(toolCallEvent.arguments || {}),
+                status: "in_progress"
+              };
+
+              updateRunMessages((messages) => {
+                const existingToolCall = messages.find(
+                  (message) => message.id === toolCallEvent.tool_call_id
+                );
+
+                if (existingToolCall && isToolCallItem(existingToolCall)) {
+                  return mergeMessagesById(messages, [
+                    {
+                      ...existingToolCall,
+                      ...toolCallItem,
+                      status: existingToolCall.status || toolCallItem.status
+                    }
+                  ]);
                 }
-              )
-            : await openai.conversations.create({
-                metadata: {}
+
+                return mergeMessagesById(messages, [toolCallItem]);
               });
+            }
+          } else if (eventType === "tool_output.created") {
+            const toolOutputEvent = event as {
+              tool_output_id?: string;
+              tool_call_id?: string;
+              output?: string;
+            };
+            if (toolOutputEvent.tool_output_id && toolOutputEvent.tool_call_id) {
+              ownedItemIds.add(toolOutputEvent.tool_output_id);
+              ownedItemIds.add(toolOutputEvent.tool_call_id);
+              const toolOutputItem: ToolOutputItem = {
+                id: toolOutputEvent.tool_output_id,
+                call_id: toolOutputEvent.tool_call_id,
+                type: "tool_output",
+                output: toolOutputEvent.output || "",
+                status: "completed"
+              };
+
+              updateRunMessages((messages) => {
+                const existingToolOutput = messages.find(
+                  (message) => message.id === toolOutputEvent.tool_output_id
+                );
+                const withOutput = mergeMessagesById(messages, [
+                  existingToolOutput && isToolOutputItem(existingToolOutput)
+                    ? {
+                        ...existingToolOutput,
+                        ...toolOutputItem
+                      }
+                    : toolOutputItem
+                ]);
+
+                return updateMessageById(withOutput, toolOutputEvent.tool_call_id!, (message) =>
+                  isToolCallItem(message)
+                    ? ({ ...message, status: "completed" } as unknown as Message)
+                    : message
+                );
+              });
+            }
+          } else if (eventType === "response.reasoning_text.done") {
+            const reasoningEvent = event as ResponseReasoningTextDoneEvent;
+            const nextText = setBufferedText(
+              reasoningTextBuffers,
+              reasoningEvent.item_id,
+              reasoningEvent.content_index,
+              reasoningEvent.text
+            );
+
+            ownedItemIds.add(reasoningEvent.item_id);
+            updateRunMessages((messages) =>
+              updateMessageById(messages, reasoningEvent.item_id, (message) =>
+                message.type === "reasoning"
+                  ? upsertReasoningTextContent(
+                      message as ReasoningItem,
+                      reasoningEvent.content_index,
+                      nextText,
+                      "completed"
+                    )
+                  : message
+              )
+            );
+          } else if (eventType === "response.output_text.done") {
+            const textEvent = event as ResponseTextDoneEvent;
+            const nextText = setBufferedText(
+              messageTextBuffers,
+              textEvent.item_id,
+              textEvent.content_index,
+              textEvent.text
+            );
+
+            ownedItemIds.add(textEvent.item_id);
+            updateRunMessages((messages) =>
+              updateMessageById(messages, textEvent.item_id, (message) =>
+                message.type === "message"
+                  ? (upsertAssistantTextContent(
+                      message as ExtendedMessage,
+                      textEvent.content_index,
+                      nextText,
+                      "completed"
+                    ) as unknown as Message)
+                  : message
+              )
+            );
+          } else if (eventType === "response.output_item.done") {
+            const doneEvent = event as ResponseOutputItemDoneEvent;
+            const item = normalizeConversationItem(doneEvent.item);
+
+            if (item) {
+              ownedItemIds.add(item.id);
+              runtimeStore.updateForRun(runtimeKey, runToken, (snapshot) => ({
+                ...snapshot,
+                messages: mergeStreamingConversationItem(snapshot.messages as Message[], item),
+                lastSeenItemId: item.id
+              }));
+            }
+          } else if (eventType === "response.completed") {
+            terminalState = "completed";
+          } else if (isTerminalChatStreamErrorEvent(eventType)) {
+            terminalState = "error";
+            console.error("Streaming error:", event);
+            runtimeStore.updateForRun(runtimeKey, runToken, (snapshot) => ({
+              ...snapshot,
+              messages: updateActiveItemStatuses(
+                snapshot.messages as Message[],
+                "error",
+                ownedItemIds
+              ),
+              error: "Failed to generate response. Please try again."
+            }));
+            break;
+          } else if (eventType === "response.cancelled") {
+            terminalState = "cancelled";
+            updateRunMessages((messages) =>
+              updateActiveItemStatuses(messages, "incomplete", ownedItemIds)
+            );
+            break;
+          }
+        }
+
+        if (
+          classifyChatStreamEof(terminalState, runtimeStore.isRunCurrent(runtimeKey, runToken)) ===
+          "truncated"
+        ) {
+          throw new Error("Response stream ended before completion");
+        }
+      } catch (error) {
+        // Commit the final partial frame before changing its status. UI cancel
+        // and account teardown clear run ownership before aborting, so their
+        // resulting iterator errors remain stale-fenced here.
+        deltaCoalescer.finish();
+        updateRunMessages((messages) =>
+          discardOwnedItemsOnError
+            ? removeOwnedChatStreamAttemptItems(messages, ownedItemIds)
+            : updateActiveItemStatuses(messages, "error", ownedItemIds)
+        );
+        throw error;
+      } finally {
+        // Natural EOF and thrown stream errors both commit the final partial
+        // batch while the run is still owned. A cancelled/replaced token fails
+        // the coalescer's current-run fence and is discarded instead.
+        deltaCoalescer.finish();
+        unregisterChatStreamDeltaCoalescer(runtimeStore, runToken, deltaCoalescer);
+      }
+    },
+    [logStreamEvent, runtimeStore]
+  );
+
+  // Every send captures its owning runtime key. Navigation only changes the
+  // projected runtime; it never changes where this request or its SSE events land.
+  const handleSendMessage = useCallback(
+    async (e?: React.FormEvent, overrideInput?: string, ownerRuntimeKey?: ChatRuntimeKey) => {
+      e?.preventDefault();
+      let runtimeKey = runtimeStore.resolveKey(ownerRuntimeKey ?? activeRuntimeKeyRef.current);
+      const startSnapshot = runtimeStore.get(runtimeKey);
+      if (!startSnapshot || !openai) return;
+
+      const originalComposer = startSnapshot.composer;
+      const textToSend = overrideInput ?? originalComposer.input;
+      const trimmedInput = textToSend.trim();
+      const originalImages = [...originalComposer.draftImages];
+      const originalDocumentText = originalComposer.documentText;
+      const originalDocumentName = originalComposer.documentName;
+      const hasContent =
+        trimmedInput.length > 0 || originalImages.length > 0 || originalDocumentText.length > 0;
+      if (!hasContent || startSnapshot.isGenerating || originalComposer.isProcessingDocument) {
+        return;
+      }
+
+      const requestModel = localState.model || DEFAULT_MODEL_ID;
+      const requestWebSearchEnabled = isWebSearchEnabled;
+      const billingStatusAtSend = billingStatus;
+      const existingConversationId =
+        startSnapshot.conversation?.id ?? conversationIdFromChatRuntimeKey(runtimeKey);
+      const isFollowUpConversation =
+        Boolean(existingConversationId) && startSnapshot.messages.length > 1;
+      const run = runtimeStore.beginRun(runtimeKey);
+      const localMessageId = uuidv4();
+      let conversationId = existingConversationId;
+      let composerRestored = false;
+      let adoptedExistingDestination = false;
+
+      const restoreOriginComposer = (message: string) => {
+        if (composerRestored) return true;
+
+        let createdUrls: string[] = [];
+        let displacedUrls: string[] = [];
+        const restored = runtimeStore.updateForRun(runtimeKey, run.token, (snapshot) => {
+          const adoptedDestinationRecovery = recoverFailedSendAfterDestinationAdoption(
+            adoptedExistingDestination,
+            snapshot.messages as Message[],
+            snapshot.composer,
+            localMessageId
+          );
+          if (adoptedDestinationRecovery) {
+            return {
+              ...snapshot,
+              messages: adoptedDestinationRecovery.messages,
+              composer: adoptedDestinationRecovery.composer,
+              error: message
+            };
+          }
+
+          const restoredUrlPlan = planRestoredImageUrls(
+            originalImages,
+            snapshot.composer.imageUrls,
+            (file) => URL.createObjectURL(file)
+          );
+          createdUrls = restoredUrlPlan.createdUrls;
+          displacedUrls = restoredUrlPlan.displacedUrls;
+
+          return {
+            ...snapshot,
+            messages: (snapshot.messages as Message[]).filter((item) => item.id !== localMessageId),
+            error: message,
+            composer: {
+              ...snapshot.composer,
+              input: textToSend,
+              draftImages: originalImages,
+              imageUrls: restoredUrlPlan.imageUrls,
+              documentText: originalDocumentText,
+              documentName: originalDocumentName,
+              isProcessingDocument: false,
+              attachmentError: null,
+              imagePasteGeneration: snapshot.composer.imagePasteGeneration + 1,
+              documentUploadGeneration: snapshot.composer.documentUploadGeneration + 1
+            }
+          };
+        });
+
+        if (!restored) {
+          for (const url of createdUrls) URL.revokeObjectURL(url);
+          return false;
+        }
+        for (const url of displacedUrls) URL.revokeObjectURL(url);
+        composerRestored = true;
+        return true;
+      };
+
+      const createResponseStream = async (
+        targetConversationId: string,
+        discardOwnedItemsOnError: boolean
+      ) => {
+        const stream = await openai.responses.create(
+          {
+            conversation: targetConversationId,
+            model: requestModel,
+            input: [{ role: "user", content: messageContent }],
+            metadata: { internal_message_id: localMessageId },
+            stream: true,
+            store: true,
+            ...(requestWebSearchEnabled && { tools: [{ type: "web_search" }] })
+          },
+          { signal: run.signal }
+        );
+
+        if (!runtimeStore.setAssistantStreaming(runtimeKey, run.token, true)) return;
+        try {
+          await processStreamingResponse(
+            stream,
+            runtimeKey,
+            run.token,
+            localMessageId,
+            discardOwnedItemsOnError
+          );
+        } finally {
+          runtimeStore.setAssistantStreaming(runtimeKey, run.token, false);
+        }
+      };
+
+      const scheduleBillingRefresh = () => {
+        const timeout = setTimeout(() => {
+          void queryClient.invalidateQueries({ queryKey: ["billingStatus"] });
+          billingRefreshTimeoutsRef.current.delete(timeout);
+        }, 3000);
+        billingRefreshTimeoutsRef.current.add(timeout);
+      };
+
+      const messageContent: (InputTextContent | InputImageContent)[] = [];
+      let finalText = trimmedInput;
+      if (originalDocumentText) {
+        finalText = originalDocumentText + (trimmedInput ? `\n\n${trimmedInput}` : "");
+      }
+      if (finalText) {
+        messageContent.push({
+          type: "input_text",
+          text: finalText
+        });
+      }
+
+      try {
+        for (const file of originalImages) {
+          try {
+            const dataUrl = await fileToDataURL(file);
+            messageContent.push({
+              type: "input_image",
+              image_url: dataUrl,
+              detail: "auto",
+              file_id: null
+            });
+          } catch (error) {
+            console.error("Failed to convert image:", error);
+          }
+        }
+        if (!runtimeStore.isRunCurrent(runtimeKey, run.token)) return;
+
+        const userMessage = {
+          id: localMessageId,
+          type: "message",
+          role: "user",
+          content: messageContent,
+          status: "completed"
+        } as unknown as Message;
+
+        const stagedImageUrls = new Set<string>();
+        const staged = runtimeStore.updateForRun(runtimeKey, run.token, (snapshot) => {
+          for (const url of snapshot.composer.imageUrls.values()) stagedImageUrls.add(url);
+          return {
+            ...snapshot,
+            messages: mergeMessagesById(snapshot.messages as Message[], [userMessage]),
+            lastSeenItemId: localMessageId,
+            composer: {
+              ...snapshot.composer,
+              input: "",
+              draftImages: [],
+              imageUrls: new Map(),
+              documentText: "",
+              documentName: "",
+              isProcessingDocument: false,
+              attachmentError: null,
+              imagePasteGeneration: snapshot.composer.imagePasteGeneration + 1,
+              documentUploadGeneration: snapshot.composer.documentUploadGeneration + 1
+            }
+          };
+        });
+        if (!staged) return;
+        registerChatOptimisticMessage(runtimeStore, run.token, localMessageId);
+        for (const url of stagedImageUrls) URL.revokeObjectURL(url);
+
+        if (!conversationId) {
+          const createParams: Parameters<typeof openai.conversations.create>[0] & {
+            project_id?: string;
+          } = {
+            metadata: {},
+            ...(originalComposer.draftProjectId && {
+              project_id: originalComposer.draftProjectId
+            })
+          };
+          const newConv = await openai.conversations.create(createParams, {
+            signal: run.signal
+          });
           conversationId = newConv.id;
-          setConversation(newConv as Conversation);
+          const sourceWasSelected = isRuntimeSelected(runtimeKey);
+          const destinationKey = createConversationChatKey(conversationId);
+          const destinationSnapshot = runtimeStore.get(destinationKey);
+          const rawRecordingOwnerKey = recordingOwnerKeyRef.current;
+          const canonicalRecordingOwnerKey = rawRecordingOwnerKey
+            ? runtimeStore.resolveKey(rawRecordingOwnerKey)
+            : null;
+          if (!canAdoptRecordingDestination(destinationKey, canonicalRecordingOwnerKey)) {
+            // Let pending microphone, recording, or transcription work finish on
+            // the idle destination. Adoption would make its eventual send fail.
+            restoreOriginComposer(
+              "This conversation is still processing a voice message. Your message was restored in its original draft."
+            );
+            return;
+          }
+          if (!canAdoptAttachmentDestination(destinationSnapshot)) {
+            // Let the destination's extraction callback finish on its original
+            // idle runtime. Adopting it into this run would fence that callback
+            // and permanently strand isProcessingDocument=true.
+            restoreOriginComposer(
+              "This conversation is still processing an attachment. Your message was restored in its original draft."
+            );
+            return;
+          }
+          const migration = runtimeStore.rekeyRunAdoptingIdleDestination(
+            runtimeKey,
+            destinationKey,
+            run.token,
+            (source, destination) => ({
+              ...source,
+              conversation: destination.conversation ?? source.conversation,
+              messages: mergeLoadedMessagesWithRuntime(
+                destination.messages as Message[],
+                source.messages
+              ),
+              composer: destination.composer,
+              error: source.error ?? destination.error,
+              lastSeenItemId: source.lastSeenItemId ?? destination.lastSeenItemId,
+              historyLoaded: source.historyLoaded || destination.historyLoaded
+            })
+          );
 
-          // Update URL with new conversation ID
-          const usp = new URLSearchParams(window.location.search);
-          usp.set("conversation_id", conversationId);
-          window.history.replaceState(null, "", `${window.location.pathname}?${usp.toString()}`);
+          if (migration.status === "source_stale") {
+            // Creation may already be visible to another tab or device. Without
+            // atomic server proof that C is empty and owned by this attempt,
+            // prefer a harmless empty orphan over deleting real chat history.
+            return;
+          }
 
-          // Update local state but flag that we just created it
-          setIsNewConversationJustCreated(true);
-          setChatId(conversationId);
+          if (migration.status === "destination_active") {
+            // Never replace or delete a destination that already owns a run.
+            // Browser history retains this source draft, so restoring here makes
+            // the original prompt and attachments recoverable with Back.
+            restoreOriginComposer(
+              "This conversation became active before your message was sent. Your message was restored in its original draft."
+            );
+            return;
+          }
 
-          // Trigger sidebar refresh to show the new conversation
+          runtimeKey = migration.key;
+          adoptedExistingDestination = migration.adoptedExistingDestination;
+          runtimeStore.updateForRun(runtimeKey, run.token, (snapshot) => ({
+            ...snapshot,
+            conversation: newConv as Conversation,
+            composer: { ...snapshot.composer, draftProjectId: null }
+          }));
+
+          const keepSelection = shouldProjectMigratedConversation(
+            isUnifiedChatMountedRef.current,
+            sourceWasSelected,
+            migration.destinationWasSelected
+          );
+          if (keepSelection) {
+            activeRuntimeKeyRef.current = runtimeKey;
+            setActiveRuntimeKey(runtimeKey);
+            setChatId(conversationId);
+            canonicalizeConversationHistoryEntry(conversationId);
+          }
           window.dispatchEvent(new Event("conversationcreated"));
         }
 
-        // Create abort controller for this request
-        const abortController = new AbortController();
-        abortControllerRef.current = abortController;
-
-        // Create streaming response - the API expects the content directly as we built it
-        const stream = await openai.responses.create(
-          {
-            conversation: conversationId,
-            model: localState.model || DEFAULT_MODEL_ID, // Use selected model or default
-            input: [{ role: "user", content: messageContent }],
-            metadata: { internal_message_id: localMessageId }, // Pass our local ID
-            stream: true,
-            store: true, // Store in conversation history
-            ...(isWebSearchEnabled && { tools: [{ type: "web_search" }] })
-          },
-          { signal: abortController.signal }
-        );
-
-        // Disable polling while streaming is active
-        assistantStreamingRef.current = true;
-
-        try {
-          // Process the streaming response
-          await processStreamingResponse(stream);
-        } finally {
-          // Re-enable polling after streaming completes
-          assistantStreamingRef.current = false;
-          setCurrentResponseId(undefined);
-
-          // Invalidate billing status after a delay to allow backend processing
-          billingRefreshTimeoutRef.current = setTimeout(() => {
-            queryClient.invalidateQueries({ queryKey: ["billingStatus"] });
-            billingRefreshTimeoutRef.current = null;
-          }, 3000);
-        }
+        await createResponseStream(conversationId, isFollowUpConversation);
+        scheduleBillingRefresh();
       } catch (error) {
         console.error("Failed to send message:", error);
-
-        // Handle usage limit errors with upsell dialogs
-        // The SDK throws errors with the message "Request failed with status 403: {json}" or "Request failed with status 413: {json}"
-        // We need to parse this to extract the actual error details
         let errorMessage = error instanceof Error ? error.message : "Something went wrong";
-
-        // Also check the cause property if it exists
         const causeMessage = (error as Error & { cause?: { message?: string } })?.cause?.message;
         if (causeMessage && causeMessage.includes("Request failed with status")) {
           errorMessage = causeMessage;
         }
 
-        // Check for 413 error (Message exceeds context limit)
-        let status413Error: { status: number; message: string } | null = null;
-        if (errorMessage.includes("Request failed with status 413:")) {
+        const parseStatusError = (status: number) => {
+          if (!errorMessage.includes(`Request failed with status ${status}:`)) return null;
           try {
-            // Extract the JSON part from the error message
-            const jsonMatch = errorMessage.match(/Request failed with status 413:\s*({.*})/);
-            if (jsonMatch && jsonMatch[1]) {
-              status413Error = JSON.parse(jsonMatch[1]);
-            }
-          } catch (parseError) {
-            console.error("Failed to parse 413 error:", parseError);
-          }
-        }
-
-        if (status413Error && status413Error.message === "Message exceeds context limit") {
-          // Remove the user message from history and restore input
-          setMessages((prev) => prev.filter((msg) => msg.id !== localMessageId));
-
-          // Restore the original input and attachments
-          if (!overrideInput) {
-            setInput(originalInput);
-            setDraftImages(originalImages);
-            // Re-create object URLs since originals were revoked by clearAllAttachments()
-            const restoredUrlMap = new Map<File, string>();
-            for (const file of originalImages) {
-              restoredUrlMap.set(file, URL.createObjectURL(file));
-            }
-            setImageUrls(restoredUrlMap);
-            setDocumentText(originalDocumentText);
-            setDocumentName(originalDocumentName);
-          }
-
-          // Show the context limit dialog
-          setContextLimitDialogOpen(true);
-          setError("Your message exceeds the context limit for this model.");
-          return; // Exit early, don't continue to other error handling
-        }
-
-        let status403Error: { status: number; message: string } | null = null;
-
-        // Check if this is a 403 error from the SDK
-        if (errorMessage.includes("Request failed with status 403:")) {
-          try {
-            // Extract the JSON part from the error message
-            const jsonMatch = errorMessage.match(/Request failed with status 403:\s*({.*})/);
-            if (jsonMatch && jsonMatch[1]) {
-              status403Error = JSON.parse(jsonMatch[1]);
-            }
-          } catch (parseError) {
-            console.error("Failed to parse 403 error:", parseError);
-          }
-        }
-
-        if (status403Error) {
-          // Remove the user message from history and restore input
-          setMessages((prev) => prev.filter((msg) => msg.id !== localMessageId));
-
-          // Restore the original input and attachments
-          if (!overrideInput) {
-            setInput(originalInput);
-            setDraftImages(originalImages);
-            // Re-create object URLs since originals were revoked by clearAllAttachments()
-            const restoredUrlMap = new Map<File, string>();
-            for (const file of originalImages) {
-              restoredUrlMap.set(file, URL.createObjectURL(file));
-            }
-            setImageUrls(restoredUrlMap);
-            setDocumentText(originalDocumentText);
-            setDocumentName(originalDocumentName);
-          }
-
-          if (status403Error.message === "Free tier token limit exceeded") {
-            // Token limit exceeded - conversation too long for free tier
-            setUpgradeFeature("tokens");
-            setUpgradeDialogOpen(true);
-            setError(
-              "This conversation is too long for the free tier. Upgrade to Pro for longer conversations."
+            const jsonMatch = errorMessage.match(
+              new RegExp(`Request failed with status ${status}:\\s*({.*})`)
             );
+            return jsonMatch?.[1]
+              ? (JSON.parse(jsonMatch[1]) as { status: number; message: string })
+              : null;
+          } catch (parseError) {
+            console.error(`Failed to parse ${status} error:`, parseError);
+            return null;
+          }
+        };
+
+        const status413Error = parseStatusError(413);
+        if (status413Error && status413Error.message === "Message exceeds context limit") {
+          restoreOriginComposer("Your message exceeds the context limit for this model.");
+          if (isRuntimeSelected(runtimeKey)) setContextLimitDialogOpen(true);
+          return;
+        }
+
+        const status403Error = parseStatusError(403);
+        if (status403Error) {
+          let displayError: string;
+          if (status403Error.message === "Free tier token limit exceeded") {
+            displayError =
+              "This conversation is too long for the free tier. Upgrade to Pro for longer conversations.";
+            if (isRuntimeSelected(runtimeKey)) {
+              setUpgradeFeature("tokens");
+              setUpgradeDialogOpen(true);
+            }
           } else if (status403Error.message === "Usage limit reached") {
-            // Usage limit reached - could be daily (free) or monthly (paid)
             const isFreeTier =
-              !billingStatus?.product_name || billingStatus.product_name.toLowerCase() === "free";
+              !billingStatusAtSend?.product_name ||
+              billingStatusAtSend.product_name.toLowerCase() === "free";
 
             if (isFreeTier) {
-              // Free tier hit daily limits
-              setUpgradeFeature("usage");
-              setUpgradeDialogOpen(true);
-              setError("You've reached your daily usage limit. Upgrade to Pro for more chats.");
+              displayError =
+                "You've reached your daily usage limit. Upgrade to Pro for more chats.";
             } else {
-              // Paid tier hit monthly limits - upsell to next tier
+              const isPro =
+                billingStatusAtSend.product_name?.toLowerCase().includes("pro") &&
+                !billingStatusAtSend.product_name?.toLowerCase().includes("max");
+              displayError = isPro
+                ? "You've reached your monthly Pro limit. Upgrade to Max for 10x more usage."
+                : "You've reached your monthly usage limit. Please wait for the next billing cycle.";
+            }
+            if (isRuntimeSelected(runtimeKey)) {
               setUpgradeFeature("usage");
               setUpgradeDialogOpen(true);
-              const isPro =
-                billingStatus.product_name?.toLowerCase().includes("pro") &&
-                !billingStatus.product_name?.toLowerCase().includes("max");
-              setError(
-                isPro
-                  ? "You've reached your monthly Pro limit. Upgrade to Max for 10x more usage."
-                  : "You've reached your monthly usage limit. Please wait for the next billing cycle."
-              );
             }
           } else {
-            setError(status403Error.message || "Access denied. Please check your subscription.");
+            displayError =
+              status403Error.message || "Access denied. Please check your subscription.";
           }
+          restoreOriginComposer(displayError);
         } else if (error instanceof Error && error.name !== "AbortError") {
-          // Retry logic for non-rate-limit errors on follow-up conversations
-          // Only retry if this is a follow-up (conversation already existed before this request)
-          const isFollowUpConversation = conversation?.id && messages.length > 1;
-
-          if (isFollowUpConversation && conversation?.id) {
+          if (isFollowUpConversation && conversationId) {
             try {
-              // Wait 1 second before retrying
               console.log("Waiting 1s before retry...");
               await new Promise((resolve) => setTimeout(resolve, 1000));
+              if (!runtimeStore.isRunCurrent(runtimeKey, run.token)) return;
 
               console.log("Retrying request once...");
-              // TODO: Consider calling os.getAttestation() here if needed for attestation refresh
-
-              // Create new abort controller for retry
-              const retryAbortController = new AbortController();
-              abortControllerRef.current = retryAbortController;
-
-              const retryStream = await openai.responses.create(
-                {
-                  conversation: conversation.id,
-                  model: localState.model || DEFAULT_MODEL_ID,
-                  input: [{ role: "user", content: messageContent }],
-                  metadata: { internal_message_id: localMessageId }, // Server prevents duplicate IDs
-                  stream: true,
-                  store: true,
-                  ...(isWebSearchEnabled && { tools: [{ type: "web_search" }] })
-                },
-                { signal: retryAbortController.signal }
-              );
-
-              // Disable polling while streaming is active
-              assistantStreamingRef.current = true;
-
-              try {
-                // Process the retry stream using the same helper function
-                await processStreamingResponse(retryStream);
-                console.log("Retry completed successfully");
-              } finally {
-                // Re-enable polling after streaming completes
-                assistantStreamingRef.current = false;
-              }
+              await createResponseStream(conversationId, false);
+              scheduleBillingRefresh();
+              console.log("Retry completed successfully");
               return;
             } catch (retryError) {
-              // Retry failed - check one last time if message actually went through
               console.error("Retry failed:", retryError);
+              if (!runtimeStore.isRunCurrent(runtimeKey, run.token)) return;
 
               try {
-                // Check the last 5 items to see if our message is there
-                const finalCheckResponse = await openai.conversations.items.list(conversation.id, {
+                const finalCheckResponse = await openai.conversations.items.list(conversationId, {
                   limit: 5,
                   order: "desc"
                 });
-
-                // Look for our message by ID - server uses our internal_message_id as the item's ID
                 const foundMessage = finalCheckResponse.data.find(
                   (item) => item.id === localMessageId
                 );
 
                 if (!foundMessage) {
-                  // Message definitely didn't go through - restore input and remove from UI
                   console.log("Message not found after retry - restoring input");
-
-                  // Remove the user message from the messages list
-                  setMessages((prev) => prev.filter((msg) => msg.id !== localMessageId));
-
-                  // Restore the original input and attachments
-                  if (!overrideInput) {
-                    setInput(originalInput);
-                    setDraftImages(originalImages);
-                    // Re-create object URLs since originals were revoked by clearAllAttachments()
-                    const restoredUrlMap = new Map<File, string>();
-                    for (const file of originalImages) {
-                      restoredUrlMap.set(file, URL.createObjectURL(file));
-                    }
-                    setImageUrls(restoredUrlMap);
-                    setDocumentText(originalDocumentText);
-                    setDocumentName(originalDocumentName);
-                  }
-
-                  setError("Failed to send message. Please try again.");
+                  restoreOriginComposer("Failed to send message. Please try again.");
                 } else {
-                  // Message actually went through! Just log it
                   console.log("Message found after retry failure - it actually went through");
                 }
               } catch (finalCheckError) {
-                // If we can't even check, assume message failed and restore input
                 console.error("Final check failed:", finalCheckError);
-
-                // Remove the user message from the messages list
-                setMessages((prev) => prev.filter((msg) => msg.id !== localMessageId));
-
-                // Restore the original input and attachments
-                if (!overrideInput) {
-                  setInput(originalInput);
-                  setDraftImages(originalImages);
-                  // Re-create object URLs since originals were revoked by clearAllAttachments()
-                  const restoredUrlMap = new Map<File, string>();
-                  for (const file of originalImages) {
-                    restoredUrlMap.set(file, URL.createObjectURL(file));
-                  }
-                  setImageUrls(restoredUrlMap);
-                  setDocumentText(originalDocumentText);
-                  setDocumentName(originalDocumentName);
-                }
-
-                setError("Failed to send message. Please try again.");
+                restoreOriginComposer("Failed to send message. Please try again.");
               }
             }
           } else {
-            // Not a follow-up conversation or other non-retryable error
-            setError(errorMessage + ". Please try again.");
+            const optimisticMessageId = getRegisteredChatOptimisticMessage(runtimeStore, run.token);
+            runtimeStore.updateForRun(runtimeKey, run.token, (snapshot) => ({
+              ...snapshot,
+              messages: markOptimisticMessageIncomplete(
+                snapshot.messages as Message[],
+                optimisticMessageId
+              ),
+              error: `${errorMessage}. Please try again.`
+            }));
           }
         }
       } finally {
-        setIsGenerating(false);
-        setCurrentResponseId(undefined);
-        abortControllerRef.current = null;
-        assistantStreamingRef.current = false;
+        unregisterChatOptimisticMessage(runtimeStore, run.token, localMessageId);
+        runtimeStore.finishRun(runtimeKey, run.token);
       }
     },
     [
-      input,
-      isGenerating,
-      isProcessingDocument,
-      openai,
-      os,
-      conversation,
-      draftProjectId,
+      billingStatus,
+      isRuntimeSelected,
+      isWebSearchEnabled,
       localState.model,
-      draftImages,
-      documentText,
-      clearAllAttachments,
+      openai,
       processStreamingResponse,
-      isWebSearchEnabled
+      queryClient,
+      runtimeStore
     ]
   );
 
@@ -3858,6 +4684,8 @@ export function UnifiedChat() {
   return (
     <div
       style={sidebarLayoutStyle}
+      data-runtime-key={runtimeStore.resolveKey(activeRuntimeKey)}
+      data-generating={isGenerating ? "true" : "false"}
       className={`grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden ${isSidebarOpen ? SIDEBAR_GRID_COLUMNS_CLASS : ""}`}
     >
       {/* Use the existing Sidebar component */}
@@ -4056,7 +4884,9 @@ export function UnifiedChat() {
                                 <button
                                   type="button"
                                   onClick={() => removeImage(i)}
-                                  className="absolute -right-1 -top-1 rounded-full border bg-background p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+                                  disabled={isGenerating}
+                                  aria-label={`Remove attachment ${i + 1}`}
+                                  className="absolute -right-1 -top-1 rounded-full border bg-background p-0.5 opacity-0 transition-opacity group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-40"
                                 >
                                   <X className="h-3 w-3" />
                                 </button>
@@ -4072,7 +4902,9 @@ export function UnifiedChat() {
                             <button
                               type="button"
                               onClick={removeDocument}
-                              className="text-muted-foreground hover:text-foreground"
+                              disabled={isGenerating}
+                              aria-label="Remove document"
+                              className="text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
                             >
                               <X className="h-3 w-3" />
                             </button>
@@ -4111,7 +4943,7 @@ export function UnifiedChat() {
                         onKeyDown={handleKeyDown}
                         onPaste={handlePaste}
                         placeholder="Message Maple..."
-                        disabled={isGenerating || isRecording}
+                        disabled={isGenerating || isRecordingForActive}
                         className={`resize-none border-0 bg-transparent pl-4 pr-8 text-base leading-6 focus-visible:ring-0 focus-visible:ring-offset-0 placeholder:text-muted-foreground/60 ${
                           isFullscreen
                             ? "flex-1 min-h-0 pt-3 pb-2"
@@ -4172,10 +5004,14 @@ export function UnifiedChat() {
                                 variant="ghost"
                                 size="sm"
                                 className="h-8 w-8 p-0 text-[hsl(var(--maple-secondary-700))] hover:bg-[hsl(var(--maple-primary-container))] hover:text-[hsl(var(--maple-secondary-700))]"
-                                disabled={isProcessingDocument}
+                                disabled={isGenerating || isProcessingDocument}
                                 aria-busy={isProcessingDocument}
                                 aria-label={
-                                  isProcessingDocument ? "Processing document" : "Add attachment"
+                                  isProcessingDocument
+                                    ? "Processing document"
+                                    : isGenerating
+                                      ? "Attachments unavailable while generating"
+                                      : "Add attachment"
                                 }
                               >
                                 {isProcessingDocument ? (
@@ -4193,11 +5029,13 @@ export function UnifiedChat() {
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="start">
                               <DropdownMenuItem
+                                disabled={isGenerating}
                                 onClick={() => {
                                   if (!canUseImages) {
                                     setUpgradeFeature("image");
                                     setUpgradeDialogOpen(true);
                                   } else {
+                                    fileInputOwnerKeyRef.current = activeRuntimeKeyRef.current;
                                     fileInputRef.current?.click();
                                   }
                                 }}
@@ -4206,6 +5044,7 @@ export function UnifiedChat() {
                                 <span>Add Images</span>
                               </DropdownMenuItem>
                               <DropdownMenuItem
+                                disabled={isGenerating}
                                 onClick={() => {
                                   if (!isTauriEnv) {
                                     setDocumentPlatformDialogOpen(true);
@@ -4213,6 +5052,7 @@ export function UnifiedChat() {
                                     setUpgradeFeature("document");
                                     setUpgradeDialogOpen(true);
                                   } else {
+                                    documentInputOwnerKeyRef.current = activeRuntimeKeyRef.current;
                                     documentInputRef.current?.click();
                                   }
                                 }}
@@ -4239,6 +5079,7 @@ export function UnifiedChat() {
                             <Button
                               type="button"
                               onClick={handleCancelResponse}
+                              aria-label="Stop generating"
                               size="icon"
                               variant="destructive"
                               className="h-8 w-8 rounded-xl sm:h-9 sm:w-9"
@@ -4248,6 +5089,7 @@ export function UnifiedChat() {
                           ) : (
                             <button
                               type="submit"
+                              aria-label="Send message"
                               disabled={
                                 isProcessingDocument ||
                                 (!input.trim() && !draftImages.length && !documentText)
@@ -4260,7 +5102,7 @@ export function UnifiedChat() {
                         </div>
                       </div>
 
-                      {isRecording && (
+                      {isRecordingForActive && (
                         <RecordingOverlay
                           isRecording={isRecording}
                           isProcessing={isProcessingSend || isTranscribing}
@@ -4303,7 +5145,9 @@ export function UnifiedChat() {
                               <button
                                 type="button"
                                 onClick={() => removeImage(i)}
-                                className="absolute -right-1 -top-1 rounded-full border bg-background p-0.5 opacity-0 transition-opacity group-hover:opacity-100"
+                                disabled={isGenerating}
+                                aria-label={`Remove attachment ${i + 1}`}
+                                className="absolute -right-1 -top-1 rounded-full border bg-background p-0.5 opacity-0 transition-opacity group-hover:opacity-100 disabled:pointer-events-none disabled:opacity-40"
                               >
                                 <X className="h-2.5 w-2.5" />
                               </button>
@@ -4319,7 +5163,9 @@ export function UnifiedChat() {
                           <button
                             type="button"
                             onClick={removeDocument}
-                            className="text-muted-foreground hover:text-foreground"
+                            disabled={isGenerating}
+                            aria-label="Remove document"
+                            className="text-muted-foreground hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
                           >
                             <X className="h-2.5 w-2.5" />
                           </button>
@@ -4342,7 +5188,7 @@ export function UnifiedChat() {
                       onKeyDown={handleKeyDown}
                       onPaste={handlePaste}
                       placeholder="Message Maple..."
-                      disabled={isGenerating || isRecording}
+                      disabled={isGenerating || isRecordingForActive}
                       className={CHAT_COMPOSER_TEXTAREA_CLASS}
                       rows={1}
                       id="message"
@@ -4393,10 +5239,14 @@ export function UnifiedChat() {
                               variant="ghost"
                               size="sm"
                               className="h-8 w-8 p-0 text-[hsl(var(--maple-secondary-700))] hover:bg-[hsl(var(--maple-primary-container))] hover:text-[hsl(var(--maple-secondary-700))]"
-                              disabled={isProcessingDocument}
+                              disabled={isGenerating || isProcessingDocument}
                               aria-busy={isProcessingDocument}
                               aria-label={
-                                isProcessingDocument ? "Processing document" : "Add attachment"
+                                isProcessingDocument
+                                  ? "Processing document"
+                                  : isGenerating
+                                    ? "Attachments unavailable while generating"
+                                    : "Add attachment"
                               }
                             >
                               {isProcessingDocument ? (
@@ -4414,11 +5264,13 @@ export function UnifiedChat() {
                           </DropdownMenuTrigger>
                           <DropdownMenuContent align="start">
                             <DropdownMenuItem
+                              disabled={isGenerating}
                               onClick={() => {
                                 if (!canUseImages) {
                                   setUpgradeFeature("image");
                                   setUpgradeDialogOpen(true);
                                 } else {
+                                  fileInputOwnerKeyRef.current = activeRuntimeKeyRef.current;
                                   fileInputRef.current?.click();
                                 }
                               }}
@@ -4427,6 +5279,7 @@ export function UnifiedChat() {
                               <span>Add Images</span>
                             </DropdownMenuItem>
                             <DropdownMenuItem
+                              disabled={isGenerating}
                               onClick={() => {
                                 if (!isTauriEnv) {
                                   setDocumentPlatformDialogOpen(true);
@@ -4434,6 +5287,7 @@ export function UnifiedChat() {
                                   setUpgradeFeature("document");
                                   setUpgradeDialogOpen(true);
                                 } else {
+                                  documentInputOwnerKeyRef.current = activeRuntimeKeyRef.current;
                                   documentInputRef.current?.click();
                                 }
                               }}
@@ -4460,6 +5314,7 @@ export function UnifiedChat() {
                           <Button
                             type="button"
                             onClick={handleCancelResponse}
+                            aria-label="Stop generating"
                             size="icon"
                             variant="destructive"
                             className="h-8 w-8 rounded-xl"
@@ -4469,6 +5324,7 @@ export function UnifiedChat() {
                         ) : (
                           <button
                             type="submit"
+                            aria-label="Send message"
                             disabled={
                               isProcessingDocument ||
                               (!input.trim() && !draftImages.length && !documentText)
@@ -4481,7 +5337,7 @@ export function UnifiedChat() {
                       </div>
                     </div>
 
-                    {isRecording && (
+                    {isRecordingForActive && (
                       <RecordingOverlay
                         isRecording={isRecording}
                         isProcessing={isProcessingSend || isTranscribing}

--- a/frontend/src/components/chatProjectionScroll.test.ts
+++ b/frontend/src/components/chatProjectionScroll.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ChatProjectionScrollCoordinator,
+  chatProjectionScrollTarget,
+  projectedUserTurnScrollTop
+} from "./chatProjectionScroll";
+
+describe("ChatProjectionScrollCoordinator", () => {
+  test("requests positioning whenever a different cached runtime is projected", () => {
+    const coordinator = new ChatProjectionScrollCoordinator<string>();
+    const resolveKey = (key: string) => key;
+
+    expect(coordinator.activate("conversation:a", resolveKey)).toBe(true);
+    expect(coordinator.takePositionRequest("conversation:a", true, resolveKey)).toBe(true);
+    expect(coordinator.takePositionRequest("conversation:a", true, resolveKey)).toBe(false);
+
+    expect(coordinator.activate("conversation:b", resolveKey)).toBe(true);
+    expect(coordinator.takePositionRequest("conversation:b", true, resolveKey)).toBe(true);
+
+    expect(coordinator.activate("conversation:a", resolveKey)).toBe(true);
+    expect(coordinator.takePositionRequest("conversation:a", true, resolveKey)).toBe(true);
+  });
+
+  test("keeps a projection request pending until its messages are ready", () => {
+    const coordinator = new ChatProjectionScrollCoordinator<string>();
+    const resolveKey = (key: string) => key;
+
+    coordinator.activate("conversation:a", resolveKey);
+    expect(coordinator.takePositionRequest("conversation:a", false, resolveKey)).toBe(false);
+    expect(coordinator.takePositionRequest("conversation:a", true, resolveKey)).toBe(true);
+  });
+
+  test("treats a draft rekey as the same logical projection", () => {
+    const coordinator = new ChatProjectionScrollCoordinator<string>();
+    const aliases = new Map<string, string>();
+    const resolveKey = (key: string) => aliases.get(key) ?? key;
+
+    coordinator.activate("draft:a", resolveKey);
+    expect(coordinator.takePositionRequest("draft:a", true, resolveKey)).toBe(true);
+
+    aliases.set("draft:a", "conversation:a");
+    expect(coordinator.activate("conversation:a", resolveKey)).toBe(false);
+    expect(coordinator.owns("draft:a", resolveKey)).toBe(true);
+    expect(coordinator.owns("conversation:a", resolveKey)).toBe(true);
+  });
+
+  test("fences delayed work to the current projection", () => {
+    const coordinator = new ChatProjectionScrollCoordinator<string>();
+    const resolveKey = (key: string) => key;
+
+    coordinator.activate("conversation:a", resolveKey);
+    const firstAVisit = coordinator.captureLease("conversation:a", resolveKey);
+    coordinator.activate("conversation:b", resolveKey);
+
+    expect(coordinator.owns("conversation:a", resolveKey)).toBe(false);
+    expect(coordinator.owns("conversation:b", resolveKey)).toBe(true);
+    expect(firstAVisit && coordinator.ownsLease(firstAVisit, resolveKey)).toBe(false);
+
+    coordinator.deactivate();
+    expect(coordinator.owns("conversation:b", resolveKey)).toBe(false);
+    expect(coordinator.activate("conversation:b", resolveKey)).toBe(true);
+  });
+
+  test("rejects delayed work from an earlier visit after an A to B to A switch", () => {
+    const coordinator = new ChatProjectionScrollCoordinator<string>();
+    const resolveKey = (key: string) => key;
+
+    coordinator.activate("conversation:a", resolveKey);
+    const firstAVisit = coordinator.captureLease("conversation:a", resolveKey)!;
+    coordinator.activate("conversation:b", resolveKey);
+    coordinator.activate("conversation:a", resolveKey);
+    const secondAVisit = coordinator.captureLease("conversation:a", resolveKey)!;
+
+    expect(coordinator.ownsLease(firstAVisit, resolveKey)).toBe(false);
+    expect(coordinator.ownsLease(secondAVisit, resolveKey)).toBe(true);
+  });
+});
+
+describe("chat projection scroll target", () => {
+  const messages = [
+    { id: "user-1", type: "message", role: "user" },
+    { id: "assistant-1", type: "message", role: "assistant" },
+    { id: "user-2", type: "message", role: "user" },
+    { id: "assistant-2", type: "message", role: "assistant" }
+  ];
+
+  test("anchors an active stream to its newest user turn", () => {
+    expect(chatProjectionScrollTarget(messages, true)).toEqual({
+      type: "latest-user",
+      messageId: "user-2"
+    });
+  });
+
+  test("opens completed chats and user-less streams at the bottom", () => {
+    expect(chatProjectionScrollTarget(messages, false)).toEqual({ type: "bottom" });
+    expect(
+      chatProjectionScrollTarget([{ id: "assistant-1", type: "message", role: "assistant" }], true)
+    ).toEqual({ type: "bottom" });
+  });
+
+  test("calculates a stable user-turn offset from the current projection", () => {
+    expect(
+      projectedUserTurnScrollTop({
+        currentScrollTop: 1200,
+        containerTop: 56,
+        userTurnTop: 380,
+        topOffset: 16
+      })
+    ).toBe(1508);
+    expect(
+      projectedUserTurnScrollTop({
+        currentScrollTop: 0,
+        containerTop: 56,
+        userTurnTop: 40,
+        topOffset: 16
+      })
+    ).toBe(0);
+  });
+});

--- a/frontend/src/components/chatProjectionScroll.ts
+++ b/frontend/src/components/chatProjectionScroll.ts
@@ -1,0 +1,118 @@
+export type ChatProjectionKeyResolver<TKey extends string> = (key: TKey) => string;
+
+export type ChatProjectionScrollLease<TKey extends string> = Readonly<{
+  ownerKey: TKey;
+  sequence: number;
+}>;
+
+function chatProjectionKeysMatch<TKey extends string>(
+  first: TKey,
+  second: TKey,
+  resolveKey: ChatProjectionKeyResolver<TKey>
+): boolean {
+  return resolveKey(first) === resolveKey(second);
+}
+
+/**
+ * Owns the one-time positioning request for the runtime currently projected
+ * into Unified Chat's shared scroll container.
+ */
+export class ChatProjectionScrollCoordinator<TKey extends string = string> {
+  private ownerKey: TKey | null = null;
+  private positionPending = false;
+  private sequence = 0;
+
+  activate(key: TKey, resolveKey: ChatProjectionKeyResolver<TKey>): boolean {
+    if (this.ownerKey && chatProjectionKeysMatch(this.ownerKey, key, resolveKey)) {
+      return false;
+    }
+
+    this.ownerKey = key;
+    this.positionPending = true;
+    this.sequence += 1;
+    return true;
+  }
+
+  deactivate(): void {
+    this.ownerKey = null;
+    this.positionPending = false;
+    this.sequence += 1;
+  }
+
+  owns(key: TKey, resolveKey: ChatProjectionKeyResolver<TKey>): boolean {
+    return Boolean(this.ownerKey && chatProjectionKeysMatch(this.ownerKey, key, resolveKey));
+  }
+
+  captureLease(
+    key: TKey,
+    resolveKey: ChatProjectionKeyResolver<TKey>
+  ): ChatProjectionScrollLease<TKey> | null {
+    if (!this.owns(key, resolveKey)) return null;
+    return Object.freeze({ ownerKey: key, sequence: this.sequence });
+  }
+
+  ownsLease(
+    lease: ChatProjectionScrollLease<TKey>,
+    resolveKey: ChatProjectionKeyResolver<TKey>
+  ): boolean {
+    return this.sequence === lease.sequence && this.owns(lease.ownerKey, resolveKey);
+  }
+
+  takePositionRequest(
+    key: TKey,
+    ready: boolean,
+    resolveKey: ChatProjectionKeyResolver<TKey>
+  ): boolean {
+    if (!ready || !this.positionPending || !this.owns(key, resolveKey)) {
+      return false;
+    }
+
+    this.positionPending = false;
+    return true;
+  }
+}
+
+export type ChatProjectionMessage = Readonly<{
+  id: string;
+  type: string;
+  role?: string;
+}>;
+
+export type ChatProjectionScrollTarget =
+  | Readonly<{ type: "latest-user"; messageId: string }>
+  | Readonly<{ type: "bottom" }>;
+
+/**
+ * A growing assistant block is not a stable bottom anchor. When returning to
+ * an active stream, keep the newest user turn visible; completed chats open at
+ * the bottom as before.
+ */
+export function chatProjectionScrollTarget(
+  messages: readonly ChatProjectionMessage[],
+  isGenerating: boolean
+): ChatProjectionScrollTarget {
+  if (isGenerating) {
+    for (let index = messages.length - 1; index >= 0; index -= 1) {
+      const message = messages[index];
+      if (message.type === "message" && message.role === "user") {
+        return { type: "latest-user", messageId: message.id };
+      }
+    }
+  }
+
+  return { type: "bottom" };
+}
+
+export function projectedUserTurnScrollTop({
+  currentScrollTop,
+  containerTop,
+  userTurnTop,
+  topOffset = 16
+}: Readonly<{
+  currentScrollTop: number;
+  containerTop: number;
+  userTurnTop: number;
+  topOffset?: number;
+}>): number {
+  return Math.max(0, currentScrollTop + userTurnTop - containerTop - topOffset);
+}

--- a/frontend/src/components/markdown.test.ts
+++ b/frontend/src/components/markdown.test.ts
@@ -98,4 +98,49 @@ describe("ThinkingBlock labels", () => {
     expect(pending).toContain("transition-opacity");
     expect(pending).toContain("animate-bounce");
   });
+
+  it("renders an untimed shimmer while a main-chat thought is streaming", () => {
+    const renderStreaming = (duration: number) =>
+      renderToStaticMarkup(
+        React.createElement(ThinkingBlock, {
+          content: "Streaming reasoning tokens.",
+          isThinking: true,
+          duration
+        })
+      );
+    const beforeSwitch = renderStreaming(20);
+    const afterSwitch = renderStreaming(1);
+
+    expect(afterSwitch).toBe(beforeSwitch);
+    expect(afterSwitch).toContain(">Thinking<");
+    expect(afterSwitch).toContain("thinking-shimmer");
+    expect(afterSwitch).not.toContain("Thinking for");
+    expect(afterSwitch).not.toContain("seconds");
+    expect(afterSwitch).not.toContain("animate-bounce");
+  });
+
+  it("keeps the completed main-chat thought duration", () => {
+    const completed = renderToStaticMarkup(
+      React.createElement(ThinkingBlock, {
+        content: "Finished reasoning tokens.",
+        isThinking: false,
+        duration: 23
+      })
+    );
+
+    expect(completed).toContain("Thought for 23 seconds");
+    expect(completed).not.toContain("thinking-shimmer");
+  });
+
+  it("keeps estimating a completed main-chat thought when no duration is reported", () => {
+    const completed = renderToStaticMarkup(
+      React.createElement(ThinkingBlock, {
+        content: Array.from({ length: 52 }, () => "word").join(" "),
+        isThinking: false
+      })
+    );
+
+    expect(completed).toContain("Thought for 2 seconds");
+    expect(completed).not.toContain("thinking-shimmer");
+  });
 });

--- a/frontend/src/components/markdown.test.ts
+++ b/frontend/src/components/markdown.test.ts
@@ -112,8 +112,10 @@ describe("ThinkingBlock labels", () => {
     const afterSwitch = renderStreaming(1);
 
     expect(afterSwitch).toBe(beforeSwitch);
-    expect(afterSwitch).toContain(">Thinking<");
+    expect(afterSwitch).toContain(">Thinking<span");
     expect(afterSwitch).toContain("thinking-shimmer");
+    expect(afterSwitch).toContain("thinking-shimmer-highlight");
+    expect(afterSwitch).toContain('aria-hidden="true"');
     expect(afterSwitch).not.toContain("Thinking for");
     expect(afterSwitch).not.toContain("seconds");
     expect(afterSwitch).not.toContain("animate-bounce");

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -100,6 +100,10 @@ function ThinkingDots() {
   );
 }
 
+function ThinkingShimmer() {
+  return <span className="thinking-shimmer">Thinking</span>;
+}
+
 export interface ThinkingBlockProps {
   content: string;
   isThinking: boolean;
@@ -116,48 +120,17 @@ export function ThinkingBlock({
   label
 }: ThinkingBlockProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [elapsedSeconds, setElapsedSeconds] = useState(0);
-  const startTimeRef = useRef<number | null>(null);
 
-  // Update elapsed time every second while thinking
-  useEffect(() => {
-    if (!isThinking) {
-      return;
-    }
-
-    // Set start time when thinking begins
-    if (startTimeRef.current === null) {
-      startTimeRef.current = Date.now();
-    }
-
-    // Start counting immediately
-    const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-    setElapsedSeconds(elapsed);
-
-    const interval = setInterval(() => {
-      if (startTimeRef.current !== null) {
-        const elapsed = Math.floor((Date.now() - startTimeRef.current) / 1000);
-        setElapsedSeconds(elapsed);
-      }
-    }, 1000);
-
-    return () => {
-      clearInterval(interval);
-      startTimeRef.current = null;
-    };
-  }, [isThinking]);
-
-  // Calculate duration text - use actual duration, elapsed time, or estimate based on word count
+  // Use the reported duration when available, otherwise estimate completed thoughts by word count.
   const displayDuration = useMemo(() => {
     if (duration) return duration;
-    if (isThinking) return elapsedSeconds;
 
     // Fallback: estimate based on word count
     const wordCount = content.trim().split(/\s+/).length;
     // Slower estimation to better match observed times (26 actual vs 23 estimated)
     const estimatedSeconds = Math.max(1, Math.round(wordCount / 26)); // ~26 words per second
     return estimatedSeconds;
-  }, [content, duration, isThinking, elapsedSeconds]);
+  }, [content, duration]);
 
   const durationText = `${displayDuration}`;
 
@@ -174,10 +147,7 @@ export function ThinkingBlock({
           <span className="min-w-0 text-sm font-medium text-muted-foreground">
             {showDuration ? (
               isThinking ? (
-                <span className="inline-flex items-center gap-2">
-                  {`Thinking for ${durationText} seconds`}
-                  <ThinkingDots />
-                </span>
+                <ThinkingShimmer />
               ) : (
                 `Thought for ${durationText} seconds`
               )

--- a/frontend/src/components/markdown.tsx
+++ b/frontend/src/components/markdown.tsx
@@ -101,7 +101,14 @@ function ThinkingDots() {
 }
 
 function ThinkingShimmer() {
-  return <span className="thinking-shimmer">Thinking</span>;
+  return (
+    <span className="thinking-shimmer">
+      Thinking
+      <span className="thinking-shimmer-highlight" aria-hidden="true">
+        Thinking
+      </span>
+    </span>
+  );
 }
 
 export interface ThinkingBlockProps {

--- a/frontend/src/contexts/ChatRuntimeContext.test.ts
+++ b/frontend/src/contexts/ChatRuntimeContext.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, spyOn, test } from "bun:test";
+import { createChatComposerState, createChatRuntimeStore } from "./ChatRuntimeContext";
+import { createChatDraftKey, createConversationChatKey } from "../services/chatRuntimeStore";
+
+type Conversation = { id: string };
+type Message = { id: string };
+
+describe("ChatRuntimeContext eviction policy", () => {
+  test("retains and restores an idle draft with unsent composer content across selection", () => {
+    const store = createChatRuntimeStore<Conversation, Message>(0);
+    const draftKey = createChatDraftKey("retained-unsent-composer");
+    const conversationKey = createConversationChatKey("visited-conversation");
+    const composer = createChatComposerState("project-a");
+    composer.input = "keep this unfinished message";
+    composer.documentText = "document payload";
+    composer.documentName = "notes.md";
+
+    store.select(draftKey, { composer });
+    store.select(conversationKey, { conversation: { id: "visited-conversation" } });
+
+    expect(store.get(draftKey)?.composer).toMatchObject({
+      input: "keep this unfinished message",
+      draftProjectId: "project-a",
+      documentText: "document payload",
+      documentName: "notes.md"
+    });
+
+    store.select(draftKey);
+    expect(store.getActiveKey()).toBe(draftKey);
+    expect(store.getActive()?.composer.input).toBe("keep this unfinished message");
+  });
+
+  test("evicts a completed rekeyed conversation even if draft project metadata is stale", () => {
+    const store = createChatRuntimeStore<Conversation, Message>(0);
+    const draftKey = createChatDraftKey("project-draft");
+    const conversationKey = createConversationChatKey("created-conversation");
+    const nextActiveKey = createConversationChatKey("next-active");
+    store.select(draftKey, {
+      composer: createChatComposerState("project-a")
+    });
+    const run = store.beginRun(draftKey);
+
+    expect(store.rekey(draftKey, conversationKey, run.token)).toBe(conversationKey);
+    expect(store.finishRun(conversationKey, run.token)).toBe(true);
+    expect(store.get(conversationKey)?.composer.draftProjectId).toBe("project-a");
+
+    store.select(nextActiveKey);
+
+    expect(store.get(conversationKey)).toBeUndefined();
+    expect(store.get(draftKey)).toBeUndefined();
+    expect(store.getActiveKey()).toBe(nextActiveKey);
+  });
+
+  test("deleting an idle superseded draft disposes only its object URLs", () => {
+    const revokeObjectURL = spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const idleDraftKey = createChatDraftKey("idle-superseded");
+    const runningDraftKey = createChatDraftKey("still-running");
+    const idleFile = new File(["idle"], "idle.png", { type: "image/png" });
+    const runningFile = new File(["running"], "running.png", { type: "image/png" });
+    const idleComposer = createChatComposerState();
+    idleComposer.draftImages = [idleFile];
+    idleComposer.imageUrls.set(idleFile, "blob:idle");
+    const runningComposer = createChatComposerState();
+    runningComposer.draftImages = [runningFile];
+    runningComposer.imageUrls.set(runningFile, "blob:running");
+
+    try {
+      store.ensure(idleDraftKey, { composer: idleComposer });
+      store.select(runningDraftKey, { composer: runningComposer });
+      const running = store.beginRun(runningDraftKey);
+
+      expect(store.delete(idleDraftKey)).toBe(true);
+
+      expect(revokeObjectURL).toHaveBeenCalledTimes(1);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:idle");
+      expect(store.get(idleDraftKey)).toBeUndefined();
+      expect(store.isRunCurrent(runningDraftKey, running.token)).toBe(true);
+      expect(running.signal.aborted).toBe(false);
+      expect(store.get(runningDraftKey)?.composer.imageUrls.get(runningFile)).toBe("blob:running");
+
+      store.dispose();
+      expect(running.signal.aborted).toBe(true);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:running");
+    } finally {
+      store.dispose();
+      revokeObjectURL.mockRestore();
+    }
+  });
+});

--- a/frontend/src/contexts/ChatRuntimeContext.tsx
+++ b/frontend/src/contexts/ChatRuntimeContext.tsx
@@ -1,0 +1,121 @@
+import { createContext, useContext, useEffect, useMemo, type ReactNode } from "react";
+import {
+  ChatRuntimeStore,
+  type ChatRuntimeKey,
+  type ChatRuntimeSnapshot,
+  type ChatRuntimeStoreOptions
+} from "@/services/chatRuntimeStore";
+import { createDeferredDisposalLifecycle } from "@/services/deferredDisposalLifecycle";
+
+export type ChatPaginationState = {
+  oldestItemId: string | undefined;
+  isLoadingOlderMessages: boolean;
+  hasMoreOlderMessages: boolean;
+};
+
+export type ChatComposerState = {
+  input: string;
+  draftProjectId: string | null;
+  draftImages: File[];
+  imageUrls: Map<File, string>;
+  documentText: string;
+  documentName: string;
+  isProcessingDocument: boolean;
+  attachmentError: string | null;
+  audioError: string | null;
+  imagePasteGeneration: number;
+  documentUploadGeneration: number;
+  pagination: ChatPaginationState;
+};
+
+export function createChatComposerState(draftProjectId: string | null = null): ChatComposerState {
+  return {
+    input: "",
+    draftProjectId,
+    draftImages: [],
+    imageUrls: new Map(),
+    documentText: "",
+    documentName: "",
+    isProcessingDocument: false,
+    attachmentError: null,
+    audioError: null,
+    imagePasteGeneration: 0,
+    documentUploadGeneration: 0,
+    pagination: {
+      oldestItemId: undefined,
+      isLoadingOlderMessages: false,
+      hasMoreOlderMessages: false
+    }
+  };
+}
+
+type UntypedChatRuntimeStore = ChatRuntimeStore<unknown, unknown, ChatComposerState>;
+
+const ChatRuntimeContext = createContext<UntypedChatRuntimeStore | null>(null);
+
+export function composerHasRetainedDraft(
+  key: ChatRuntimeKey,
+  composer: ChatComposerState
+): boolean {
+  return (
+    composer.input.length > 0 ||
+    (key.startsWith("draft:") && composer.draftProjectId !== null) ||
+    composer.draftImages.length > 0 ||
+    composer.documentText.length > 0 ||
+    composer.documentName.length > 0 ||
+    composer.isProcessingDocument
+  );
+}
+
+function disposeComposerResources(
+  snapshot: ChatRuntimeSnapshot<unknown, unknown, ChatComposerState>
+): void {
+  for (const url of snapshot.composer.imageUrls.values()) {
+    URL.revokeObjectURL(url);
+  }
+}
+
+export function createChatRuntimeStore<TConversation = unknown, TMessage = unknown>(
+  maxInactiveCompletedEntries = 20
+): ChatRuntimeStore<TConversation, TMessage, ChatComposerState> {
+  const options: ChatRuntimeStoreOptions<TConversation, TMessage, ChatComposerState> = {
+    createComposer: createChatComposerState,
+    maxInactiveCompletedEntries,
+    canEvict: (snapshot) =>
+      !snapshot.isGenerating &&
+      !snapshot.assistantStreaming &&
+      snapshot.runToken === null &&
+      !composerHasRetainedDraft(snapshot.key, snapshot.composer),
+    disposeEntry: disposeComposerResources
+  };
+  return new ChatRuntimeStore(options);
+}
+
+/**
+ * Owns in-memory chat streams and drafts for one authenticated account scope.
+ * The parent keys this provider by user ID, so an account transition disposes
+ * controllers and object URLs without making sensitive state module-global.
+ */
+export function ChatRuntimeProvider({ children }: { children: ReactNode }) {
+  const store = useMemo(() => createChatRuntimeStore(), []);
+  const disposalLifecycle = useMemo(
+    () => createDeferredDisposalLifecycle(() => store.dispose()),
+    [store]
+  );
+
+  useEffect(() => disposalLifecycle.activate(), [disposalLifecycle]);
+
+  return <ChatRuntimeContext.Provider value={store}>{children}</ChatRuntimeContext.Provider>;
+}
+
+export function useChatRuntimeStore<TConversation, TMessage>(): ChatRuntimeStore<
+  TConversation,
+  TMessage,
+  ChatComposerState
+> {
+  const store = useContext(ChatRuntimeContext);
+  if (!store) {
+    throw new Error("useChatRuntimeStore must be used within a ChatRuntimeProvider");
+  }
+  return store as unknown as ChatRuntimeStore<TConversation, TMessage, ChatComposerState>;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -326,15 +326,23 @@
   }
 
   .thinking-shimmer {
+    position: relative;
     display: inline-block;
+    color: inherit;
+  }
+
+  .thinking-shimmer-highlight {
+    position: absolute;
+    inset: 0;
     color: transparent;
+    pointer-events: none;
     background-image: linear-gradient(
       90deg,
-      hsl(var(--muted-foreground) / 0.72) 0%,
-      hsl(var(--muted-foreground) / 0.72) 38%,
-      hsl(var(--foreground) / 0.82) 50%,
-      hsl(var(--muted-foreground) / 0.72) 62%,
-      hsl(var(--muted-foreground) / 0.72) 100%
+      transparent 0%,
+      transparent 38%,
+      hsl(var(--foreground) / 0.65) 50%,
+      transparent 62%,
+      transparent 100%
     );
     background-position: 200% center;
     background-repeat: no-repeat;
@@ -345,9 +353,8 @@
   }
 
   @media (prefers-reduced-motion: reduce), (forced-colors: active) {
-    .thinking-shimmer {
-      color: inherit;
-      background: none;
+    .thinking-shimmer-highlight {
+      display: none;
       animation: none;
     }
   }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -314,6 +314,44 @@
     caret-color: hsl(var(--maple-primary));
   }
 
+  @keyframes thinking-shimmer {
+    0%,
+    20% {
+      background-position: 200% center;
+    }
+    80%,
+    100% {
+      background-position: -100% center;
+    }
+  }
+
+  .thinking-shimmer {
+    display: inline-block;
+    color: transparent;
+    background-image: linear-gradient(
+      90deg,
+      hsl(var(--muted-foreground) / 0.72) 0%,
+      hsl(var(--muted-foreground) / 0.72) 38%,
+      hsl(var(--foreground) / 0.82) 50%,
+      hsl(var(--muted-foreground) / 0.72) 62%,
+      hsl(var(--muted-foreground) / 0.72) 100%
+    );
+    background-position: 200% center;
+    background-repeat: no-repeat;
+    background-size: 250% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    animation: thinking-shimmer 2.4s linear infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce), (forced-colors: active) {
+    .thinking-shimmer {
+      color: inherit;
+      background: none;
+      animation: none;
+    }
+  }
+
   /* Title animation for conversation title updates */
   @keyframes title-flash {
     0% {

--- a/frontend/src/services/chatAttachmentOwnership.test.ts
+++ b/frontend/src/services/chatAttachmentOwnership.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canAdoptAttachmentDestination,
+  mutateAttachmentComposerWhenIdle,
+  planRestoredImageUrls
+} from "./chatAttachmentOwnership";
+
+describe("chat attachment ownership", () => {
+  test("blocks attachment mutation only for the runtime with an active run", () => {
+    const runningComposer = { attachments: ["a.png"] };
+    const idleComposer = { attachments: ["b.png"] };
+
+    const runningResult = mutateAttachmentComposerWhenIdle(
+      { isGenerating: true, composer: runningComposer },
+      (composer) => ({ attachments: [...composer.attachments, "follow-up.png"] })
+    );
+    const idleResult = mutateAttachmentComposerWhenIdle(
+      { isGenerating: false, composer: idleComposer },
+      (composer) => ({ attachments: [...composer.attachments, "follow-up.png"] })
+    );
+
+    expect(runningResult).toEqual({ composer: runningComposer, didMutate: false });
+    expect(runningResult.composer).toBe(runningComposer);
+    expect(idleResult).toEqual({
+      composer: { attachments: ["b.png", "follow-up.png"] },
+      didMutate: true
+    });
+  });
+
+  test("restoration reuses owned URLs and identifies replaced URLs for revocation", () => {
+    const retainedFile = { name: "retained.png" };
+    const restoredFile = { name: "restored.png" };
+    const displacedFile = { name: "displaced.png" };
+    const createdFor: string[] = [];
+
+    const plan = planRestoredImageUrls(
+      [retainedFile, restoredFile],
+      new Map([
+        [retainedFile, "blob:retained"],
+        [displacedFile, "blob:displaced"]
+      ]),
+      (file) => {
+        createdFor.push(file.name);
+        return `blob:created-${file.name}`;
+      }
+    );
+
+    expect(plan.imageUrls).toEqual(
+      new Map([
+        [retainedFile, "blob:retained"],
+        [restoredFile, "blob:created-restored.png"]
+      ])
+    );
+    expect(createdFor).toEqual(["restored.png"]);
+    expect(plan.createdUrls).toEqual(["blob:created-restored.png"]);
+    expect(plan.displacedUrls).toEqual(["blob:displaced"]);
+  });
+
+  test("rejects adoption while the destination owns document processing", () => {
+    expect(canAdoptAttachmentDestination({ composer: { isProcessingDocument: true } })).toBe(false);
+    expect(canAdoptAttachmentDestination({ composer: { isProcessingDocument: false } })).toBe(true);
+    expect(canAdoptAttachmentDestination(undefined)).toBe(true);
+  });
+});

--- a/frontend/src/services/chatAttachmentOwnership.ts
+++ b/frontend/src/services/chatAttachmentOwnership.ts
@@ -1,0 +1,70 @@
+export type AttachmentComposerMutationResult<TComposer> = Readonly<{
+  composer: TComposer;
+  didMutate: boolean;
+}>;
+
+/**
+ * Attachment controls are owned by one chat runtime. Once that runtime starts a
+ * run, its snapshotted attachments stay immutable until the run finishes.
+ */
+export function mutateAttachmentComposerWhenIdle<TComposer>(
+  runtime: Readonly<{ isGenerating: boolean; composer: TComposer }>,
+  updater: (composer: TComposer) => TComposer
+): AttachmentComposerMutationResult<TComposer> {
+  if (runtime.isGenerating) {
+    return { composer: runtime.composer, didMutate: false };
+  }
+
+  return { composer: updater(runtime.composer), didMutate: true };
+}
+
+/**
+ * An in-flight document extraction owns its destination runtime until its
+ * completion callback clears the processing flag. Adopting that destination
+ * into another active run would fence the callback and leave the composer
+ * permanently busy.
+ */
+export function canAdoptAttachmentDestination(
+  destination: Readonly<{ composer: Readonly<{ isProcessingDocument: boolean }> }> | undefined
+): boolean {
+  return !destination?.composer.isProcessingDocument;
+}
+
+export type RestoredImageUrlPlan<TFile> = Readonly<{
+  imageUrls: Map<TFile, string>;
+  createdUrls: string[];
+  displacedUrls: string[];
+}>;
+
+/**
+ * Reuse URLs that still belong to the snapshotted files, create only missing
+ * URLs, and report every replaced URL so the caller can revoke it after the
+ * owning runtime update succeeds.
+ */
+export function planRestoredImageUrls<TFile>(
+  files: readonly TFile[],
+  currentUrls: ReadonlyMap<TFile, string>,
+  createObjectUrl: (file: TFile) => string
+): RestoredImageUrlPlan<TFile> {
+  const imageUrls = new Map<TFile, string>();
+  const createdUrls: string[] = [];
+
+  for (const file of files) {
+    const existingUrl = currentUrls.get(file);
+    if (existingUrl) {
+      imageUrls.set(file, existingUrl);
+      continue;
+    }
+
+    const createdUrl = createObjectUrl(file);
+    createdUrls.push(createdUrl);
+    imageUrls.set(file, createdUrl);
+  }
+
+  const retainedUrls = new Set(imageUrls.values());
+  const displacedUrls = Array.from(new Set(currentUrls.values())).filter(
+    (url) => !retainedUrls.has(url)
+  );
+
+  return { imageUrls, createdUrls, displacedUrls };
+}

--- a/frontend/src/services/chatHistoryAccountScope.test.ts
+++ b/frontend/src/services/chatHistoryAccountScope.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, test } from "bun:test";
+import { QueryClient } from "@tanstack/react-query";
+import {
+  INITIAL_CHAT_HISTORY_RETRY_COUNT,
+  conversationHistoryQueryKey,
+  initialChatHistoryPage,
+  shouldLoadConversationHistory
+} from "./chatHistoryAccountScope";
+
+describe("chat history account scope", () => {
+  test("keeps cached conversation pages isolated by authenticated user", () => {
+    const queryClient = new QueryClient();
+    const userAKey = conversationHistoryQueryKey("user-a");
+    const userBKey = conversationHistoryQueryKey("user-b");
+    const cachedConversations = [{ id: "conversation-a" }];
+
+    queryClient.setQueryData(userAKey, cachedConversations);
+
+    expect(queryClient.getQueryData<typeof cachedConversations>(userAKey)).toEqual(
+      cachedConversations
+    );
+    expect(queryClient.getQueryData<typeof cachedConversations>(userBKey)).toBeUndefined();
+    expect(conversationHistoryQueryKey(undefined)).toEqual(["conversations", null]);
+  });
+
+  test("loads only for a concrete authenticated user and retries one transient failure", () => {
+    expect(shouldLoadConversationHistory(undefined)).toBe(false);
+    expect(shouldLoadConversationHistory("")).toBe(false);
+    expect(shouldLoadConversationHistory("user-a")).toBe(true);
+    expect(INITIAL_CHAT_HISTORY_RETRY_COUNT).toBe(1);
+  });
+
+  test("recovers a first authenticated load after one transient failure", async () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    });
+    let attempts = 0;
+
+    const conversations = await queryClient.fetchQuery({
+      queryKey: conversationHistoryQueryKey("first-login-user"),
+      queryFn: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error("authentication still settling");
+        return [{ id: "existing-chat" }];
+      },
+      retry: INITIAL_CHAT_HISTORY_RETRY_COUNT,
+      retryDelay: 0
+    });
+
+    expect(attempts).toBe(2);
+    expect(initialChatHistoryPage(conversations).conversations).toEqual([{ id: "existing-chat" }]);
+  });
+
+  test("hydrates local pagination from returned or cached query data", () => {
+    const fullPage = Array.from({ length: 20 }, (_, index) => ({ id: `chat-${index}` }));
+    expect(initialChatHistoryPage(fullPage)).toEqual({
+      conversations: fullPage,
+      oldestConversationId: "chat-19",
+      hasMoreConversations: true
+    });
+    expect(initialChatHistoryPage([])).toEqual({
+      conversations: [],
+      oldestConversationId: undefined,
+      hasMoreConversations: false
+    });
+  });
+});

--- a/frontend/src/services/chatHistoryAccountScope.ts
+++ b/frontend/src/services/chatHistoryAccountScope.ts
@@ -1,0 +1,26 @@
+export const INITIAL_CHAT_HISTORY_PAGE_SIZE = 20;
+export const INITIAL_CHAT_HISTORY_RETRY_COUNT = 1;
+
+export function conversationHistoryQueryKey(userId: string | undefined) {
+  return ["conversations", userId ?? null] as const;
+}
+
+export function shouldLoadConversationHistory(userId: string | undefined): userId is string {
+  return typeof userId === "string" && userId.length > 0;
+}
+
+export type InitialChatHistoryPage<TConversation> = Readonly<{
+  conversations: readonly TConversation[];
+  oldestConversationId: string | undefined;
+  hasMoreConversations: boolean;
+}>;
+
+export function initialChatHistoryPage<TConversation extends { id: string }>(
+  conversations: readonly TConversation[]
+): InitialChatHistoryPage<TConversation> {
+  return {
+    conversations: [...conversations],
+    oldestConversationId: conversations.at(-1)?.id,
+    hasMoreConversations: conversations.length === INITIAL_CHAT_HISTORY_PAGE_SIZE
+  };
+}

--- a/frontend/src/services/chatOptimisticMessageOwnership.test.ts
+++ b/frontend/src/services/chatOptimisticMessageOwnership.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getRegisteredChatOptimisticMessage,
+  markOptimisticMessageIncomplete,
+  registerChatOptimisticMessage,
+  unregisterChatOptimisticMessage
+} from "./chatOptimisticMessageOwnership";
+
+describe("chat optimistic message ownership", () => {
+  test("a remounted view marks the exact pre-response optimistic message incomplete", () => {
+    const persistentRuntimeStore = {};
+    const runToken = 17;
+    const sourceMessage = { id: "source-user", text: "source prompt", status: "completed" };
+    const olderMessage = { id: "older-user", text: "older prompt", status: "completed" };
+    registerChatOptimisticMessage(persistentRuntimeStore, runToken, sourceMessage.id);
+
+    // A new UnifiedChat mount has only the persistent store and run token.
+    const ownedMessageId = getRegisteredChatOptimisticMessage(persistentRuntimeStore, runToken);
+    const messages = markOptimisticMessageIncomplete([olderMessage, sourceMessage], ownedMessageId);
+
+    expect(messages).toEqual([olderMessage, { ...sourceMessage, status: "incomplete" }]);
+    expect(
+      unregisterChatOptimisticMessage(persistentRuntimeStore, runToken, sourceMessage.id)
+    ).toBe(true);
+    expect(getRegisteredChatOptimisticMessage(persistentRuntimeStore, runToken)).toBeUndefined();
+  });
+
+  test("identity-safe unregister cannot clear a replacement registration", () => {
+    const persistentRuntimeStore = {};
+    registerChatOptimisticMessage(persistentRuntimeStore, 23, "obsolete");
+    registerChatOptimisticMessage(persistentRuntimeStore, 23, "replacement");
+
+    expect(unregisterChatOptimisticMessage(persistentRuntimeStore, 23, "obsolete")).toBe(false);
+    expect(getRegisteredChatOptimisticMessage(persistentRuntimeStore, 23)).toBe("replacement");
+    expect(unregisterChatOptimisticMessage(persistentRuntimeStore, 23, "replacement")).toBe(true);
+  });
+
+  test("a post-response failure cannot guess and alter an unrelated user message", () => {
+    const messages = [{ id: "existing-user", status: "completed" }];
+
+    expect(markOptimisticMessageIncomplete(messages, undefined)).toEqual(messages);
+    expect(messages[0]?.status).toBe("completed");
+  });
+});

--- a/frontend/src/services/chatOptimisticMessageOwnership.ts
+++ b/frontend/src/services/chatOptimisticMessageOwnership.ts
@@ -1,0 +1,44 @@
+const optimisticMessageByRuntimeOwner = new WeakMap<object, Map<number, string>>();
+
+/** Registers the exact optimistic user item owned by an account-scoped run. */
+export function registerChatOptimisticMessage(
+  runtimeOwner: object,
+  runToken: number,
+  messageId: string
+): void {
+  const registry = optimisticMessageByRuntimeOwner.get(runtimeOwner) ?? new Map<number, string>();
+  registry.set(runToken, messageId);
+  optimisticMessageByRuntimeOwner.set(runtimeOwner, registry);
+}
+
+/** A remounted chat view can recover ownership through the persistent store. */
+export function getRegisteredChatOptimisticMessage(
+  runtimeOwner: object,
+  runToken: number
+): string | undefined {
+  return optimisticMessageByRuntimeOwner.get(runtimeOwner)?.get(runToken);
+}
+
+/** Identity-safe removal cannot clear a replacement registration. */
+export function unregisterChatOptimisticMessage(
+  runtimeOwner: object,
+  runToken: number,
+  messageId: string
+): boolean {
+  const registry = optimisticMessageByRuntimeOwner.get(runtimeOwner);
+  if (registry?.get(runToken) !== messageId) return false;
+
+  registry.delete(runToken);
+  if (registry.size === 0) optimisticMessageByRuntimeOwner.delete(runtimeOwner);
+  return true;
+}
+
+export function markOptimisticMessageIncomplete<TMessage extends Readonly<{ id: string }>>(
+  messages: readonly TMessage[],
+  messageId: string | undefined
+): TMessage[] {
+  if (!messageId) return [...messages];
+  return messages.map((message) =>
+    message.id === messageId ? ({ ...message, status: "incomplete" } as TMessage) : message
+  );
+}

--- a/frontend/src/services/chatRecordingNavigation.test.ts
+++ b/frontend/src/services/chatRecordingNavigation.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, test } from "bun:test";
+import { createChatDraftKey, createConversationChatKey } from "./chatRuntimeStore";
+import {
+  canAdoptRecordingDestination,
+  cleanupRecordingForNavigation,
+  cleanupRecordingForTeardown,
+  isRecordingOwnershipCurrent
+} from "./chatRecordingNavigation";
+
+describe("cleanupRecordingForNavigation", () => {
+  test("blocks adoption for the runtime that owns pending or active voice work", () => {
+    const destination = createConversationChatKey("voice-destination");
+
+    expect(canAdoptRecordingDestination(destination, destination)).toBe(false);
+    expect(
+      canAdoptRecordingDestination(destination, createConversationChatKey("other-recording"))
+    ).toBe(true);
+    expect(canAdoptRecordingDestination(destination, null)).toBe(true);
+  });
+
+  test("clears a pending draft owner before the destination becomes interactive", () => {
+    const draftKey = createChatDraftKey("pending-recording");
+    const actions: string[] = [];
+
+    const result = cleanupRecordingForNavigation({
+      ownerKey: draftKey,
+      destinationKey: createConversationChatKey("destination"),
+      recorder: null,
+      stream: null,
+      clearOwnership: () => actions.push("clear-owner"),
+      clearRecorder: () => actions.push("clear-recorder"),
+      clearStream: () => actions.push("clear-stream")
+    });
+
+    expect(result).toEqual({ stopped: true, errors: [] });
+    expect(actions).toEqual(["clear-owner", "clear-recorder", "clear-stream"]);
+  });
+
+  test("stops every active conversation recording resource even when one cleanup throws", () => {
+    const ownerKey = createConversationChatKey("active-recording");
+    const actions: string[] = [];
+
+    const result = cleanupRecordingForNavigation({
+      ownerKey,
+      destinationKey: createChatDraftKey("next-draft"),
+      recorder: {
+        stopRecording: () => {
+          actions.push("stop-recorder");
+          throw new Error("recorder stop failed");
+        }
+      },
+      stream: {
+        getTracks: () => [
+          { stop: () => actions.push("stop-track-1") },
+          { stop: () => actions.push("stop-track-2") }
+        ]
+      },
+      clearOwnership: () => actions.push("clear-owner"),
+      clearRecorder: () => actions.push("clear-recorder"),
+      clearStream: () => actions.push("clear-stream")
+    });
+
+    expect(result.stopped).toBe(true);
+    expect(result.errors).toHaveLength(1);
+    expect(actions).toEqual([
+      "clear-owner",
+      "stop-recorder",
+      "stop-track-1",
+      "stop-track-2",
+      "clear-recorder",
+      "clear-stream"
+    ]);
+  });
+
+  test("preserves recording resources only when the owner remains selected", () => {
+    const ownerKey = createConversationChatKey("recording-owner");
+    let cleanupCalls = 0;
+
+    const result = cleanupRecordingForNavigation({
+      ownerKey,
+      destinationKey: ownerKey,
+      recorder: { stopRecording: () => (cleanupCalls += 1) },
+      stream: { getTracks: () => [{ stop: () => (cleanupCalls += 1) }] },
+      clearOwnership: () => (cleanupCalls += 1),
+      clearRecorder: () => (cleanupCalls += 1),
+      clearStream: () => (cleanupCalls += 1)
+    });
+
+    expect(result).toEqual({ stopped: false, errors: [] });
+    expect(cleanupCalls).toBe(0);
+  });
+
+  test("does nothing when there is no recording owner", () => {
+    let cleanupCalls = 0;
+
+    const result = cleanupRecordingForNavigation({
+      ownerKey: null,
+      destinationKey: createChatDraftKey("destination"),
+      recorder: null,
+      stream: null,
+      clearOwnership: () => (cleanupCalls += 1),
+      clearRecorder: () => (cleanupCalls += 1),
+      clearStream: () => (cleanupCalls += 1)
+    });
+
+    expect(result.stopped).toBe(false);
+    expect(cleanupCalls).toBe(0);
+  });
+
+  test("full teardown clears ownership before stopping conversation resources", () => {
+    const ownerKey = createConversationChatKey("teardown-owner");
+    let currentOwner: string | null = ownerKey;
+    const actions: string[] = [];
+
+    const result = cleanupRecordingForTeardown({
+      recorder: {
+        stopRecording: () => actions.push(`stop-recorder:${currentOwner ?? "cleared"}`)
+      },
+      stream: {
+        getTracks: () => [{ stop: () => actions.push("stop-track") }]
+      },
+      clearOwnership: () => {
+        currentOwner = null;
+        actions.push("clear-owner");
+      },
+      clearRecorder: () => actions.push("clear-recorder"),
+      clearStream: () => actions.push("clear-stream")
+    });
+
+    expect(result).toEqual({ errors: [] });
+    expect(actions).toEqual([
+      "clear-owner",
+      "stop-recorder:cleared",
+      "stop-track",
+      "clear-recorder",
+      "clear-stream"
+    ]);
+  });
+
+  test("late microphone and transcription completions cannot commit after teardown", () => {
+    const ownerKey = createChatDraftKey("late-async-owner");
+    let currentOwner: string | null = ownerKey;
+    let currentSessionToken = 1;
+    let lateRecorderCreations = 0;
+    let lateSends = 0;
+    const commitLateMicrophone = () => {
+      if (isRecordingOwnershipCurrent(ownerKey, 1, currentOwner, currentSessionToken, true)) {
+        lateRecorderCreations += 1;
+      }
+    };
+    const commitLateTranscription = () => {
+      if (isRecordingOwnershipCurrent(ownerKey, 1, currentOwner, currentSessionToken, true)) {
+        lateSends += 1;
+      }
+    };
+
+    expect(isRecordingOwnershipCurrent(ownerKey, 1, currentOwner, currentSessionToken, true)).toBe(
+      true
+    );
+    cleanupRecordingForTeardown({
+      recorder: null,
+      stream: null,
+      clearOwnership: () => {
+        currentOwner = null;
+        currentSessionToken += 1;
+      },
+      clearRecorder: () => {},
+      clearStream: () => {}
+    });
+    commitLateMicrophone();
+    commitLateTranscription();
+
+    expect(lateRecorderCreations).toBe(0);
+    expect(lateSends).toBe(0);
+    expect(isRecordingOwnershipCurrent(ownerKey, 1, ownerKey, 1, false)).toBe(false);
+  });
+
+  test("a late session cannot commit after returning to the same chat", () => {
+    const ownerKey = createConversationChatKey("same-chat");
+
+    expect(isRecordingOwnershipCurrent(ownerKey, 1, ownerKey, 2, true)).toBe(false);
+    expect(isRecordingOwnershipCurrent(ownerKey, 2, ownerKey, 2, true)).toBe(true);
+  });
+
+  test("a delayed A stop callback releases only captured A resources after B takes ownership", () => {
+    const ownerA = createConversationChatKey("owner-a");
+    const ownerB = createConversationChatKey("owner-b");
+    let stoppedATracks = 0;
+    let stoppedBTracks = 0;
+    const streamA = { getTracks: () => [{ stop: () => (stoppedATracks += 1) }] };
+    const streamB = { getTracks: () => [{ stop: () => (stoppedBTracks += 1) }] };
+    let currentOwner: string | null = ownerA;
+    let currentStream: typeof streamA | null = streamA;
+    const capturedAStream = currentStream;
+    let transcriptionStarts = 0;
+
+    // B replaces both refs before RecordRTC invokes A's delayed stop callback.
+    currentOwner = ownerB;
+    currentStream = streamB;
+
+    if (!isRecordingOwnershipCurrent(ownerA, 1, currentOwner, 2, true)) {
+      capturedAStream.getTracks().forEach((track) => track.stop());
+      if (currentStream === capturedAStream) currentStream = null;
+    } else {
+      transcriptionStarts += 1;
+    }
+
+    expect(stoppedATracks).toBe(1);
+    expect(stoppedBTracks).toBe(0);
+    expect(currentOwner).toBe(ownerB);
+    expect(currentStream).toBe(streamB);
+    expect(transcriptionStarts).toBe(0);
+  });
+});

--- a/frontend/src/services/chatRecordingNavigation.ts
+++ b/frontend/src/services/chatRecordingNavigation.ts
@@ -1,0 +1,136 @@
+import type { ChatRuntimeKey } from "./chatRuntimeStore";
+
+export type ChatRecordingStopper = {
+  stopRecording: (callback: () => void) => void;
+};
+
+export type ChatRecordingStream = {
+  getTracks: () => ReadonlyArray<{ stop: () => void }>;
+};
+
+export type ChatRecordingNavigationCleanupResult = Readonly<{
+  stopped: boolean;
+  errors: readonly unknown[];
+}>;
+
+export type ChatRecordingResourceCleanupOptions = Readonly<{
+  recorder: ChatRecordingStopper | null;
+  stream: ChatRecordingStream | null;
+  clearOwnership: () => void;
+  clearRecorder: () => void;
+  clearStream: () => void;
+}>;
+
+export type ChatRecordingNavigationCleanupOptions = ChatRecordingResourceCleanupOptions &
+  Readonly<{
+    /** Keys must be canonicalized through ChatRuntimeStore.resolveKey first. */
+    ownerKey: ChatRuntimeKey | null;
+    destinationKey: ChatRuntimeKey;
+  }>;
+
+export type ChatRecordingTeardownCleanupResult = Readonly<{
+  errors: readonly unknown[];
+}>;
+
+/**
+ * Keys must already be canonicalized through ChatRuntimeStore.resolveKey.
+ * Pending microphone access, active recording, and transcription all retain the
+ * same owner key, so none of them may have their destination adopted by a run.
+ */
+export function canAdoptRecordingDestination(
+  destinationKey: ChatRuntimeKey,
+  recordingOwnerKey: ChatRuntimeKey | null
+): boolean {
+  return recordingOwnerKey !== destinationKey;
+}
+
+function cleanupRecordingResources({
+  recorder,
+  stream,
+  clearOwnership,
+  clearRecorder,
+  clearStream
+}: ChatRecordingResourceCleanupOptions): unknown[] {
+  const errors: unknown[] = [];
+  const run = (action: () => void) => {
+    try {
+      action();
+    } catch (error) {
+      errors.push(error);
+    }
+  };
+
+  // Ownership is fenced before any fallible cleanup, preventing late async
+  // microphone or transcription work from committing after navigation/teardown.
+  run(clearOwnership);
+  if (recorder) run(() => recorder.stopRecording(() => {}));
+
+  if (stream) {
+    let tracks: ReadonlyArray<{ stop: () => void }> = [];
+    run(() => {
+      tracks = stream.getTracks();
+    });
+    for (const track of tracks) run(() => track.stop());
+  }
+
+  run(clearRecorder);
+  run(clearStream);
+  return errors;
+}
+
+/** Stops every local recording resource during unmount or account teardown. */
+export function cleanupRecordingForTeardown(
+  options: ChatRecordingResourceCleanupOptions
+): ChatRecordingTeardownCleanupResult {
+  return { errors: cleanupRecordingResources(options) };
+}
+
+/**
+ * Guards commits after awaited microphone/transcription work. The runtime check
+ * also fences account teardown, where the owner ref and store entry both vanish.
+ */
+export function isRecordingOwnershipCurrent(
+  expectedOwnerKey: ChatRuntimeKey,
+  expectedSessionToken: number,
+  currentOwnerKey: ChatRuntimeKey | null,
+  currentSessionToken: number,
+  ownerRuntimeExists: boolean
+): boolean {
+  return (
+    currentOwnerKey === expectedOwnerKey &&
+    currentSessionToken === expectedSessionToken &&
+    ownerRuntimeExists
+  );
+}
+
+/**
+ * Stops recording work owned by the chat being left. Recording UI and browser
+ * media resources are component-local, so preserving them offscreen would make
+ * the destination chat inherit an invisible, globally blocking microphone.
+ * Ownership is cleared before resources are stopped, fencing pending
+ * getUserMedia and transcription completions before the destination becomes
+ * interactive.
+ */
+export function cleanupRecordingForNavigation({
+  ownerKey,
+  destinationKey,
+  recorder,
+  stream,
+  clearOwnership,
+  clearRecorder,
+  clearStream
+}: ChatRecordingNavigationCleanupOptions): ChatRecordingNavigationCleanupResult {
+  if (!ownerKey || ownerKey === destinationKey) {
+    return { stopped: false, errors: [] };
+  }
+
+  const errors = cleanupRecordingResources({
+    recorder,
+    stream,
+    clearOwnership,
+    clearRecorder,
+    clearStream
+  });
+
+  return { stopped: true, errors };
+}

--- a/frontend/src/services/chatRuntimeNavigation.test.ts
+++ b/frontend/src/services/chatRuntimeNavigation.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import {
+  canonicalConversationHistoryHref,
+  conversationIdFromChatRuntimeKey,
+  createFreshChatHistoryEntry,
+  draftRuntimeKeyFromHistoryState,
+  historyStateWithDraftRuntimeKey,
+  pushFreshChatHistoryEntry,
+  runtimeKeyForChatLocation,
+  shouldProjectMigratedConversation
+} from "./chatRuntimeNavigation";
+import {
+  ChatRuntimeStore,
+  createChatDraftKey,
+  createConversationChatKey
+} from "./chatRuntimeStore";
+
+describe("chat runtime history navigation", () => {
+  test("restores the same draft runtime from a bare home history entry", () => {
+    const draftKey = createChatDraftKey("retained-composer");
+    const historyState = historyStateWithDraftRuntimeKey(
+      { __TSR_key: "router-owned", unrelated: 42 },
+      draftKey
+    );
+
+    expect(runtimeKeyForChatLocation(undefined, historyState)).toBe(draftKey);
+    expect(historyState).toEqual({
+      __TSR_key: "router-owned",
+      unrelated: 42,
+      mapleChatDraftRuntimeKey: draftKey
+    });
+  });
+
+  test("uses the URL conversation instead of a saved draft runtime", () => {
+    const draftKey = createChatDraftKey("previous-draft");
+
+    expect(
+      runtimeKeyForChatLocation("conversation-a", historyStateWithDraftRuntimeKey({}, draftKey))
+    ).toBe(createConversationChatKey("conversation-a"));
+  });
+
+  test("a saved draft history entry follows an offscreen rekeyed conversation", () => {
+    const draftKey = createChatDraftKey("creating-conversation");
+    const conversationKey = createConversationChatKey("created-offscreen");
+    const store = new ChatRuntimeStore<unknown, unknown, { input: string }>({
+      createComposer: () => ({ input: "" })
+    });
+    store.select(draftKey, { composer: { input: "original prompt" } });
+    const run = store.beginRun(draftKey);
+    store.rekey(draftKey, conversationKey, run.token);
+
+    const restoredKey = runtimeKeyForChatLocation(
+      undefined,
+      historyStateWithDraftRuntimeKey({}, draftKey)
+    );
+
+    expect(restoredKey).toBe(draftKey);
+    const restoredCanonicalKey = store.resolveKey(restoredKey);
+    const restoredConversationId = conversationIdFromChatRuntimeKey(restoredCanonicalKey);
+    expect(restoredCanonicalKey).toBe(conversationKey);
+    expect(restoredConversationId).toBe("created-offscreen");
+    expect(
+      canonicalConversationHistoryHref(
+        {
+          pathname: "/",
+          search: "?keep=1&project_id=stale-project",
+          hash: "#latest-turn"
+        },
+        restoredConversationId!
+      )
+    ).toBe("/?keep=1&conversation_id=created-offscreen#latest-turn");
+    expect(store.get(restoredKey)?.composer.input).toBe("original prompt");
+    store.dispose();
+  });
+
+  test("does not project a migrated conversation after Unified Chat unmounts", () => {
+    expect(shouldProjectMigratedConversation(false, true, false)).toBe(false);
+    expect(shouldProjectMigratedConversation(false, false, true)).toBe(false);
+    expect(shouldProjectMigratedConversation(true, true, false)).toBe(true);
+    expect(shouldProjectMigratedConversation(true, false, true)).toBe(true);
+  });
+
+  test("creates a distinct keyed history entry for every explicit new chat", () => {
+    const previous = createFreshChatHistoryEntry("first");
+    const next = createFreshChatHistoryEntry("second");
+
+    expect(previous.draftRuntimeKey).toBe(createChatDraftKey("first"));
+    expect(next.draftRuntimeKey).toBe(createChatDraftKey("second"));
+    expect(next.draftRuntimeKey).not.toBe(previous.draftRuntimeKey);
+    expect(draftRuntimeKeyFromHistoryState(previous.historyState)).toBe(previous.draftRuntimeKey);
+    expect(draftRuntimeKeyFromHistoryState(next.historyState)).toBe(next.draftRuntimeKey);
+  });
+
+  test("pushes a fresh keyed project draft without replacing the streaming history entry", () => {
+    const calls: Array<{ state: unknown; url: string | URL | null | undefined }> = [];
+    const history = {
+      pushState: (state: unknown, _unused: string, url?: string | URL | null) => {
+        calls.push({ state, url });
+      }
+    };
+
+    const detail = pushFreshChatHistoryEntry(history, "/?keep=1", "project-a", "project-draft");
+
+    expect(calls).toEqual([
+      {
+        state: { mapleChatDraftRuntimeKey: createChatDraftKey("project-draft") },
+        url: "/?keep=1"
+      }
+    ]);
+    expect(detail).toEqual({
+      projectId: "project-a",
+      draftRuntimeKey: createChatDraftKey("project-draft")
+    });
+  });
+
+  test("ignores malformed or non-draft history values", () => {
+    expect(draftRuntimeKeyFromHistoryState(null)).toBeNull();
+    expect(
+      draftRuntimeKeyFromHistoryState({ mapleChatDraftRuntimeKey: "conversation:a" })
+    ).toBeNull();
+    expect(draftRuntimeKeyFromHistoryState({ mapleChatDraftRuntimeKey: "draft:" })).toBeNull();
+  });
+});

--- a/frontend/src/services/chatRuntimeNavigation.ts
+++ b/frontend/src/services/chatRuntimeNavigation.ts
@@ -1,0 +1,101 @@
+import {
+  createChatDraftKey,
+  createConversationChatKey,
+  type ChatRuntimeKey,
+  type DraftChatRuntimeKey
+} from "./chatRuntimeStore";
+
+const CHAT_DRAFT_RUNTIME_HISTORY_STATE_KEY = "mapleChatDraftRuntimeKey";
+
+export type NewChatNavigationDetail = Readonly<{
+  projectId?: string | null;
+  draftRuntimeKey?: DraftChatRuntimeKey;
+}>;
+
+export type ChatHistoryLocation = Readonly<{
+  pathname: string;
+  search: string;
+  hash: string;
+}>;
+
+function historyStateRecord(state: unknown): Record<string, unknown> {
+  return state !== null && typeof state === "object" && !Array.isArray(state)
+    ? (state as Record<string, unknown>)
+    : {};
+}
+
+export function isDraftChatRuntimeKey(value: unknown): value is DraftChatRuntimeKey {
+  return typeof value === "string" && value.startsWith("draft:") && value.length > "draft:".length;
+}
+
+export function draftRuntimeKeyFromHistoryState(state: unknown): DraftChatRuntimeKey | null {
+  const value = historyStateRecord(state)[CHAT_DRAFT_RUNTIME_HISTORY_STATE_KEY];
+  return isDraftChatRuntimeKey(value) ? value : null;
+}
+
+export function historyStateWithDraftRuntimeKey(
+  state: unknown,
+  draftRuntimeKey: DraftChatRuntimeKey
+): Record<string, unknown> {
+  return {
+    ...historyStateRecord(state),
+    [CHAT_DRAFT_RUNTIME_HISTORY_STATE_KEY]: draftRuntimeKey
+  };
+}
+
+export function runtimeKeyForChatLocation(
+  conversationId: string | undefined,
+  historyState: unknown,
+  createDraftKey: () => DraftChatRuntimeKey = createChatDraftKey
+): ChatRuntimeKey {
+  if (conversationId) return createConversationChatKey(conversationId);
+  return draftRuntimeKeyFromHistoryState(historyState) ?? createDraftKey();
+}
+
+export function conversationIdFromChatRuntimeKey(key: ChatRuntimeKey): string | undefined {
+  const prefix = "conversation:";
+  return key.startsWith(prefix) && key.length > prefix.length
+    ? key.slice(prefix.length)
+    : undefined;
+}
+
+export function canonicalConversationHistoryHref(
+  location: ChatHistoryLocation,
+  conversationId: string
+): string {
+  const params = new URLSearchParams(location.search);
+  params.delete("project_id");
+  params.set("conversation_id", conversationId);
+  const search = params.toString();
+  return `${location.pathname}${search ? `?${search}` : ""}${location.hash}`;
+}
+
+export function shouldProjectMigratedConversation(
+  isUnifiedChatMounted: boolean,
+  sourceWasSelected: boolean,
+  destinationWasSelected: boolean
+): boolean {
+  return isUnifiedChatMounted && (sourceWasSelected || destinationWasSelected);
+}
+
+export function createFreshChatHistoryEntry(draftId?: string): Readonly<{
+  draftRuntimeKey: DraftChatRuntimeKey;
+  historyState: Record<string, unknown>;
+}> {
+  const draftRuntimeKey = createChatDraftKey(draftId);
+  return {
+    draftRuntimeKey,
+    historyState: historyStateWithDraftRuntimeKey({}, draftRuntimeKey)
+  };
+}
+
+export function pushFreshChatHistoryEntry(
+  history: Pick<History, "pushState">,
+  url: string,
+  projectId: string | null,
+  draftId?: string
+): NewChatNavigationDetail {
+  const freshChat = createFreshChatHistoryEntry(draftId);
+  history.pushState(freshChat.historyState, "", url);
+  return { projectId, draftRuntimeKey: freshChat.draftRuntimeKey };
+}

--- a/frontend/src/services/chatRuntimeStore.test.ts
+++ b/frontend/src/services/chatRuntimeStore.test.ts
@@ -624,6 +624,45 @@ describe("ChatRuntimeStore", () => {
     expect(aNotifications).toBe(1);
   });
 
+  test("publishes active-run keys only when run membership changes", () => {
+    const store = createStore();
+    const snapshots: string[][] = [];
+    const initialSnapshot = store.getActiveRunKeys();
+    store.subscribeActiveRuns(() => {
+      snapshots.push([...store.getActiveRunKeys()]);
+    });
+
+    const runA = store.beginRun(A);
+    const afterA = store.getActiveRunKeys();
+    expect(afterA).toEqual([A]);
+    expect(Object.isFrozen(afterA)).toBe(true);
+
+    store.updateForRun(A, runA.token, (snapshot) => ({
+      ...snapshot,
+      messages: [streamingMessage("a-assistant", "delta")]
+    }));
+    expect(store.getActiveRunKeys()).toBe(afterA);
+    expect(snapshots).toEqual([[A]]);
+
+    const runB = store.beginRun(B);
+    expect(new Set(store.getActiveRunKeys())).toEqual(new Set([A, B]));
+    expect(store.finishRun(A, runA.token)).toBe(true);
+    expect(store.getActiveRunKeys()).toEqual([B]);
+    expect(store.cancelRun(B, runB.token)?.key).toBe(B);
+    expect(store.getActiveRunKeys()).toBe(initialSnapshot);
+
+    const draft = createChatDraftKey("active-rekey");
+    const conversation = createConversationChatKey("active-rekeyed-conversation");
+    const draftRun = store.beginRun(draft);
+    expect(store.getActiveRunKeys()).toEqual([draft]);
+    expect(store.rekey(draft, conversation, draftRun.token)).toBe(conversation);
+    expect(store.getActiveRunKeys()).toEqual([conversation]);
+
+    store.dispose();
+    expect(store.getActiveRunKeys()).toBe(initialSnapshot);
+    expect(snapshots).toEqual([[A], [A, B], [B], [], [draft], [conversation], []]);
+  });
+
   test("evicts only least-recent inactive completed entries and disposes their resources", () => {
     const disposed: Array<{ key: string; reason: string }> = [];
     const store = createStore({

--- a/frontend/src/services/chatRuntimeStore.test.ts
+++ b/frontend/src/services/chatRuntimeStore.test.ts
@@ -663,6 +663,249 @@ describe("ChatRuntimeStore", () => {
     expect(snapshots).toEqual([[A], [A, B], [B], [], [draft], [conversation], []]);
   });
 
+  test("uses identity-safe visible-chat ownership to classify successful completions", () => {
+    const store = createStore();
+    const owner = {};
+
+    const staleLease = store.claimVisibleChat(owner, A);
+    const replacementLease = store.claimVisibleChat(owner, B);
+    expect(Object.isFrozen(staleLease)).toBe(true);
+    expect(Object.isFrozen(replacementLease)).toBe(true);
+    expect(replacementLease.sequence).toBeGreaterThan(staleLease.sequence);
+    store.releaseVisibleChat(staleLease);
+    expect(store.isChatVisible(A)).toBe(false);
+    expect(store.isChatVisible(B)).toBe(true);
+
+    const visibleRun = store.beginRun(B, { groupId: "project-visible" });
+    expect(store.completeRun(B, visibleRun.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+
+    const offscreenRun = store.beginRun(A, { groupId: "project-offscreen" });
+    expect(store.completeRun(A, offscreenRun.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([A]);
+    expect(store.getCompletedUnreadGroupId(A)).toBe("project-offscreen");
+
+    store.releaseVisibleChat(replacementLease);
+    expect(store.isChatVisible(B)).toBe(false);
+    const formerlyVisibleRun = store.beginRun(B, { groupId: "project-visible" });
+    expect(store.completeRun(B, formerlyVisibleRun.token)).toBe(true);
+    expect(new Set(store.getCompletedUnreadKeys())).toEqual(new Set([A, B]));
+  });
+
+  test("clears completed-unread state on visibility, a new run, and an explicit read", () => {
+    const store = createStore();
+    const owner = {};
+
+    const first = store.beginRun(A, { groupId: "project-a" });
+    expect(store.completeRun(A, first.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([A]);
+
+    store.select(A);
+    expect(store.getCompletedUnreadKeys()).toEqual([A]);
+    const visibleLease = store.claimVisibleChat(owner, A);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+    store.releaseVisibleChat(visibleLease);
+
+    store.clearSelection();
+    const second = store.beginRun(A, { groupId: "project-a" });
+    expect(store.completeRun(A, second.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([A]);
+
+    const replacement = store.beginRun(A, { groupId: "project-a" });
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+    expect(store.finishRun(A, replacement.token)).toBe(true);
+
+    const third = store.beginRun(A, { groupId: "project-a" });
+    expect(store.completeRun(A, third.token)).toBe(true);
+    expect(store.markCompletionRead(A)).toBe(true);
+    expect(store.markCompletionRead(A)).toBe(false);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+  });
+
+  test("does not mark failures, cancellations, or stale completions unread", () => {
+    const store = createStore();
+
+    const failed = store.beginRun(A, { groupId: "project-a" });
+    expect(store.finishRun(A, failed.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+
+    const cancelled = store.beginRun(B, { groupId: "project-b" });
+    expect(store.cancelRun(B, cancelled.token)?.key).toBe(B);
+    expect(store.completeRun(B, cancelled.token)).toBe(false);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+
+    const stale = store.beginRun(A, { groupId: "project-old" });
+    expect(store.finishRun(A, stale.token)).toBe(true);
+    const current = store.beginRun(A, { groupId: "project-current" });
+
+    expect(store.completeRun(A, stale.token)).toBe(false);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+    expect(store.isRunCurrent(A, current.token)).toBe(true);
+    expect(store.finishRun(A, current.token)).toBe(true);
+  });
+
+  test("keeps unread completion canonical through draft rekey and visible aliases", () => {
+    const store = createStore();
+    const draft = createChatDraftKey("completion-alias");
+    const conversation = createConversationChatKey("completion-canonical");
+    const run = store.beginRun(draft, { groupId: "project-a" });
+
+    expect(store.rekey(draft, conversation, run.token)).toBe(conversation);
+    expect(store.completeRun(draft, run.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([conversation]);
+    expect(store.getCompletedUnreadGroupId(draft)).toBe("project-a");
+
+    expect(store.markCompletionRead(draft)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+
+    const owner = {};
+    const visibleDraft = createChatDraftKey("visible-completion-alias");
+    const visibleConversation = createConversationChatKey("visible-completion-canonical");
+    const visibleRun = store.beginRun(visibleDraft, { groupId: "project-b" });
+    store.claimVisibleChat(owner, visibleDraft);
+
+    expect(store.rekey(visibleDraft, visibleConversation, visibleRun.token)).toBe(
+      visibleConversation
+    );
+    expect(store.completeRun(visibleDraft, visibleRun.token)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+  });
+
+  test("retains unread metadata across LRU eviction and clears unread-only deletion", () => {
+    const store = createStore({ maxInactiveCompletedEntries: 0 });
+    const run = store.beginRun(A, { groupId: "project-a" });
+
+    expect(store.completeRun(A, run.token)).toBe(true);
+    expect(store.get(A)).toBeUndefined();
+    expect(store.getCompletedUnreadKeys()).toEqual([A]);
+    expect(store.getCompletedUnreadGroupId(A)).toBe("project-a");
+
+    expect(store.delete(A)).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+    expect(store.getCompletedUnreadGroupId(A)).toBeUndefined();
+    expect(store.delete(A)).toBe(false);
+  });
+
+  test("publishes stable, targeted activity notifications for group changes", () => {
+    const store = createStore();
+    let activeNotifications = 0;
+    let unreadNotifications = 0;
+    store.subscribeActiveRuns(() => {
+      activeNotifications += 1;
+    });
+    store.subscribeCompletedUnread(() => {
+      unreadNotifications += 1;
+    });
+
+    const runA = store.beginRun(A, { groupId: "project-one" });
+    const activeAfterBegin = store.getActiveRunKeys();
+    expect(activeNotifications).toBe(1);
+    expect(unreadNotifications).toBe(0);
+    expect(Object.isFrozen(activeAfterBegin)).toBe(true);
+
+    store.updateForRun(A, runA.token, (snapshot) => ({
+      ...snapshot,
+      messages: [streamingMessage("a-assistant", "delta")]
+    }));
+    expect(store.getActiveRunKeys()).toBe(activeAfterBegin);
+    expect(activeNotifications).toBe(1);
+    expect(unreadNotifications).toBe(0);
+
+    expect(store.updateActivityGroup(A, "project-two")).toBe(true);
+    const activeAfterGroupChange = store.getActiveRunKeys();
+    expect(activeAfterGroupChange).toEqual([A]);
+    expect(activeAfterGroupChange).not.toBe(activeAfterBegin);
+    expect(store.getActiveRunGroupId(A)).toBe("project-two");
+    expect(activeNotifications).toBe(2);
+    expect(unreadNotifications).toBe(0);
+
+    expect(store.updateActivityGroup(A, "project-two")).toBe(false);
+    expect(store.getActiveRunKeys()).toBe(activeAfterGroupChange);
+    expect(activeNotifications).toBe(2);
+
+    expect(store.completeRun(A, runA.token)).toBe(true);
+    const unreadAfterCompletion = store.getCompletedUnreadKeys();
+    expect(unreadAfterCompletion).toEqual([A]);
+    expect(Object.isFrozen(unreadAfterCompletion)).toBe(true);
+    expect(activeNotifications).toBe(3);
+    expect(unreadNotifications).toBe(1);
+
+    expect(store.updateActivityGroup(A, "project-three")).toBe(true);
+    expect(store.getCompletedUnreadKeys()).toEqual([A]);
+    expect(store.getCompletedUnreadKeys()).not.toBe(unreadAfterCompletion);
+    expect(store.getCompletedUnreadGroupId(A)).toBe("project-three");
+    expect(activeNotifications).toBe(3);
+    expect(unreadNotifications).toBe(2);
+
+    const runB = store.beginRun(B, { groupId: "project-three" });
+    expect(store.reassignActivityGroup("project-three", "project-four")).toBe(true);
+    expect(store.getActiveRunGroupId(B)).toBe("project-four");
+    expect(store.getCompletedUnreadGroupId(A)).toBe("project-four");
+    expect(activeNotifications).toBe(5);
+    expect(unreadNotifications).toBe(3);
+
+    expect(store.finishRun(B, runB.token)).toBe(true);
+  });
+
+  test("deletes active and unread members of an activity group", () => {
+    const store = createStore();
+    const idle = createConversationChatKey("idle-project-member");
+    const activeRun = store.beginRun(A, { groupId: "project-delete" });
+    const unreadRun = store.beginRun(B, { groupId: "project-delete" });
+    expect(store.completeRun(B, unreadRun.token)).toBe(true);
+    store.ensure(idle, { historyLoaded: true });
+    expect(store.updateActivityGroup(idle, "project-delete")).toBe(true);
+    expect(store.getActivityGroupId(idle)).toBe("project-delete");
+
+    const deleted = store.deleteActivityGroup("project-delete");
+
+    expect(new Set(deleted)).toEqual(new Set([A, B, idle]));
+    expect(Object.isFrozen(deleted)).toBe(true);
+    expect(activeRun.signal.aborted).toBe(true);
+    expect(store.get(A)).toBeUndefined();
+    expect(store.get(B)).toBeUndefined();
+    expect(store.get(idle)).toBeUndefined();
+    expect(store.getActiveRunKeys()).toEqual([]);
+    expect(store.getCompletedUnreadKeys()).toEqual([]);
+    expect(store.deleteActivityGroup("project-delete")).toEqual([]);
+  });
+
+  test("dispose resets unread and visible ownership state and notifies subscribers", () => {
+    const store = createStore();
+    const emptyActiveSnapshot = store.getActiveRunKeys();
+    const emptyUnreadSnapshot = store.getCompletedUnreadKeys();
+    const owner = {};
+    const completed = store.beginRun(A, { groupId: "project-a" });
+    expect(store.completeRun(A, completed.token)).toBe(true);
+    const active = store.beginRun(B, { groupId: "project-b" });
+    const visibleLease = store.claimVisibleChat(owner, B);
+    let activeNotifications = 0;
+    let unreadNotifications = 0;
+    store.subscribeActiveRuns(() => {
+      activeNotifications += 1;
+    });
+    store.subscribeCompletedUnread(() => {
+      unreadNotifications += 1;
+    });
+
+    store.dispose();
+
+    expect(active.signal.aborted).toBe(true);
+    expect(store.getActiveRunKeys()).toBe(emptyActiveSnapshot);
+    expect(store.getCompletedUnreadKeys()).toBe(emptyUnreadSnapshot);
+    expect(store.getCompletedUnreadGroupId(A)).toBeUndefined();
+    expect(activeNotifications).toBe(1);
+    expect(unreadNotifications).toBe(1);
+    expect(() => store.claimVisibleChat(owner, A)).toThrow("has been disposed");
+    expect(() => store.releaseVisibleChat(visibleLease)).not.toThrow();
+    expect(store.isChatVisible(B)).toBe(false);
+    expect(() => store.markCompletionRead(A)).toThrow("has been disposed");
+    expect(() => store.updateActivityGroup(A, null)).toThrow("has been disposed");
+    expect(() => store.reassignActivityGroup("project-a", null)).toThrow("has been disposed");
+    expect(() => store.deleteActivityGroup("project-a")).toThrow("has been disposed");
+    expect(() => store.subscribeCompletedUnread(() => {})).toThrow("has been disposed");
+  });
+
   test("evicts only least-recent inactive completed entries and disposes their resources", () => {
     const disposed: Array<{ key: string; reason: string }> = [];
     const store = createStore({

--- a/frontend/src/services/chatRuntimeStore.test.ts
+++ b/frontend/src/services/chatRuntimeStore.test.ts
@@ -1,0 +1,784 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ChatRuntimeStore,
+  createChatDraftKey,
+  createConversationChatKey,
+  type ChatRuntimeRunUpdater,
+  type ChatRuntimeSnapshot
+} from "./chatRuntimeStore";
+
+type Conversation = { id: string; title: string };
+type Message = { id: string; text: string; status: "streaming" | "completed" };
+type Composer = { input: string; attachmentIds: string[] };
+type Snapshot = ChatRuntimeSnapshot<Conversation, Message, Composer>;
+
+const A = createConversationChatKey("a");
+const B = createConversationChatKey("b");
+
+function createStore(
+  options: {
+    maxInactiveCompletedEntries?: number;
+    canEvict?: (snapshot: Snapshot) => boolean;
+    disposeEntry?: (snapshot: Snapshot, reason: "evicted" | "deleted" | "disposed") => void;
+  } = {}
+) {
+  return new ChatRuntimeStore<Conversation, Message, Composer>({
+    createComposer: () => ({ input: "", attachmentIds: [] }),
+    ...options
+  });
+}
+
+function streamingMessage(id: string, text: string): Message {
+  return { id, text, status: "streaming" };
+}
+
+describe("ChatRuntimeStore", () => {
+  test("keeps concurrent A and B runs isolated while A receives offscreen updates", () => {
+    const store = createStore();
+    store.select(A, {
+      conversation: { id: "a", title: "Chat A" },
+      messages: [{ id: "a-user", text: "Question A", status: "completed" }],
+      lastSeenItemId: "a-user",
+      historyLoaded: true
+    });
+
+    const runA = store.beginRun(A);
+    store.setCurrentResponseId(A, runA.token, "response-a");
+    store.setAssistantStreaming(A, runA.token, true);
+    expect(
+      store.updateForRun(A, runA.token, (snapshot) => ({
+        ...snapshot,
+        messages: [...snapshot.messages, streamingMessage("a-assistant", "one ")]
+      }))
+    ).toBe(true);
+
+    store.select(B, {
+      conversation: { id: "b", title: "Chat B" },
+      messages: [{ id: "b-user", text: "Question B", status: "completed" }],
+      historyLoaded: true
+    });
+    const runB = store.beginRun(B);
+    store.setCurrentResponseId(B, runB.token, "response-b");
+    store.setAssistantStreaming(B, runB.token, true);
+    store.updateForRun(B, runB.token, (snapshot) => ({
+      ...snapshot,
+      messages: [...snapshot.messages, streamingMessage("b-assistant", "answer B")]
+    }));
+
+    // A's HTTP iterator can continue dispatching while B is the selected chat.
+    store.updateForRun(A, runA.token, (snapshot) => ({
+      ...snapshot,
+      messages: snapshot.messages.map((message) =>
+        message.id === "a-assistant" ? { ...message, text: `${message.text}two` } : message
+      ),
+      lastSeenItemId: "a-assistant"
+    }));
+
+    expect(store.getActiveKey()).toBe(B);
+    expect(store.getActive()?.messages.at(-1)?.text).toBe("answer B");
+    expect(store.get(A)?.messages.at(-1)?.text).toBe("one two");
+    expect(store.get(A)?.isGenerating).toBe(true);
+    expect(store.get(B)?.isGenerating).toBe(true);
+    expect(runA.signal.aborted).toBe(false);
+    expect(runB.signal.aborted).toBe(false);
+
+    store.finishRun(B, runB.token, (snapshot) => ({
+      ...snapshot,
+      messages: snapshot.messages.map((message) => ({ ...message, status: "completed" }))
+    }));
+    store.select(A);
+
+    expect(store.getActive()?.messages.at(-1)?.text).toBe("one two");
+    expect(store.getActive()?.assistantStreaming).toBe(true);
+    expect(store.getActive()?.currentResponseId).toBe("response-a");
+    expect(store.get(B)?.isGenerating).toBe(false);
+  });
+
+  test("finishes A offscreen without changing selected running B", () => {
+    const store = createStore();
+    store.select(A, {
+      messages: [streamingMessage("a-assistant", "answer A")]
+    });
+    const runA = store.beginRun(A);
+    store.setCurrentResponseId(A, runA.token, "response-a");
+    store.setAssistantStreaming(A, runA.token, true);
+
+    store.select(B, {
+      messages: [streamingMessage("b-assistant", "answer B")]
+    });
+    const runB = store.beginRun(B);
+    store.setCurrentResponseId(B, runB.token, "response-b");
+    store.setAssistantStreaming(B, runB.token, true);
+    const selectedBSnapshot = store.get(B);
+
+    expect(
+      store.finishRun(A, runA.token, (snapshot) => ({
+        ...snapshot,
+        messages: snapshot.messages.map((message) => ({
+          ...message,
+          status: "completed"
+        }))
+      }))
+    ).toBe(true);
+
+    expect(store.getActiveKey()).toBe(B);
+    expect(store.get(B)).toBe(selectedBSnapshot);
+    expect(store.get(B)).toMatchObject({
+      isGenerating: true,
+      assistantStreaming: true,
+      currentResponseId: "response-b",
+      runToken: runB.token
+    });
+    expect(runB.signal.aborted).toBe(false);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: false,
+      assistantStreaming: false,
+      currentResponseId: undefined,
+      runToken: null
+    });
+    expect(store.get(A)?.messages.at(-1)?.status).toBe("completed");
+  });
+
+  test("owns composer state independently for every chat", () => {
+    const store = createStore();
+    store.select(A);
+    store.update(A, (snapshot) => ({
+      ...snapshot,
+      composer: { input: "draft A", attachmentIds: ["a.png"] }
+    }));
+
+    store.select(B);
+    store.update(B, (snapshot) => ({
+      ...snapshot,
+      composer: { input: "draft B", attachmentIds: ["b.pdf"] }
+    }));
+    store.update(A, (snapshot) => ({
+      ...snapshot,
+      composer: { ...snapshot.composer, input: "updated A while offscreen" }
+    }));
+
+    expect(store.getActive()?.composer).toEqual({ input: "draft B", attachmentIds: ["b.pdf"] });
+    expect(store.get(A)?.composer).toEqual({
+      input: "updated A while offscreen",
+      attachmentIds: ["a.png"]
+    });
+
+    store.select(A);
+    expect(store.getActive()?.composer.input).toBe("updated A while offscreen");
+  });
+
+  test("rekeys a draft safely without stealing focus and keeps the old key as an alias", () => {
+    const store = createStore();
+    const draft = createChatDraftKey("pending-a");
+    const conversation = createConversationChatKey("created-a");
+    store.select(A);
+    store.ensure(draft, {
+      composer: { input: "draft prompt", attachmentIds: ["image"] },
+      messages: [streamingMessage("local-user", "draft prompt")]
+    });
+    const run = store.beginRun(draft);
+    store.setCurrentResponseId(draft, run.token, "created-response");
+
+    expect(store.rekey(draft, conversation, run.token)).toBe(conversation);
+    expect(store.getActiveKey()).toBe(A);
+    expect(store.resolveKey(draft)).toBe(conversation);
+    expect(store.get(draft)).toBe(store.get(conversation));
+    expect(store.get(conversation)?.composer.input).toBe("draft prompt");
+    expect(store.isRunCurrent(draft, run.token)).toBe(true);
+
+    expect(
+      store.updateForRun(draft, run.token, (snapshot) => ({
+        ...snapshot,
+        conversation: { id: "created-a", title: "Created" },
+        messages: [...snapshot.messages, streamingMessage("assistant", "still streaming")]
+      }))
+    ).toBe(true);
+    expect(store.get(conversation)?.messages.at(-1)?.text).toBe("still streaming");
+
+    store.select(draft);
+    expect(store.getActiveKey()).toBe(conversation);
+    const activeDraft = createChatDraftKey("active");
+    store.select(activeDraft);
+    const activeRun = store.beginRun(activeDraft);
+    const activeConversation = createConversationChatKey("active-created");
+    store.rekey(activeDraft, activeConversation, activeRun.token);
+    expect(store.getActiveKey()).toBe(activeConversation);
+  });
+
+  test("a stale run cannot rekey replacement state after cancellation", () => {
+    const store = createStore();
+    const draft = createChatDraftKey("stale-create");
+    const staleConversation = createConversationChatKey("stale-created");
+    const currentConversation = createConversationChatKey("current-created");
+    store.select(draft);
+    const staleRun = store.beginRun(draft);
+    store.cancelRun(draft, staleRun.token);
+    const replacement = store.beginRun(draft);
+
+    expect(store.rekey(draft, staleConversation, staleRun.token)).toBeNull();
+    expect(store.resolveKey(draft)).toBe(draft);
+    expect(store.getActiveKey()).toBe(draft);
+    expect(store.isRunCurrent(draft, replacement.token)).toBe(true);
+    expect(replacement.signal.aborted).toBe(false);
+
+    expect(store.rekey(draft, currentConversation, replacement.token)).toBe(currentConversation);
+    expect(store.getActiveKey()).toBe(currentConversation);
+  });
+
+  test("stale adoption leaves an independently discovered destination untouched", () => {
+    const store = createStore();
+    const draft = createChatDraftKey("stale-source");
+    const conversation = createConversationChatKey("independently-discovered");
+    store.select(draft, {
+      messages: [{ id: "source-user", text: "source prompt", status: "completed" }]
+    });
+    const sourceRun = store.beginRun(draft);
+    store.select(conversation, {
+      conversation: { id: "independently-discovered", title: "Discovered elsewhere" },
+      messages: [{ id: "remote-user", text: "remote prompt", status: "completed" }],
+      historyLoaded: true
+    });
+    const destinationBefore = store.get(conversation);
+    store.cancelRun(draft, sourceRun.token);
+
+    const result = store.rekeyRunAdoptingIdleDestination(
+      draft,
+      conversation,
+      sourceRun.token,
+      () => {
+        throw new Error("a stale source must not merge the destination");
+      }
+    );
+
+    expect(result).toEqual({ status: "source_stale" });
+    expect(store.get(conversation)).toBe(destinationBefore);
+    expect(store.resolveKey(draft)).toBe(draft);
+    expect(store.get(draft)?.messages[0]?.text).toBe("source prompt");
+    expect(sourceRun.signal.aborted).toBe(true);
+  });
+
+  test("atomically adopts an idle selected destination while the source run continues", () => {
+    const disposed: Array<{ key: string; reason: string }> = [];
+    const store = createStore({
+      disposeEntry: (snapshot, reason) => disposed.push({ key: snapshot.key, reason })
+    });
+    const draft = createChatDraftKey("server-create-race");
+    const conversation = createConversationChatKey("discovered-before-create-returned");
+    store.select(draft, {
+      messages: [{ id: "optimistic-user", text: "source prompt", status: "completed" }],
+      composer: { input: "", attachmentIds: [] }
+    });
+    const sourceRun = store.beginRun(draft);
+    store.setCurrentResponseId(draft, sourceRun.token, "source-response");
+
+    store.select(conversation, {
+      conversation: { id: "discovered-before-create-returned", title: "New Conversation" },
+      messages: [{ id: "server-history", text: "loaded first", status: "completed" }],
+      composer: { input: "selected destination draft", attachmentIds: ["destination.png"] },
+      historyLoaded: true
+    });
+    const observedDestinationSnapshots: Array<Snapshot | undefined> = [];
+    const unsubscribe = store.subscribeKey(conversation, () => {
+      observedDestinationSnapshots.push(store.get(conversation));
+    });
+
+    const result = store.rekeyRunAdoptingIdleDestination(
+      draft,
+      conversation,
+      sourceRun.token,
+      (source, destination) => ({
+        conversation: destination.conversation ?? source.conversation,
+        messages: [...destination.messages, ...source.messages],
+        composer: destination.composer,
+        currentResponseId: source.currentResponseId,
+        error: source.error,
+        lastSeenItemId: source.lastSeenItemId ?? destination.lastSeenItemId,
+        assistantStreaming: source.assistantStreaming,
+        historyLoaded: source.historyLoaded || destination.historyLoaded
+      })
+    );
+
+    expect(result).toEqual({
+      status: "migrated",
+      key: conversation,
+      adoptedExistingDestination: true,
+      destinationWasSelected: true
+    });
+    expect(observedDestinationSnapshots).toHaveLength(1);
+    expect(observedDestinationSnapshots[0]).toBeDefined();
+    expect(disposed).toEqual([]);
+    expect(store.getActiveKey()).toBe(conversation);
+    expect(store.resolveKey(draft)).toBe(conversation);
+    expect(store.isRunCurrent(conversation, sourceRun.token)).toBe(true);
+    expect(sourceRun.signal.aborted).toBe(false);
+    expect(store.get(conversation)).toMatchObject({
+      isGenerating: true,
+      currentResponseId: "source-response",
+      historyLoaded: true,
+      composer: {
+        input: "selected destination draft",
+        attachmentIds: ["destination.png"]
+      }
+    });
+    expect(store.get(conversation)?.messages.map((message) => message.id)).toEqual([
+      "server-history",
+      "optimistic-user"
+    ]);
+    unsubscribe();
+  });
+
+  test("fails closed when the destination owns a run and leaves both prompts recoverable", () => {
+    const store = createStore();
+    const draft = createChatDraftKey("source-with-prompt");
+    const conversation = createConversationChatKey("busy-destination");
+    store.select(draft, {
+      messages: [{ id: "source-user", text: "source prompt", status: "completed" }]
+    });
+    const sourceRun = store.beginRun(draft);
+    store.select(conversation, {
+      messages: [{ id: "destination-user", text: "destination prompt", status: "completed" }]
+    });
+    const destinationRun = store.beginRun(conversation);
+    const destinationBeforeCollision = store.get(conversation);
+
+    const result = store.rekeyRunAdoptingIdleDestination(
+      draft,
+      conversation,
+      sourceRun.token,
+      (source) => source
+    );
+
+    expect(result).toEqual({ status: "destination_active", key: conversation });
+    expect(store.resolveKey(draft)).toBe(draft);
+    expect(store.get(conversation)).toBe(destinationBeforeCollision);
+    expect(store.isRunCurrent(draft, sourceRun.token)).toBe(true);
+    expect(store.isRunCurrent(conversation, destinationRun.token)).toBe(true);
+    expect(sourceRun.signal.aborted).toBe(false);
+    expect(destinationRun.signal.aborted).toBe(false);
+
+    // The caller can restore the source prompt in its history-addressable draft
+    // without mutating the selected destination's run ownership.
+    store.updateForRun(draft, sourceRun.token, (snapshot) => ({
+      ...snapshot,
+      messages: [],
+      composer: { ...snapshot.composer, input: "source prompt" },
+      error: "Source prompt restored"
+    }));
+    store.finishRun(draft, sourceRun.token);
+    expect(store.get(conversation)).toMatchObject({
+      isGenerating: true,
+      runToken: destinationRun.token,
+      composer: { input: "" }
+    });
+    expect(store.get(draft)).toMatchObject({
+      isGenerating: false,
+      runToken: null,
+      composer: { input: "source prompt" },
+      error: "Source prompt restored",
+      messages: []
+    });
+  });
+
+  test("keeps a draft-key subscriber live through rekey and conversation-key updates", () => {
+    const store = createStore();
+    const draft = createChatDraftKey("subscribed-draft");
+    const conversation = createConversationChatKey("subscribed-conversation");
+    store.select(draft);
+    const run = store.beginRun(draft);
+    let notifications = 0;
+    const unsubscribe = store.subscribeKey(draft, () => {
+      notifications += 1;
+    });
+
+    expect(store.rekey(draft, conversation, run.token)).toBe(conversation);
+    expect(notifications).toBe(1);
+    expect(store.get(draft)).toBe(store.get(conversation));
+
+    expect(
+      store.updateForRun(conversation, run.token, (snapshot) => ({
+        ...snapshot,
+        messages: [...snapshot.messages, streamingMessage("assistant", "continued")]
+      }))
+    ).toBe(true);
+
+    expect(notifications).toBe(2);
+    expect(store.get(draft)).toBe(store.get(conversation));
+    expect(store.get(draft)?.messages.at(-1)?.text).toBe("continued");
+    unsubscribe();
+  });
+
+  test("cancels only the keyed run and returns its owned response ID and controller", () => {
+    const store = createStore();
+    store.select(A);
+    const runA = store.beginRun(A);
+    store.setCurrentResponseId(A, runA.token, "response-a");
+    store.setAssistantStreaming(A, runA.token, true);
+
+    store.select(B);
+    const runB = store.beginRun(B);
+    store.setCurrentResponseId(B, runB.token, "response-b");
+    store.setAssistantStreaming(B, runB.token, true);
+
+    const cancelled = store.cancelRun(A, runA.token);
+
+    expect(cancelled).toEqual({
+      key: A,
+      token: runA.token,
+      responseId: "response-a",
+      controller: runA.controller
+    });
+    expect(runA.signal.aborted).toBe(true);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: false,
+      assistantStreaming: false,
+      currentResponseId: undefined,
+      runToken: null
+    });
+
+    expect(runB.signal.aborted).toBe(false);
+    expect(store.get(B)).toMatchObject({
+      isGenerating: true,
+      assistantStreaming: true,
+      currentResponseId: "response-b",
+      runToken: runB.token
+    });
+  });
+
+  test("stale run updates and completion cannot clear a replacement run", () => {
+    const store = createStore();
+    store.select(A);
+    const first = store.beginRun(A);
+    store.setCurrentResponseId(A, first.token, "old-response");
+    expect(store.finishRun(A, first.token)).toBe(true);
+
+    const replacement = store.beginRun(A);
+    store.setCurrentResponseId(A, replacement.token, "new-response");
+    store.setAssistantStreaming(A, replacement.token, true);
+
+    expect(
+      store.updateForRun(A, first.token, (snapshot) => ({
+        ...snapshot,
+        error: "stale delta"
+      }))
+    ).toBe(false);
+    expect(store.finishRun(A, first.token)).toBe(false);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: true,
+      assistantStreaming: true,
+      currentResponseId: "new-response",
+      error: null,
+      runToken: replacement.token
+    });
+
+    expect(store.finishRun(A, replacement.token)).toBe(true);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: false,
+      assistantStreaming: false,
+      currentResponseId: undefined,
+      runToken: null
+    });
+  });
+
+  test("a stale abort callback cannot cancel the replacement run", () => {
+    const store = createStore();
+    store.select(A);
+    const first = store.beginRun(A);
+    store.setCurrentResponseId(A, first.token, "old-response");
+    expect(store.finishRun(A, first.token)).toBe(true);
+    let synchronousAbortCancellation: ReturnType<typeof store.cancelRun> | undefined;
+    first.signal.addEventListener("abort", () => {
+      synchronousAbortCancellation = store.cancelRun(A, first.token);
+    });
+
+    const replacement = store.beginRun(A);
+    store.setCurrentResponseId(A, replacement.token, "new-response");
+    store.setAssistantStreaming(A, replacement.token, true);
+    first.controller.abort();
+
+    expect(first.signal.aborted).toBe(true);
+    expect(synchronousAbortCancellation).toBeNull();
+    expect(replacement.signal.aborted).toBe(false);
+    expect(store.isRunCurrent(A, replacement.token)).toBe(true);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: true,
+      assistantStreaming: true,
+      currentResponseId: "new-response",
+      runToken: replacement.token
+    });
+  });
+
+  test("refuses to replace an active same-chat run", () => {
+    const store = createStore();
+    store.select(A);
+    const activeRun = store.beginRun(A);
+    store.setCurrentResponseId(A, activeRun.token, "active-response");
+
+    expect(() => store.beginRun(A)).toThrow("already has an active run");
+    expect(activeRun.signal.aborted).toBe(false);
+    expect(store.isRunCurrent(A, activeRun.token)).toBe(true);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: true,
+      currentResponseId: "active-response",
+      runToken: activeRun.token
+    });
+  });
+
+  test("beginRun always returns ownership before fallible resource eviction", () => {
+    const store = createStore({
+      maxInactiveCompletedEntries: 0,
+      disposeEntry: () => {
+        throw new Error("resource disposal failed");
+      }
+    });
+    store.ensure(B);
+
+    const run = store.beginRun(A);
+
+    expect(store.isRunCurrent(A, run.token)).toBe(true);
+    expect(run.signal.aborted).toBe(false);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: true,
+      runToken: run.token
+    });
+  });
+
+  test("updateForRun cannot expose an idle snapshot while its controller is active", () => {
+    const store = createStore();
+    store.select(A);
+    const run = store.beginRun(A);
+    const unsafeActiveSnapshot = store.get(A)!;
+    const unsafeUpdater = (() => ({
+      ...unsafeActiveSnapshot,
+      isGenerating: false
+    })) as unknown as ChatRuntimeRunUpdater<Conversation, Message, Composer>;
+
+    expect(store.updateForRun(A, run.token, unsafeUpdater)).toBe(true);
+
+    expect(store.isRunCurrent(A, run.token)).toBe(true);
+    expect(store.get(A)).toMatchObject({
+      isGenerating: true,
+      runToken: run.token
+    });
+    expect(() => store.beginRun(A)).toThrow("already has an active run");
+  });
+
+  test("tokenless updates cannot overwrite run-owned replacement fields", () => {
+    const store = createStore();
+    store.select(A);
+    const staleSnapshot = store.get(A)!;
+    const activeRun = store.beginRun(A);
+    store.setCurrentResponseId(A, activeRun.token, "active-response");
+    store.setAssistantStreaming(A, activeRun.token, true);
+
+    // A stale callback may still return a whole pre-run snapshot at runtime.
+    // Generic updates must accept its safe fields while retaining run ownership.
+    store.update(A, () => ({
+      ...staleSnapshot,
+      composer: { input: "safe composer update", attachmentIds: [] }
+    }));
+
+    expect(store.get(A)).toMatchObject({
+      composer: { input: "safe composer update", attachmentIds: [] },
+      isGenerating: true,
+      currentResponseId: "active-response",
+      assistantStreaming: true,
+      runToken: activeRun.token
+    });
+  });
+
+  test("publishes stable global and keyed snapshot revisions", () => {
+    const store = createStore();
+    store.ensure(A);
+    store.ensure(B);
+    const initialGlobalRevision = store.getSubscriberRevision();
+    const initialARevision = store.get(A)?.revision;
+    let globalNotifications = 0;
+    let aNotifications = 0;
+    let bNotifications = 0;
+    const unsubscribeGlobal = store.subscribe(() => {
+      globalNotifications += 1;
+    });
+    const unsubscribeA = store.subscribeKey(A, () => {
+      aNotifications += 1;
+    });
+    const unsubscribeB = store.subscribeKey(B, () => {
+      bNotifications += 1;
+    });
+
+    store.update(B, (snapshot) => ({ ...snapshot, historyLoaded: true }));
+    expect(aNotifications).toBe(0);
+    expect(bNotifications).toBe(1);
+    store.update(A, (snapshot) => ({ ...snapshot, historyLoaded: true }));
+
+    expect(store.getSubscriberRevision()).toBe(initialGlobalRevision + 2);
+    expect(store.get(A)?.revision).toBe((initialARevision ?? 0) + 1);
+    expect(globalNotifications).toBe(2);
+    expect(aNotifications).toBe(1);
+    expect(bNotifications).toBe(1);
+
+    unsubscribeGlobal();
+    unsubscribeA();
+    unsubscribeB();
+    store.update(A, (snapshot) => ({ ...snapshot, error: "after unsubscribe" }));
+    expect(globalNotifications).toBe(2);
+    expect(aNotifications).toBe(1);
+  });
+
+  test("evicts only least-recent inactive completed entries and disposes their resources", () => {
+    const disposed: Array<{ key: string; reason: string }> = [];
+    const store = createStore({
+      maxInactiveCompletedEntries: 1,
+      disposeEntry: (snapshot, reason) => disposed.push({ key: snapshot.key, reason })
+    });
+    const C = createConversationChatKey("c");
+    const D = createConversationChatKey("d");
+    store.select(A);
+    store.ensure(B);
+    store.ensure(C);
+
+    expect(store.get(B)).toBeUndefined();
+    expect(store.get(C)).toBeDefined();
+    expect(disposed).toEqual([{ key: B, reason: "evicted" }]);
+
+    const runD = store.beginRun(D);
+    expect(store.get(C)).toBeDefined();
+    expect(store.get(D)?.isGenerating).toBe(true);
+    store.finishRun(D, runD.token);
+
+    expect(store.get(C)).toBeUndefined();
+    expect(store.get(D)).toBeDefined();
+    expect(disposed).toContainEqual({ key: C, reason: "evicted" });
+
+    store.dispose();
+    expect(disposed).toContainEqual({ key: A, reason: "disposed" });
+    expect(disposed).toContainEqual({ key: D, reason: "disposed" });
+  });
+
+  test("retains an evicted draft conversation alias for Back but clears it on delete", () => {
+    const store = createStore({ maxInactiveCompletedEntries: 0 });
+    const draft = createChatDraftKey("offscreen-history");
+    const conversation = createConversationChatKey("offscreen-created");
+
+    store.select(draft);
+    const run = store.beginRun(draft);
+    expect(store.rekey(draft, conversation, run.token)).toBe(conversation);
+    store.finishRun(conversation, run.token);
+
+    store.select(A);
+    expect(store.get(conversation)).toBeUndefined();
+    expect(store.resolveKey(draft)).toBe(conversation);
+
+    const restored = store.select(draft);
+    expect(restored.key).toBe(conversation);
+    expect(store.getActiveKey()).toBe(conversation);
+
+    store.select(A);
+    expect(store.get(conversation)).toBeUndefined();
+    expect(store.delete(conversation)).toBe(true);
+    expect(store.resolveKey(draft)).toBe(draft);
+    expect(store.get(draft)).toBeUndefined();
+  });
+
+  test("dispose is terminal, clears subscriptions, and is safe when callbacks reenter", () => {
+    const disposedKeys: string[] = [];
+    const store = createStore({
+      disposeEntry: (snapshot) => {
+        disposedKeys.push(snapshot.key);
+        store.dispose();
+        expect(() => store.ensure(createConversationChatKey("late-callback"))).toThrow(
+          "has been disposed"
+        );
+      }
+    });
+    store.select(A);
+    store.ensure(B);
+    const run = store.beginRun(A);
+    let notifications = 0;
+    const unsubscribe = store.subscribe(() => {
+      notifications += 1;
+      store.dispose();
+      expect(() => store.clearSelection()).toThrow("has been disposed");
+    });
+
+    store.dispose();
+
+    expect(run.signal.aborted).toBe(true);
+    expect(disposedKeys).toEqual([A, B]);
+    expect(notifications).toBe(1);
+    expect(store.getActiveKey()).toBeNull();
+    expect(store.get(A)).toBeUndefined();
+    expect(() => store.select(A)).toThrow("has been disposed");
+    expect(store.updateForRun(A, run.token, (snapshot) => snapshot)).toBe(false);
+    expect(store.finishRun(A, run.token)).toBe(false);
+    expect(store.completeRun(A, run.token)).toBe(false);
+    expect(store.cancelRun(A, run.token)).toBeNull();
+    expect(store.rekey(A, createConversationChatKey("late-created"), run.token)).toBeNull();
+    expect(() => store.beginRun(A)).toThrow("has been disposed");
+    expect(() => store.subscribe(() => {})).toThrow("has been disposed");
+
+    unsubscribe();
+    store.dispose();
+    expect(disposedKeys).toEqual([A, B]);
+    expect(notifications).toBe(1);
+  });
+
+  test("dispose completes every abort, resource callback, and listener when some throw", () => {
+    const disposedKeys: string[] = [];
+    const store = createStore({
+      disposeEntry: (snapshot) => {
+        disposedKeys.push(snapshot.key);
+        if (snapshot.key === A) throw new Error("resource disposal failed");
+      }
+    });
+    store.select(A);
+    const runA = store.beginRun(A);
+    store.select(B);
+    const runB = store.beginRun(B);
+    let laterListenerCalls = 0;
+    store.subscribe(() => {
+      throw new Error("listener failed");
+    });
+    store.subscribe(() => {
+      laterListenerCalls += 1;
+    });
+
+    expect(() => store.dispose()).toThrow("resource disposal failed");
+
+    expect(runA.signal.aborted).toBe(true);
+    expect(runB.signal.aborted).toBe(true);
+    expect(disposedKeys).toEqual([A, B]);
+    expect(laterListenerCalls).toBe(1);
+    expect(store.get(A)).toBeUndefined();
+    expect(store.get(B)).toBeUndefined();
+    expect(() => store.ensure(A)).toThrow("has been disposed");
+  });
+
+  test("subscriber exceptions cannot strand beginRun or hide cancellation metadata", () => {
+    const store = createStore();
+    store.select(A);
+    let laterListenerCalls = 0;
+    store.subscribe(() => {
+      throw new Error("broken subscriber");
+    });
+    store.subscribe(() => {
+      laterListenerCalls += 1;
+    });
+
+    const run = store.beginRun(A);
+    expect(store.isRunCurrent(A, run.token)).toBe(true);
+    expect(run.signal.aborted).toBe(false);
+    expect(store.setCurrentResponseId(A, run.token, "response-a")).toBe(true);
+
+    const cancelled = store.cancelRun(A, run.token);
+
+    expect(cancelled).toEqual({
+      key: A,
+      token: run.token,
+      responseId: "response-a",
+      controller: run.controller
+    });
+    expect(run.signal.aborted).toBe(true);
+    expect(store.get(A)?.runToken).toBeNull();
+    expect(laterListenerCalls).toBe(3);
+  });
+});

--- a/frontend/src/services/chatRuntimeStore.ts
+++ b/frontend/src/services/chatRuntimeStore.ts
@@ -1,5 +1,7 @@
 export type ChatRuntimeKey = string;
 
+const EMPTY_CHAT_RUNTIME_KEYS: readonly ChatRuntimeKey[] = Object.freeze([]);
+
 export type DraftChatRuntimeKey = `draft:${string}`;
 export type ConversationChatRuntimeKey = `conversation:${string}`;
 
@@ -142,6 +144,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   >();
   private readonly aliases = new Map<ChatRuntimeKey, ChatRuntimeKey>();
   private readonly listeners = new Set<() => void>();
+  private readonly activeRunListeners = new Set<() => void>();
   private readonly createComposer: () => TComposer;
   private readonly maxInactiveCompletedEntries: number;
   private readonly canEvict: (
@@ -154,6 +157,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
       ) => void)
     | undefined;
   private activeKey: ChatRuntimeKey | null = null;
+  private activeRunKeysSnapshot = EMPTY_CHAT_RUNTIME_KEYS;
   private subscriberRevision = 0;
   private nextRunToken = 0;
   private touchRevision = 0;
@@ -182,6 +186,14 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   };
 
   readonly getSubscriberRevision = (): number => this.subscriberRevision;
+
+  readonly subscribeActiveRuns = (listener: () => void): (() => void) => {
+    this.assertNotDisposed();
+    this.activeRunListeners.add(listener);
+    return () => this.activeRunListeners.delete(listener);
+  };
+
+  readonly getActiveRunKeys = (): readonly ChatRuntimeKey[] => this.activeRunKeysSnapshot;
 
   subscribeKey(key: ChatRuntimeKey, listener: () => void): () => void {
     let lastSnapshot = this.get(key);
@@ -607,10 +619,13 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     this.disposed = true;
     const currentEntries = Array.from(this.entries.values());
     const currentListeners = Array.from(this.listeners);
+    const currentActiveRunListeners = Array.from(this.activeRunListeners);
     this.entries.clear();
     this.aliases.clear();
     this.activeKey = null;
+    this.activeRunKeysSnapshot = EMPTY_CHAT_RUNTIME_KEYS;
     this.listeners.clear();
+    this.activeRunListeners.clear();
     this.subscriberRevision += 1;
 
     this.runAll([
@@ -618,7 +633,8 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
         entry.activeRun ? [() => entry.activeRun!.controller.abort()] : []
       ),
       ...currentEntries.map((entry) => () => this.disposeEntry?.(entry.snapshot, "disposed")),
-      () => this.notifyListeners(currentListeners)
+      () => this.notifyListeners(currentListeners),
+      () => this.notifyListeners(currentActiveRunListeners)
     ]);
   }
 
@@ -757,8 +773,27 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   }
 
   private publish(): void {
+    this.publishActiveRunKeys();
     this.subscriberRevision += 1;
     this.notifyListeners(this.listeners);
+  }
+
+  private publishActiveRunKeys(): void {
+    const nextKeys = Array.from(this.entries.entries())
+      .filter(([, entry]) => entry.activeRun !== null)
+      .map(([key]) => key);
+    const previousKeys = this.activeRunKeysSnapshot;
+
+    if (
+      nextKeys.length === previousKeys.length &&
+      nextKeys.every((key, index) => key === previousKeys[index])
+    ) {
+      return;
+    }
+
+    this.activeRunKeysSnapshot =
+      nextKeys.length === 0 ? EMPTY_CHAT_RUNTIME_KEYS : Object.freeze(nextKeys);
+    this.notifyListeners(this.activeRunListeners);
   }
 
   private notifyListeners(listeners: Iterable<() => void>): void {

--- a/frontend/src/services/chatRuntimeStore.ts
+++ b/frontend/src/services/chatRuntimeStore.ts
@@ -1,0 +1,776 @@
+export type ChatRuntimeKey = string;
+
+export type DraftChatRuntimeKey = `draft:${string}`;
+export type ConversationChatRuntimeKey = `conversation:${string}`;
+
+let fallbackDraftKeySequence = 0;
+
+export function createChatDraftKey(id?: string): DraftChatRuntimeKey {
+  const generatedId =
+    id ??
+    globalThis.crypto?.randomUUID?.() ??
+    `${Date.now().toString(36)}-${(++fallbackDraftKeySequence).toString(36)}`;
+  if (!generatedId) throw new Error("Chat draft key ID must not be empty");
+  return `draft:${generatedId}`;
+}
+
+export function createConversationChatKey(conversationId: string): ConversationChatRuntimeKey {
+  if (!conversationId) throw new Error("Conversation ID must not be empty");
+  return `conversation:${conversationId}`;
+}
+
+export type ChatRuntimeSnapshot<TConversation, TMessage, TComposer> = Readonly<{
+  key: ChatRuntimeKey;
+  revision: number;
+  conversation: TConversation | null;
+  messages: readonly TMessage[];
+  composer: TComposer;
+  isGenerating: boolean;
+  currentResponseId: string | undefined;
+  error: string | null;
+  lastSeenItemId: string | undefined;
+  assistantStreaming: boolean;
+  historyLoaded: boolean;
+  runToken: number | null;
+}>;
+
+export type ChatRuntimeInitialState<TConversation, TMessage, TComposer> = Partial<
+  Pick<
+    ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+    "conversation" | "messages" | "composer" | "error" | "lastSeenItemId" | "historyLoaded"
+  >
+>;
+
+type ChatRuntimeRunOwnedField = "isGenerating" | "currentResponseId" | "assistantStreaming";
+
+export type ChatRuntimeSafeSnapshot<TConversation, TMessage, TComposer> = Omit<
+  ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+  ChatRuntimeRunOwnedField
+>;
+
+export type ChatRuntimeStateUpdate<TConversation, TMessage, TComposer> = Omit<
+  ChatRuntimeSafeSnapshot<TConversation, TMessage, TComposer>,
+  "key" | "revision" | "runToken"
+>;
+
+export type ChatRuntimeRunStateUpdate<TConversation, TMessage, TComposer> = Omit<
+  ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+  "key" | "revision" | "runToken"
+>;
+
+export type ChatRuntimeActiveRunSnapshot<TConversation, TMessage, TComposer> = Omit<
+  ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+  "isGenerating"
+>;
+
+export type ChatRuntimeActiveRunStateUpdate<TConversation, TMessage, TComposer> = Omit<
+  ChatRuntimeRunStateUpdate<TConversation, TMessage, TComposer>,
+  "isGenerating"
+> & { readonly isGenerating?: never };
+
+export type ChatRuntimeUpdater<TConversation, TMessage, TComposer> = (
+  snapshot: ChatRuntimeSafeSnapshot<TConversation, TMessage, TComposer>
+) => ChatRuntimeStateUpdate<TConversation, TMessage, TComposer>;
+
+export type ChatRuntimeRunUpdater<TConversation, TMessage, TComposer> = (
+  snapshot: ChatRuntimeActiveRunSnapshot<TConversation, TMessage, TComposer>
+) => ChatRuntimeActiveRunStateUpdate<TConversation, TMessage, TComposer>;
+
+export type ChatRuntimeIdleDestinationMerger<TConversation, TMessage, TComposer> = (
+  source: ChatRuntimeActiveRunSnapshot<TConversation, TMessage, TComposer>,
+  destination: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>
+) => ChatRuntimeActiveRunStateUpdate<TConversation, TMessage, TComposer>;
+
+export type ChatRuntimeRunRekeyResult =
+  | Readonly<{
+      status: "migrated";
+      key: ChatRuntimeKey;
+      adoptedExistingDestination: boolean;
+      destinationWasSelected: boolean;
+    }>
+  | Readonly<{ status: "source_stale" }>
+  | Readonly<{ status: "destination_active"; key: ChatRuntimeKey }>;
+
+export type ChatRuntimeRunHandle = Readonly<{
+  key: ChatRuntimeKey;
+  token: number;
+  controller: AbortController;
+  signal: AbortSignal;
+}>;
+
+export type CancelledChatRuntimeRun = Readonly<{
+  key: ChatRuntimeKey;
+  token: number;
+  responseId: string | undefined;
+  controller: AbortController;
+}>;
+
+export type ChatRuntimeStoreOptions<TConversation, TMessage, TComposer> = Readonly<{
+  createComposer: () => TComposer;
+  maxInactiveCompletedEntries?: number;
+  canEvict?: (snapshot: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>) => boolean;
+  disposeEntry?: (
+    snapshot: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+    reason: "evicted" | "deleted" | "disposed"
+  ) => void;
+}>;
+
+type ActiveRun = {
+  token: number;
+  controller: AbortController;
+};
+
+type RuntimeEntry<TConversation, TMessage, TComposer> = {
+  snapshot: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>;
+  activeRun: ActiveRun | null;
+  lastTouched: number;
+};
+
+/**
+ * In-memory ownership boundary for Chat state that must survive navigation.
+ *
+ * The store deliberately has no React or OpenAI SDK dependency. A UI can read it
+ * with useSyncExternalStore by subscribing to `subscribe` and using
+ * `getSubscriberRevision` as the snapshot. Network loops retain the key and run
+ * token returned by `beginRun`, so an offscreen chat can keep receiving events
+ * without writing into the currently selected chat.
+ */
+export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
+  private readonly entries = new Map<
+    ChatRuntimeKey,
+    RuntimeEntry<TConversation, TMessage, TComposer>
+  >();
+  private readonly aliases = new Map<ChatRuntimeKey, ChatRuntimeKey>();
+  private readonly listeners = new Set<() => void>();
+  private readonly createComposer: () => TComposer;
+  private readonly maxInactiveCompletedEntries: number;
+  private readonly canEvict: (
+    snapshot: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>
+  ) => boolean;
+  private readonly disposeEntry:
+    | ((
+        snapshot: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+        reason: "evicted" | "deleted" | "disposed"
+      ) => void)
+    | undefined;
+  private activeKey: ChatRuntimeKey | null = null;
+  private subscriberRevision = 0;
+  private nextRunToken = 0;
+  private touchRevision = 0;
+  private disposed = false;
+
+  constructor(options: ChatRuntimeStoreOptions<TConversation, TMessage, TComposer>) {
+    this.createComposer = options.createComposer;
+    this.maxInactiveCompletedEntries = options.maxInactiveCompletedEntries ?? 20;
+    if (
+      !Number.isInteger(this.maxInactiveCompletedEntries) ||
+      this.maxInactiveCompletedEntries < 0
+    ) {
+      throw new Error("maxInactiveCompletedEntries must be a non-negative integer");
+    }
+    this.canEvict =
+      options.canEvict ??
+      ((snapshot) =>
+        !snapshot.isGenerating && !snapshot.assistantStreaming && snapshot.runToken === null);
+    this.disposeEntry = options.disposeEntry;
+  }
+
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.assertNotDisposed();
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  readonly getSubscriberRevision = (): number => this.subscriberRevision;
+
+  subscribeKey(key: ChatRuntimeKey, listener: () => void): () => void {
+    let lastSnapshot = this.get(key);
+    return this.subscribe(() => {
+      const nextSnapshot = this.get(key);
+      if (nextSnapshot === lastSnapshot) return;
+      lastSnapshot = nextSnapshot;
+      listener();
+    });
+  }
+
+  getActiveKey(): ChatRuntimeKey | null {
+    return this.activeKey;
+  }
+
+  getActive(): ChatRuntimeSnapshot<TConversation, TMessage, TComposer> | undefined {
+    return this.activeKey === null ? undefined : this.entries.get(this.activeKey)?.snapshot;
+  }
+
+  resolveKey(key: ChatRuntimeKey): ChatRuntimeKey {
+    let current = key;
+    const path: ChatRuntimeKey[] = [];
+    const visited = new Set<ChatRuntimeKey>();
+
+    while (this.aliases.has(current)) {
+      if (visited.has(current)) {
+        throw new Error(`Chat runtime alias cycle detected at ${current}`);
+      }
+      visited.add(current);
+      path.push(current);
+      current = this.aliases.get(current)!;
+    }
+
+    for (const alias of path) {
+      this.aliases.set(alias, current);
+    }
+    return current;
+  }
+
+  get(key: ChatRuntimeKey): ChatRuntimeSnapshot<TConversation, TMessage, TComposer> | undefined {
+    return this.entries.get(this.resolveKey(key))?.snapshot;
+  }
+
+  ensure(
+    key: ChatRuntimeKey,
+    initial: ChatRuntimeInitialState<TConversation, TMessage, TComposer> = {}
+  ): ChatRuntimeSnapshot<TConversation, TMessage, TComposer> {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    const existing = this.entries.get(canonicalKey);
+    if (existing) return existing.snapshot;
+
+    const entry = this.createEntry(canonicalKey, initial);
+    this.entries.set(canonicalKey, entry);
+    this.evictInactiveCompletedEntries(canonicalKey);
+    this.publish();
+    return entry.snapshot;
+  }
+
+  select(
+    key: ChatRuntimeKey,
+    initial: ChatRuntimeInitialState<TConversation, TMessage, TComposer> = {}
+  ): ChatRuntimeSnapshot<TConversation, TMessage, TComposer> {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    let entry = this.entries.get(canonicalKey);
+    let changed = false;
+    if (!entry) {
+      entry = this.createEntry(canonicalKey, initial);
+      this.entries.set(canonicalKey, entry);
+      changed = true;
+    }
+
+    this.touch(entry);
+    if (this.activeKey !== canonicalKey) {
+      this.activeKey = canonicalKey;
+      changed = true;
+    }
+
+    changed = this.evictInactiveCompletedEntries() || changed;
+    if (changed) this.publish();
+    return entry.snapshot;
+  }
+
+  clearSelection(): void {
+    this.assertNotDisposed();
+    if (this.activeKey === null) return;
+    this.activeKey = null;
+    this.evictInactiveCompletedEntries();
+    this.publish();
+  }
+
+  update(
+    key: ChatRuntimeKey,
+    updater: ChatRuntimeUpdater<TConversation, TMessage, TComposer>
+  ): ChatRuntimeSnapshot<TConversation, TMessage, TComposer> {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.requireEntry(canonicalKey);
+    const previous = entry.snapshot;
+    const updated = updater(previous);
+    entry.snapshot = this.updatedSnapshot(
+      previous,
+      { ...previous, ...updated },
+      {
+        isGenerating: previous.isGenerating,
+        currentResponseId: previous.currentResponseId,
+        assistantStreaming: previous.assistantStreaming,
+        runToken: previous.runToken
+      }
+    );
+    this.touch(entry);
+    this.evictInactiveCompletedEntries();
+    this.publish();
+    return entry.snapshot;
+  }
+
+  updateForRun(
+    key: ChatRuntimeKey,
+    token: number,
+    updater: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
+  ): boolean {
+    if (this.disposed) return false;
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.entries.get(canonicalKey);
+    if (!entry || entry.activeRun?.token !== token) return false;
+
+    const updated = updater(entry.snapshot);
+    entry.snapshot = this.updatedSnapshot(
+      entry.snapshot,
+      { ...entry.snapshot, ...updated },
+      {
+        isGenerating: true,
+        currentResponseId: updated.currentResponseId,
+        assistantStreaming: updated.assistantStreaming,
+        runToken: token
+      }
+    );
+    this.touch(entry);
+    this.evictInactiveCompletedEntries();
+    this.publish();
+    return true;
+  }
+
+  beginRun(key: ChatRuntimeKey): ChatRuntimeRunHandle {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.entries.get(canonicalKey) ?? this.createAndStoreEntry(canonicalKey);
+    if (entry.activeRun) {
+      throw new Error(`Chat runtime already has an active run: ${canonicalKey}`);
+    }
+    const controller = new AbortController();
+    const token = ++this.nextRunToken;
+
+    entry.activeRun = { token, controller };
+    entry.snapshot = this.updatedSnapshot(
+      entry.snapshot,
+      {
+        ...entry.snapshot,
+        isGenerating: true,
+        currentResponseId: undefined,
+        error: null,
+        assistantStreaming: false
+      },
+      {
+        isGenerating: true,
+        currentResponseId: undefined,
+        assistantStreaming: false,
+        runToken: token
+      }
+    );
+    this.touch(entry);
+    this.publish();
+
+    return { key: canonicalKey, token, controller, signal: controller.signal };
+  }
+
+  isRunCurrent(key: ChatRuntimeKey, token: number): boolean {
+    return this.entries.get(this.resolveKey(key))?.activeRun?.token === token;
+  }
+
+  setCurrentResponseId(key: ChatRuntimeKey, token: number, responseId: string): boolean {
+    return this.updateForRun(key, token, (snapshot) => ({
+      ...snapshot,
+      currentResponseId: responseId
+    }));
+  }
+
+  setAssistantStreaming(key: ChatRuntimeKey, token: number, streaming: boolean): boolean {
+    return this.updateForRun(key, token, (snapshot) => ({
+      ...snapshot,
+      assistantStreaming: streaming
+    }));
+  }
+
+  finishRun(
+    key: ChatRuntimeKey,
+    token: number,
+    updater?: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
+  ): boolean {
+    if (this.disposed) return false;
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.entries.get(canonicalKey);
+    if (!entry || entry.activeRun?.token !== token) return false;
+
+    const completed = updater ? { ...entry.snapshot, ...updater(entry.snapshot) } : entry.snapshot;
+    entry.activeRun = null;
+    entry.snapshot = this.updatedSnapshot(
+      entry.snapshot,
+      {
+        ...completed,
+        isGenerating: false,
+        currentResponseId: undefined,
+        assistantStreaming: false
+      },
+      {
+        isGenerating: false,
+        currentResponseId: undefined,
+        assistantStreaming: false,
+        runToken: null
+      }
+    );
+    this.touch(entry);
+    this.evictInactiveCompletedEntries();
+    this.publish();
+    return true;
+  }
+
+  completeRun(
+    key: ChatRuntimeKey,
+    token: number,
+    updater?: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
+  ): boolean {
+    return this.finishRun(key, token, updater);
+  }
+
+  cancelRun(key: ChatRuntimeKey, token: number): CancelledChatRuntimeRun | null {
+    if (this.disposed) return null;
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.entries.get(canonicalKey);
+    const run = entry?.activeRun;
+    if (!entry || !run || run.token !== token) return null;
+
+    const responseId = entry.snapshot.currentResponseId;
+    entry.activeRun = null;
+    entry.snapshot = this.updatedSnapshot(
+      entry.snapshot,
+      {
+        ...entry.snapshot,
+        isGenerating: false,
+        currentResponseId: undefined,
+        assistantStreaming: false
+      },
+      {
+        isGenerating: false,
+        currentResponseId: undefined,
+        assistantStreaming: false,
+        runToken: null
+      }
+    );
+    this.touch(entry);
+    // Clear ownership first so a synchronous abort listener is stale-fenced.
+    this.runAll([
+      () => run.controller.abort(),
+      () => {
+        this.evictInactiveCompletedEntries();
+      },
+      () => this.publish()
+    ]);
+    return { key: canonicalKey, token: run.token, responseId, controller: run.controller };
+  }
+
+  rekey(
+    fromKey: ChatRuntimeKey,
+    toKey: ChatRuntimeKey,
+    expectedRunToken: number
+  ): ChatRuntimeKey | null {
+    if (this.disposed) return null;
+    const canonicalFrom = this.resolveKey(fromKey);
+    const entry = this.entries.get(canonicalFrom);
+    if (!entry || entry.activeRun?.token !== expectedRunToken) return null;
+
+    const canonicalTo = this.resolveKey(toKey);
+    if (canonicalFrom === canonicalTo) return canonicalTo;
+    if (canonicalTo !== toKey) {
+      throw new Error(`Cannot rekey chat runtime to aliased key ${toKey}`);
+    }
+
+    if (this.entries.has(canonicalTo)) {
+      throw new Error(`Cannot rekey chat runtime: ${canonicalTo} already exists`);
+    }
+
+    return this.moveRunEntry(fromKey, canonicalFrom, canonicalTo, entry);
+  }
+
+  /**
+   * Moves an owned run to its server conversation key without exposing a
+   * delete/recreate gap when navigation discovered that conversation first.
+   * An idle destination is folded into the source by the caller-provided
+   * merger; its resources become part of the surviving entry and are not
+   * disposed. A destination with its own run is never replaced.
+   */
+  rekeyRunAdoptingIdleDestination(
+    fromKey: ChatRuntimeKey,
+    toKey: ChatRuntimeKey,
+    expectedRunToken: number,
+    mergeIdleDestination: ChatRuntimeIdleDestinationMerger<TConversation, TMessage, TComposer>
+  ): ChatRuntimeRunRekeyResult {
+    if (this.disposed) return { status: "source_stale" };
+    const canonicalFrom = this.resolveKey(fromKey);
+    const sourceEntry = this.entries.get(canonicalFrom);
+    if (!sourceEntry || sourceEntry.activeRun?.token !== expectedRunToken) {
+      return { status: "source_stale" };
+    }
+
+    const canonicalTo = this.resolveKey(toKey);
+    if (canonicalFrom === canonicalTo) {
+      return {
+        status: "migrated",
+        key: canonicalTo,
+        adoptedExistingDestination: false,
+        destinationWasSelected: this.activeKey === canonicalTo
+      };
+    }
+    if (canonicalTo !== toKey) {
+      throw new Error(`Cannot rekey chat runtime to aliased key ${toKey}`);
+    }
+
+    const destinationEntry = this.entries.get(canonicalTo);
+    if (destinationEntry?.activeRun) {
+      return { status: "destination_active", key: canonicalTo };
+    }
+
+    const destinationWasSelected = this.activeKey === canonicalTo;
+    const mergedUpdate = destinationEntry
+      ? mergeIdleDestination(sourceEntry.snapshot, destinationEntry.snapshot)
+      : undefined;
+    const key = this.moveRunEntry(fromKey, canonicalFrom, canonicalTo, sourceEntry, mergedUpdate);
+
+    return {
+      status: "migrated",
+      key,
+      adoptedExistingDestination: destinationEntry !== undefined,
+      destinationWasSelected
+    };
+  }
+
+  private moveRunEntry(
+    fromKey: ChatRuntimeKey,
+    canonicalFrom: ChatRuntimeKey,
+    canonicalTo: ChatRuntimeKey,
+    entry: RuntimeEntry<TConversation, TMessage, TComposer>,
+    mergedUpdate?: ChatRuntimeActiveRunStateUpdate<TConversation, TMessage, TComposer>
+  ): ChatRuntimeKey {
+    const aliasesForEntry = Array.from(this.aliases.keys()).filter(
+      (alias) => this.resolveKey(alias) === canonicalFrom
+    );
+    const sourceWasSelected = this.activeKey === canonicalFrom;
+    const destinationWasSelected = this.activeKey === canonicalTo;
+
+    if (mergedUpdate) {
+      const previous = entry.snapshot;
+      entry.snapshot = this.updatedSnapshot(
+        previous,
+        { ...previous, ...mergedUpdate },
+        {
+          isGenerating: true,
+          currentResponseId: previous.currentResponseId,
+          assistantStreaming: previous.assistantStreaming,
+          runToken: entry.activeRun!.token
+        }
+      );
+    }
+
+    this.entries.delete(canonicalFrom);
+    // An adopted idle destination is replaced atomically. Its resource-bearing
+    // state must have been transferred by mergedUpdate, so no disposal callback
+    // runs and subscribers never observe a missing destination.
+    this.entries.delete(canonicalTo);
+    entry.snapshot = Object.freeze({
+      ...entry.snapshot,
+      key: canonicalTo,
+      revision: entry.snapshot.revision + 1
+    });
+    this.touch(entry);
+    this.entries.set(canonicalTo, entry);
+
+    this.aliases.set(canonicalFrom, canonicalTo);
+    this.aliases.set(fromKey, canonicalTo);
+    for (const alias of aliasesForEntry) {
+      this.aliases.set(alias, canonicalTo);
+    }
+    if (sourceWasSelected || destinationWasSelected) {
+      this.activeKey = canonicalTo;
+    }
+
+    this.publish();
+    return canonicalTo;
+  }
+
+  delete(key: ChatRuntimeKey): boolean {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.entries.get(canonicalKey);
+    if (!entry) {
+      const removedAlias = this.detachAliases(canonicalKey);
+      if (removedAlias) this.publish();
+      return removedAlias;
+    }
+
+    this.detachEntry(canonicalKey);
+    if (this.activeKey === canonicalKey) this.activeKey = null;
+    this.runAll([
+      () => entry.activeRun?.controller.abort(),
+      () => this.disposeEntry?.(entry.snapshot, "deleted"),
+      () => this.publish()
+    ]);
+    return true;
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    const currentEntries = Array.from(this.entries.values());
+    const currentListeners = Array.from(this.listeners);
+    this.entries.clear();
+    this.aliases.clear();
+    this.activeKey = null;
+    this.listeners.clear();
+    this.subscriberRevision += 1;
+
+    this.runAll([
+      ...currentEntries.flatMap((entry) =>
+        entry.activeRun ? [() => entry.activeRun!.controller.abort()] : []
+      ),
+      ...currentEntries.map((entry) => () => this.disposeEntry?.(entry.snapshot, "disposed")),
+      () => this.notifyListeners(currentListeners)
+    ]);
+  }
+
+  private createEntry(
+    key: ChatRuntimeKey,
+    initial: ChatRuntimeInitialState<TConversation, TMessage, TComposer>
+  ): RuntimeEntry<TConversation, TMessage, TComposer> {
+    return {
+      snapshot: Object.freeze({
+        key,
+        revision: 0,
+        conversation: initial.conversation ?? null,
+        messages: [...(initial.messages ?? [])],
+        composer: initial.composer ?? this.createComposer(),
+        isGenerating: false,
+        currentResponseId: undefined,
+        error: initial.error ?? null,
+        lastSeenItemId: initial.lastSeenItemId,
+        assistantStreaming: false,
+        historyLoaded: initial.historyLoaded ?? false,
+        runToken: null
+      }),
+      activeRun: null,
+      lastTouched: ++this.touchRevision
+    };
+  }
+
+  private createAndStoreEntry(
+    key: ChatRuntimeKey
+  ): RuntimeEntry<TConversation, TMessage, TComposer> {
+    const entry = this.createEntry(key, {});
+    this.entries.set(key, entry);
+    return entry;
+  }
+
+  private updatedSnapshot(
+    previous: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+    updated: ChatRuntimeRunStateUpdate<TConversation, TMessage, TComposer>,
+    ownership: Pick<
+      ChatRuntimeSnapshot<TConversation, TMessage, TComposer>,
+      ChatRuntimeRunOwnedField | "runToken"
+    >
+  ): ChatRuntimeSnapshot<TConversation, TMessage, TComposer> {
+    return Object.freeze({
+      ...updated,
+      key: previous.key,
+      revision: previous.revision + 1,
+      messages: updated.messages === previous.messages ? previous.messages : [...updated.messages],
+      ...ownership
+    });
+  }
+
+  private requireEntry(
+    canonicalKey: ChatRuntimeKey
+  ): RuntimeEntry<TConversation, TMessage, TComposer> {
+    const entry = this.entries.get(canonicalKey);
+    if (!entry) throw new Error(`Unknown chat runtime key: ${canonicalKey}`);
+    return entry;
+  }
+
+  private touch(entry: RuntimeEntry<TConversation, TMessage, TComposer>): void {
+    entry.lastTouched = ++this.touchRevision;
+  }
+
+  private evictInactiveCompletedEntries(protectedKey?: ChatRuntimeKey): boolean {
+    const completedInactiveEntries = Array.from(this.entries.entries())
+      .filter(
+        ([key, entry]) =>
+          key !== this.activeKey && entry.activeRun === null && this.canEvict(entry.snapshot)
+      )
+      .sort((left, right) => left[1].lastTouched - right[1].lastTouched);
+
+    const excess = completedInactiveEntries.length - this.maxInactiveCompletedEntries;
+    if (excess <= 0) return false;
+    const candidates = completedInactiveEntries.filter(([key]) => key !== protectedKey);
+    const entriesToEvict = candidates.slice(0, excess);
+    this.runAll(
+      entriesToEvict.map(
+        ([key]) =>
+          () =>
+            this.removeEntry(key, "evicted")
+      )
+    );
+    return entriesToEvict.length > 0;
+  }
+
+  private removeEntry(canonicalKey: ChatRuntimeKey, reason: "evicted" | "deleted"): void {
+    const entry = this.detachEntry(canonicalKey, reason === "evicted");
+    if (entry) this.disposeEntry?.(entry.snapshot, reason);
+  }
+
+  private detachEntry(
+    canonicalKey: ChatRuntimeKey,
+    preserveAliases = false
+  ): RuntimeEntry<TConversation, TMessage, TComposer> | undefined {
+    const entry = this.entries.get(canonicalKey);
+    this.entries.delete(canonicalKey);
+    // A draft history entry may be the only browser address for a conversation
+    // that finished creating offscreen. Keep that lightweight redirect when its
+    // cached snapshot is merely evicted, so Back can recreate/load the server
+    // conversation. Explicit deletion and account disposal still clear aliases.
+    if (preserveAliases) return entry;
+    this.detachAliases(canonicalKey);
+    return entry;
+  }
+
+  private detachAliases(canonicalKey: ChatRuntimeKey): boolean {
+    let removed = false;
+    for (const alias of Array.from(this.aliases.keys())) {
+      if (this.resolveKey(alias) === canonicalKey) {
+        this.aliases.delete(alias);
+        removed = true;
+      }
+    }
+    return removed;
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) throw new Error("Chat runtime store has been disposed");
+  }
+
+  private runAll(actions: ReadonlyArray<() => void>): void {
+    let firstError: unknown;
+    let hasError = false;
+    for (const action of actions) {
+      try {
+        action();
+      } catch (error) {
+        if (!hasError) {
+          firstError = error;
+          hasError = true;
+        }
+      }
+    }
+    if (hasError) throw firstError;
+  }
+
+  private publish(): void {
+    this.subscriberRevision += 1;
+    this.notifyListeners(this.listeners);
+  }
+
+  private notifyListeners(listeners: Iterable<() => void>): void {
+    // Subscribers are observers: one broken observer must not change a completed
+    // runtime mutation, hide cancellation metadata, or strand a controller.
+    for (const listener of Array.from(listeners)) {
+      try {
+        listener();
+      } catch {
+        // Keep notifying the remaining subscribers. Rendering layers surface
+        // their own errors without changing this store's ownership outcome.
+      }
+    }
+  }
+}

--- a/frontend/src/services/chatRuntimeStore.ts
+++ b/frontend/src/services/chatRuntimeStore.ts
@@ -100,6 +100,15 @@ export type ChatRuntimeRunHandle = Readonly<{
   signal: AbortSignal;
 }>;
 
+export type ChatRuntimeRunContext = Readonly<{
+  groupId?: string | null;
+}>;
+
+export type ChatRuntimeVisibleLease = Readonly<{
+  owner: object;
+  sequence: number;
+}>;
+
 export type CancelledChatRuntimeRun = Readonly<{
   key: ChatRuntimeKey;
   token: number;
@@ -120,11 +129,13 @@ export type ChatRuntimeStoreOptions<TConversation, TMessage, TComposer> = Readon
 type ActiveRun = {
   token: number;
   controller: AbortController;
+  groupId: string | null;
 };
 
 type RuntimeEntry<TConversation, TMessage, TComposer> = {
   snapshot: ChatRuntimeSnapshot<TConversation, TMessage, TComposer>;
   activeRun: ActiveRun | null;
+  groupId: string | null;
   lastTouched: number;
 };
 
@@ -145,6 +156,8 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   private readonly aliases = new Map<ChatRuntimeKey, ChatRuntimeKey>();
   private readonly listeners = new Set<() => void>();
   private readonly activeRunListeners = new Set<() => void>();
+  private readonly completedUnreadListeners = new Set<() => void>();
+  private readonly completedUnreadGroups = new Map<ChatRuntimeKey, string | null>();
   private readonly createComposer: () => TComposer;
   private readonly maxInactiveCompletedEntries: number;
   private readonly canEvict: (
@@ -158,6 +171,10 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     | undefined;
   private activeKey: ChatRuntimeKey | null = null;
   private activeRunKeysSnapshot = EMPTY_CHAT_RUNTIME_KEYS;
+  private completedUnreadKeysSnapshot = EMPTY_CHAT_RUNTIME_KEYS;
+  private visibleChatLease: ChatRuntimeVisibleLease | null = null;
+  private visibleChatKey: ChatRuntimeKey | null = null;
+  private nextVisibleChatLeaseSequence = 0;
   private subscriberRevision = 0;
   private nextRunToken = 0;
   private touchRevision = 0;
@@ -194,6 +211,138 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   };
 
   readonly getActiveRunKeys = (): readonly ChatRuntimeKey[] => this.activeRunKeysSnapshot;
+
+  readonly subscribeCompletedUnread = (listener: () => void): (() => void) => {
+    this.assertNotDisposed();
+    this.completedUnreadListeners.add(listener);
+    return () => this.completedUnreadListeners.delete(listener);
+  };
+
+  readonly getCompletedUnreadKeys = (): readonly ChatRuntimeKey[] =>
+    this.completedUnreadKeysSnapshot;
+
+  getActiveRunGroupId(key: ChatRuntimeKey): string | null | undefined {
+    return this.entries.get(this.resolveKey(key))?.activeRun?.groupId;
+  }
+
+  getCompletedUnreadGroupId(key: ChatRuntimeKey): string | null | undefined {
+    return this.completedUnreadGroups.get(this.resolveKey(key));
+  }
+
+  getActivityGroupId(key: ChatRuntimeKey): string | null | undefined {
+    const canonicalKey = this.resolveKey(key);
+    return this.entries.get(canonicalKey)?.groupId ?? this.completedUnreadGroups.get(canonicalKey);
+  }
+
+  claimVisibleChat(owner: object, key: ChatRuntimeKey): ChatRuntimeVisibleLease {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    const lease = Object.freeze({
+      owner,
+      sequence: ++this.nextVisibleChatLeaseSequence
+    });
+    this.visibleChatLease = lease;
+    this.visibleChatKey = canonicalKey;
+    if (this.completedUnreadGroups.delete(canonicalKey)) this.publish();
+    return lease;
+  }
+
+  releaseVisibleChat(lease: ChatRuntimeVisibleLease): void {
+    if (this.disposed) return;
+    if (this.visibleChatLease !== lease) return;
+    this.visibleChatLease = null;
+    this.visibleChatKey = null;
+  }
+
+  isChatVisible(key: ChatRuntimeKey): boolean {
+    return (
+      this.visibleChatLease !== null &&
+      this.visibleChatKey !== null &&
+      this.resolveKey(this.visibleChatKey) === this.resolveKey(key)
+    );
+  }
+
+  markCompletionRead(key: ChatRuntimeKey): boolean {
+    this.assertNotDisposed();
+    if (!this.completedUnreadGroups.delete(this.resolveKey(key))) return false;
+    this.publish();
+    return true;
+  }
+
+  updateActivityGroup(key: ChatRuntimeKey, groupId: string | null): boolean {
+    this.assertNotDisposed();
+    const canonicalKey = this.resolveKey(key);
+    const entry = this.entries.get(canonicalKey);
+    const activeRun = entry?.activeRun;
+    let entryGroupChanged = false;
+    let activeGroupChanged = false;
+    let unreadGroupChanged = false;
+
+    if (entry && entry.groupId !== groupId) {
+      entry.groupId = groupId;
+      entryGroupChanged = true;
+    }
+    if (activeRun && activeRun.groupId !== groupId) {
+      activeRun.groupId = groupId;
+      activeGroupChanged = true;
+    }
+    if (
+      this.completedUnreadGroups.has(canonicalKey) &&
+      this.completedUnreadGroups.get(canonicalKey) !== groupId
+    ) {
+      this.completedUnreadGroups.set(canonicalKey, groupId);
+      unreadGroupChanged = true;
+    }
+
+    if (entryGroupChanged || activeGroupChanged || unreadGroupChanged) {
+      this.publish(activeGroupChanged, unreadGroupChanged);
+    }
+    return entryGroupChanged || activeGroupChanged || unreadGroupChanged;
+  }
+
+  reassignActivityGroup(fromGroupId: string, toGroupId: string | null): boolean {
+    this.assertNotDisposed();
+    let entryGroupChanged = false;
+    let activeGroupChanged = false;
+    let unreadGroupChanged = false;
+
+    for (const entry of this.entries.values()) {
+      if (entry.groupId === fromGroupId) {
+        entry.groupId = toGroupId;
+        entryGroupChanged = true;
+      }
+      if (entry.activeRun?.groupId === fromGroupId) {
+        entry.activeRun.groupId = toGroupId;
+        activeGroupChanged = true;
+      }
+    }
+    for (const [key, groupId] of this.completedUnreadGroups) {
+      if (groupId === fromGroupId) {
+        this.completedUnreadGroups.set(key, toGroupId);
+        unreadGroupChanged = true;
+      }
+    }
+
+    if (entryGroupChanged || activeGroupChanged || unreadGroupChanged) {
+      this.publish(activeGroupChanged, unreadGroupChanged);
+    }
+    return entryGroupChanged || activeGroupChanged || unreadGroupChanged;
+  }
+
+  deleteActivityGroup(groupId: string): readonly ChatRuntimeKey[] {
+    this.assertNotDisposed();
+    const keys = new Set<ChatRuntimeKey>();
+
+    for (const [key, entry] of this.entries) {
+      if (entry.groupId === groupId || entry.activeRun?.groupId === groupId) keys.add(key);
+    }
+    for (const [key, completedGroupId] of this.completedUnreadGroups) {
+      if (completedGroupId === groupId) keys.add(key);
+    }
+
+    for (const key of keys) this.delete(key);
+    return Object.freeze(Array.from(keys));
+  }
 
   subscribeKey(key: ChatRuntimeKey, listener: () => void): () => void {
     let lastSnapshot = this.get(key);
@@ -272,7 +421,6 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
       this.activeKey = canonicalKey;
       changed = true;
     }
-
     changed = this.evictInactiveCompletedEntries() || changed;
     if (changed) this.publish();
     return entry.snapshot;
@@ -338,7 +486,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     return true;
   }
 
-  beginRun(key: ChatRuntimeKey): ChatRuntimeRunHandle {
+  beginRun(key: ChatRuntimeKey, context: ChatRuntimeRunContext = {}): ChatRuntimeRunHandle {
     this.assertNotDisposed();
     const canonicalKey = this.resolveKey(key);
     const entry = this.entries.get(canonicalKey) ?? this.createAndStoreEntry(canonicalKey);
@@ -348,7 +496,10 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     const controller = new AbortController();
     const token = ++this.nextRunToken;
 
-    entry.activeRun = { token, controller };
+    this.completedUnreadGroups.delete(canonicalKey);
+    const groupId = context.groupId === undefined ? entry.groupId : context.groupId;
+    entry.groupId = groupId;
+    entry.activeRun = { token, controller, groupId };
     entry.snapshot = this.updatedSnapshot(
       entry.snapshot,
       {
@@ -394,12 +545,30 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     token: number,
     updater?: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
   ): boolean {
+    return this.settleRun(key, token, false, updater);
+  }
+
+  completeRun(
+    key: ChatRuntimeKey,
+    token: number,
+    updater?: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
+  ): boolean {
+    return this.settleRun(key, token, true, updater);
+  }
+
+  private settleRun(
+    key: ChatRuntimeKey,
+    token: number,
+    completedSuccessfully: boolean,
+    updater?: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
+  ): boolean {
     if (this.disposed) return false;
     const canonicalKey = this.resolveKey(key);
     const entry = this.entries.get(canonicalKey);
     if (!entry || entry.activeRun?.token !== token) return false;
 
     const completed = updater ? { ...entry.snapshot, ...updater(entry.snapshot) } : entry.snapshot;
+    const completedGroupId = entry.activeRun.groupId;
     entry.activeRun = null;
     entry.snapshot = this.updatedSnapshot(
       entry.snapshot,
@@ -416,18 +585,17 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
         runToken: null
       }
     );
+    const visibleChatKey =
+      this.visibleChatLease && this.visibleChatKey ? this.resolveKey(this.visibleChatKey) : null;
+    if (completedSuccessfully && visibleChatKey !== canonicalKey) {
+      this.completedUnreadGroups.set(canonicalKey, completedGroupId);
+    } else {
+      this.completedUnreadGroups.delete(canonicalKey);
+    }
     this.touch(entry);
     this.evictInactiveCompletedEntries();
     this.publish();
     return true;
-  }
-
-  completeRun(
-    key: ChatRuntimeKey,
-    token: number,
-    updater?: ChatRuntimeRunUpdater<TConversation, TMessage, TComposer>
-  ): boolean {
-    return this.finishRun(key, token, updater);
   }
 
   cancelRun(key: ChatRuntimeKey, token: number): CancelledChatRuntimeRun | null {
@@ -438,6 +606,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     if (!entry || !run || run.token !== token) return null;
 
     const responseId = entry.snapshot.currentResponseId;
+    this.completedUnreadGroups.delete(canonicalKey);
     entry.activeRun = null;
     entry.snapshot = this.updatedSnapshot(
       entry.snapshot,
@@ -568,6 +737,9 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
       );
     }
 
+    this.completedUnreadGroups.delete(canonicalFrom);
+    this.completedUnreadGroups.delete(canonicalTo);
+
     this.entries.delete(canonicalFrom);
     // An adopted idle destination is replaced atomically. Its resource-bearing
     // state must have been transferred by mergedUpdate, so no disposal callback
@@ -589,6 +761,13 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     if (sourceWasSelected || destinationWasSelected) {
       this.activeKey = canonicalTo;
     }
+    if (
+      this.visibleChatKey !== null &&
+      (this.resolveKey(this.visibleChatKey) === canonicalFrom ||
+        this.resolveKey(this.visibleChatKey) === canonicalTo)
+    ) {
+      this.visibleChatKey = canonicalTo;
+    }
 
     this.publish();
     return canonicalTo;
@@ -600,12 +779,18 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     const entry = this.entries.get(canonicalKey);
     if (!entry) {
       const removedAlias = this.detachAliases(canonicalKey);
-      if (removedAlias) this.publish();
-      return removedAlias;
+      const removedUnread = this.completedUnreadGroups.delete(canonicalKey);
+      if (removedAlias || removedUnread) this.publish();
+      return removedAlias || removedUnread;
     }
 
+    this.completedUnreadGroups.delete(canonicalKey);
     this.detachEntry(canonicalKey);
     if (this.activeKey === canonicalKey) this.activeKey = null;
+    if (this.visibleChatKey && this.resolveKey(this.visibleChatKey) === canonicalKey) {
+      this.visibleChatLease = null;
+      this.visibleChatKey = null;
+    }
     this.runAll([
       () => entry.activeRun?.controller.abort(),
       () => this.disposeEntry?.(entry.snapshot, "deleted"),
@@ -620,12 +805,18 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     const currentEntries = Array.from(this.entries.values());
     const currentListeners = Array.from(this.listeners);
     const currentActiveRunListeners = Array.from(this.activeRunListeners);
+    const currentCompletedUnreadListeners = Array.from(this.completedUnreadListeners);
     this.entries.clear();
     this.aliases.clear();
+    this.completedUnreadGroups.clear();
     this.activeKey = null;
+    this.visibleChatLease = null;
+    this.visibleChatKey = null;
     this.activeRunKeysSnapshot = EMPTY_CHAT_RUNTIME_KEYS;
+    this.completedUnreadKeysSnapshot = EMPTY_CHAT_RUNTIME_KEYS;
     this.listeners.clear();
     this.activeRunListeners.clear();
+    this.completedUnreadListeners.clear();
     this.subscriberRevision += 1;
 
     this.runAll([
@@ -634,7 +825,8 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
       ),
       ...currentEntries.map((entry) => () => this.disposeEntry?.(entry.snapshot, "disposed")),
       () => this.notifyListeners(currentListeners),
-      () => this.notifyListeners(currentActiveRunListeners)
+      () => this.notifyListeners(currentActiveRunListeners),
+      () => this.notifyListeners(currentCompletedUnreadListeners)
     ]);
   }
 
@@ -658,6 +850,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
         runToken: null
       }),
       activeRun: null,
+      groupId: null,
       lastTouched: ++this.touchRevision
     };
   }
@@ -772,19 +965,21 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     if (hasError) throw firstError;
   }
 
-  private publish(): void {
-    this.publishActiveRunKeys();
+  private publish(forceActiveRunKeys = false, forceCompletedUnreadKeys = false): void {
+    this.publishActiveRunKeys(forceActiveRunKeys);
+    this.publishCompletedUnreadKeys(forceCompletedUnreadKeys);
     this.subscriberRevision += 1;
     this.notifyListeners(this.listeners);
   }
 
-  private publishActiveRunKeys(): void {
+  private publishActiveRunKeys(force = false): void {
     const nextKeys = Array.from(this.entries.entries())
       .filter(([, entry]) => entry.activeRun !== null)
       .map(([key]) => key);
     const previousKeys = this.activeRunKeysSnapshot;
 
     if (
+      !force &&
       nextKeys.length === previousKeys.length &&
       nextKeys.every((key, index) => key === previousKeys[index])
     ) {
@@ -794,6 +989,23 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     this.activeRunKeysSnapshot =
       nextKeys.length === 0 ? EMPTY_CHAT_RUNTIME_KEYS : Object.freeze(nextKeys);
     this.notifyListeners(this.activeRunListeners);
+  }
+
+  private publishCompletedUnreadKeys(force = false): void {
+    const nextKeys = Array.from(this.completedUnreadGroups.keys());
+    const previousKeys = this.completedUnreadKeysSnapshot;
+
+    if (
+      !force &&
+      nextKeys.length === previousKeys.length &&
+      nextKeys.every((key, index) => key === previousKeys[index])
+    ) {
+      return;
+    }
+
+    this.completedUnreadKeysSnapshot =
+      nextKeys.length === 0 ? EMPTY_CHAT_RUNTIME_KEYS : Object.freeze(nextKeys);
+    this.notifyListeners(this.completedUnreadListeners);
   }
 
   private notifyListeners(listeners: Iterable<() => void>): void {

--- a/frontend/src/services/chatSendFailureRecovery.test.ts
+++ b/frontend/src/services/chatSendFailureRecovery.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, test } from "bun:test";
+import { recoverFailedSendAfterDestinationAdoption } from "./chatSendFailureRecovery";
+
+describe("recoverFailedSendAfterDestinationAdoption", () => {
+  test("keeps destination B composer resources while retaining failed source A", () => {
+    const destinationImageUrls = new Map([["destination-file", "blob:destination-b"]]);
+    const destinationComposer = {
+      input: "destination B draft",
+      documentText: "destination B document",
+      imageUrls: destinationImageUrls,
+      imagePasteGeneration: 7,
+      documentUploadGeneration: 11
+    };
+    const destinationHistory = {
+      id: "destination-history",
+      text: "existing destination history",
+      status: "completed"
+    };
+    const sourceMessage = {
+      id: "source-a",
+      text: "source A prompt",
+      status: "completed"
+    };
+
+    const recovery = recoverFailedSendAfterDestinationAdoption(
+      true,
+      [destinationHistory, sourceMessage],
+      destinationComposer,
+      sourceMessage.id
+    );
+
+    expect(recovery).not.toBeNull();
+    expect(recovery?.composer).toBe(destinationComposer);
+    expect(recovery?.composer.imageUrls).toBe(destinationImageUrls);
+    expect(recovery?.composer).toEqual(destinationComposer);
+    expect(recovery?.messages).toEqual([
+      destinationHistory,
+      { ...sourceMessage, status: "incomplete" }
+    ]);
+  });
+
+  test("leaves regular sends on the existing origin-composer recovery path", () => {
+    expect(
+      recoverFailedSendAfterDestinationAdoption(
+        false,
+        [{ id: "source-a", status: "completed" }],
+        { input: "origin" },
+        "source-a"
+      )
+    ).toBeNull();
+  });
+});

--- a/frontend/src/services/chatSendFailureRecovery.ts
+++ b/frontend/src/services/chatSendFailureRecovery.ts
@@ -1,0 +1,29 @@
+export type AdoptedDestinationFailureRecovery<TMessage, TComposer> = Readonly<{
+  messages: TMessage[];
+  composer: TComposer;
+}>;
+
+/**
+ * Once a source run adopts an independently selected destination runtime, that
+ * destination owns its composer and object URLs. A later source-send failure
+ * must leave those resources untouched and keep the source prompt recoverable
+ * in the optimistic message instead of restoring it over the destination draft.
+ */
+export function recoverFailedSendAfterDestinationAdoption<
+  TMessage extends Readonly<{ id: string }>,
+  TComposer
+>(
+  adoptedExistingDestination: boolean,
+  messages: readonly TMessage[],
+  composer: TComposer,
+  sourceMessageId: string
+): AdoptedDestinationFailureRecovery<TMessage, TComposer> | null {
+  if (!adoptedExistingDestination) return null;
+
+  return {
+    messages: messages.map((message) =>
+      message.id === sourceMessageId ? ({ ...message, status: "incomplete" } as TMessage) : message
+    ),
+    composer
+  };
+}

--- a/frontend/src/services/chatStreamDeltaCoalescer.test.ts
+++ b/frontend/src/services/chatStreamDeltaCoalescer.test.ts
@@ -1,0 +1,292 @@
+import { describe, expect, test } from "bun:test";
+import {
+  classifyChatStreamEof,
+  createChatStreamDeltaCoalescer,
+  flushRegisteredChatStreamDeltas,
+  isTerminalChatStreamErrorEvent,
+  registerChatStreamDeltaCoalescer,
+  removeOwnedChatStreamAttemptItems,
+  unregisterChatStreamDeltaCoalescer,
+  type ChatStreamDeltaScheduler,
+  type ChatStreamTextDelta
+} from "./chatStreamDeltaCoalescer";
+
+function createManualScheduler() {
+  let nextHandle = 0;
+  const tasks = new Map<number, () => void>();
+  const scheduler: ChatStreamDeltaScheduler = {
+    schedule: (task) => {
+      const handle = ++nextHandle;
+      tasks.set(handle, task);
+      return handle;
+    },
+    cancel: (handle) => tasks.delete(handle as number)
+  };
+
+  return {
+    scheduler,
+    pendingCount: () => tasks.size,
+    runNext: () => {
+      const next = tasks.entries().next().value as [number, () => void] | undefined;
+      if (!next) return false;
+      tasks.delete(next[0]);
+      next[1]();
+      return true;
+    }
+  };
+}
+
+function delta(text: string, overrides: Partial<ChatStreamTextDelta> = {}): ChatStreamTextDelta {
+  return {
+    kind: "message",
+    itemId: "assistant",
+    contentIndex: 0,
+    delta: text,
+    ...overrides
+  };
+}
+
+describe("createChatStreamDeltaCoalescer", () => {
+  test("removes only a failed attempt's response items before retry", () => {
+    const userMessage = { id: "local-user", kind: "user" };
+    const previousAssistant = { id: "previous-assistant", kind: "assistant" };
+    const failedAssistant = { id: "failed-assistant", kind: "assistant" };
+    const failedReasoning = { id: "failed-reasoning", kind: "reasoning" };
+    const otherRuntimeItem = { id: "other-runtime-item", kind: "assistant" };
+
+    expect(
+      removeOwnedChatStreamAttemptItems(
+        [userMessage, previousAssistant, failedAssistant, failedReasoning, otherRuntimeItem],
+        new Set([failedAssistant.id, failedReasoning.id])
+      )
+    ).toEqual([userMessage, previousAssistant, otherRuntimeItem]);
+  });
+
+  test("distinguishes completed, truncated, and stale-cancel iterator EOF", () => {
+    expect(classifyChatStreamEof("completed", true)).toBe("completed");
+    expect(classifyChatStreamEof(null, true)).toBe("truncated");
+    expect(classifyChatStreamEof(null, false)).toBe("stale");
+    expect(classifyChatStreamEof("cancelled", true)).toBe("terminal");
+    expect(classifyChatStreamEof("error", true)).toBe("terminal");
+  });
+
+  test("recognizes OpenAI and OpenSecret terminal stream-error event names", () => {
+    expect(isTerminalChatStreamErrorEvent("error")).toBe(true);
+    expect(isTerminalChatStreamErrorEvent("response.error")).toBe(true);
+    expect(isTerminalChatStreamErrorEvent("response.failed")).toBe(true);
+    expect(isTerminalChatStreamErrorEvent("response.cancelled")).toBe(false);
+    expect(isTerminalChatStreamErrorEvent("response.completed")).toBe(false);
+  });
+
+  test("preserves chunk order while publishing only once per scheduled batch", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("one "));
+    coalescer.enqueue(delta("two "));
+    coalescer.enqueue(delta("three"));
+
+    expect(manual.pendingCount()).toBe(1);
+    expect(batches).toEqual([]);
+    manual.runNext();
+    expect(batches).toEqual([[delta("one two three")]]);
+  });
+
+  test("keeps message, reasoning, item, and content-index targets independent", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("m0-a"));
+    coalescer.enqueue(delta("r0", { kind: "reasoning" }));
+    coalescer.enqueue(delta("m1", { contentIndex: 1 }));
+    coalescer.enqueue(delta("m0-b"));
+
+    manual.runNext();
+    expect(batches).toEqual([
+      [delta("m0-am0-b"), delta("r0", { kind: "reasoning" }), delta("m1", { contentIndex: 1 })]
+    ]);
+  });
+
+  test("keeps concurrent run queues and timers independent", () => {
+    const manual = createManualScheduler();
+    const batchesA: ChatStreamTextDelta[][] = [];
+    const batchesB: ChatStreamTextDelta[][] = [];
+    const coalescerA = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batchesA.push(batch)
+    });
+    const coalescerB = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batchesB.push(batch)
+    });
+
+    coalescerA.enqueue(delta("A"));
+    coalescerB.enqueue(delta("B"));
+    expect(manual.pendingCount()).toBe(2);
+
+    manual.runNext();
+    expect(batchesA).toEqual([[delta("A")]]);
+    expect(batchesB).toEqual([]);
+    manual.runNext();
+    expect(batchesB).toEqual([[delta("B")]]);
+  });
+
+  test("flushes synchronously for terminal processing and cancels the timer", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("terminal text"));
+    expect(coalescer.flush()).toBe(true);
+    expect(batches).toEqual([[delta("terminal text")]]);
+    expect(manual.pendingCount()).toBe(0);
+    expect(manual.runNext()).toBe(false);
+  });
+
+  test("can flush the last partial frame before run ownership is cancelled", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    let isCurrent = true;
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => isCurrent,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("visible before stop"));
+    coalescer.flush();
+    isCurrent = false;
+
+    expect(batches).toEqual([[delta("visible before stop")]]);
+    expect(manual.pendingCount()).toBe(0);
+  });
+
+  test("finish flushes synchronously, closes the queue, and rejects later deltas", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("last"));
+    expect(coalescer.finish()).toBe(true);
+    coalescer.enqueue(delta("too late"));
+
+    expect(coalescer.isClosed()).toBe(true);
+    expect(batches).toEqual([[delta("last")]]);
+    expect(manual.pendingCount()).toBe(0);
+  });
+
+  test("a thrown stream can flush its final partial frame before terminal status", () => {
+    const manual = createManualScheduler();
+    const rendered = { text: "", status: "streaming" };
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => {
+        rendered.text += batch.map((item) => item.delta).join("");
+      }
+    });
+
+    coalescer.enqueue(delta("final partial"));
+    coalescer.finish();
+    rendered.status = "error";
+
+    expect(rendered).toEqual({ text: "final partial", status: "error" });
+    expect(manual.pendingCount()).toBe(0);
+  });
+
+  test("drops delayed deltas after the owning run becomes stale", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    let isCurrent = true;
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => isCurrent,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("stale"));
+    isCurrent = false;
+    manual.runNext();
+
+    expect(batches).toEqual([]);
+    expect(coalescer.hasPending()).toBe(false);
+    expect(coalescer.isClosed()).toBe(true);
+  });
+
+  test("discard prevents a cancelled run's queued task from firing", () => {
+    const manual = createManualScheduler();
+    const batches: ChatStreamTextDelta[][] = [];
+    const coalescer = createChatStreamDeltaCoalescer({
+      scheduler: manual.scheduler,
+      isCurrent: () => true,
+      onFlush: (batch) => batches.push(batch)
+    });
+
+    coalescer.enqueue(delta("cancelled"));
+    coalescer.discard();
+
+    expect(manual.pendingCount()).toBe(0);
+    expect(manual.runNext()).toBe(false);
+    expect(batches).toEqual([]);
+  });
+
+  test("a remounted consumer can preflush a run registered by the previous mount", () => {
+    const persistentRuntimeStore = {};
+    let flushCount = 0;
+    const mountACoalescer = {
+      flush: () => {
+        flushCount += 1;
+        return true;
+      }
+    };
+
+    registerChatStreamDeltaCoalescer(persistentRuntimeStore, 17, mountACoalescer);
+    // A new UnifiedChat mount has only the persistent store and run token.
+    expect(flushRegisteredChatStreamDeltas(persistentRuntimeStore, 17)).toBe(true);
+    expect(flushCount).toBe(1);
+    expect(unregisterChatStreamDeltaCoalescer(persistentRuntimeStore, 17, mountACoalescer)).toBe(
+      true
+    );
+    expect(flushRegisteredChatStreamDeltas(persistentRuntimeStore, 17)).toBe(false);
+  });
+
+  test("identity-safe unregister cannot remove a replacement for the same token", () => {
+    const persistentRuntimeStore = {};
+    let replacementFlushes = 0;
+    const obsolete = { flush: () => true };
+    const replacement = {
+      flush: () => {
+        replacementFlushes += 1;
+        return true;
+      }
+    };
+
+    registerChatStreamDeltaCoalescer(persistentRuntimeStore, 23, obsolete);
+    registerChatStreamDeltaCoalescer(persistentRuntimeStore, 23, replacement);
+
+    expect(unregisterChatStreamDeltaCoalescer(persistentRuntimeStore, 23, obsolete)).toBe(false);
+    expect(flushRegisteredChatStreamDeltas(persistentRuntimeStore, 23)).toBe(true);
+    expect(replacementFlushes).toBe(1);
+    expect(unregisterChatStreamDeltaCoalescer(persistentRuntimeStore, 23, replacement)).toBe(true);
+  });
+});

--- a/frontend/src/services/chatStreamDeltaCoalescer.ts
+++ b/frontend/src/services/chatStreamDeltaCoalescer.ts
@@ -1,0 +1,199 @@
+export type ChatStreamTextDelta = {
+  kind: "message" | "reasoning";
+  itemId: string;
+  contentIndex: number;
+  delta: string;
+};
+
+export type ChatStreamDeltaScheduler = {
+  schedule: (task: () => void, delayMs: number) => unknown;
+  cancel: (handle: unknown) => void;
+};
+
+export type ChatStreamTerminalState = "completed" | "cancelled" | "error" | null;
+export type ChatStreamEofDisposition = "completed" | "terminal" | "truncated" | "stale";
+
+type ChatStreamDeltaCoalescerOptions = {
+  delayMs?: number;
+  isCurrent: () => boolean;
+  onFlush: (deltas: ChatStreamTextDelta[]) => void;
+  scheduler?: ChatStreamDeltaScheduler;
+};
+
+type FlushableChatStreamDeltaCoalescer = {
+  flush: () => boolean;
+};
+
+const coalescersByRuntimeOwner = new WeakMap<
+  object,
+  Map<number, FlushableChatStreamDeltaCoalescer>
+>();
+
+const defaultScheduler: ChatStreamDeltaScheduler = {
+  schedule: (task, delayMs) => setTimeout(task, delayMs),
+  cancel: (handle) => clearTimeout(handle as ReturnType<typeof setTimeout>)
+};
+
+const DEFAULT_STREAM_DELTA_FLUSH_DELAY_MS = 40;
+
+/**
+ * OpenAI emits `error` or `response.failed`; OpenSecret's terminal stream-error
+ * event is currently named `response.error`.
+ */
+export function isTerminalChatStreamErrorEvent(eventType: string): boolean {
+  return eventType === "error" || eventType === "response.error" || eventType === "response.failed";
+}
+
+/**
+ * A clean iterator EOF is not proof that the response completed: fetch streams
+ * can close without a terminal SSE event. Intentional cancellation and account
+ * teardown clear run ownership first, so their EOF remains silent.
+ */
+export function classifyChatStreamEof(
+  terminalState: ChatStreamTerminalState,
+  isRunCurrent: boolean
+): ChatStreamEofDisposition {
+  if (terminalState === "completed") return "completed";
+  if (terminalState !== null) return "terminal";
+  return isRunCurrent ? "truncated" : "stale";
+}
+
+/**
+ * Removes only response items created by one failed stream attempt. The local
+ * user message and items from earlier turns or concurrent runs are not owned by
+ * this attempt and therefore remain untouched before a retry.
+ */
+export function removeOwnedChatStreamAttemptItems<TMessage extends Readonly<{ id: string }>>(
+  messages: readonly TMessage[],
+  ownedItemIds: ReadonlySet<string>
+): TMessage[] {
+  if (ownedItemIds.size === 0) return [...messages];
+  return messages.filter((message) => !ownedItemIds.has(message.id));
+}
+
+function deltaTargetKey(delta: ChatStreamTextDelta): string {
+  return `${delta.kind}\u0000${delta.itemId}\u0000${delta.contentIndex}`;
+}
+
+/**
+ * Keeps cancellation lookup scoped to the account-owned runtime store rather
+ * than a particular UnifiedChat mount. The WeakMap cannot retain a disposed
+ * account store, and identity-safe removal cannot unregister a replacement.
+ */
+export function registerChatStreamDeltaCoalescer(
+  runtimeOwner: object,
+  runToken: number,
+  coalescer: FlushableChatStreamDeltaCoalescer
+): void {
+  const registry = coalescersByRuntimeOwner.get(runtimeOwner) ?? new Map();
+  registry.set(runToken, coalescer);
+  coalescersByRuntimeOwner.set(runtimeOwner, registry);
+}
+
+export function flushRegisteredChatStreamDeltas(runtimeOwner: object, runToken: number): boolean {
+  return coalescersByRuntimeOwner.get(runtimeOwner)?.get(runToken)?.flush() ?? false;
+}
+
+export function unregisterChatStreamDeltaCoalescer(
+  runtimeOwner: object,
+  runToken: number,
+  coalescer: FlushableChatStreamDeltaCoalescer
+): boolean {
+  const registry = coalescersByRuntimeOwner.get(runtimeOwner);
+  if (registry?.get(runToken) !== coalescer) return false;
+
+  registry.delete(runToken);
+  if (registry.size === 0) coalescersByRuntimeOwner.delete(runtimeOwner);
+  return true;
+}
+
+/**
+ * Coalesces high-frequency SSE text deltas without sharing state between runs.
+ * A run-token check immediately before every flush prevents a cancelled run's
+ * delayed task from writing into a replacement run for the same conversation.
+ */
+export function createChatStreamDeltaCoalescer({
+  delayMs = DEFAULT_STREAM_DELTA_FLUSH_DELAY_MS,
+  isCurrent,
+  onFlush,
+  scheduler = defaultScheduler
+}: ChatStreamDeltaCoalescerOptions) {
+  let scheduledHandle: unknown | null = null;
+  let pendingOrder: string[] = [];
+  let pendingByTarget = new Map<string, ChatStreamTextDelta>();
+  let closed = false;
+
+  const takePending = (): ChatStreamTextDelta[] => {
+    const deltas = pendingOrder.map((key) => pendingByTarget.get(key)!);
+    pendingOrder = [];
+    pendingByTarget = new Map();
+    return deltas;
+  };
+
+  const flushScheduledBatch = (): boolean => {
+    scheduledHandle = null;
+    if (pendingOrder.length === 0) return false;
+
+    const deltas = takePending();
+    if (!isCurrent()) {
+      closed = true;
+      return false;
+    }
+    onFlush(deltas);
+    return true;
+  };
+
+  const flush = (): boolean => {
+    if (scheduledHandle !== null) {
+      scheduler.cancel(scheduledHandle);
+      scheduledHandle = null;
+    }
+    if (pendingOrder.length === 0) return false;
+
+    const deltas = takePending();
+    if (!isCurrent()) {
+      closed = true;
+      return false;
+    }
+    onFlush(deltas);
+    return true;
+  };
+
+  const discard = (): void => {
+    if (scheduledHandle !== null) {
+      scheduler.cancel(scheduledHandle);
+      scheduledHandle = null;
+    }
+    pendingOrder = [];
+    pendingByTarget = new Map();
+    closed = true;
+  };
+
+  return {
+    enqueue(delta: ChatStreamTextDelta): void {
+      if (closed || !delta.delta) return;
+
+      const key = deltaTargetKey(delta);
+      const pending = pendingByTarget.get(key);
+      if (pending) {
+        pending.delta += delta.delta;
+      } else {
+        pendingOrder.push(key);
+        pendingByTarget.set(key, { ...delta });
+      }
+
+      if (scheduledHandle === null) {
+        scheduledHandle = scheduler.schedule(flushScheduledBatch, delayMs);
+      }
+    },
+    flush,
+    finish(): boolean {
+      const didFlush = flush();
+      closed = true;
+      return didFlush;
+    },
+    discard,
+    hasPending: () => pendingOrder.length > 0,
+    isClosed: () => closed
+  };
+}

--- a/frontend/src/services/deferredDisposalLifecycle.test.ts
+++ b/frontend/src/services/deferredDisposalLifecycle.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+import { createDeferredDisposalLifecycle } from "./deferredDisposalLifecycle";
+
+describe("createDeferredDisposalLifecycle", () => {
+  test("ignores Strict Mode effect cleanup but disposes after the real unmount", () => {
+    const queuedTasks: Array<() => void> = [];
+    let disposeCount = 0;
+    const lifecycle = createDeferredDisposalLifecycle(
+      () => {
+        disposeCount += 1;
+      },
+      (task) => queuedTasks.push(task)
+    );
+
+    const strictModeCleanup = lifecycle.activate();
+    strictModeCleanup();
+    const realUnmountCleanup = lifecycle.activate();
+
+    queuedTasks.shift()?.();
+    expect(disposeCount).toBe(0);
+
+    realUnmountCleanup();
+    queuedTasks.shift()?.();
+    expect(disposeCount).toBe(1);
+  });
+});

--- a/frontend/src/services/deferredDisposalLifecycle.ts
+++ b/frontend/src/services/deferredDisposalLifecycle.ts
@@ -1,0 +1,31 @@
+export type DeferredDisposalScheduler = (task: () => void) => void;
+
+const scheduleAfterEffectReplay: DeferredDisposalScheduler = (task) => {
+  setTimeout(task, 0);
+};
+
+/**
+ * Defers ownership cleanup long enough for React Strict Mode to replay an
+ * effect. A replayed activation invalidates the first cleanup; a real unmount
+ * has no matching activation and therefore disposes the resource once.
+ */
+export function createDeferredDisposalLifecycle(
+  dispose: () => void,
+  schedule: DeferredDisposalScheduler = scheduleAfterEffectReplay
+) {
+  let activation = 0;
+
+  return {
+    activate(): () => void {
+      const ownedActivation = ++activation;
+
+      return () => {
+        schedule(() => {
+          if (activation === ownedActivation) {
+            dispose();
+          }
+        });
+      };
+    }
+  };
+}


### PR DESCRIPTION
## Summary

- add account-scoped, keyed Chat runtimes so each conversation and draft owns its messages, composer, attachments, pagination, errors, and active response
- keep concurrent SSE responses alive offscreen and restore accumulated output when users switch back
- make New Chat, Back/Forward, cancellation, attachment, voice, stream-failure, and send-failure paths safe across concurrent conversations
- make initial chat history account-scoped and hydrate the current sidebar from returned or cached query data, so existing chats appear after both cold login and logout/login without a refresh
- show an Agent-style spinner on every Chat sidebar row with an active response, using coarse run-membership updates so streaming deltas do not rerender the sidebar

## Scope

Frontend-only, in-memory continuity for the active app session. This does not add cross-reload SSE resumption or require OpenSecret or billing changes.

## Validation

- 313 Bun tests passed with 1,067 assertions
- TypeScript, Prettier, production build, and git diff checks passed
- ESLint passed with 0 errors and 13 pre-existing warnings
- paid-Pro local full-stack testing verified simultaneous long responses, offscreen completion, exact cross-chat isolation, per-chat draft restoration, Back/Forward, and selected-chat-only cancellation
- cold first login and logout/login both restored existing sidebar chats without a refresh or creating a chat
- two simultaneous Chat responses showed independent sidebar spinners; switching back revealed accumulated output, and stopping one removed only its spinner