### PR TITLE
Fix later chat history pagination during rapid upward scrolling

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -83,6 +83,7 @@ import {
   CHAT_HISTORY_TOP_MARGIN_PX,
   ChatHistoryPaginationGate,
   chatHistoryCursorProgressed,
+  chatHistoryScrolledBackward,
   requiredChatHistoryBottomCompensation,
   restoredChatHistoryAnchorScrollTop,
   restoredChatHistoryScrollTop,
@@ -2318,6 +2319,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
     const previousScrollTop = container.scrollTop;
     container.scrollTop = restoredScrollTop;
+    previousPointerScrollTopRef.current = container.scrollTop;
     if (Math.abs(container.scrollTop - previousScrollTop) > 0.5) {
       // WKWebView emits `scrollend` for this programmatic anchor restore even
       // when trackpad momentum is still active. Ignore that one synthetic end;
@@ -3168,6 +3170,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     };
 
     const handleHistoryWheel = (event: WheelEvent) => {
+      previousPointerScrollTopRef.current = container.scrollTop;
       if (event.deltaY >= 0) {
         if (event.deltaY > 0) {
           gate.endGesture();
@@ -3196,6 +3199,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       }
       touchHistoryGestureActiveRef.current = true;
       previousTouchYRef.current = event.touches[0]?.clientY ?? null;
+      previousPointerScrollTopRef.current = container.scrollTop;
       gate.endGesture();
     };
 
@@ -3248,12 +3252,17 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
     const handleHistoryScroll = () => {
       const nextScrollTop = container.scrollTop;
+      const scrolledBackward = chatHistoryScrolledBackward(
+        previousPointerScrollTopRef.current,
+        nextScrollTop
+      );
 
-      if (
-        pointerHistoryGestureActiveRef.current &&
-        nextScrollTop < previousPointerScrollTopRef.current
-      ) {
-        gate.beginGesture();
+      if (scrolledBackward) {
+        if (pointerHistoryGestureActiveRef.current) {
+          gate.beginGesture();
+        }
+        // Wheel, touch, and keyboard input arm before native scrolling updates the
+        // geometry. Recheck afterward, but never create intent from scrolling alone.
         maybeLoadOlderMessages();
       } else if (
         (pointerHistoryGestureActiveRef.current ||
@@ -3305,6 +3314,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       }
       if (!isBackwardHistoryKey(event)) return;
 
+      previousPointerScrollTopRef.current = container.scrollTop;
       gate.beginGesture();
       maybeLoadOlderMessages();
 

--- a/frontend/src/components/chatHistoryPagination.test.ts
+++ b/frontend/src/components/chatHistoryPagination.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   ChatHistoryPaginationGate,
   chatHistoryCursorProgressed,
+  chatHistoryScrolledBackward,
   requiredChatHistoryBottomCompensation,
   restoredChatHistoryAnchorScrollTop,
   restoredChatHistoryScrollTop
@@ -192,6 +193,28 @@ describe("ChatHistoryPaginationGate", () => {
         topBoundaryVisible: true
       })
     ).toBe(false);
+  });
+});
+
+describe("chatHistoryScrolledBackward", () => {
+  test("rechecks the boundary after native upward scrolling applies", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginGesture();
+    expect(
+      gate.tryStartLoad({
+        canLoad: true,
+        topBoundaryVisible: false
+      })
+    ).toBe(false);
+
+    expect(chatHistoryScrolledBackward(240, 80)).toBe(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+  });
+
+  test("does not recheck on stationary or forward scroll changes", () => {
+    expect(chatHistoryScrolledBackward(80, 80)).toBe(false);
+    expect(chatHistoryScrolledBackward(80, 240)).toBe(false);
   });
 });
 

--- a/frontend/src/components/chatHistoryPagination.ts
+++ b/frontend/src/components/chatHistoryPagination.ts
@@ -38,6 +38,13 @@ export function chatHistoryCursorProgressed(
   return Boolean(nextOldestItemId && nextOldestItemId !== currentOldestItemId);
 }
 
+export function chatHistoryScrolledBackward(
+  previousScrollTop: number,
+  nextScrollTop: number
+): boolean {
+  return nextScrollTop < previousScrollTop;
+}
+
 export class ChatHistoryPaginationGate {
   private intentArmed = false;
   private gestureActive = false;


### PR DESCRIPTION
## Summary

- recheck the history boundary after native upward scrolling applies for wheel, touch, keyboard, and scrollbar input
- synchronize the comparison baseline after anchor restoration so programmatic scrolls cannot become fresh pagination intent
- add focused coverage for the post-scroll retry path and forward/stationary movement

## Validation

- `bun run format:check`
- `bun run lint` (0 errors; 13 existing warnings)
- `bun test` (361 passed)
- `bun run build`
- request-instrumented web GUI with a 90-item tool-heavy chat: exactly one older-page request per deliberate reach through pages 2-5, anchor drift within 0.25 px, and no request past the oldest item
- isolated native macOS WKWebView cold-start smoke through later pages, plus short-chat top-alignment regression check
- three independent reviews (correctness, lifecycle/concurrency, and UX/regression) found no high- or critical-severity defects

Closes #692