### PR TITLE
Fix Linux auto-updater package routing

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -22,6 +22,17 @@ async fn restart_for_update(app_handle: tauri::AppHandle) -> Result<(), String> 
 }
 
 #[cfg(desktop)]
+#[tauri::command]
+fn get_pending_update_failure() -> Result<Option<String>, String> {
+    let version = FAILED_UPDATE_VERSION
+        .lock()
+        .map_err(|e| format!("Failed to lock FAILED_UPDATE_VERSION mutex: {e}"))?
+        .clone();
+
+    Ok((!version.is_empty()).then_some(version))
+}
+
+#[cfg(desktop)]
 fn handle_desktop_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEvent) {
     let tauri::RunEvent::ExitRequested { code, api, .. } = event else {
         return;
@@ -117,6 +128,7 @@ pub fn run() {
             proxy::test_proxy_port,
             pdf_extractor::extract_document_content,
             restart_for_update,
+            get_pending_update_failure,
             tts::tts_get_status,
             tts::tts_download_models,
             tts::tts_load_models,
@@ -180,10 +192,11 @@ pub fn run() {
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
                     log::info!("Performing automatic update check on startup");
 
-                    // This will check for updates, download if available, and install them
-                    // The update will be applied silently in the background
-                    // It will take effect the next time the application is started
-                    let _ = check_for_updates(app_handle.clone()).await;
+                    // This checks for updates, downloads the matching platform bundle,
+                    // and invokes its installer. The update takes effect after restart.
+                    if let Err(e) = check_for_updates(app_handle.clone(), false).await {
+                        log::error!("Automatic update check failed: {e}");
+                    }
 
                     // Set up hourly update checks
                     let hourly_app_handle = app_handle.clone();
@@ -197,7 +210,7 @@ pub fn run() {
                             log::info!("Performing scheduled hourly update check");
 
                             // Check for updates
-                            let _ = check_for_updates(hourly_app_handle.clone()).await;
+                            let _ = check_for_updates(hourly_app_handle.clone(), false).await;
                         }
                     });
                 });
@@ -269,23 +282,12 @@ pub fn run() {
                                 "Check for updates menu item clicked - clearing dismissal flags and triggering update check..."
                             );
 
-                            // Clear the dismissal flags to ensure the user always gets prompted
-                            // even if they previously dismissed an update
-                            UPDATE_DOWNLOADED.store(false, Ordering::SeqCst);
-                            {
-                                match CURRENT_VERSION.lock() {
-                                    Ok(mut version) => version.clear(),
-                                    Err(e) => log::error!("Failed to lock CURRENT_VERSION mutex when clearing: {e}")
-                                }
-                            }
-                            log::info!("Dismissal flags cleared - user will be prompted for any available updates");
-
                             // Clone the app handle to use in the async task
                             let app_handle_clone = app_handle_for_menu.clone();
 
                             // Spawn a new async task to check for updates (non-blocking)
                             tauri::async_runtime::spawn(async move {
-                                match check_for_updates(app_handle_clone).await {
+                                match check_for_updates(app_handle_clone, true).await {
                                     Ok(_) => log::info!("Update check completed successfully"),
                                     Err(e) => log::error!("Update check failed: {e}"),
                                 }
@@ -400,11 +402,32 @@ static AGENT_EXIT_CLEANUP_STARTED: AtomicBool = AtomicBool::new(false);
 static AGENT_EXIT_CLEANUP_COMPLETE: AtomicBool = AtomicBool::new(false);
 #[cfg(desktop)]
 static CURRENT_VERSION: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
+#[cfg(desktop)]
+static FAILED_UPDATE_VERSION: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
+#[cfg(desktop)]
+static UPDATE_CHECK_LOCK: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));
 
 /// Check for updates silently in the background
 #[cfg(desktop)]
-async fn check_for_updates(app_handle: tauri::AppHandle) -> Result<(), String> {
+async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> Result<(), String> {
     use tauri_plugin_updater::UpdaterExt;
+
+    let _check_guard = UPDATE_CHECK_LOCK.lock().await;
+
+    if force_retry {
+        UPDATE_DOWNLOADED.store(false, Ordering::SeqCst);
+        match CURRENT_VERSION.lock() {
+            Ok(mut version) => version.clear(),
+            Err(e) => log::error!("Failed to lock CURRENT_VERSION mutex when clearing: {e}"),
+        }
+        match FAILED_UPDATE_VERSION.lock() {
+            Ok(mut version) => version.clear(),
+            Err(e) => {
+                log::error!("Failed to lock FAILED_UPDATE_VERSION mutex when clearing: {e}")
+            }
+        }
+        log::info!("Update state cleared for user-requested retry");
+    }
 
     log::info!("Checking for updates...");
 
@@ -439,10 +462,28 @@ async fn check_for_updates(app_handle: tauri::AppHandle) -> Result<(), String> {
                 return Ok(());
             }
 
+            let failed_update_version = match FAILED_UPDATE_VERSION.lock() {
+                Ok(guard) => guard.clone(),
+                Err(e) => {
+                    log::error!("Failed to lock FAILED_UPDATE_VERSION mutex: {e}");
+                    String::new()
+                }
+            };
+
+            if failed_update_version == update.version {
+                log::info!(
+                    "Update to version {} already failed to install in this session, skipping automatic retry",
+                    update.version
+                );
+                return Ok(());
+            }
+
             log::info!("Update available, attempting to download and install");
 
             // Download the update
-            let progress_fn = |downloaded: usize, total: Option<u64>| {
+            let mut downloaded = 0_u64;
+            let progress_fn = move |chunk_length: usize, total: Option<u64>| {
+                downloaded = downloaded.saturating_add(chunk_length as u64);
                 if let Some(total) = total {
                     log::info!("Download progress: {downloaded}/{total} bytes");
                 } else {
@@ -451,12 +492,12 @@ async fn check_for_updates(app_handle: tauri::AppHandle) -> Result<(), String> {
             };
 
             let download_complete = || {
-                log::info!("Download complete!");
+                log::info!("Download stream received; verifying signature");
             };
 
             match update.download(progress_fn, download_complete).await {
                 Ok(bytes) => {
-                    log::info!("Update downloaded successfully");
+                    log::info!("Update downloaded and signature verified");
                     log::info!("Installing update to version {}", update.version);
 
                     // Try to install the update immediately
@@ -464,6 +505,13 @@ async fn check_for_updates(app_handle: tauri::AppHandle) -> Result<(), String> {
                         Ok(_) => {
                             // Log that the update is ready
                             log::info!("Update installed successfully. Will be applied on next application restart.");
+
+                            match FAILED_UPDATE_VERSION.lock() {
+                                Ok(mut version) => version.clear(),
+                                Err(e) => log::error!(
+                                    "Failed to lock FAILED_UPDATE_VERSION mutex when clearing: {e}"
+                                ),
+                            }
 
                             // Mark this version as downloaded to prevent redundant downloads/notifications
                             {
@@ -503,13 +551,37 @@ async fn check_for_updates(app_handle: tauri::AppHandle) -> Result<(), String> {
                                     update.version
                                 );
                             }
+
+                            Ok(())
                         }
                         Err(e) => {
-                            log::error!("Failed to install update: {e}");
+                            let error = format!("Failed to install update: {e}");
+                            log::error!("{error}");
+
+                            match FAILED_UPDATE_VERSION.lock() {
+                                Ok(mut version) => *version = update.version.clone(),
+                                Err(lock_error) => log::error!(
+                                    "Failed to lock FAILED_UPDATE_VERSION mutex when recording failure: {lock_error}"
+                                ),
+                            }
+
+                            #[derive(Clone, serde::Serialize)]
+                            struct UpdateFailedPayload {
+                                version: String,
+                            }
+
+                            if let Err(emit_error) = app_handle.emit(
+                                "update-failed",
+                                UpdateFailedPayload {
+                                    version: update.version.clone(),
+                                },
+                            ) {
+                                log::error!("Failed to emit update-failed event: {emit_error}");
+                            }
+
+                            Err(error)
                         }
                     }
-
-                    Ok(())
                 }
                 Err(e) => {
                     log::error!("Failed to download update: {e}");

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -11,11 +11,9 @@
   },
   "plugins": {
     "updater": {
-      "active": true,
       "endpoints": [
         "https://github.com/OpenSecretCloud/Maple/releases/latest/download/latest.json"
       ],
-      "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCRjU0OEJCM0M2OTNEQjAKUldTd1BXazh1MGoxUyt3TXdHREU1WUdzL1VNYlludXhORHpQSUc1cGxSSW1kdEYrOXNPNzRjdUUK"
     },
     "deep-link": {

--- a/frontend/src/components/UpdateEventListener.tsx
+++ b/frontend/src/components/UpdateEventListener.tsx
@@ -2,9 +2,14 @@ import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { useNotification } from "@/contexts/NotificationContext";
+import { openExternalUrl } from "@/utils/openUrl";
 import { isTauri } from "@/utils/platform";
 
 interface UpdateReadyPayload {
+  version: string;
+}
+
+interface UpdateFailedPayload {
   version: string;
 }
 
@@ -16,16 +21,43 @@ export function UpdateEventListener() {
       return;
     }
 
+    let disposed = false;
     let unlistenUpdateReady: (() => void) | null = null;
+    let unlistenUpdateFailed: (() => void) | null = null;
+
+    const showUpdateFailed = (version: string) => {
+      showNotification({
+        type: "error",
+        title: "Update Failed",
+        message: `Maple couldn't install version ${version} automatically. Download the latest installer to update manually.`,
+        duration: 0,
+        actions: [
+          {
+            label: "Later",
+            variant: "secondary",
+            onClick: () => {
+              // Just dismiss - the notification will close automatically
+            }
+          },
+          {
+            label: "Download Manually",
+            variant: "primary",
+            onClick: () => {
+              void openExternalUrl("https://trymaple.ai/downloads");
+            }
+          }
+        ]
+      });
+    };
 
     const setupListeners = async () => {
       try {
-        unlistenUpdateReady = await listen<UpdateReadyPayload>("update-ready", (event) => {
+        const unlistenReady = await listen<UpdateReadyPayload>("update-ready", (event) => {
           const { version } = event.payload;
           showNotification({
             type: "update",
-            title: "Update Ready",
-            message: `Version ${version} has been downloaded and is ready to install.`,
+            title: "Update Installed",
+            message: `Version ${version} has been installed. Restart Maple to finish updating.`,
             duration: 0,
             actions: [
               {
@@ -49,6 +81,26 @@ export function UpdateEventListener() {
             ]
           });
         });
+        if (disposed) {
+          unlistenReady();
+          return;
+        }
+        unlistenUpdateReady = unlistenReady;
+
+        const unlistenFailed = await listen<UpdateFailedPayload>("update-failed", (event) => {
+          const { version } = event.payload;
+          showUpdateFailed(version);
+        });
+        if (disposed) {
+          unlistenFailed();
+          return;
+        }
+        unlistenUpdateFailed = unlistenFailed;
+
+        const pendingFailure = await invoke<string | null>("get_pending_update_failure");
+        if (!disposed && pendingFailure) {
+          showUpdateFailed(pendingFailure);
+        }
       } catch (error) {
         console.error("Failed to setup update event listeners:", error);
       }
@@ -57,7 +109,9 @@ export function UpdateEventListener() {
     setupListeners();
 
     return () => {
+      disposed = true;
       if (unlistenUpdateReady) unlistenUpdateReady();
+      if (unlistenUpdateFailed) unlistenUpdateFailed();
     };
   }, [showNotification]);
 

--- a/scripts/ci/latest-json.sh
+++ b/scripts/ci/latest-json.sh
@@ -47,21 +47,31 @@ find_one_artifact() {
 
 macos_bundle="$(find_one_artifact '*.app.tar.gz')"
 macos_sig="$(find_one_artifact '*.app.tar.gz.sig')"
-linux_bundle="$(find_one_artifact 'Maple_*.AppImage')"
-linux_sig="$(find_one_artifact 'Maple_*.AppImage.sig')"
+linux_appimage_bundle="$(find_one_artifact 'Maple_*_amd64.AppImage')"
+linux_appimage_sig="$(find_one_artifact 'Maple_*_amd64.AppImage.sig')"
+linux_deb_bundle="$(find_one_artifact 'Maple_*_amd64.deb')"
+linux_deb_sig="$(find_one_artifact 'Maple_*_amd64.deb.sig')"
+linux_rpm_bundle="$(find_one_artifact 'Maple-*.x86_64.rpm')"
+linux_rpm_sig="$(find_one_artifact 'Maple-*.x86_64.rpm.sig')"
 windows_bundle_basename="$(windows_release_setup_exe_basename_for_version "${release_tag#v}")"
 windows_bundle="$(find_one_artifact "${windows_bundle_basename}")"
 windows_sig="$(find_one_artifact "${windows_bundle_basename}.sig")"
 
 verify_tauri_updater_signature "${macos_bundle}" "${macos_sig}" "$(basename "${macos_bundle}")"
-verify_tauri_updater_signature "${linux_bundle}" "${linux_sig}" "$(basename "${linux_bundle}")"
+verify_tauri_updater_signature "${linux_appimage_bundle}" "${linux_appimage_sig}" "$(basename "${linux_appimage_bundle}")"
+verify_tauri_updater_signature "${linux_deb_bundle}" "${linux_deb_sig}" "$(basename "${linux_deb_bundle}")"
+verify_tauri_updater_signature "${linux_rpm_bundle}" "${linux_rpm_sig}" "$(basename "${linux_rpm_bundle}")"
 verify_tauri_updater_signature "${windows_bundle}" "${windows_sig}" "$(basename "${windows_bundle}")"
 
 macos_sig_content="$(cat "${macos_sig}")"
-linux_sig_content="$(cat "${linux_sig}")"
+linux_appimage_sig_content="$(cat "${linux_appimage_sig}")"
+linux_deb_sig_content="$(cat "${linux_deb_sig}")"
+linux_rpm_sig_content="$(cat "${linux_rpm_sig}")"
 windows_sig_content="$(cat "${windows_sig}")"
 macos_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${macos_bundle}")"
-linux_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_bundle}")"
+linux_appimage_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_appimage_bundle}")"
+linux_deb_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_deb_bundle}")"
+linux_rpm_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_rpm_bundle}")"
 windows_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${windows_bundle}")"
 
 tmp="$(mktemp)"
@@ -70,10 +80,14 @@ jq -S -n \
   --arg notes "See the release notes at https://github.com/OpenSecretCloud/Maple/releases/tag/${release_tag}" \
   --arg pub_date "${pub_date}" \
   --arg macos_sig "${macos_sig_content}" \
-  --arg linux_sig "${linux_sig_content}" \
+  --arg linux_appimage_sig "${linux_appimage_sig_content}" \
+  --arg linux_deb_sig "${linux_deb_sig_content}" \
+  --arg linux_rpm_sig "${linux_rpm_sig_content}" \
   --arg windows_sig "${windows_sig_content}" \
   --arg macos_url "${macos_url}" \
-  --arg linux_url "${linux_url}" \
+  --arg linux_appimage_url "${linux_appimage_url}" \
+  --arg linux_deb_url "${linux_deb_url}" \
+  --arg linux_rpm_url "${linux_rpm_url}" \
   --arg windows_url "${windows_url}" \
   '{
     notes: $notes,
@@ -87,8 +101,20 @@ jq -S -n \
         url: $macos_url
       },
       "linux-x86_64": {
-        signature: $linux_sig,
-        url: $linux_url
+        signature: $linux_appimage_sig,
+        url: $linux_appimage_url
+      },
+      "linux-x86_64-appimage": {
+        signature: $linux_appimage_sig,
+        url: $linux_appimage_url
+      },
+      "linux-x86_64-deb": {
+        signature: $linux_deb_sig,
+        url: $linux_deb_url
+      },
+      "linux-x86_64-rpm": {
+        signature: $linux_rpm_sig,
+        url: $linux_rpm_url
       },
       "windows-x86_64": {
         signature: $windows_sig,
@@ -108,11 +134,31 @@ jq -e '
   and (.platforms."darwin-x86_64".signature | type == "string" and length > 0)
   and (.platforms."linux-x86_64".url | startswith("https://"))
   and (.platforms."linux-x86_64".signature | type == "string" and length > 0)
+  and (.platforms."linux-x86_64-appimage".url | startswith("https://") and endswith(".AppImage"))
+  and (.platforms."linux-x86_64-appimage".signature | type == "string" and length > 0)
+  and (.platforms."linux-x86_64-deb".url | startswith("https://") and endswith(".deb"))
+  and (.platforms."linux-x86_64-deb".signature | type == "string" and length > 0)
+  and (.platforms."linux-x86_64-rpm".url | startswith("https://") and endswith(".rpm"))
+  and (.platforms."linux-x86_64-rpm".signature | type == "string" and length > 0)
+  and (.platforms."linux-x86_64" == .platforms."linux-x86_64-appimage")
   and (.platforms."windows-x86_64".url | startswith("https://"))
   and (.platforms."windows-x86_64".signature | type == "string" and length > 0)
 ' "${out}" >/dev/null
 
 repro_dir="${TAURI_DIR}/target/reproducibility"
 mkdir -p "${repro_dir}"
-write_sha256_manifest "${repro_dir}/latest-json-final.sha256" "${out}" "${macos_sig}" "${linux_sig}" "${windows_sig}"
-print_file_hashes "${out}" "${macos_sig}" "${linux_sig}" "${windows_sig}"
+write_sha256_manifest \
+  "${repro_dir}/latest-json-final.sha256" \
+  "${out}" \
+  "${macos_sig}" \
+  "${linux_appimage_sig}" \
+  "${linux_deb_sig}" \
+  "${linux_rpm_sig}" \
+  "${windows_sig}"
+print_file_hashes \
+  "${out}" \
+  "${macos_sig}" \
+  "${linux_appimage_sig}" \
+  "${linux_deb_sig}" \
+  "${linux_rpm_sig}" \
+  "${windows_sig}"

--- a/scripts/ci/verify-release-artifacts.sh
+++ b/scripts/ci/verify-release-artifacts.sh
@@ -737,7 +737,7 @@ verify_web() {
 
 verify_latest_json() {
   local final_manifest latest_json
-  local platform url signature basename artifact sig_file sig_content
+  local platform url signature basename artifact sig_file sig_content expected_pattern
 
   final_manifest="$(proof_file_required latest-json-final.sha256)"
   verify_file_manifest "${final_manifest}"
@@ -747,12 +747,44 @@ verify_latest_json() {
     (.version | type == "string" and length > 0)
     and (.pub_date | type == "string" and length > 0)
     and (.platforms | type == "object")
+    and (.platforms."linux-x86_64" == .platforms."linux-x86_64-appimage")
   ' "${latest_json}" >/dev/null
 
-  for platform in darwin-aarch64 darwin-x86_64 linux-x86_64 windows-x86_64; do
+  for platform in \
+    darwin-aarch64 \
+    darwin-x86_64 \
+    linux-x86_64 \
+    linux-x86_64-appimage \
+    linux-x86_64-deb \
+    linux-x86_64-rpm \
+    windows-x86_64; do
     url="$(jq -er --arg platform "${platform}" '.platforms[$platform].url' "${latest_json}")"
     signature="$(jq -er --arg platform "${platform}" '.platforms[$platform].signature' "${latest_json}")"
     basename="$(basename "${url}")"
+
+    case "${platform}" in
+      darwin-*)
+        expected_pattern='*.app.tar.gz'
+        ;;
+      linux-x86_64 | linux-x86_64-appimage)
+        expected_pattern='Maple_*_amd64.AppImage'
+        ;;
+      linux-x86_64-deb)
+        expected_pattern='Maple_*_amd64.deb'
+        ;;
+      linux-x86_64-rpm)
+        expected_pattern='Maple-*.x86_64.rpm'
+        ;;
+      windows-x86_64)
+        expected_pattern='Maple_*_x64-setup.exe'
+        ;;
+    esac
+
+    if [[ "${basename}" != ${expected_pattern} ]]; then
+      echo "latest.json URL for ${platform} does not select ${expected_pattern}: ${basename}" >&2
+      return 1
+    fi
+
     artifact="$(artifact_for_label "${basename}")"
     sig_file="$(artifact_for_label "${basename}.sig")"
     sig_content="$(cat "${sig_file}")"


### PR DESCRIPTION
## Summary

- Generate standard bundle-aware Linux updater entries for AppImage, Debian, and RPM packages while keeping the generic Linux entry as the AppImage fallback.
- Verify that each platform entry selects the correct signed package type before release publication.
- Report cumulative download progress, propagate install errors, serialize updater attempts, suppress repeated failed installs for the session, and offer a durable manual-download fallback.
- Remove obsolete updater config fields and make the success notification accurately say that installation has completed and a restart is required.

## Root cause

Tauri updater 2.10.1 checks the bundle-specific key first (for example, `linux-x86_64-deb`) and falls back to `linux-x86_64`. Maple only emitted the generic key and pointed it at the AppImage, so Debian and RPM installs downloaded a validly signed AppImage and then rejected it as the wrong native package format.

The reported 16 KiB progress line was a separate logging issue: Tauri supplies each chunk length to the callback, while Maple logged that value as cumulative progress.

This is forward-looking only; it does not rewrite existing release assets or manifests. Clients too old to understand typed updater keys may need one manual upgrade. The generic key remains mapped to AppImage so existing AppImage clients retain their fallback.

## Validation

- `nix flake check --print-build-logs`
- `nix develop .#ci -c ./scripts/ci/frontend.sh` (332 tests passed)
- `nix develop .#ci -c ./scripts/ci/rust.sh` (205 passed, 1 ignored)
- Repository pre-commit hook, including the production frontend build

I could not run the real Linux package-manager/elevation flow from macOS. The release workflow will build and verify the signed Linux packages; an actual Ubuntu 24.04 install/update remains the final end-to-end check.
