### PR TITLE
build: share Cargo intermediates across Maple workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,32 @@ override the default. (See `.env.example`)
 
 ## Building
 
+### Shared Rust build cache with Nix
+
+Local Maple Nix shells use Cargo's separate build directory support to share
+Rust intermediate artifacts across Maple checkouts. Final artifacts remain in
+the current checkout under `frontend/src-tauri/target`, so existing Tauri,
+debugger, and packaging paths do not change.
+
+The default cache is separated by host system and pinned Rust version:
+
+```text
+$HOME/.cache/opensecret-workspaces/cargo-build/maple/<nix-system>/rust-<version>
+```
+
+An existing `CARGO_BUILD_BUILD_DIR` takes precedence. To temporarily restore
+Cargo's traditional checkout-local layout, set
+`MAPLE_DISABLE_SHARED_CARGO_BUILD_DIR=1` before entering `nix develop`. CI does
+not enable the local shared cache automatically.
+
+Raw `cargo clean` removes both the checkout's target directory and the
+configured shared build directory. To clean only the current checkout without
+invalidating other Maple workspaces, run:
+
+```bash
+nix develop -c just clean-local
+```
+
 ### Desktop Builds
 
 Use the `just` commands for desktop builds:

--- a/docs/ios-tts-local-development.md
+++ b/docs/ios-tts-local-development.md
@@ -107,7 +107,9 @@ This is fixed by adding `CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=NEVER` to the cmake f
 ### Cargo Not Finding Library
 
 1. Ensure `.cargo/config.toml` uses absolute paths
-2. Clean and rebuild: `cd frontend/src-tauri && cargo clean`
+2. Clean checkout-local artifacts with `nix develop -c just clean-local`, then
+   rebuild. Do not use raw `cargo clean` from a local Nix shell because its
+   intermediate build directory may be shared with other Maple workspaces.
 3. Verify the library exists: `ls -la onnxruntime-ios/onnxruntime.xcframework/ios-arm64-simulator/`
 
 ## Architecture Notes

--- a/flake.nix
+++ b/flake.nix
@@ -578,7 +578,15 @@
           ${lib.optionalString pkgs.stdenv.isDarwin "export MAPLE_NIX_LIBICONV=${pkgs.libiconv}"}
           export CARGO_TERM_COLOR=always
           export RUST_BACKTRACE=1
+          if [ -z "''${CI:-}" ] \
+            && [ "''${MAPLE_DISABLE_SHARED_CARGO_BUILD_DIR:-0}" != "1" ] \
+            && [ -z "''${CARGO_BUILD_BUILD_DIR:-}" ]; then
+            export CARGO_BUILD_BUILD_DIR="$HOME/.cache/opensecret-workspaces/cargo-build/maple/${system}/rust-${versions.rust}"
+          fi
           echo "Maple Nix toolchain: bun $(bun --version), $(rustc --version)"
+          if [ -n "''${CARGO_BUILD_BUILD_DIR:-}" ]; then
+            echo "Maple Cargo build cache: $CARGO_BUILD_BUILD_DIR"
+          fi
         '';
 
         pathShellHook = packages: ''

--- a/justfile
+++ b/justfile
@@ -96,6 +96,11 @@ rust-clippy:
 rust-lint:
     cd frontend/src-tauri && cargo fmt --check && cargo clippy -- -D warnings
 
+# Remove only this checkout's final Cargo artifacts. Raw `cargo clean` also
+# removes CARGO_BUILD_BUILD_DIR, which may be shared by multiple workspaces.
+clean-local:
+    cd frontend/src-tauri && CARGO_BUILD_BUILD_DIR=target cargo clean
+
 # Update version across all required files
 update-version version:
     #!/usr/bin/env bash


### PR DESCRIPTION
## Summary

- configure local Nix development shells to share Cargo intermediate artifacts across Maple workspaces, segmented by Nix system and Rust version
- keep final binaries and bundles in each workspace-local `target` directory
- preserve explicit overrides, skip CI, and provide `MAPLE_DISABLE_SHARED_CARGO_BUILD_DIR=1`
- add `just clean-local` and document why raw `cargo clean` can remove the shared cache

## Validation

- `nix flake check --no-build --no-write-lock-file --print-build-logs`
- frontend production build and 244 tests through the commit hook
- complete unsigned Tauri GUI builds in two managed Maple workspaces
- both builds produced an arm64 executable, `.app`, and DMG; both DMGs passed `hdiutil verify`
- verified default, CI, opt-out, and explicit-override environment behavior
- verified both workspaces report the same Cargo `build_directory` and separate `target_directory` values

## Pilot results

- local target directories: 0.86 GiB each, versus an observed 11.24 GiB median for existing populated Maple targets
- shared intermediate cache after both builds: 9.84 GiB
- combined storage for two workspaces: 11.57 GiB, approximately 48.5% less than two median conventional targets
- second-workspace Cargo build: 32.5 seconds versus 184 seconds cold (5.66x faster)

The shared cache is local-development-only. CI and reproducible release builds retain their existing Cargo layout.