### PR TITLE
Fix Agent Mode context limits per model

### DIFF
--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -264,6 +264,8 @@ pub struct AgentCreateSessionRequest {
     pub project_root: Option<String>,
     pub title: Option<String>,
     pub model: Option<String>,
+    #[serde(default)]
+    pub context_limit: Option<usize>,
     pub mode: Option<String>,
     pub mcp_server_names: Option<Vec<String>>,
 }
@@ -274,6 +276,8 @@ pub struct AgentSendMessageRequest {
     pub session_id: String,
     pub text: String,
     pub model: Option<String>,
+    #[serde(default)]
+    pub context_limit: Option<usize>,
     pub mode: Option<String>,
     #[serde(default)]
     pub vision_capable: bool,
@@ -1211,6 +1215,7 @@ pub async fn agent_create_session(
         project_root: None,
         title: None,
         model: None,
+        context_limit: None,
         mode: None,
         mcp_server_names: None,
     });
@@ -1284,6 +1289,7 @@ pub async fn agent_create_session(
                 web_tool_state: &web_tool_state,
                 session: &session,
                 model: &model,
+                context_limit: request.context_limit,
                 mode: &mode,
                 primary_model_supports_vision: false,
             },
@@ -2004,6 +2010,7 @@ pub async fn agent_send_message(
                 web_tool_state: &web_tool_state,
                 session: &session,
                 model: &model,
+                context_limit: request.context_limit,
                 mode: &effective_mode,
                 primary_model_supports_vision: request.vision_capable,
             },
@@ -3285,23 +3292,48 @@ struct SessionAgentConfiguration<'a> {
     web_tool_state: &'a Arc<WebToolState>,
     session: &'a Session,
     model: &'a str,
+    context_limit: Option<usize>,
     mode: &'a str,
     primary_model_supports_vision: bool,
+}
+
+fn maple_model_config(
+    model: &str,
+    context_limit: Option<usize>,
+) -> Result<goose_providers::model::ModelConfig, String> {
+    let mut model_config =
+        goose::model_config::model_config_from_user_config(MAPLE_PROVIDER_NAME, model)
+            .map_err(|e| format!("Failed to configure Goose model {model}: {e}"))?;
+    // Maple's authoritative catalog value is per session. Explicitly clear any
+    // process-global Goose context override when metadata is unavailable.
+    model_config.context_limit = context_limit.filter(|limit| *limit > 0);
+    Ok(model_config)
 }
 
 async fn install_maple_provider<T>(
     agent: &Arc<Agent>,
     transport: &Arc<T>,
-    session_id: &str,
+    session: &Session,
     model: &str,
+    context_limit: Option<usize>,
 ) -> Result<(), String>
 where
     T: provider::MapleInferenceTransport + 'static,
 {
-    let model_config =
-        goose::model_config::model_config_from_user_config(MAPLE_PROVIDER_NAME, model)
-            .map_err(|e| format!("Failed to configure Goose model {model}: {e}"))?;
-    install_maple_provider_config(agent, transport, session_id, model_config).await
+    // A session snapshot that came from the authoritative catalog remains the
+    // best same-model value when a later UI/catalog version omits metadata.
+    // Do not preserve it across a model change, where it may describe a
+    // different provider window.
+    let context_limit = context_limit.filter(|limit| *limit > 0).or_else(|| {
+        session
+            .model_config
+            .as_ref()
+            .filter(|config| config.model_name == model)
+            .and_then(|config| config.context_limit)
+            .filter(|limit| *limit > 0)
+    });
+    let model_config = maple_model_config(model, context_limit)?;
+    install_maple_provider_config(agent, transport, &session.id, model_config).await
 }
 
 async fn install_maple_provider_config<T>(
@@ -3366,6 +3398,7 @@ async fn configure_session_agent(
         web_tool_state,
         session,
         model,
+        context_limit,
         mode,
         primary_model_supports_vision,
     } = configuration;
@@ -3385,7 +3418,7 @@ async fn configure_session_agent(
         session,
     )?;
     let mcp_errors = mcp_connection_errors(manager_result.extension_results, &session_mcp_keys);
-    install_maple_provider(&agent, maple_api_session, &session.id, model).await?;
+    install_maple_provider(&agent, maple_api_session, session, model, context_limit).await?;
     agent
         .update_goose_mode(GOOSE_PERMISSION_ROUTING_MODE, &session.id)
         .await
@@ -5675,6 +5708,146 @@ mod tests {
         let _ = fs::remove_dir_all(test_root);
     }
 
+    #[tokio::test]
+    async fn maple_context_limits_are_isolated_and_persisted_per_session() {
+        let test_root = recent_roots_test_dir("per-session-context-limits");
+        let session_manager = Arc::new(SessionManager::new(test_root.join("sessions")));
+        let permission_manager = Arc::new(PermissionManager::new(test_root.join("permissions")));
+        let agent_manager = Arc::new(
+            AgentManager::new(
+                GooseAgentConfig::new(
+                    Arc::clone(&session_manager),
+                    permission_manager,
+                    None,
+                    GooseMode::SmartApprove,
+                    true,
+                    GoosePlatform::GooseDesktop,
+                ),
+                Some(2),
+            )
+            .await
+            .unwrap(),
+        );
+        let transport = Arc::new(InertMapleTransport);
+        agent_manager
+            .set_default_provider(Arc::new(MapleProvider::new(Arc::clone(&transport))))
+            .await;
+
+        let glm_session = session_manager
+            .create_session(
+                test_root.clone(),
+                "GLM task".to_string(),
+                SessionType::User,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let kimi_session = session_manager
+            .create_session(
+                test_root.clone(),
+                "Kimi task".to_string(),
+                SessionType::User,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+
+        let glm_agent = get_or_create_session_agent(
+            &agent_manager,
+            &transport,
+            &glm_session,
+            RuntimeContext::default(),
+        )
+        .await
+        .unwrap();
+        install_maple_provider(
+            &glm_agent.agent,
+            &transport,
+            &glm_session,
+            "glm-5-2",
+            Some(384_000),
+        )
+        .await
+        .unwrap();
+        drop(glm_agent);
+
+        let kimi_agent = get_or_create_session_agent(
+            &agent_manager,
+            &transport,
+            &kimi_session,
+            RuntimeContext::default(),
+        )
+        .await
+        .unwrap();
+        install_maple_provider(
+            &kimi_agent.agent,
+            &transport,
+            &kimi_session,
+            "auto:powerful",
+            Some(256_000),
+        )
+        .await
+        .unwrap();
+        drop(kimi_agent);
+
+        let persisted_glm = session_manager
+            .get_session(&glm_session.id, false)
+            .await
+            .unwrap();
+        let persisted_kimi = session_manager
+            .get_session(&kimi_session.id, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            persisted_glm
+                .model_config
+                .as_ref()
+                .map(|config| (config.model_name.as_str(), config.context_limit)),
+            Some(("glm-5-2", Some(384_000)))
+        );
+        assert_eq!(
+            persisted_kimi
+                .model_config
+                .as_ref()
+                .map(|config| (config.model_name.as_str(), config.context_limit)),
+            Some(("auto:powerful", Some(256_000)))
+        );
+
+        let glm_agent = get_or_create_session_agent(
+            &agent_manager,
+            &transport,
+            &persisted_glm,
+            RuntimeContext::default(),
+        )
+        .await
+        .unwrap();
+        install_maple_provider(
+            &glm_agent.agent,
+            &transport,
+            &persisted_glm,
+            "glm-5-2",
+            None,
+        )
+        .await
+        .unwrap();
+        drop(glm_agent);
+        let persisted_glm = session_manager
+            .get_session(&glm_session.id, false)
+            .await
+            .unwrap();
+        assert_eq!(
+            persisted_glm
+                .model_config
+                .as_ref()
+                .and_then(|config| config.context_limit),
+            Some(384_000)
+        );
+
+        drop(agent_manager);
+        drop(session_manager);
+        let _ = fs::remove_dir_all(test_root);
+    }
+
     #[test]
     fn project_skills_trust_persists_both_decisions_and_is_one_time() {
         let test_root = recent_roots_test_dir("skills-trust");
@@ -6699,16 +6872,53 @@ mod tests {
         }))
         .unwrap();
         assert!(!without_capability.vision_capable);
+        assert_eq!(without_capability.context_limit, None);
 
         let with_capability: AgentSendMessageRequest = serde_json::from_value(json!({
             "sessionId": "session-1",
             "text": "Inspect the image",
             "model": "future-vision-model",
             "mode": "smart_approve",
+            "contextLimit": 384000,
             "visionCapable": true
         }))
         .unwrap();
         assert!(with_capability.vision_capable);
+        assert_eq!(with_capability.context_limit, Some(384_000));
+
+        let create_request: AgentCreateSessionRequest = serde_json::from_value(json!({
+            "projectRoot": "/tmp/project",
+            "model": "kimi-k2-6",
+            "contextLimit": 256000
+        }))
+        .unwrap();
+        assert_eq!(create_request.context_limit, Some(256_000));
+    }
+
+    #[test]
+    fn maple_model_config_uses_only_valid_per_session_context_limits() {
+        assert_eq!(
+            maple_model_config("glm-5-2", Some(384_000))
+                .unwrap()
+                .context_limit,
+            Some(384_000)
+        );
+        assert_eq!(
+            maple_model_config("auto:powerful", Some(256_000))
+                .unwrap()
+                .context_limit,
+            Some(256_000)
+        );
+        assert_eq!(
+            maple_model_config("glm-5-2", None).unwrap().context_limit,
+            None
+        );
+        assert_eq!(
+            maple_model_config("glm-5-2", Some(0))
+                .unwrap()
+                .context_limit,
+            None
+        );
     }
 
     #[test]

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -131,6 +131,8 @@ import {
   DEFAULT_AGENT_MODEL,
   PRIMARY_AGENT_MODEL_IDS,
   reconcileAgentModel,
+  reconcileAgentModelForCatalog,
+  resolveAgentModelContextLimit,
   resolveAgentModelVisionCapability
 } from "@/services/agentModels";
 import { SIDEBAR_GRID_COLUMNS_CLASS, getSidebarLayoutStyle } from "@/constants/layout";
@@ -276,7 +278,9 @@ function buildFallbackModelAliases(models: OpenSecretModel[]): OpenSecretModelAl
 
 export function AgentMode({ userId }: { userId: string }) {
   const openai = useOpenAI();
-  const { availableModels, modelAliases } = useLocalState();
+  const os = useOpenSecret();
+  const { availableModels, setAvailableModels, modelAliases, setModelAliases, setHasWhisperModel } =
+    useLocalState();
   const { agentSessionSelection } = usePersistentHomeNavigation();
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
@@ -319,6 +323,7 @@ export function AgentMode({ userId }: { userId: string }) {
   const [isAuthTransitionReady, setIsAuthTransitionReady] = useState(false);
   const [isInitializing, setIsInitializing] = useState(true);
   const [isStarting, setIsStarting] = useState(false);
+  const [isAgentModelCatalogLoading, setIsAgentModelCatalogLoading] = useState(true);
   const [isPermissionModeUpdating, setIsPermissionModeUpdating] = useState(false);
   const [isProjectRootRegistrationPending, setIsProjectRootRegistrationPending] = useState(false);
   const [projectSkillsTrustPrompt, setProjectSkillsTrustPrompt] =
@@ -365,11 +370,27 @@ export function AgentMode({ userId }: { userId: string }) {
   const thoughtLabelFinalRequestRegistryRef = useRef(new AgentThoughtLabelFinalRequestRegistry());
   const thoughtPhaseSeededRunIdsRef = useRef(new Set<string>());
   const openaiRef = useRef(openai);
+  const openSecretRef = useRef(os);
+  const currentAgentModelRef = useRef(model);
+  const agentModelStateSettersRef = useRef({
+    setAvailableModels,
+    setModelAliases,
+    setHasWhisperModel
+  });
+  const authoritativeModelCatalogRef = useRef<OpenSecretModelCatalog | null>(null);
+  const selectableAgentModelsRef = useRef<OpenSecretModel[] | null>(null);
   const userIdRef = useRef(userId);
   const thoughtLabelProvisionalSchedulerRef = useRef<AgentThoughtLabelProvisionalScheduler | null>(
     null
   );
   openaiRef.current = openai;
+  openSecretRef.current = os;
+  currentAgentModelRef.current = model;
+  agentModelStateSettersRef.current = {
+    setAvailableModels,
+    setModelAliases,
+    setHasWhisperModel
+  };
   userIdRef.current = userId;
 
   if (!thoughtLabelProvisionalSchedulerRef.current) {
@@ -644,6 +665,7 @@ export function AgentMode({ userId }: { userId: string }) {
     isProjectOrderSaving ||
     isProjectRootRegistrationPending ||
     isProjectRemovalPending ||
+    isAgentModelCatalogLoading ||
     isProjectSkillsTrustLoading ||
     isProjectSkillsTrustSaving ||
     projectSkillsTrustPrompt !== null;
@@ -1171,9 +1193,14 @@ export function AgentMode({ userId }: { userId: string }) {
           ],
           removedRoots
         );
-        const nextModel = status.model || config.defaultModel || DEFAULT_MODEL;
+        const configuredModel = status.model || config.defaultModel || DEFAULT_MODEL;
+        const selectableModels = selectableAgentModelsRef.current;
+        const nextModel = selectableModels
+          ? reconcileAgentModel(configuredModel, selectableModels)
+          : configuredModel;
         const nextMode = normalizeAgentPermissionMode(status.mode);
         setProjectRoot(root);
+        currentAgentModelRef.current = nextModel;
         setModel(nextModel);
         applyAuthoritativeMode(nextMode);
 
@@ -1311,8 +1338,108 @@ export function AgentMode({ userId }: { userId: string }) {
   const selectModel = useCallback((value: string) => {
     if (isAgentModelLockedRef.current) return;
     interactionGenerationRef.current += 1;
+    currentAgentModelRef.current = value;
     setModel(value);
   }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    authoritativeModelCatalogRef.current = null;
+    selectableAgentModelsRef.current = null;
+    setIsAgentModelCatalogLoading(true);
+
+    void (async () => {
+      try {
+        const modelClient = openSecretRef.current as unknown as ModelCatalogClient;
+        const {
+          setAvailableModels: updateAvailableModels,
+          setModelAliases: updateModelAliases,
+          setHasWhisperModel: updateHasWhisperModel
+        } = agentModelStateSettersRef.current;
+
+        if (modelClient.fetchModelCatalog) {
+          try {
+            const catalog = await modelClient.fetchModelCatalog();
+            if (cancelled) return;
+            const selectableModels = catalog.data.filter(isSelectableChatModel);
+            const hasCatalogWhisperModel = catalog.data.some(
+              (catalogModel) => catalogModel.id === "whisper-large-v3"
+            );
+            authoritativeModelCatalogRef.current = catalog;
+            selectableAgentModelsRef.current = selectableModels;
+            updateAvailableModels(selectableModels);
+            updateModelAliases(catalog.aliases);
+            updateHasWhisperModel(
+              catalog.audio?.transcription?.available ?? hasCatalogWhisperModel
+            );
+            const currentModel = currentAgentModelRef.current;
+            const reconciledModel = reconcileAgentModelForCatalog(
+              currentModel,
+              selectableModels,
+              isAgentModelLockedRef.current
+            );
+            if (reconciledModel !== currentModel) {
+              // Catalog reconciliation is not a user interaction and must not
+              // invalidate concurrent account/session initialization.
+              currentAgentModelRef.current = reconciledModel;
+              setModel(reconciledModel);
+            }
+            return;
+          } catch (fetchCatalogError) {
+            if (import.meta.env.DEV) {
+              console.warn(
+                "Failed to fetch model catalog, falling back to fetchModels:",
+                fetchCatalogError
+              );
+            }
+          }
+        }
+
+        if (modelClient.fetchModels) {
+          const models = await modelClient.fetchModels();
+          if (cancelled) return;
+          const availableGenerateModels = models.filter((availableModel) => {
+            const tasks = availableModel.tasks || [];
+            if (tasks.length > 0) return tasks.includes("generate");
+            const id = availableModel.id.toLowerCase();
+            return !id.includes("whisper") && !id.includes("embed");
+          });
+          updateHasWhisperModel(
+            models.some((availableModel) => availableModel.id === "whisper-large-v3")
+          );
+          selectableAgentModelsRef.current = availableGenerateModels;
+          updateAvailableModels(availableGenerateModels);
+          updateModelAliases(buildFallbackModelAliases(availableGenerateModels));
+          const currentModel = currentAgentModelRef.current;
+          const reconciledModel = reconcileAgentModelForCatalog(
+            currentModel,
+            availableGenerateModels,
+            isAgentModelLockedRef.current
+          );
+          if (reconciledModel !== currentModel) {
+            currentAgentModelRef.current = reconciledModel;
+            setModel(reconciledModel);
+          }
+        }
+      } catch (fetchError) {
+        if (import.meta.env.DEV) {
+          console.warn("Failed to fetch model metadata:", fetchError);
+        }
+      } finally {
+        if (!cancelled) setIsAgentModelCatalogLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const contextLimitForModel = useCallback(
+    (modelId: string) =>
+      resolveAgentModelContextLimit(modelId, authoritativeModelCatalogRef.current),
+    []
+  );
 
   const selectMode = useCallback(
     (value: AgentPermissionMode) => {
@@ -1448,6 +1575,7 @@ export function AgentMode({ userId }: { userId: string }) {
           projectRoot,
           title: "New task",
           model: model || DEFAULT_MODEL,
+          contextLimit: contextLimitForModel(model || DEFAULT_MODEL),
           mode: selectedModeRef.current,
           mcpServerNames: selectedNewChatMcpServerNames
         });
@@ -1485,6 +1613,7 @@ export function AgentMode({ userId }: { userId: string }) {
     [
       applyAuthoritativeMode,
       agentSessionSelection,
+      contextLimitForModel,
       model,
       projectRoot,
       replaceSessionTimeline,
@@ -1512,6 +1641,7 @@ export function AgentMode({ userId }: { userId: string }) {
           projectRoot,
           title: "New task",
           model: model || DEFAULT_MODEL,
+          contextLimit: contextLimitForModel(model || DEFAULT_MODEL),
           mode: selectedModeRef.current,
           mcpServerNames: selectedNewChatMcpServerNames
         });
@@ -1554,6 +1684,7 @@ export function AgentMode({ userId }: { userId: string }) {
     applyAuthoritativeMode,
     agentSessionSelection,
     beginSessionSelection,
+    contextLimitForModel,
     finishSessionSelection,
     model,
     projectRoot,
@@ -1607,7 +1738,13 @@ export function AgentMode({ userId }: { userId: string }) {
         setActiveSessionId(detail.session.id);
         agentSessionSelection.remember(userId, detail.session.id);
         setProjectRoot(detail.session.projectRoot);
+        isAgentModelLockedRef.current =
+          detail.session.messageCount > 0 ||
+          hasAgentUserMessage(detail.timeline) ||
+          Boolean(activeRunsBySessionRef.current[detail.session.id]) ||
+          pendingSendTokensRef.current.has(detail.session.id);
         if (detail.session.model) {
+          currentAgentModelRef.current = detail.session.model;
           setModel(detail.session.model);
         }
         applyAuthoritativeMode(normalizeAgentPermissionMode(detail.session.mode));
@@ -1736,6 +1873,7 @@ export function AgentMode({ userId }: { userId: string }) {
           sessionId,
           text,
           model: model || DEFAULT_MODEL,
+          contextLimit: contextLimitForModel(model || DEFAULT_MODEL),
           mode: selectedModeRef.current,
           visionCapable: resolveAgentModelVisionCapability(
             model || DEFAULT_MODEL,
@@ -1788,6 +1926,7 @@ export function AgentMode({ userId }: { userId: string }) {
     activeRunsBySession,
     availableModels,
     clearPendingSend,
+    contextLimitForModel,
     ensureRuntimeAndSession,
     input,
     isAgentSendLocked,
@@ -3482,25 +3621,10 @@ function AgentModelSelector({
   model: string;
   onModelChange: (value: string) => void;
 }) {
-  const {
-    availableModels,
-    setAvailableModels,
-    modelAliases,
-    setModelAliases,
-    billingStatus,
-    setHasWhisperModel
-  } = useLocalState();
-  const os = useOpenSecret();
-  const isFetching = useRef(false);
-  const hasFetched = useRef(false);
-  const currentModelRef = useRef(model);
+  const { availableModels, modelAliases, billingStatus } = useLocalState();
   const [upgradeDialogOpen, setUpgradeDialogOpen] = useState(false);
   const [selectedModelName, setSelectedModelName] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);
-
-  useEffect(() => {
-    currentModelRef.current = model;
-  }, [model]);
 
   const modelById = useMemo(() => {
     return new Map(availableModels.map((availableModel) => [availableModel.id, availableModel]));
@@ -3509,80 +3633,6 @@ function AgentModelSelector({
   const aliasById = useMemo(() => {
     return new Map(modelAliases.map((alias) => [alias.id, alias]));
   }, [modelAliases]);
-
-  const reconcileSelectedConcreteModel = useCallback(
-    (models: OpenSecretModel[]) => {
-      const currentModel = currentModelRef.current;
-      const reconciledModel = reconcileAgentModel(currentModel, models);
-      if (reconciledModel !== currentModel) {
-        onModelChange(reconciledModel);
-      }
-    },
-    [onModelChange]
-  );
-
-  const fetchCatalog = useCallback(async () => {
-    if (hasFetched.current || isFetching.current) return;
-
-    // LocalState may hold only normal chat's last selected model plus placeholder
-    // aliases, so it is not proof that Agent Mode has a complete catalog.
-    isFetching.current = true;
-
-    try {
-      const modelClient = os as unknown as ModelCatalogClient;
-
-      if (modelClient.fetchModelCatalog) {
-        try {
-          const catalog = await modelClient.fetchModelCatalog();
-          const selectableModels = catalog.data.filter(isSelectableChatModel);
-          const hasCatalogWhisperModel = catalog.data.some(
-            (catalogModel) => catalogModel.id === "whisper-large-v3"
-          );
-          hasFetched.current = true;
-          setAvailableModels(selectableModels);
-          setModelAliases(catalog.aliases);
-          setHasWhisperModel(catalog.audio?.transcription?.available ?? hasCatalogWhisperModel);
-          reconcileSelectedConcreteModel(selectableModels);
-
-          return;
-        } catch (fetchCatalogError) {
-          if (import.meta.env.DEV) {
-            console.warn(
-              "Failed to fetch model catalog, falling back to fetchModels:",
-              fetchCatalogError
-            );
-          }
-        }
-      }
-
-      if (modelClient.fetchModels) {
-        const models = await modelClient.fetchModels();
-        const availableGenerateModels = models.filter((availableModel) => {
-          const tasks = availableModel.tasks || [];
-          if (tasks.length > 0) return tasks.includes("generate");
-          const id = availableModel.id.toLowerCase();
-          return !id.includes("whisper") && !id.includes("embed");
-        });
-        hasFetched.current = true;
-        setHasWhisperModel(
-          models.some((availableModel) => availableModel.id === "whisper-large-v3")
-        );
-        setAvailableModels(availableGenerateModels);
-        setModelAliases(buildFallbackModelAliases(availableGenerateModels));
-        reconcileSelectedConcreteModel(availableGenerateModels);
-      }
-    } catch (fetchError) {
-      if (import.meta.env.DEV) {
-        console.warn("Failed to fetch model metadata:", fetchError);
-      }
-    } finally {
-      isFetching.current = false;
-    }
-  }, [os, reconcileSelectedConcreteModel, setAvailableModels, setHasWhisperModel, setModelAliases]);
-
-  useEffect(() => {
-    void fetchCatalog();
-  }, [fetchCatalog]);
 
   const getAlias = useCallback(
     (modelId: string): OpenSecretModelAlias | undefined => {
@@ -3790,7 +3840,6 @@ function AgentModelSelector({
               <DropdownMenuItem
                 onSelect={(event) => {
                   event.preventDefault();
-                  void fetchCatalog();
                   setShowAdvanced(true);
                 }}
                 className="flex cursor-pointer items-center gap-2 px-3 py-1.5"

--- a/frontend/src/services/agentModels.test.ts
+++ b/frontend/src/services/agentModels.test.ts
@@ -5,6 +5,8 @@ import {
   PRIMARY_AGENT_MODEL_IDS,
   fallbackAgentModel,
   reconcileAgentModel,
+  reconcileAgentModelForCatalog,
+  resolveAgentModelContextLimit,
   resolveAgentModelVisionCapability
 } from "./agentModels";
 
@@ -30,6 +32,11 @@ describe("Agent Mode model defaults", () => {
   test("replaces a missing concrete model with the best available default", () => {
     expect(reconcileAgentModel("retired-model", models)).toBe(DEFAULT_AGENT_MODEL);
     expect(reconcileAgentModel(DEFAULT_AGENT_MODEL, [{ id: "kimi-k2-6" }])).toBe(QUICK_MODEL_ALIAS);
+  });
+
+  test("catalog refresh preserves a started task's locked model", () => {
+    expect(reconcileAgentModelForCatalog("retired-model", models, true)).toBe("retired-model");
+    expect(reconcileAgentModelForCatalog("retired-model", models, false)).toBe(DEFAULT_AGENT_MODEL);
   });
 });
 
@@ -71,5 +78,85 @@ describe("resolveAgentModelVisionCapability", () => {
   test("fails closed when the model capability is unknown", () => {
     expect(resolveAgentModelVisionCapability("unknown", catalog, [])).toBe(false);
     expect(resolveAgentModelVisionCapability(QUICK_MODEL_ALIAS, catalog, [])).toBe(false);
+  });
+});
+
+describe("resolveAgentModelContextLimit", () => {
+  const catalog = {
+    data: [
+      { id: "glm-5-2", context_window: 384_000, max_context_tokens: 384_000 },
+      { id: "kimi-k2-6", context_window: 256_000, max_context_tokens: 256_000 },
+      { id: "gemma4-31b", context_window: 256_000, max_context_tokens: 256_000 }
+    ],
+    aliases: [
+      { id: QUICK_MODEL_ALIAS, target_model: "glm-5-2" },
+      { id: POWERFUL_MODEL_ALIAS, target_model: "kimi-k2-6" }
+    ]
+  };
+
+  test("uses exact concrete-model context windows", () => {
+    expect(resolveAgentModelContextLimit("glm-5-2", catalog)).toBe(384_000);
+    expect(resolveAgentModelContextLimit("kimi-k2-6", catalog)).toBe(256_000);
+    expect(resolveAgentModelContextLimit("gemma4-31b", catalog)).toBe(256_000);
+  });
+
+  test("resolves aliases through their current concrete target", () => {
+    expect(resolveAgentModelContextLimit(POWERFUL_MODEL_ALIAS, catalog)).toBe(256_000);
+    expect(
+      resolveAgentModelContextLimit(POWERFUL_MODEL_ALIAS, {
+        ...catalog,
+        aliases: [{ id: POWERFUL_MODEL_ALIAS, target_model: "glm-5-2" }]
+      })
+    ).toBe(384_000);
+  });
+
+  test("accepts either compatible field when the other is absent", () => {
+    expect(
+      resolveAgentModelContextLimit("context-window-only", {
+        data: [{ id: "context-window-only", context_window: 384_000 }],
+        aliases: []
+      })
+    ).toBe(384_000);
+    expect(
+      resolveAgentModelContextLimit("max-context-only", {
+        data: [{ id: "max-context-only", max_context_tokens: 256_000 }],
+        aliases: []
+      })
+    ).toBe(256_000);
+  });
+
+  test("fails closed for unavailable or inconsistent metadata", () => {
+    expect(resolveAgentModelContextLimit("glm-5-2", null)).toBeUndefined();
+    expect(resolveAgentModelContextLimit("missing", catalog)).toBeUndefined();
+    expect(
+      resolveAgentModelContextLimit(POWERFUL_MODEL_ALIAS, {
+        data: catalog.data,
+        aliases: [{ id: POWERFUL_MODEL_ALIAS, target_model: "missing" }]
+      })
+    ).toBeUndefined();
+    expect(
+      resolveAgentModelContextLimit("mismatch", {
+        data: [{ id: "mismatch", context_window: 384_000, max_context_tokens: 256_000 }],
+        aliases: []
+      })
+    ).toBeUndefined();
+  });
+
+  test.each([
+    0,
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    Number.MAX_SAFE_INTEGER + 1,
+    "384000",
+    null
+  ])("rejects invalid context metadata %p", (contextWindow) => {
+    expect(
+      resolveAgentModelContextLimit("invalid", {
+        data: [{ id: "invalid", context_window: contextWindow }],
+        aliases: []
+      })
+    ).toBeUndefined();
   });
 });

--- a/frontend/src/services/agentModels.ts
+++ b/frontend/src/services/agentModels.ts
@@ -18,6 +18,20 @@ type AgentModelAliasReference = {
   };
 };
 
+type AgentModelContextReference = {
+  id: string;
+  context_window?: unknown;
+  max_context_tokens?: unknown;
+};
+
+type AgentModelContextCatalogReference = {
+  data: AgentModelContextReference[];
+  aliases: Array<{
+    id: string;
+    target_model?: string;
+  }>;
+};
+
 export function fallbackAgentModel(models: AgentModelReference[]): string {
   return models.some((model) => model.id === DEFAULT_AGENT_MODEL)
     ? DEFAULT_AGENT_MODEL
@@ -31,6 +45,14 @@ export function reconcileAgentModel(currentModel: string, models: AgentModelRefe
   }
   if (models.some((model) => model.id === currentModel)) return currentModel;
   return fallbackAgentModel(models);
+}
+
+export function reconcileAgentModelForCatalog(
+  currentModel: string,
+  models: AgentModelReference[],
+  isModelLocked: boolean
+): string {
+  return isModelLocked ? currentModel : reconcileAgentModel(currentModel, models);
 }
 
 export function resolveAgentModelVisionCapability(
@@ -47,4 +69,41 @@ export function resolveAgentModelVisionCapability(
   }
 
   return models.find((candidate) => candidate.id === modelId)?.capabilities?.vision ?? false;
+}
+
+function isValidContextLimit(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value > 0;
+}
+
+function contextLimitFromModel(model: AgentModelContextReference | undefined): number | undefined {
+  if (!model) return undefined;
+
+  const contextWindow = model.context_window;
+  const maxContextTokens = model.max_context_tokens;
+  const hasContextWindow = contextWindow !== undefined;
+  const hasMaxContextTokens = maxContextTokens !== undefined;
+
+  if (!hasContextWindow && !hasMaxContextTokens) return undefined;
+  if (hasContextWindow && !isValidContextLimit(contextWindow)) return undefined;
+  if (hasMaxContextTokens && !isValidContextLimit(maxContextTokens)) return undefined;
+  if (hasContextWindow && hasMaxContextTokens && contextWindow !== maxContextTokens) {
+    return undefined;
+  }
+
+  return isValidContextLimit(contextWindow)
+    ? contextWindow
+    : isValidContextLimit(maxContextTokens)
+      ? maxContextTokens
+      : undefined;
+}
+
+export function resolveAgentModelContextLimit(
+  modelId: string,
+  catalog: AgentModelContextCatalogReference | null
+): number | undefined {
+  if (!catalog) return undefined;
+
+  const alias = catalog.aliases.find((candidate) => candidate.id === modelId);
+  const concreteModelId = alias?.target_model || modelId;
+  return contextLimitFromModel(catalog.data.find((candidate) => candidate.id === concreteModelId));
 }

--- a/frontend/src/services/agentRuntimeService.test.ts
+++ b/frontend/src/services/agentRuntimeService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import {
   AgentRuntimeService,
   type AgentRuntimeBridge,
+  type AgentCreateSessionRequest,
   type AgentSendMessageRequest
 } from "./agentRuntimeService";
 
@@ -42,12 +43,28 @@ describe("AgentRuntimeService", () => {
     const request: AgentSendMessageRequest = {
       sessionId: "session-1",
       text: "hello",
+      contextLimit: 384_000,
       visionCapable: false
     };
 
     await service.sendMessage("user-a", request);
 
     expect(bridge.events).toEqual(["fence:user-a", "sync:user-a", "invoke:agent_send_message"]);
+    expect(bridge.lastArgs).toEqual({ userId: "user-a", request });
+  });
+
+  test("session creation forwards the selected model context limit", async () => {
+    const bridge = new RecordingBridge();
+    const service = new AgentRuntimeService(bridge);
+    const request: AgentCreateSessionRequest = {
+      projectRoot: "/tmp/project",
+      model: "kimi-k2-6",
+      contextLimit: 256_000
+    };
+
+    await service.createSession("user-a", request);
+
+    expect(bridge.events).toEqual(["fence:user-a", "sync:user-a", "invoke:agent_create_session"]);
     expect(bridge.lastArgs).toEqual({ userId: "user-a", request });
   });
 });

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -90,6 +90,7 @@ export interface AgentCreateSessionRequest {
   projectRoot?: string | null;
   title?: string | null;
   model?: string | null;
+  contextLimit?: number | null;
   mode?: string | null;
   mcpServerNames?: string[] | null;
 }
@@ -128,6 +129,7 @@ export interface AgentSendMessageRequest {
   sessionId: string;
   text: string;
   model?: string | null;
+  contextLimit?: number | null;
   mode?: string | null;
   visionCapable: boolean;
 }


### PR DESCRIPTION
## Summary
- resolve context windows from the rich OpenSecret SDK catalog, including aliases
- carry the selected model context through session creation and sends into Goose per-session `ModelConfig`
- preserve a same-model persisted context window if later metadata is unavailable, without process-global or cross-model leakage
- keep populated sessions on their persisted model when catalog loading completes late
- cover GLM 384k, Kimi/Gemma 256k, aliases, invalid metadata, bridge forwarding, and native persistence/isolation

## Testing
- `nix develop -c bash -c "cd frontend && bun run build"`
- `nix develop -c bash -c "cd frontend && bun test"` (359 passed)
- `nix develop -c just lint` (0 errors; 13 existing warnings)
- `nix develop -c bash -c "cd frontend && src-tauri/scripts/run-with-desktop-onnxruntime.sh cargo test --manifest-path src-tauri/Cargo.toml --lib"` (207 passed, 1 ignored OCR fixture)
- `nix develop -c just rust-lint`
- managed local OpenSecret, billing, Postgres, Continuum, and flags smoke passed with a deterministic Pro account
- exact native macOS debug bundle: resumed GLM and Kimi tasks returned exact smoke markers; Goose persisted context limits of 384000 and 256000
- independent frontend, native/Goose, integration, tests, and security reviews found no remaining high or critical issues

Fixes #678