### PR TITLE
Preserve unsent New Chat drafts across navigation

### DIFF
--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -51,10 +51,15 @@ import { DeleteConversationProjectDialog } from "@/components/DeleteConversation
 import { MoveChatsDialog } from "@/components/MoveChatsDialog";
 import { listAllConversationProjects, listAllConversations } from "@/utils/paginatedLists";
 import {
-  pushFreshChatHistoryEntry,
+  createChatHistoryEntryForDraft,
+  pushChatHistoryEntryForDraft,
   type NewChatNavigationDetail
 } from "@/services/chatRuntimeNavigation";
 import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
+import {
+  createAndRememberChatDraftKey,
+  resumeOrCreateChatDraftKey
+} from "@/services/chatDraftSelection";
 import { createConversationChatKey } from "@/services/chatRuntimeStore";
 import {
   INITIAL_CHAT_HISTORY_RETRY_COUNT,
@@ -941,7 +946,6 @@ export function ChatHistoryList({
       params.set("project_id", projectId);
 
       window.history.replaceState({}, "", params.toString() ? `/?${params.toString()}` : "/");
-      window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId } }));
       window.dispatchEvent(new Event("projectselected"));
     },
     [router, setSelectedProjectId]
@@ -959,11 +963,12 @@ export function ChatHistoryList({
       params.delete("conversation_id");
       params.delete("project_id");
       const url = params.toString() ? `/?${params.toString()}` : "/";
-      const detail = pushFreshChatHistoryEntry(window.history, url, projectId);
+      const draftRuntimeKey = resumeOrCreateChatDraftKey(runtimeStore, projectId);
+      const detail = pushChatHistoryEntryForDraft(window.history, url, projectId, draftRuntimeKey);
       window.dispatchEvent(new CustomEvent<NewChatNavigationDetail>("newchat", { detail }));
       setTimeout(() => document.getElementById("message")?.focus(), 0);
     },
-    [router, setSelectedProjectId]
+    [router, runtimeStore, setSelectedProjectId]
   );
 
   const handleCreateProject = useCallback(
@@ -1002,8 +1007,18 @@ export function ChatHistoryList({
       const params = new URLSearchParams(window.location.search);
       params.delete("conversation_id");
       params.delete("project_id");
-      window.history.replaceState({}, "", params.toString() ? `/?${params.toString()}` : "/");
-      window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
+      const draftRuntimeKey = createAndRememberChatDraftKey(runtimeStore, null);
+      const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
+      window.history.replaceState(
+        chatEntry.historyState,
+        "",
+        params.toString() ? `/?${params.toString()}` : "/"
+      );
+      window.dispatchEvent(
+        new CustomEvent<NewChatNavigationDetail>("newchat", {
+          detail: { projectId: null, draftRuntimeKey: chatEntry.draftRuntimeKey }
+        })
+      );
       window.dispatchEvent(new Event("projectselected"));
     };
 

--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -155,6 +155,7 @@ export function ChatHistoryList({
   const [selectedProject, setSelectedProject] = useState<ConversationProjectListItem | null>(null);
   const [expandedProjectId, setExpandedProjectId] = useState<string | null>(selectedProjectId);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const preventProjectMenuFocusRestoreRef = useRef(false);
 
   // Pagination states
   const [oldestConversationId, setOldestConversationId] = useState<string | undefined>();
@@ -953,6 +954,7 @@ export function ChatHistoryList({
 
   const handleNewChatInProject = useCallback(
     async (projectId: string) => {
+      preventProjectMenuFocusRestoreRef.current = true;
       setSelectedProjectId(projectId);
 
       if (window.location.pathname !== "/") {
@@ -1469,7 +1471,13 @@ export function ChatHistoryList({
                             <MoreHorizontal className="h-4 w-4" strokeWidth={ICON_STROKE} />
                           </button>
                         </DropdownMenuTrigger>
-                        <DropdownMenuContent>
+                        <DropdownMenuContent
+                          onCloseAutoFocus={(event) => {
+                            if (!preventProjectMenuFocusRestoreRef.current) return;
+                            preventProjectMenuFocusRestoreRef.current = false;
+                            event.preventDefault();
+                          }}
+                        >
                           <DropdownMenuItem onClick={() => void handleNewChatInProject(project.id)}>
                             <SquarePen className="mr-2 h-4 w-4" strokeWidth={ICON_STROKE} />
                             New Chat in Project

--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -57,8 +57,8 @@ import {
 } from "@/services/chatRuntimeNavigation";
 import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
 import {
-  createAndRememberChatDraftKey,
-  resumeOrCreateChatDraftKey
+  resumeOrCreateChatDraftKey,
+  rootChatDraftKeyAfterProjectDeletion
 } from "@/services/chatDraftSelection";
 import { createConversationChatKey } from "@/services/chatRuntimeStore";
 import {
@@ -1009,7 +1009,7 @@ export function ChatHistoryList({
       const params = new URLSearchParams(window.location.search);
       params.delete("conversation_id");
       params.delete("project_id");
-      const draftRuntimeKey = createAndRememberChatDraftKey(runtimeStore, null);
+      const draftRuntimeKey = rootChatDraftKeyAfterProjectDeletion(runtimeStore);
       const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
       window.history.replaceState(
         chatEntry.historyState,

--- a/frontend/src/components/ProjectDetailView.tsx
+++ b/frontend/src/components/ProjectDetailView.tsx
@@ -49,7 +49,15 @@ import { listAllConversationProjects } from "@/utils/paginatedLists";
 import { SIDEBAR_GRID_COLUMNS_CLASS, SIDEBAR_LAYOUT_STYLE } from "@/constants/layout";
 import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
 import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
+import {
+  createAndRememberChatDraftKey,
+  resumeOrCreateChatDraftKey
+} from "@/services/chatDraftSelection";
 import { createConversationChatKey } from "@/services/chatRuntimeStore";
+import {
+  createChatHistoryEntryForDraft,
+  type NewChatNavigationDetail
+} from "@/services/chatRuntimeNavigation";
 
 const PROJECT_PAGE_SIZE = 20;
 const MAX_SELECTION = 20;
@@ -328,10 +336,20 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
     const params = new URLSearchParams(window.location.search);
     params.delete("project_id");
     params.delete("conversation_id");
-    window.history.replaceState(null, "", params.toString() ? `/?${params.toString()}` : "/");
-    window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId } }));
+    const draftRuntimeKey = resumeOrCreateChatDraftKey(runtimeStore, projectId);
+    const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
+    window.history.replaceState(
+      chatEntry.historyState,
+      "",
+      params.toString() ? `/?${params.toString()}` : "/"
+    );
+    window.dispatchEvent(
+      new CustomEvent<NewChatNavigationDetail>("newchat", {
+        detail: { projectId, draftRuntimeKey: chatEntry.draftRuntimeKey }
+      })
+    );
     setTimeout(() => document.getElementById("message")?.focus(), 0);
-  }, [projectId, setSelectedProjectId]);
+  }, [projectId, runtimeStore, setSelectedProjectId]);
 
   const handleSelectConversation = useCallback(
     (conversation: Conversation) => {
@@ -371,8 +389,14 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
     runtimeStore.deleteActivityGroup(projectId);
     await invalidateConversationData();
     setSelectedProjectId(null);
-    window.history.replaceState({}, "", "/");
-    window.dispatchEvent(new CustomEvent("newchat", { detail: { projectId: null } }));
+    const draftRuntimeKey = createAndRememberChatDraftKey(runtimeStore, null);
+    const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
+    window.history.replaceState(chatEntry.historyState, "", "/");
+    window.dispatchEvent(
+      new CustomEvent<NewChatNavigationDetail>("newchat", {
+        detail: { projectId: null, draftRuntimeKey: chatEntry.draftRuntimeKey }
+      })
+    );
     window.dispatchEvent(new Event("projectselected"));
   }, [invalidateConversationData, os, projectId, runtimeStore, setSelectedProjectId]);
 

--- a/frontend/src/components/ProjectDetailView.tsx
+++ b/frontend/src/components/ProjectDetailView.tsx
@@ -50,8 +50,8 @@ import { SIDEBAR_GRID_COLUMNS_CLASS, SIDEBAR_LAYOUT_STYLE } from "@/constants/la
 import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
 import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
 import {
-  createAndRememberChatDraftKey,
-  resumeOrCreateChatDraftKey
+  resumeOrCreateChatDraftKey,
+  rootChatDraftKeyAfterProjectDeletion
 } from "@/services/chatDraftSelection";
 import { createConversationChatKey } from "@/services/chatRuntimeStore";
 import {
@@ -389,7 +389,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
     runtimeStore.deleteActivityGroup(projectId);
     await invalidateConversationData();
     setSelectedProjectId(null);
-    const draftRuntimeKey = createAndRememberChatDraftKey(runtimeStore, null);
+    const draftRuntimeKey = rootChatDraftKeyAfterProjectDeletion(runtimeStore);
     const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
     window.history.replaceState(chatEntry.historyState, "", "/");
     window.dispatchEvent(

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -39,8 +39,10 @@ import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { hasApiAccess } from "@/billing/billingAccess";
 import { WorkspaceModeSwitch, type WorkspaceMode } from "@/components/WorkspaceModeSwitch";
 import { usePersistentHomeNavigation } from "@/contexts/PersistentHomeNavigationContext";
+import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
+import { resumeOrCreateChatDraftKey } from "@/services/chatDraftSelection";
 import {
-  createFreshChatHistoryEntry,
+  createChatHistoryEntryForDraft,
   type NewChatNavigationDetail
 } from "@/services/chatRuntimeNavigation";
 
@@ -63,6 +65,7 @@ export function Sidebar({
   const location = useLocation();
   const { returnToHome } = usePersistentHomeNavigation();
   const os = useOpenSecret();
+  const runtimeStore = useChatRuntimeStore<unknown, unknown>();
   const userId = os.auth.user?.user.id;
   const {
     searchQuery,
@@ -116,11 +119,12 @@ export function Sidebar({
     });
 
     if (location.pathname === "/") {
-      const freshChat = createFreshChatHistoryEntry();
-      window.history.pushState(freshChat.historyState, "", "/");
+      const draftRuntimeKey = resumeOrCreateChatDraftKey(runtimeStore, null);
+      const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
+      window.history.pushState(chatEntry.historyState, "", "/");
       window.dispatchEvent(
         new CustomEvent<NewChatNavigationDetail>("newchat", {
-          detail: { projectId: null, draftRuntimeKey: freshChat.draftRuntimeKey }
+          detail: { projectId: null, draftRuntimeKey: chatEntry.draftRuntimeKey }
         })
       );
       setTimeout(() => document.getElementById("message")?.focus(), 0);

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -129,6 +129,12 @@ import {
   type ChatComposerState
 } from "@/contexts/ChatRuntimeContext";
 import {
+  draftScopeForRuntimeSelection,
+  moveRememberedChatDraftToScope,
+  rememberChatDraftInScope,
+  resumeOrCreateChatDraftKey
+} from "@/services/chatDraftSelection";
+import {
   createChatDraftKey,
   createConversationChatKey,
   type ChatRuntimeKey,
@@ -137,7 +143,7 @@ import {
 import {
   canonicalConversationHistoryHref,
   conversationIdFromChatRuntimeKey,
-  createFreshChatHistoryEntry,
+  createChatHistoryEntryForDraft,
   draftRuntimeKeyFromHistoryState,
   historyStateWithDraftRuntimeKey,
   isDraftChatRuntimeKey,
@@ -1676,8 +1682,11 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const [initialRuntimeSelection] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     const urlConversationId = params.get("conversation_id") || undefined;
+    const initialDraftProjectId = selectedProjectId ?? null;
     const runtimeKey = runtimeKeyForChatLocation(urlConversationId, window.history.state, () =>
-      createChatDraftKey(`unified-chat-${runtimeInstanceId}`)
+      resumeOrCreateChatDraftKey(runtimeStore, initialDraftProjectId, () =>
+        createChatDraftKey(`unified-chat-${runtimeInstanceId}`)
+      )
     );
     return {
       runtimeKey,
@@ -1724,6 +1733,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   }, [isVisible, renderedRuntimeKey, runtimeStore, visibleChatOwner]);
 
   useLayoutEffect(() => {
+    if (!isVisible) return;
     const canonicalKey = runtimeStore.resolveKey(renderedRuntimeKey);
     const canonicalConversationId = conversationIdFromChatRuntimeKey(canonicalKey);
     if (canonicalConversationId) {
@@ -1731,6 +1741,9 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       return;
     }
     if (!isDraftChatRuntimeKey(canonicalKey)) return;
+    const draftProjectId = activeRuntime.composer.draftProjectId;
+    rememberChatDraftInScope(runtimeStore, canonicalKey, draftProjectId);
+    if (selectedProjectId !== draftProjectId) setSelectedProjectId(draftProjectId);
     if (draftRuntimeKeyFromHistoryState(window.history.state) === canonicalKey) return;
 
     window.history.replaceState(
@@ -1738,7 +1751,14 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       "",
       window.location.href
     );
-  }, [renderedRuntimeKey, runtimeStore]);
+  }, [
+    activeRuntime.composer.draftProjectId,
+    isVisible,
+    renderedRuntimeKey,
+    runtimeStore,
+    selectedProjectId,
+    setSelectedProjectId
+  ]);
 
   const isRuntimeSelected = useCallback(
     (key: ChatRuntimeKey) => runtimeStore.isChatVisible(key),
@@ -1771,13 +1791,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       return true;
     },
     [runtimeStore]
-  );
-
-  const updateActiveComposer = useCallback(
-    (updater: (composer: ChatComposerState) => ChatComposerState) => {
-      updateComposerForKey(activeRuntimeKeyRef.current, updater);
-    },
-    [updateComposerForKey]
   );
 
   // The active view is only a projection. Background conversations keep their
@@ -1856,12 +1869,19 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     [setInputForKey]
   );
   const setDraftProjectId = useCallback(
-    (update: StateUpdate<string | null>) =>
-      updateActiveComposer((composer) => ({
+    (update: StateUpdate<string | null>) => {
+      const key = activeRuntimeKeyRef.current;
+      const snapshot = runtimeStore.get(key);
+      if (!snapshot) return;
+      const nextDraftProjectId = resolveStateUpdate(snapshot.composer.draftProjectId, update);
+      if (moveRememberedChatDraftToScope(runtimeStore, key, nextDraftProjectId)) return;
+
+      updateComposerForKey(key, (composer) => ({
         ...composer,
-        draftProjectId: resolveStateUpdate(composer.draftProjectId, update)
-      })),
-    [updateActiveComposer]
+        draftProjectId: nextDraftProjectId
+      }));
+    },
+    [runtimeStore, updateComposerForKey]
   );
   const [upgradeDialogOpen, setUpgradeDialogOpen] = useState(false);
   const [upgradeFeature, setUpgradeFeature] = useState<
@@ -2479,13 +2499,16 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const selectFreshDraftRuntime = useCallback(
     (projectId: string | null, requestedDraftKey?: DraftChatRuntimeKey) => {
       const key = requestedDraftKey ?? createChatDraftKey();
+      const draftProjectId = draftScopeForRuntimeSelection(runtimeStore, key, projectId);
       stopRecordingForNavigation(key);
       runtimeStore.select(key, {
-        composer: createChatComposerState(projectId)
+        composer: createChatComposerState(draftProjectId)
       });
+      rememberChatDraftInScope(runtimeStore, key, draftProjectId);
       activeRuntimeKeyRef.current = key;
       setActiveRuntimeKey(key);
       setChatId(undefined);
+      setSelectedProjectId(draftProjectId);
       window.history.replaceState(
         historyStateWithDraftRuntimeKey(window.history.state, key),
         "",
@@ -2493,7 +2516,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       );
       return key;
     },
-    [runtimeStore, stopRecordingForNavigation]
+    [runtimeStore, setSelectedProjectId, stopRecordingForNavigation]
   );
 
   // Unified event handling for conversation changes. Selection never clears or
@@ -3373,17 +3396,33 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     const newUrl = usp.toString()
       ? `${window.location.pathname}?${usp.toString()}`
       : window.location.pathname;
-    const freshChat = createFreshChatHistoryEntry();
-    window.history.pushState(freshChat.historyState, "", newUrl);
+    const draftRuntimeKey = resumeOrCreateChatDraftKey(runtimeStore, null);
+    const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
+    window.history.pushState(chatEntry.historyState, "", newUrl);
     window.dispatchEvent(
       new CustomEvent<NewChatNavigationDetail>("newchat", {
-        detail: { projectId: null, draftRuntimeKey: freshChat.draftRuntimeKey }
+        detail: { projectId: null, draftRuntimeKey: chatEntry.draftRuntimeKey }
       })
     );
     if (isSidebarOpen) {
       toggleSidebar();
     }
-  }, [isSidebarOpen, setSelectedProjectId, toggleSidebar]);
+  }, [isSidebarOpen, runtimeStore, setSelectedProjectId, toggleSidebar]);
+
+  const handleNewChatFromUpgrade = useCallback(() => {
+    const projectId = selectedProjectId ?? null;
+    const draftRuntimeKey = resumeOrCreateChatDraftKey(runtimeStore, projectId);
+    const chatEntry = createChatHistoryEntryForDraft(draftRuntimeKey);
+    const params = new URLSearchParams(window.location.search);
+    params.delete("conversation_id");
+    const url = params.toString() ? `/?${params.toString()}` : "/";
+    window.history.replaceState(chatEntry.historyState, "", url);
+    window.dispatchEvent(
+      new CustomEvent<NewChatNavigationDetail>("newchat", {
+        detail: { projectId, draftRuntimeKey: chatEntry.draftRuntimeKey }
+      })
+    );
+  }, [runtimeStore, selectedProjectId]);
 
   // Check user's billing access
   const billingStatus = localState.billingStatus;
@@ -5510,6 +5549,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         <UpgradePromptDialog
           open={upgradeDialogOpen}
           onOpenChange={setUpgradeDialogOpen}
+          onStartNewChat={handleNewChatFromUpgrade}
           feature={
             upgradeFeature === "document"
               ? "document"

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -2119,11 +2119,23 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     // Focus when not generating and textbox is not disabled
     if (!isGenerating && textareaRef.current && !textareaRef.current.disabled) {
       // Small delay to ensure DOM is ready
-      setTimeout(() => {
-        textareaRef.current?.focus();
+      const focusTimeout = setTimeout(() => {
+        const textarea = textareaRef.current;
+        if (!textarea) return;
+
+        textarea.focus();
+        if (
+          isDraftChatRuntimeKey(runtimeStore.resolveKey(renderedRuntimeKey)) &&
+          textarea.value.length > 0
+        ) {
+          const end = textarea.value.length;
+          textarea.setSelectionRange(end, end);
+        }
       }, 100);
+
+      return () => clearTimeout(focusTimeout);
     }
-  }, [isCompactLayout, isGenerating, messages.length, chatId]);
+  }, [isCompactLayout, isGenerating, messages.length, chatId, renderedRuntimeKey, runtimeStore]);
 
   // Improved scroll detection - track if user is near bottom
   const handleScroll = useCallback(() => {

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -1967,6 +1967,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   // Refs
   const textareaRef = useRef<HTMLTextAreaElement>(null);
+  const placeComposerCaretAtEndRef = useRef(true);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const historyTopSentinelRef = useRef<HTMLDivElement>(null);
@@ -2112,6 +2113,10 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   // Auto-focus textbox on desktop (not mobile/landscape-mobile to avoid keyboard popup interrupting reading)
   // Focus when: app launches, new chat, conversation loads, or assistant finishes streaming
+  useLayoutEffect(() => {
+    placeComposerCaretAtEndRef.current = true;
+  }, [renderedRuntimeKey]);
+
   useEffect(() => {
     // Skip on compact layouts (mobile + landscape mobile) to avoid keyboard popup
     if (isCompactLayout) return;
@@ -2124,10 +2129,9 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         if (!textarea) return;
 
         textarea.focus();
-        if (
-          isDraftChatRuntimeKey(runtimeStore.resolveKey(renderedRuntimeKey)) &&
-          textarea.value.length > 0
-        ) {
+        const shouldPlaceCaretAtEnd = placeComposerCaretAtEndRef.current;
+        placeComposerCaretAtEndRef.current = false;
+        if (shouldPlaceCaretAtEnd && textarea.value.length > 0) {
           const end = textarea.value.length;
           textarea.setSelectionRange(end, end);
         }
@@ -2135,7 +2139,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
       return () => clearTimeout(focusTimeout);
     }
-  }, [isCompactLayout, isGenerating, messages.length, chatId, renderedRuntimeKey, runtimeStore]);
+  }, [isCompactLayout, isGenerating, messages.length, chatId, renderedRuntimeKey]);
 
   // Improved scroll detection - track if user is near bottom
   const handleScroll = useCallback(() => {

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -28,13 +28,15 @@ interface UpgradePromptDialogProps {
   onOpenChange: (open: boolean) => void;
   feature: "image" | "voice" | "model" | "document" | "usage" | "tokens" | "agent";
   modelName?: string;
+  onStartNewChat?: () => void;
 }
 
 export function UpgradePromptDialog({
   open,
   onOpenChange,
   feature,
-  modelName
+  modelName,
+  onStartNewChat
 }: UpgradePromptDialogProps) {
   const navigate = useNavigate();
   const localState = useLocalState();
@@ -51,6 +53,10 @@ export function UpgradePromptDialog({
 
   const handleNewChat = () => {
     onOpenChange(false);
+    if (onStartNewChat) {
+      onStartNewChat();
+      return;
+    }
     // Trigger new chat event
     window.dispatchEvent(new Event("newchat"));
     // Clear the URL

--- a/frontend/src/contexts/ChatRuntimeContext.test.ts
+++ b/frontend/src/contexts/ChatRuntimeContext.test.ts
@@ -4,7 +4,8 @@ import {
   draftScopeForRuntimeSelection,
   moveRememberedChatDraftToScope,
   rememberChatDraftInScope,
-  resumeOrCreateChatDraftKey
+  resumeOrCreateChatDraftKey,
+  rootChatDraftKeyAfterProjectDeletion
 } from "../services/chatDraftSelection";
 import { createChatDraftKey, createConversationChatKey } from "../services/chatRuntimeStore";
 
@@ -296,6 +297,29 @@ describe("ChatRuntimeContext eviction policy", () => {
     );
     expect(resumeOrCreateChatDraftKey(store, null)).toBe(rootKey);
     expect(resumeOrCreateChatDraftKey(store, "project-b")).toBe(otherProjectKey);
+  });
+
+  test("landing after project deletion restores an unrelated retained root draft", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const rootKey = createChatDraftKey("root-before-project-deletion");
+    const projectKey = createChatDraftKey("deleted-project-draft");
+    const unexpectedReplacementKey = createChatDraftKey("unexpected-root-replacement");
+    const rootComposer = createChatComposerState();
+    rootComposer.input = "keep this root draft";
+
+    store.ensure(rootKey, { composer: rootComposer });
+    store.rememberDraftKey(null, rootKey);
+    store.ensure(projectKey, { composer: createChatComposerState("project-a") });
+    store.rememberDraftKey("project-a", projectKey);
+    store.updateActivityGroup(projectKey, "project-a");
+
+    expect(store.deleteActivityGroup("project-a")).toEqual([projectKey]);
+    expect(rootChatDraftKeyAfterProjectDeletion(store, () => unexpectedReplacementKey)).toBe(
+      rootKey
+    );
+    expect(store.getRememberedDraftKey(null)).toBe(rootKey);
+    expect(store.get(rootKey)?.composer.input).toBe("keep this root draft");
+    expect(store.get(unexpectedReplacementKey)).toBeUndefined();
   });
 
   test("remembered drafts and resources stay isolated across separate store instances", () => {

--- a/frontend/src/contexts/ChatRuntimeContext.test.ts
+++ b/frontend/src/contexts/ChatRuntimeContext.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, spyOn, test } from "bun:test";
 import { createChatComposerState, createChatRuntimeStore } from "./ChatRuntimeContext";
+import {
+  draftScopeForRuntimeSelection,
+  moveRememberedChatDraftToScope,
+  rememberChatDraftInScope,
+  resumeOrCreateChatDraftKey
+} from "../services/chatDraftSelection";
 import { createChatDraftKey, createConversationChatKey } from "../services/chatRuntimeStore";
 
 type Conversation = { id: string };
@@ -28,6 +34,301 @@ describe("ChatRuntimeContext eviction policy", () => {
     store.select(draftKey);
     expect(store.getActiveKey()).toBe(draftKey);
     expect(store.getActive()?.composer.input).toBe("keep this unfinished message");
+  });
+
+  test("resumes the remembered offscreen New Chat draft with its exact composer resources", () => {
+    const revokeObjectURL = spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const draftKey = createChatDraftKey("remembered-global");
+    const conversationKey = createConversationChatKey("visited-conversation");
+    const image = new File(["image"], "draft.png", { type: "image/png" });
+    const composer = createChatComposerState();
+    composer.input = "unfinished thought";
+    composer.draftImages = [image];
+    composer.imageUrls.set(image, "blob:remembered-global");
+    composer.documentText = "draft document";
+    composer.documentName = "draft.md";
+
+    store.select(draftKey, { composer });
+    store.rememberDraftKey(null, draftKey);
+    store.claimVisibleChat({}, draftKey);
+    store.select(conversationKey, { conversation: { id: "visited-conversation" } });
+    store.claimVisibleChat({}, conversationKey);
+
+    try {
+      const resumedKey = resumeOrCreateChatDraftKey(store, null, () => {
+        throw new Error("should not create a replacement draft");
+      });
+
+      store.select(resumedKey, { composer: createChatComposerState() });
+      store.claimVisibleChat({}, resumedKey);
+
+      expect(resumedKey).toBe(draftKey);
+      expect(store.get(resumedKey)?.composer).toBe(composer);
+      expect(store.get(resumedKey)?.composer.draftImages[0]).toBe(image);
+      expect(store.get(resumedKey)?.composer.imageUrls.get(image)).toBe("blob:remembered-global");
+      expect(store.get(resumedKey)?.composer.documentText).toBe("draft document");
+
+      const replacementKey = createChatDraftKey("replacement-global");
+      expect(resumeOrCreateChatDraftKey(store, null, () => replacementKey)).toBe(replacementKey);
+      expect(store.get(draftKey)?.composer).toBe(composer);
+      expect(revokeObjectURL).not.toHaveBeenCalled();
+    } finally {
+      store.dispose();
+      revokeObjectURL.mockRestore();
+    }
+  });
+
+  test("keeps remembered New Chat drafts isolated by project scope", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const globalKey = createChatDraftKey("global");
+    const projectAKey = createChatDraftKey("project-a");
+    const projectBKey = createChatDraftKey("project-b");
+
+    const globalComposer = createChatComposerState();
+    globalComposer.input = "global draft";
+    const projectAComposer = createChatComposerState("project-a");
+    projectAComposer.input = "project A draft";
+    const projectBComposer = createChatComposerState("project-b");
+    projectBComposer.input = "project B draft";
+
+    store.ensure(globalKey, { composer: globalComposer });
+    store.ensure(projectAKey, { composer: projectAComposer });
+    store.ensure(projectBKey, { composer: projectBComposer });
+    store.rememberDraftKey(null, globalKey);
+    store.rememberDraftKey("project-a", projectAKey);
+    store.rememberDraftKey("project-b", projectBKey);
+
+    expect(resumeOrCreateChatDraftKey(store, null)).toBe(globalKey);
+    expect(resumeOrCreateChatDraftKey(store, "project-a")).toBe(projectAKey);
+    expect(resumeOrCreateChatDraftKey(store, "project-b")).toBe(projectBKey);
+  });
+
+  test("preserves an existing root scope instead of falling back to the current project", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const rootKey = createChatDraftKey("existing-root-scope");
+    const missingKey = createChatDraftKey("missing-scope");
+    const composer = createChatComposerState(null);
+    composer.input = "root draft";
+    store.ensure(rootKey, { composer });
+
+    expect(draftScopeForRuntimeSelection(store, rootKey, "project-a")).toBeNull();
+    expect(draftScopeForRuntimeSelection(store, missingKey, "project-a")).toBe("project-a");
+  });
+
+  test("mount registration gives a restored project draft deletion ownership", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const projectKey = createChatDraftKey("mounted-project-draft");
+    const composer = createChatComposerState("project-a");
+    composer.input = "mounted project draft";
+    store.ensure(projectKey, { composer });
+
+    expect(rememberChatDraftInScope(store, projectKey, "project-a")).toBe(true);
+    expect(store.getRememberedDraftKey("project-a")).toBe(projectKey);
+    expect(store.deleteActivityGroup("project-a")).toEqual([projectKey]);
+    expect(store.get(projectKey)).toBeUndefined();
+  });
+
+  test("creates a fresh draft instead of reusing the currently visible or running draft", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const visibleKey = createChatDraftKey("visible");
+    const nextKey = createChatDraftKey("next");
+    const runningKey = createChatDraftKey("running");
+    const afterRunningKey = createChatDraftKey("after-running");
+    const visibleComposer = createChatComposerState();
+    visibleComposer.input = "keep the old visible draft";
+
+    store.select(visibleKey, { composer: visibleComposer });
+    store.rememberDraftKey(null, visibleKey);
+    store.claimVisibleChat({}, visibleKey);
+
+    expect(resumeOrCreateChatDraftKey(store, null, () => nextKey)).toBe(nextKey);
+    expect(store.getRememberedDraftKey(null)).toBe(nextKey);
+    expect(store.get(nextKey)?.composer.draftProjectId).toBeNull();
+
+    store.select(runningKey);
+    store.rememberDraftKey(null, runningKey);
+    store.beginRun(runningKey);
+
+    expect(resumeOrCreateChatDraftKey(store, null, () => afterRunningKey)).toBe(afterRunningKey);
+    expect(store.getRememberedDraftKey(null)).toBe(afterRunningKey);
+    expect(store.get(afterRunningKey)).toBeDefined();
+  });
+
+  test("a late production-style draft adoption cannot clear its materialized replacement", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const sourceKey = createChatDraftKey("source");
+    const replacementKey = createChatDraftKey("replacement");
+    const conversationKey = createConversationChatKey("created-conversation");
+    const image = new File(["replacement"], "replacement.png", { type: "image/png" });
+    const replacementComposer = createChatComposerState();
+    replacementComposer.input = "a second prompt";
+    replacementComposer.draftImages = [image];
+    replacementComposer.imageUrls.set(image, "blob:replacement");
+    replacementComposer.documentText = "replacement document";
+
+    store.select(sourceKey);
+    store.rememberDraftKey(null, sourceKey);
+    store.claimVisibleChat({}, sourceKey);
+    const run = store.beginRun(sourceKey);
+    expect(resumeOrCreateChatDraftKey(store, null, () => replacementKey)).toBe(replacementKey);
+    store.select(replacementKey);
+    store.update(replacementKey, (snapshot) => ({ ...snapshot, composer: replacementComposer }));
+    store.claimVisibleChat({}, replacementKey);
+    store.ensure(conversationKey, {
+      conversation: { id: "created-conversation" },
+      historyLoaded: true
+    });
+
+    expect(
+      store.rekeyRunAdoptingIdleDestination(
+        sourceKey,
+        conversationKey,
+        run.token,
+        (source, destination) => ({
+          ...source,
+          conversation: destination.conversation,
+          historyLoaded: destination.historyLoaded
+        })
+      )
+    ).toMatchObject({ status: "migrated", key: conversationKey });
+    expect(store.getRememberedDraftKey(null)).toBe(replacementKey);
+    store.select(conversationKey);
+    store.claimVisibleChat({}, conversationKey);
+    expect(resumeOrCreateChatDraftKey(store, null)).toBe(replacementKey);
+    expect(store.get(replacementKey)?.composer).toBe(replacementComposer);
+    expect(store.get(replacementKey)?.composer.draftImages[0]).toBe(image);
+    expect(store.isRunCurrent(conversationKey, run.token)).toBe(true);
+    expect(run.signal.aborted).toBe(false);
+  });
+
+  test("a normal draft rekey clears only its own remembered scope", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const sourceKey = createChatDraftKey("normally-rekeyed-source");
+    const otherProjectKey = createChatDraftKey("unrelated-project-draft");
+    const conversationKey = createConversationChatKey("normally-created-conversation");
+    const otherComposer = createChatComposerState("project-b");
+    otherComposer.input = "unrelated project draft";
+
+    store.select(sourceKey);
+    store.rememberDraftKey(null, sourceKey);
+    store.ensure(otherProjectKey, { composer: otherComposer });
+    store.rememberDraftKey("project-b", otherProjectKey);
+    const run = store.beginRun(sourceKey);
+
+    expect(store.rekey(sourceKey, conversationKey, run.token)).toBe(conversationKey);
+    expect(store.getRememberedDraftKey(null)).toBeNull();
+    expect(store.getRememberedDraftKey("project-b")).toBe(otherProjectKey);
+  });
+
+  test("moving a remembered draft updates deletion ownership without losing resources", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const draftKey = createChatDraftKey("moved-project-draft");
+    const image = new File(["moved"], "moved.png", { type: "image/png" });
+    const composer = createChatComposerState("project-a");
+    composer.input = "keep this while moving projects";
+    composer.draftImages = [image];
+    composer.imageUrls.set(image, "blob:moved-project-draft");
+
+    store.select(draftKey, { composer });
+    store.rememberDraftKey("project-a", draftKey);
+    store.updateActivityGroup(draftKey, "project-a");
+
+    expect(moveRememberedChatDraftToScope(store, draftKey, "project-b")).toBe(true);
+    expect(store.getRememberedDraftKey("project-a")).toBeNull();
+    expect(store.getRememberedDraftKey("project-b")).toBe(draftKey);
+    expect(store.getActivityGroupId(draftKey)).toBe("project-b");
+    expect(store.deleteActivityGroup("project-a")).toEqual([]);
+    expect(resumeOrCreateChatDraftKey(store, "project-b")).toBe(draftKey);
+    expect(store.get(draftKey)?.composer.input).toBe("keep this while moving projects");
+    expect(store.get(draftKey)?.composer.draftImages[0]).toBe(image);
+    expect(store.get(draftKey)?.composer.imageUrls).toBe(composer.imageUrls);
+    expect(store.get(draftKey)?.composer.imageUrls.get(image)).toBe("blob:moved-project-draft");
+
+    expect(moveRememberedChatDraftToScope(store, draftKey, null)).toBe(true);
+    expect(store.getRememberedDraftKey("project-b")).toBeNull();
+    expect(store.getRememberedDraftKey(null)).toBe(draftKey);
+    expect(store.deleteActivityGroup("project-b")).toEqual([]);
+    expect(resumeOrCreateChatDraftKey(store, null)).toBe(draftKey);
+  });
+
+  test("deletion clears the remembered draft for that runtime or project", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const globalKey = createChatDraftKey("deleted-global");
+    const projectKey = createChatDraftKey("deleted-project");
+    const nextGlobalKey = createChatDraftKey("next-global");
+    const nextProjectKey = createChatDraftKey("next-project");
+
+    store.ensure(globalKey);
+    store.rememberDraftKey(null, globalKey);
+    expect(store.delete(globalKey)).toBe(true);
+    expect(resumeOrCreateChatDraftKey(store, null, () => nextGlobalKey)).toBe(nextGlobalKey);
+
+    store.ensure(projectKey, { composer: createChatComposerState("project-a") });
+    store.updateActivityGroup(projectKey, "project-a");
+    store.rememberDraftKey("project-a", projectKey);
+    expect(store.deleteActivityGroup("project-a")).toEqual([projectKey]);
+    expect(resumeOrCreateChatDraftKey(store, "project-a", () => nextProjectKey)).toBe(
+      nextProjectKey
+    );
+  });
+
+  test("project deletion clears an unmaterialized slot without touching other scopes", () => {
+    const store = createChatRuntimeStore<Conversation, Message>();
+    const deletedProjectKey = createChatDraftKey("unmaterialized-deleted-project");
+    const rootKey = createChatDraftKey("kept-root");
+    const otherProjectKey = createChatDraftKey("kept-other-project");
+    const replacementKey = createChatDraftKey("replacement-deleted-project");
+    const rootComposer = createChatComposerState();
+    rootComposer.input = "root draft";
+    const otherComposer = createChatComposerState("project-b");
+    otherComposer.input = "other project draft";
+
+    store.rememberDraftKey("project-a", deletedProjectKey);
+    store.ensure(rootKey, { composer: rootComposer });
+    store.rememberDraftKey(null, rootKey);
+    store.ensure(otherProjectKey, { composer: otherComposer });
+    store.rememberDraftKey("project-b", otherProjectKey);
+
+    expect(store.deleteActivityGroup("project-a")).toEqual([]);
+    expect(resumeOrCreateChatDraftKey(store, "project-a", () => replacementKey)).toBe(
+      replacementKey
+    );
+    expect(resumeOrCreateChatDraftKey(store, null)).toBe(rootKey);
+    expect(resumeOrCreateChatDraftKey(store, "project-b")).toBe(otherProjectKey);
+  });
+
+  test("remembered drafts and resources stay isolated across separate store instances", () => {
+    const revokeObjectURL = spyOn(URL, "revokeObjectURL").mockImplementation(() => {});
+    const firstAccountStore = createChatRuntimeStore<Conversation, Message>();
+    const secondAccountStore = createChatRuntimeStore<Conversation, Message>();
+    const firstAccountKey = createChatDraftKey("first-account");
+    const secondAccountKey = createChatDraftKey("second-account");
+    const image = new File(["private"], "private.png", { type: "image/png" });
+    const composer = createChatComposerState();
+    composer.input = "first account draft";
+    composer.draftImages = [image];
+    composer.imageUrls.set(image, "blob:first-account");
+
+    try {
+      firstAccountStore.select(firstAccountKey, { composer });
+      firstAccountStore.rememberDraftKey(null, firstAccountKey);
+      const run = firstAccountStore.beginRun(firstAccountKey);
+
+      expect(resumeOrCreateChatDraftKey(secondAccountStore, null, () => secondAccountKey)).toBe(
+        secondAccountKey
+      );
+
+      firstAccountStore.dispose();
+
+      expect(run.signal.aborted).toBe(true);
+      expect(revokeObjectURL).toHaveBeenCalledWith("blob:first-account");
+      expect(secondAccountStore.getRememberedDraftKey(null)).toBe(secondAccountKey);
+    } finally {
+      firstAccountStore.dispose();
+      secondAccountStore.dispose();
+      revokeObjectURL.mockRestore();
+    }
   });
 
   test("evicts a completed rekeyed conversation even if draft project metadata is stale", () => {

--- a/frontend/src/services/chatDraftSelection.ts
+++ b/frontend/src/services/chatDraftSelection.ts
@@ -43,6 +43,13 @@ export function resumeOrCreateChatDraftKey<TConversation, TMessage>(
   return createAndRememberChatDraftKey(store, draftProjectId, createDraftKey);
 }
 
+export function rootChatDraftKeyAfterProjectDeletion<TConversation, TMessage>(
+  store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
+  createDraftKey: () => DraftChatRuntimeKey = createChatDraftKey
+): DraftChatRuntimeKey {
+  return resumeOrCreateChatDraftKey(store, null, createDraftKey);
+}
+
 export function draftScopeForRuntimeSelection<TConversation, TMessage>(
   store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
   key: ChatRuntimeKey,

--- a/frontend/src/services/chatDraftSelection.ts
+++ b/frontend/src/services/chatDraftSelection.ts
@@ -1,0 +1,103 @@
+import {
+  composerHasRetainedDraft,
+  createChatComposerState,
+  type ChatComposerState
+} from "@/contexts/ChatRuntimeContext";
+import {
+  ChatRuntimeStore,
+  createChatDraftKey,
+  type ChatRuntimeKey,
+  type DraftChatRuntimeKey
+} from "@/services/chatRuntimeStore";
+import { isDraftChatRuntimeKey } from "@/services/chatRuntimeNavigation";
+
+export function resumeOrCreateChatDraftKey<TConversation, TMessage>(
+  store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
+  draftProjectId: string | null,
+  createDraftKey: () => DraftChatRuntimeKey = createChatDraftKey
+): DraftChatRuntimeKey {
+  const rememberedKey = store.getRememberedDraftKey(draftProjectId);
+  if (rememberedKey) {
+    const canonicalKey = store.resolveKey(rememberedKey);
+    const snapshot = store.get(rememberedKey);
+    const activeKey = store.getActiveKey();
+    const isCurrentVisibleDraft =
+      activeKey !== null &&
+      store.resolveKey(activeKey) === canonicalKey &&
+      store.isChatVisible(rememberedKey);
+    const canResume =
+      canonicalKey === rememberedKey &&
+      !isCurrentVisibleDraft &&
+      (snapshot === undefined ||
+        (snapshot.conversation === null &&
+          snapshot.messages.length === 0 &&
+          !snapshot.isGenerating &&
+          !snapshot.assistantStreaming &&
+          snapshot.runToken === null &&
+          snapshot.composer.draftProjectId === draftProjectId &&
+          composerHasRetainedDraft(snapshot.key, snapshot.composer)));
+
+    if (canResume) return rememberedKey;
+  }
+
+  return createAndRememberChatDraftKey(store, draftProjectId, createDraftKey);
+}
+
+export function draftScopeForRuntimeSelection<TConversation, TMessage>(
+  store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
+  key: ChatRuntimeKey,
+  fallbackScopeId: string | null
+): string | null {
+  const snapshot = store.get(key);
+  return snapshot ? snapshot.composer.draftProjectId : fallbackScopeId;
+}
+
+export function rememberChatDraftInScope<TConversation, TMessage>(
+  store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
+  key: ChatRuntimeKey,
+  scopeId: string | null
+): boolean {
+  const canonicalKey = store.resolveKey(key);
+  if (!isDraftChatRuntimeKey(canonicalKey)) return false;
+  store.rememberDraftKey(scopeId, canonicalKey);
+  store.updateActivityGroup(canonicalKey, scopeId);
+  return true;
+}
+
+export function createAndRememberChatDraftKey<TConversation, TMessage>(
+  store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
+  scopeId: string | null,
+  createDraftKey: () => DraftChatRuntimeKey = createChatDraftKey
+): DraftChatRuntimeKey {
+  const freshKey = createDraftKey();
+  store.ensure(freshKey, { composer: createChatComposerState(scopeId) });
+  rememberChatDraftInScope(store, freshKey, scopeId);
+  return freshKey;
+}
+
+export function moveRememberedChatDraftToScope<TConversation, TMessage>(
+  store: ChatRuntimeStore<TConversation, TMessage, ChatComposerState>,
+  key: ChatRuntimeKey,
+  nextDraftProjectId: string | null
+): boolean {
+  const canonicalKey = store.resolveKey(key);
+  if (!isDraftChatRuntimeKey(canonicalKey)) return false;
+
+  const snapshot = store.get(canonicalKey);
+  if (!snapshot || snapshot.conversation !== null) return false;
+
+  const previousDraftProjectId = snapshot.composer.draftProjectId;
+  if (previousDraftProjectId !== nextDraftProjectId) {
+    store.update(canonicalKey, (current) => ({
+      ...current,
+      composer: {
+        ...current.composer,
+        draftProjectId: nextDraftProjectId
+      }
+    }));
+  }
+
+  store.forgetRememberedDraftKey(previousDraftProjectId, canonicalKey);
+  rememberChatDraftInScope(store, canonicalKey, nextDraftProjectId);
+  return true;
+}

--- a/frontend/src/services/chatRuntimeNavigation.test.ts
+++ b/frontend/src/services/chatRuntimeNavigation.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, test } from "bun:test";
 import {
   canonicalConversationHistoryHref,
   conversationIdFromChatRuntimeKey,
+  createChatHistoryEntryForDraft,
   createFreshChatHistoryEntry,
   draftRuntimeKeyFromHistoryState,
   historyStateWithDraftRuntimeKey,
   pushFreshChatHistoryEntry,
+  pushChatHistoryEntryForDraft,
   runtimeKeyForChatLocation,
   shouldProjectMigratedConversation
 } from "./chatRuntimeNavigation";
@@ -89,6 +91,31 @@ describe("chat runtime history navigation", () => {
     expect(next.draftRuntimeKey).not.toBe(previous.draftRuntimeKey);
     expect(draftRuntimeKeyFromHistoryState(previous.historyState)).toBe(previous.draftRuntimeKey);
     expect(draftRuntimeKeyFromHistoryState(next.historyState)).toBe(next.draftRuntimeKey);
+  });
+
+  test("creates and pushes history entries for an existing retained draft key", () => {
+    const draftKey = createChatDraftKey("retained");
+    const entry = createChatHistoryEntryForDraft(draftKey);
+    const calls: Array<{ state: unknown; url: string | URL | null | undefined }> = [];
+    const history = {
+      pushState: (state: unknown, _unused: string, url?: string | URL | null) => {
+        calls.push({ state, url });
+      }
+    };
+
+    const detail = pushChatHistoryEntryForDraft(history, "/?keep=1", null, draftKey);
+
+    expect(entry).toEqual({
+      draftRuntimeKey: draftKey,
+      historyState: { mapleChatDraftRuntimeKey: draftKey }
+    });
+    expect(calls).toEqual([
+      {
+        state: { mapleChatDraftRuntimeKey: draftKey },
+        url: "/?keep=1"
+      }
+    ]);
+    expect(detail).toEqual({ projectId: null, draftRuntimeKey: draftKey });
   });
 
   test("pushes a fresh keyed project draft without replacing the streaming history entry", () => {

--- a/frontend/src/services/chatRuntimeNavigation.ts
+++ b/frontend/src/services/chatRuntimeNavigation.ts
@@ -82,7 +82,13 @@ export function createFreshChatHistoryEntry(draftId?: string): Readonly<{
   draftRuntimeKey: DraftChatRuntimeKey;
   historyState: Record<string, unknown>;
 }> {
-  const draftRuntimeKey = createChatDraftKey(draftId);
+  return createChatHistoryEntryForDraft(createChatDraftKey(draftId));
+}
+
+export function createChatHistoryEntryForDraft(draftRuntimeKey: DraftChatRuntimeKey): Readonly<{
+  draftRuntimeKey: DraftChatRuntimeKey;
+  historyState: Record<string, unknown>;
+}> {
   return {
     draftRuntimeKey,
     historyState: historyStateWithDraftRuntimeKey({}, draftRuntimeKey)
@@ -95,7 +101,16 @@ export function pushFreshChatHistoryEntry(
   projectId: string | null,
   draftId?: string
 ): NewChatNavigationDetail {
-  const freshChat = createFreshChatHistoryEntry(draftId);
-  history.pushState(freshChat.historyState, "", url);
-  return { projectId, draftRuntimeKey: freshChat.draftRuntimeKey };
+  return pushChatHistoryEntryForDraft(history, url, projectId, createChatDraftKey(draftId));
+}
+
+export function pushChatHistoryEntryForDraft(
+  history: Pick<History, "pushState">,
+  url: string,
+  projectId: string | null,
+  draftRuntimeKey: DraftChatRuntimeKey
+): NewChatNavigationDetail {
+  const entry = createChatHistoryEntryForDraft(draftRuntimeKey);
+  history.pushState(entry.historyState, "", url);
+  return { projectId, draftRuntimeKey: entry.draftRuntimeKey };
 }

--- a/frontend/src/services/chatRuntimeStore.ts
+++ b/frontend/src/services/chatRuntimeStore.ts
@@ -158,6 +158,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   private readonly activeRunListeners = new Set<() => void>();
   private readonly completedUnreadListeners = new Set<() => void>();
   private readonly completedUnreadGroups = new Map<ChatRuntimeKey, string | null>();
+  private readonly rememberedDraftKeys = new Map<string | null, DraftChatRuntimeKey>();
   private readonly createComposer: () => TComposer;
   private readonly maxInactiveCompletedEntries: number;
   private readonly canEvict: (
@@ -232,6 +233,28 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
   getActivityGroupId(key: ChatRuntimeKey): string | null | undefined {
     const canonicalKey = this.resolveKey(key);
     return this.entries.get(canonicalKey)?.groupId ?? this.completedUnreadGroups.get(canonicalKey);
+  }
+
+  rememberDraftKey(scopeId: string | null, key: DraftChatRuntimeKey): void {
+    this.assertNotDisposed();
+    this.rememberedDraftKeys.set(scopeId, key);
+  }
+
+  getRememberedDraftKey(scopeId: string | null): DraftChatRuntimeKey | null {
+    this.assertNotDisposed();
+    return this.rememberedDraftKeys.get(scopeId) ?? null;
+  }
+
+  forgetRememberedDraftKey(scopeId: string | null, expectedKey?: DraftChatRuntimeKey): boolean {
+    this.assertNotDisposed();
+    const rememberedKey = this.rememberedDraftKeys.get(scopeId);
+    if (
+      rememberedKey === undefined ||
+      (expectedKey !== undefined && rememberedKey !== expectedKey)
+    ) {
+      return false;
+    }
+    return this.rememberedDraftKeys.delete(scopeId);
   }
 
   claimVisibleChat(owner: object, key: ChatRuntimeKey): ChatRuntimeVisibleLease {
@@ -340,6 +363,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
       if (completedGroupId === groupId) keys.add(key);
     }
 
+    this.rememberedDraftKeys.delete(groupId);
     for (const key of keys) this.delete(key);
     return Object.freeze(Array.from(keys));
   }
@@ -723,6 +747,8 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     const sourceWasSelected = this.activeKey === canonicalFrom;
     const destinationWasSelected = this.activeKey === canonicalTo;
 
+    this.forgetDraftKeysResolvingTo(canonicalFrom);
+
     if (mergedUpdate) {
       const previous = entry.snapshot;
       entry.snapshot = this.updatedSnapshot(
@@ -778,13 +804,15 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     const canonicalKey = this.resolveKey(key);
     const entry = this.entries.get(canonicalKey);
     if (!entry) {
+      const removedRememberedDraft = this.forgetDraftKeysResolvingTo(canonicalKey);
       const removedAlias = this.detachAliases(canonicalKey);
       const removedUnread = this.completedUnreadGroups.delete(canonicalKey);
-      if (removedAlias || removedUnread) this.publish();
-      return removedAlias || removedUnread;
+      if (removedRememberedDraft || removedAlias || removedUnread) this.publish();
+      return removedRememberedDraft || removedAlias || removedUnread;
     }
 
     this.completedUnreadGroups.delete(canonicalKey);
+    this.forgetDraftKeysResolvingTo(canonicalKey);
     this.detachEntry(canonicalKey);
     if (this.activeKey === canonicalKey) this.activeKey = null;
     if (this.visibleChatKey && this.resolveKey(this.visibleChatKey) === canonicalKey) {
@@ -809,6 +837,7 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
     this.entries.clear();
     this.aliases.clear();
     this.completedUnreadGroups.clear();
+    this.rememberedDraftKeys.clear();
     this.activeKey = null;
     this.visibleChatLease = null;
     this.visibleChatKey = null;
@@ -943,6 +972,16 @@ export class ChatRuntimeStore<TConversation, TMessage, TComposer> {
       }
     }
     return removed;
+  }
+
+  private forgetDraftKeysResolvingTo(canonicalKey: ChatRuntimeKey): boolean {
+    let changed = false;
+    for (const [scopeId, draftKey] of this.rememberedDraftKeys) {
+      if (this.resolveKey(draftKey) !== canonicalKey) continue;
+      this.rememberedDraftKeys.delete(scopeId);
+      changed = true;
+    }
+    return changed;
   }
 
   private assertNotDisposed(): void {


### PR DESCRIPTION
## Summary

- remember one unsent New Chat runtime per root or project scope
- restore the exact composer and attachment state when returning through New Chat, history, or a route remount
- keep scope moves, deletion, account disposal, and draft-to-conversation rekeys identity-safe

This is an in-memory convenience enhancement; explicit New Chat while already viewing a draft still opens a separate blank draft, and browser Back can restore the previous one.

## Validation

- `nix develop -c bun test` (344 passed)
- production build/typecheck through the pre-commit hook
- `nix develop -c bun run lint` (0 errors; 13 existing warnings)
- `nix develop -c bun run format:check`
- local managed-stack browser E2E covering root and project draft restoration, explicit rotation plus Back, attachment restoration, Settings and route remounts, Project View, and project deletion