### PR TITLE
Skip Tauri builds for web-only pull requests

### DIFF
--- a/.github/workflows/android-pr-build.yml
+++ b/.github/workflows/android-pr-build.yml
@@ -8,7 +8,14 @@ on:
     branches: [ master ]
 
 jobs:
+  changes:
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/tauri-pr-change-detection.yml
+
   build-android:
+    needs: changes
+    if: ${{ always() && !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.tauri != 'false') }}
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -8,7 +8,14 @@ on:
     branches: [master]
 
 jobs:
+  changes:
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/tauri-pr-change-detection.yml
+
   build-macos:
+    needs: changes
+    if: ${{ always() && !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.tauri != 'false') }}
     runs-on: macos-26-xlarge
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
@@ -67,6 +74,8 @@ jobs:
           retention-days: 5
 
   build-linux:
+    needs: changes
+    if: ${{ always() && !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.tauri != 'false') }}
     runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
@@ -124,6 +133,8 @@ jobs:
           retention-days: 5
 
   build-windows:
+    needs: changes
+    if: ${{ always() && !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.tauri != 'false') }}
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4

--- a/.github/workflows/mobile-pr-build.yml
+++ b/.github/workflows/mobile-pr-build.yml
@@ -8,7 +8,14 @@ on:
     branches: [ master ]
 
 jobs:
+  changes:
+    permissions:
+      pull-requests: read
+    uses: ./.github/workflows/tauri-pr-change-detection.yml
+
   build-ios:
+    needs: changes
+    if: ${{ always() && !cancelled() && (needs.changes.result != 'success' || needs.changes.outputs.tauri != 'false') }}
     runs-on: macos-26-xlarge
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4

--- a/.github/workflows/tauri-pr-change-detection.yml
+++ b/.github/workflows/tauri-pr-change-detection.yml
@@ -1,0 +1,79 @@
+name: Detect Tauri PR Changes
+
+on:
+  workflow_call:
+    outputs:
+      tauri:
+        description: Whether the pull request touches Tauri build inputs
+        value: ${{ jobs.detect.outputs.tauri }}
+
+permissions:
+  pull-requests: read
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      tauri: ${{ steps.filter.outputs.tauri }}
+    steps:
+      - name: Detect Tauri build inputs
+        id: filter
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+        with:
+          script: |
+            const webOnlyPrefixes = [
+              ".agents/",
+              "docs/",
+              "frontend/public/",
+              "frontend/src/",
+            ];
+            const webOnlyFiles = new Set([
+              ".gitignore",
+              ".repo_ignore",
+              "LICENSE",
+              "README.md",
+              "frontend/icon.svg",
+              "frontend/index.html",
+            ]);
+            const isWebOnlyPath = (path) =>
+              webOnlyFiles.has(path) ||
+              webOnlyPrefixes.some((prefix) => path.startsWith(prefix));
+
+            // Default to running the native builds if change detection is unavailable
+            // or GitHub returns a truncated file list.
+            let runTauriBuilds = true;
+            try {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.payload.pull_request.number,
+                per_page: 100,
+              });
+              const expectedFileCount = context.payload.pull_request.changed_files;
+              if (files.length !== expectedFileCount) {
+                core.warning(
+                  `Expected ${expectedFileCount} changed files but GitHub returned ${files.length}; running Tauri builds.`,
+                );
+              } else {
+                const tauriInputs = files.filter((file) => {
+                  const paths = [file.filename, file.previous_filename].filter(Boolean);
+                  return paths.some((path) => !isWebOnlyPath(path));
+                });
+                runTauriBuilds = tauriInputs.length > 0;
+
+                if (runTauriBuilds) {
+                  const triggeringPaths = tauriInputs
+                    .slice(0, 20)
+                    .map((file) => file.filename);
+                  core.info(
+                    `Running Tauri builds because these inputs changed: ${JSON.stringify(triggeringPaths)}`,
+                  );
+                } else {
+                  core.info("Skipping Tauri builds because this PR only changes web UI or documentation files.");
+                }
+              }
+            } catch (error) {
+              core.warning(`Could not classify changed files; running Tauri builds. ${error.message}`);
+            }
+
+            core.setOutput("tauri", runTauriBuilds ? "true" : "false");

--- a/flake.nix
+++ b/flake.nix
@@ -682,6 +682,7 @@
               mobile-build.yml \
               release.yml \
               rust-tests.yml \
+              tauri-pr-change-detection.yml \
               web-build.yml \
               zapstore-publish.yml
             touch "$out"


### PR DESCRIPTION
## Summary

- add a shared PR change detector for web UI and documentation-only changes
- skip macOS, Linux, Windows, iOS, and Android Tauri jobs only after an explicit web-only result
- fail open to native builds for unknown paths, incomplete API results, or detector failures
- leave frontend/web checks and all master/release builds unchanged

## Validation

- `nix develop .#ci -c actionlint .github/workflows/android-pr-build.yml .github/workflows/desktop-pr-build.yml .github/workflows/mobile-pr-build.yml .github/workflows/tauri-pr-change-detection.yml`
- `git diff --check`
- independent correctness and security review

Application, Rust, and platform builds/tests were not run because this is a CI-only workflow change.
