### PR TITLE
Fix rapid later chat history pagination

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -81,6 +81,7 @@ import { isLinux, isTauri } from "@/utils/platform";
 import { ConversationProjectPicker } from "@/components/ConversationProjectPicker";
 import {
   CHAT_HISTORY_TOP_MARGIN_PX,
+  CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS,
   ChatHistoryPaginationGate,
   chatHistoryCursorProgressed,
   requiredChatHistoryBottomCompensation,
@@ -3180,13 +3181,16 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         return;
       }
 
-      gate.beginGesture();
+      gate.beginWheelGesture(event.timeStamp);
       maybeLoadOlderMessages();
 
       if (wheelGestureEndTimeoutRef.current) {
         clearTimeout(wheelGestureEndTimeoutRef.current);
       }
-      wheelGestureEndTimeoutRef.current = setTimeout(finishWheelGesture, 180);
+      wheelGestureEndTimeoutRef.current = setTimeout(
+        finishWheelGesture,
+        CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS
+      );
     };
 
     const handleHistoryTouchStart = (event: TouchEvent) => {

--- a/frontend/src/components/chatHistoryPagination.test.ts
+++ b/frontend/src/components/chatHistoryPagination.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS,
   ChatHistoryPaginationGate,
   chatHistoryCursorProgressed,
   requiredChatHistoryBottomCompensation,
@@ -80,6 +81,49 @@ describe("ChatHistoryPaginationGate", () => {
 
     expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
     expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+  });
+
+  test("uses wheel event timestamps when a busy render delays the quiet timer", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(1_000);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+    gate.finishLoad();
+
+    // Residual input inside the quiet period still belongs to the consumed gesture.
+    gate.beginWheelGesture(1_100);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+    // The timeout callback has not run, but the next event proves that the
+    // configured quiet period elapsed after the final residual input.
+    gate.beginWheelGesture(1_100 + CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+  });
+
+  test("loads later pages from fresh wheel bursts without waiting for timer callbacks", () => {
+    const gate = new ChatHistoryPaginationGate();
+    let loadCount = 0;
+    let eventTimestamp = 0;
+
+    gate.beginWheelGesture(eventTimestamp);
+    if (gate.tryStartLoad(visibleBoundary)) loadCount += 1;
+    gate.finishLoad();
+
+    for (let page = 2; page <= 4; page += 1) {
+      // Closely spaced momentum cannot rearm the consumed page.
+      eventTimestamp += 60;
+      gate.beginWheelGesture(eventTimestamp);
+      expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+      // A new burst after the same quiet period used by the fallback timer can.
+      eventTimestamp += CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS;
+      gate.beginWheelGesture(eventTimestamp);
+      if (gate.tryStartLoad(visibleBoundary)) loadCount += 1;
+      expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+      gate.finishLoad();
+    }
+
+    expect(loadCount).toBe(4);
   });
 
   test("does not rearm when the consumed gesture crosses a restored boundary again", () => {

--- a/frontend/src/components/chatHistoryPagination.ts
+++ b/frontend/src/components/chatHistoryPagination.ts
@@ -1,4 +1,5 @@
 export const CHAT_HISTORY_TOP_MARGIN_PX = 100;
+export const CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS = 180;
 
 export type ChatHistoryScrollSnapshot = {
   scrollTop: number;
@@ -42,6 +43,23 @@ export class ChatHistoryPaginationGate {
   private intentArmed = false;
   private gestureActive = false;
   private loadInFlight = false;
+  private lastWheelInputAt: number | null = null;
+
+  beginWheelGesture(eventTimestamp: number): void {
+    if (
+      this.lastWheelInputAt !== null &&
+      eventTimestamp - this.lastWheelInputAt >= CHAT_HISTORY_WHEEL_GESTURE_QUIET_MS
+    ) {
+      // A busy prepend/render can delay the compatibility timeout past the next
+      // physical swipe. Preserve the same quiet-period boundary synchronously
+      // from the browser event timestamps so that swipe is not consumed as
+      // momentum from the previous page.
+      this.endGesture();
+    }
+
+    this.lastWheelInputAt = eventTimestamp;
+    this.beginGesture();
+  }
 
   beginGesture(): void {
     if (this.gestureActive) return;
@@ -55,11 +73,13 @@ export class ChatHistoryPaginationGate {
   endGesture(): void {
     this.gestureActive = false;
     this.intentArmed = false;
+    this.lastWheelInputAt = null;
   }
 
   resetIntent(): void {
     this.gestureActive = false;
     this.intentArmed = false;
+    this.lastWheelInputAt = null;
   }
 
   tryStartLoad({


### PR DESCRIPTION
## Summary

- end the consumed wheel gesture synchronously when event timestamps show the existing 180 ms quiet boundary, even if a busy prepend delayed the fallback timer
- retain the one-page-per-gesture and load-in-flight guards
- add focused coverage for delayed timer callbacks and rapid pages 2 through 4

The failure on master was reproduced with a 296 ms gap between consecutive upward wheel events: the first prepend delayed the gesture timeout, then the second wheel event cleared that still-pending timeout and stayed attached to the already-consumed gesture.

## Validation

- native macOS Maple app against the managed local OpenSecret, billing, feature-flag, and database services
- tool-heavy 65-item conversation spanning four history pages
- rapid later-page gestures loaded exactly one page each, preserved the visible anchor, and issued no idle cascade
- final cold runtime recorded three advancing older-page requests total: the initial older page plus two back-to-back later pages
- bun test: 387 passed
- bun run typecheck
- bun run lint: 0 errors, 13 existing warnings
- bun run build
- managed workspace smoke
- fresh correctness, lifecycle/security, and UX/regression reviews

Supersedes #708.

Closes #692