### PR TITLE
fix(auth): handle Apple sign-in completion once

### DIFF
--- a/frontend/src/components/AppleAuthProvider.test.tsx
+++ b/frontend/src/components/AppleAuthProvider.test.tsx
@@ -1,0 +1,318 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import type { AppleAuthorization } from "./AppleAuthProvider";
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+interface FakeScript {
+  async: boolean;
+  parentNode: FakeHead | null;
+  src: string;
+}
+
+interface FakeHead {
+  appendChild(script: FakeScript): FakeScript;
+  removeChild(script: FakeScript): FakeScript;
+}
+
+class FakeDocument extends EventTarget {
+  readonly addedEventTypes: string[] = [];
+  readonly head: FakeHead = {
+    appendChild: (script) => {
+      script.parentNode = this.head;
+      return script;
+    },
+    removeChild: (script) => {
+      script.parentNode = null;
+      return script;
+    }
+  };
+
+  override addEventListener(
+    type: string,
+    callback: EventListenerOrEventListenerObject | null,
+    options?: AddEventListenerOptions | boolean
+  ): void {
+    this.addedEventTypes.push(type);
+    super.addEventListener(type, callback, options);
+  }
+
+  createElement(): FakeScript {
+    return { async: false, parentNode: null, src: "" };
+  }
+}
+
+interface SignInControl {
+  reject(error: unknown): void;
+  resolve(result: { authorization: AppleAuthorization }): void;
+}
+
+function appleEvent(type: "AppleIDSignInOnSuccess" | "AppleIDSignInOnFailure", detail: unknown) {
+  const event = new Event(type);
+  Object.defineProperty(event, "detail", { value: detail });
+  return event;
+}
+
+let currentOpenSecret: Record<string, unknown>;
+const realOpenSecret = await import("@opensecret/react");
+mock.module("@opensecret/react", () => ({
+  ...realOpenSecret,
+  useOpenSecret: () => currentOpenSecret
+}));
+
+const { initBillingService } = await import("@/billing/billingService");
+const { AppleAuthProvider } = await import("./AppleAuthProvider");
+
+const originalGlobals = {
+  document: Object.getOwnPropertyDescriptor(globalThis, "document"),
+  localStorage: Object.getOwnPropertyDescriptor(globalThis, "localStorage"),
+  sessionStorage: Object.getOwnPropertyDescriptor(globalThis, "sessionStorage"),
+  window: Object.getOwnPropertyDescriptor(globalThis, "window")
+};
+
+function setGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+    writable: true
+  });
+}
+
+function restoreGlobal(name: string, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
+describe("AppleAuthProvider", () => {
+  let documentTarget: FakeDocument;
+  let renderer: ReactTestRenderer | null;
+  let signInControls: SignInControl[];
+  let initiateAppleAuth: ReturnType<typeof mock>;
+  let handleAppleCallback: ReturnType<typeof mock>;
+  let onError: ReturnType<typeof mock>;
+  let onSuccess: ReturnType<typeof mock>;
+  let redirectAfterLogin: ReturnType<typeof mock>;
+  let appleInit: ReturnType<typeof mock>;
+  let appleSignIn: ReturnType<typeof mock>;
+  let originalConsoleError: typeof console.error;
+
+  beforeEach(() => {
+    renderer = null;
+    originalConsoleError = console.error;
+    console.error = mock(() => {});
+    documentTarget = new FakeDocument();
+    signInControls = [];
+    const states = ["state-one", "state-two", "state-three", "state-four"];
+
+    initiateAppleAuth = mock(async () => ({ state: states.shift() ?? "unexpected-state" }));
+    handleAppleCallback = mock(async () => {});
+    onError = mock(() => {});
+    onSuccess = mock(() => {});
+    redirectAfterLogin = mock(() => {});
+    appleInit = mock(() => {});
+    appleSignIn = mock(
+      () =>
+        new Promise<{ authorization: AppleAuthorization }>((resolve, reject) => {
+          signInControls.push({ resolve, reject });
+        })
+    );
+
+    currentOpenSecret = {
+      initiateAppleAuth,
+      handleAppleCallback
+    };
+    initBillingService(currentOpenSecret as never);
+
+    const localStorage = new MemoryStorage();
+    const sessionStorage = new MemoryStorage();
+    const windowValue = {
+      AppleID: {
+        auth: {
+          init: appleInit,
+          signIn: appleSignIn
+        }
+      },
+      localStorage,
+      location: {
+        href: "https://trymaple.ai/login",
+        origin: "https://trymaple.ai",
+        protocol: "https:"
+      },
+      sessionStorage
+    };
+
+    setGlobal("document", documentTarget);
+    setGlobal("localStorage", localStorage);
+    setGlobal("sessionStorage", sessionStorage);
+    setGlobal("window", windowValue);
+  });
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+    }
+    restoreGlobal("document", originalGlobals.document);
+    restoreGlobal("localStorage", originalGlobals.localStorage);
+    restoreGlobal("sessionStorage", originalGlobals.sessionStorage);
+    restoreGlobal("window", originalGlobals.window);
+    console.error = originalConsoleError;
+  });
+
+  async function startAttempt(): Promise<{ completion: Promise<void>; control: SignInControl }> {
+    let completion: Promise<void> | undefined;
+    await act(async () => {
+      completion = renderer?.root.findByType("button").props.onClick();
+      for (let index = 0; index < 5 && signInControls.length === 0; index += 1) {
+        await Promise.resolve();
+      }
+    });
+
+    const control = signInControls.shift();
+    if (!completion || !control) throw new Error("Apple sign-in attempt did not start");
+    return { completion, control };
+  }
+
+  test("uses only the signIn promise and retries with fresh state after cancellation or rejection", async () => {
+    await act(async () => {
+      renderer = create(
+        <AppleAuthProvider
+          inviteCode="invite-one"
+          onError={onError}
+          onSuccess={onSuccess}
+          redirectAfterLogin={redirectAfterLogin}
+          selectedPlan="pro"
+        />
+      );
+    });
+
+    expect(
+      documentTarget.addedEventTypes.filter((type) => type.startsWith("AppleIDSignIn"))
+    ).toEqual([]);
+
+    const firstAttempt = await startAttempt();
+    await act(async () => {
+      await renderer?.root.findByType("button").props.onClick();
+    });
+    expect(initiateAppleAuth).toHaveBeenCalledTimes(1);
+    expect(appleSignIn).toHaveBeenCalledTimes(1);
+
+    documentTarget.dispatchEvent(
+      appleEvent("AppleIDSignInOnSuccess", {
+        authorization: { code: "event-code", state: "state-one" }
+      })
+    );
+    documentTarget.dispatchEvent(
+      appleEvent("AppleIDSignInOnFailure", { error: "event-only-error" })
+    );
+    await Promise.resolve();
+
+    expect(handleAppleCallback).toHaveBeenCalledTimes(0);
+    expect(onError).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      firstAttempt.control.reject({ error: "user_cancelled_authorize" });
+      await firstAttempt.completion;
+    });
+
+    expect(onError).toHaveBeenCalledTimes(0);
+    expect(handleAppleCallback).toHaveBeenCalledTimes(0);
+
+    const legacyCancellationAttempt = await startAttempt();
+    await act(async () => {
+      legacyCancellationAttempt.control.reject({ error: "popup_closed_by_user" });
+      await legacyCancellationAttempt.completion;
+    });
+
+    expect(onError).toHaveBeenCalledTimes(0);
+    expect(handleAppleCallback).toHaveBeenCalledTimes(0);
+
+    const failedAttempt = await startAttempt();
+    await act(async () => {
+      failedAttempt.control.reject({ error: "authorization_failed" });
+      await failedAttempt.completion;
+    });
+
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onError.mock.calls[0]?.[0]).toEqual(new Error("authorization_failed"));
+    expect(handleAppleCallback).toHaveBeenCalledTimes(0);
+
+    await act(async () => {
+      renderer?.update(
+        <AppleAuthProvider
+          inviteCode="invite-two"
+          onError={onError}
+          onSuccess={onSuccess}
+          redirectAfterLogin={redirectAfterLogin}
+          selectedPlan="max"
+        />
+      );
+    });
+
+    const retry = await startAttempt();
+    documentTarget.dispatchEvent(
+      appleEvent("AppleIDSignInOnSuccess", {
+        authorization: { code: "promise-code", state: "state-two" }
+      })
+    );
+    documentTarget.dispatchEvent(
+      appleEvent("AppleIDSignInOnFailure", { error: "ignored-event-error" })
+    );
+    await Promise.resolve();
+    expect(handleAppleCallback).toHaveBeenCalledTimes(0);
+    expect(onError).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      retry.control.resolve({
+        authorization: { code: "promise-code", state: "state-four" }
+      });
+      await retry.completion;
+    });
+
+    expect(initiateAppleAuth).toHaveBeenCalledTimes(4);
+    expect(initiateAppleAuth).toHaveBeenNthCalledWith(1, "invite-one");
+    expect(initiateAppleAuth).toHaveBeenNthCalledWith(2, "invite-one");
+    expect(initiateAppleAuth).toHaveBeenNthCalledWith(3, "invite-one");
+    expect(initiateAppleAuth).toHaveBeenNthCalledWith(4, "invite-two");
+    expect(appleInit).toHaveBeenCalledTimes(4);
+    expect(appleInit.mock.calls[0]?.[0]).toMatchObject({ state: "state-one" });
+    expect(appleInit.mock.calls[1]?.[0]).toMatchObject({ state: "state-two" });
+    expect(appleInit.mock.calls[2]?.[0]).toMatchObject({ state: "state-three" });
+    expect(appleInit.mock.calls[3]?.[0]).toMatchObject({ state: "state-four" });
+    expect(handleAppleCallback).toHaveBeenCalledTimes(1);
+    expect(handleAppleCallback).toHaveBeenCalledWith("promise-code", "state-four", "invite-two");
+    expect(onError).toHaveBeenCalledTimes(1);
+    expect(onSuccess).toHaveBeenCalledTimes(1);
+    expect(redirectAfterLogin).toHaveBeenCalledTimes(1);
+    expect(redirectAfterLogin).toHaveBeenCalledWith("max");
+  });
+});

--- a/frontend/src/components/AppleAuthProvider.tsx
+++ b/frontend/src/components/AppleAuthProvider.tsx
@@ -8,7 +8,6 @@ import { Apple } from "./icons/Apple";
 import { getBillingService } from "@/billing/billingService";
 import { getSafeInternalRedirect } from "@/utils/internalRedirect";
 
-// Define the props interface
 interface AppleAuthProviderProps {
   onSuccess?: () => void;
   onError?: (error: Error) => void;
@@ -21,7 +20,12 @@ interface AppleAuthProviderProps {
   children?: React.ReactNode;
 }
 
-// Define AppleID interface which will be added to window
+export interface AppleAuthorization {
+  code: string;
+  state: string;
+  id_token?: string;
+}
+
 declare global {
   interface Window {
     AppleID: {
@@ -35,43 +39,25 @@ declare global {
           usePopup: boolean;
         }) => void;
         signIn: () => Promise<{
-          authorization: {
-            code: string;
-            state: string;
-            id_token?: string;
-          };
+          authorization: AppleAuthorization;
         }>;
       };
     };
   }
 }
 
-// Define Apple Sign In event types
-interface AppleSignInAuthorizationData {
-  code: string;
-  state: string;
-  id_token?: string;
+function getAppleAuthError(value: unknown): Error {
+  if (value instanceof Error) return value;
+  if (value && typeof value === "object") {
+    const error = (value as Record<string, unknown>).error;
+    if (typeof error === "string" && error) return new Error(error);
+  }
+
+  return new Error("Apple authentication failed");
 }
 
-interface AppleSignInSuccessEventDetail {
-  data?: {
-    authorization?: AppleSignInAuthorizationData;
-  };
-  authorization?: AppleSignInAuthorizationData;
-  code?: string;
-  state?: string;
-  id_token?: string;
-}
-
-interface AppleSignInSuccessEvent extends Event {
-  detail: AppleSignInSuccessEventDetail | string;
-  authorization?: AppleSignInAuthorizationData;
-}
-
-interface AppleSignInFailureEvent extends Event {
-  detail: {
-    error: string;
-  };
+function isAppleAuthCancellation(error: Error): boolean {
+  return error.message === "user_cancelled_authorize" || error.message === "popup_closed_by_user";
 }
 
 export function AppleAuthProvider({
@@ -87,335 +73,128 @@ export function AppleAuthProvider({
 }: AppleAuthProviderProps) {
   const os = useOpenSecret();
   const appleScriptLoaded = useRef(false);
-  const appleAuthInitialized = useRef(false);
   const rawNonceRef = useRef<string>("");
-  const isInitializing = useRef(false);
+  const isSignInPending = useRef(false);
 
-  // Load Apple Sign In JS SDK on mount (but don't initialize auth yet)
   useEffect(() => {
-    // Don't load the script multiple times
     if (appleScriptLoaded.current) return;
-
-    // Skip if we're in a Tauri environment (will use native flow on iOS)
     if (window.location.protocol === "tauri:") return;
 
-    // Load Apple Sign In JS SDK
     const script = document.createElement("script");
     script.src =
       "https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/en_US/appleid.auth.js";
     script.async = true;
-    script.onload = () => {
-      // SDK loaded successfully
-    };
     document.head.appendChild(script);
-
     appleScriptLoaded.current = true;
 
     return () => {
-      // Clean up script on unmount if needed
       if (script.parentNode) {
         script.parentNode.removeChild(script);
       }
+      appleScriptLoaded.current = false;
     };
   }, []);
 
   const initializeAppleAuth = async () => {
     if (!window.AppleID) {
-      console.error("[Apple Auth] AppleID JS SDK not loaded");
-      return;
+      throw new Error("Apple Sign In SDK not loaded");
     }
 
-    // Prevent double initialization
-    if (isInitializing.current || appleAuthInitialized.current) {
-      return;
+    // A retry is a new authorization attempt, so it gets a fresh backend state and nonce.
+    const initiateResult = await os.initiateAppleAuth(inviteCode || "");
+    rawNonceRef.current = uuidv4();
+    const hashedNonce = bytesToHex(sha256(new TextEncoder().encode(rawNonceRef.current)));
+
+    sessionStorage.setItem("apple_auth_nonce", rawNonceRef.current);
+    const state = initiateResult.state || "";
+    sessionStorage.setItem("apple_auth_state", state);
+
+    if (selectedPlan) {
+      sessionStorage.setItem("selected_plan", selectedPlan);
     }
-    isInitializing.current = true;
+
+    window.AppleID.auth.init({
+      clientId: "cloud.opensecret.maple.services",
+      scope: "name email",
+      redirectURI: window.location.origin + "/auth/apple/callback",
+      state,
+      nonce: hashedNonce,
+      usePopup: true
+    });
+  };
+
+  const completeAuthorization = async (authorization: AppleAuthorization) => {
+    sessionStorage.removeItem("apple_auth_state");
+    await os.handleAppleCallback(authorization.code, authorization.state, inviteCode || "");
 
     try {
-      try {
-        // First we need to get the proper state and auth URL from the backend
-        const initiateResult = await os.initiateAppleAuth(inviteCode || "");
-
-        // Generate the nonce for Apple
-        rawNonceRef.current = uuidv4();
-        const hashedNonce = bytesToHex(sha256(new TextEncoder().encode(rawNonceRef.current)));
-
-        // Store the raw nonce in sessionStorage to access it during callback
-        sessionStorage.setItem("apple_auth_nonce", rawNonceRef.current);
-
-        // Store the state from the backend for CSRF validation
-        const state = initiateResult.state || "";
-        sessionStorage.setItem("apple_auth_state", state);
-
-        // Store selected plan if present
-        if (selectedPlan) {
-          sessionStorage.setItem("selected_plan", selectedPlan);
-        }
-
-        // Initialize Apple auth with required parameters
-        window.AppleID.auth.init({
-          clientId: "cloud.opensecret.maple.services", // Apple Services ID
-          scope: "name email",
-          redirectURI: window.location.origin + "/auth/apple/callback",
-          state: state, // Use the state from the backend
-          nonce: hashedNonce,
-          usePopup: true // Using popup to capture authentication on client side
-        });
-      } catch (error) {
-        console.error("[Apple Auth] Failed to initialize:", error);
-        if (onError && error instanceof Error) {
-          onError(error);
-        }
-      }
-
-      // Add event listeners for Apple Sign In response
-      document.addEventListener("AppleIDSignInOnSuccess", async (event) => {
-        // Handle successful response
-        try {
-          // Cast event to AppleSignInSuccessEvent
-          const appleEvent = event as AppleSignInSuccessEvent;
-
-          // Access the data - the structure might vary
-          let code, state;
-
-          // Different versions of Apple Sign In JS SDK might structure the data differently
-          if (
-            typeof appleEvent.detail === "object" &&
-            appleEvent.detail.data?.authorization?.code
-          ) {
-            // Standard structure
-            code = appleEvent.detail.data.authorization.code;
-            state = appleEvent.detail.data.authorization.state;
-          } else if (
-            typeof appleEvent.detail === "object" &&
-            appleEvent.detail.authorization?.code
-          ) {
-            // Alternative structure
-            code = appleEvent.detail.authorization.code;
-            state = appleEvent.detail.authorization.state;
-          } else if (typeof appleEvent.detail === "object" && appleEvent.detail.code) {
-            // Simplified structure
-            code = appleEvent.detail.code;
-            state = appleEvent.detail.state;
-          } else if (appleEvent.authorization?.code) {
-            // Another possible structure
-            code = appleEvent.authorization.code;
-            state = appleEvent.authorization.state;
-          } else if (typeof appleEvent.detail === "string") {
-            // Sometimes the data might be a stringified JSON
-            try {
-              const parsedData = JSON.parse(appleEvent.detail);
-              code = parsedData.code || parsedData.authorization?.code;
-              state = parsedData.state || parsedData.authorization?.state;
-            } catch (e) {
-              console.error("[Apple Auth] Failed to parse string data:", e);
-            }
-          }
-
-          if (code && state) {
-            // Validate state for CSRF protection
-            // TODO: Fix state validation later
-            // const storedState = sessionStorage.getItem("apple_auth_state");
-            // if (state !== storedState) {
-            //   throw new Error("Invalid state parameter - potential CSRF attack");
-            // }
-
-            // Clear the stored state after validation
-            sessionStorage.removeItem("apple_auth_state");
-
-            // Call the OpenSecret SDK to handle the authentication
-            await os.handleAppleCallback(code, state, inviteCode || "");
-
-            // Clear any existing billing token to prevent session mixing
-            try {
-              getBillingService().clearToken();
-            } catch (billingError) {
-              console.warn("Failed to clear billing token:", billingError);
-            }
-
-            // Check if this is a Tauri app auth flow (desktop or mobile)
-            const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";
-
-            if (isTauriAuth) {
-              // Clear the flag
-              localStorage.removeItem("redirect-to-native");
-
-              // Handle Tauri redirect - redirect back to desktop app
-              const accessToken = localStorage.getItem("access_token") || "";
-              const refreshToken = localStorage.getItem("refresh_token");
-
-              let deepLinkUrl = `cloud.opensecret.maple://auth?access_token=${encodeURIComponent(accessToken)}`;
-
-              if (refreshToken) {
-                deepLinkUrl += `&refresh_token=${encodeURIComponent(refreshToken)}`;
-              }
-
-              const postAuthRedirect = sessionStorage.getItem("post_auth_redirect");
-              sessionStorage.removeItem("post_auth_redirect");
-              const safePostAuthRedirect = getSafeInternalRedirect(postAuthRedirect);
-
-              if (!selectedPlan && safePostAuthRedirect) {
-                deepLinkUrl += `&next=${encodeURIComponent(safePostAuthRedirect)}`;
-              }
-
-              setTimeout(() => {
-                window.location.href = deepLinkUrl;
-              }, 1000);
-
-              return;
-            }
-
-            // Handle web flow - regular navigation
-            if (onSuccess) {
-              onSuccess();
-            }
-
-            if (redirectAfterLogin) {
-              redirectAfterLogin(selectedPlan);
-            }
-          } else {
-            throw new Error("Missing required authentication data");
-          }
-        } catch (error) {
-          console.error("[Apple Auth] Error processing authentication:", error);
-          if (onError && error instanceof Error) {
-            onError(error);
-          }
-        }
-      });
-
-      // Listen for authorization failures
-      document.addEventListener("AppleIDSignInOnFailure", (event) => {
-        const failureEvent = event as AppleSignInFailureEvent;
-        const errorMessage = failureEvent.detail.error;
-        console.error("[Apple Auth] Sign In failed:", errorMessage);
-
-        // Don't show error for user closing the popup - they already know
-        if (errorMessage === "popup_closed_by_user") {
-          return;
-        }
-
-        if (onError) {
-          onError(new Error(errorMessage || "Apple authentication failed"));
-        }
-      });
-
-      appleAuthInitialized.current = true;
-      isInitializing.current = false;
-    } catch (error) {
-      console.error("[Apple Auth] Failed to initialize Apple Sign In:", error);
-      isInitializing.current = false;
-      if (onError && error instanceof Error) {
-        onError(error);
-      }
+      getBillingService().clearToken();
+    } catch (billingError) {
+      console.warn("Failed to clear billing token:", billingError);
     }
+
+    const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";
+    if (isTauriAuth) {
+      localStorage.removeItem("redirect-to-native");
+
+      const accessToken = localStorage.getItem("access_token") || "";
+      const refreshToken = localStorage.getItem("refresh_token");
+      let deepLinkUrl = `cloud.opensecret.maple://auth?access_token=${encodeURIComponent(accessToken)}`;
+
+      if (refreshToken) {
+        deepLinkUrl += `&refresh_token=${encodeURIComponent(refreshToken)}`;
+      }
+
+      const postAuthRedirect = sessionStorage.getItem("post_auth_redirect");
+      sessionStorage.removeItem("post_auth_redirect");
+      const safePostAuthRedirect = getSafeInternalRedirect(postAuthRedirect);
+
+      if (!selectedPlan && safePostAuthRedirect) {
+        deepLinkUrl += `&next=${encodeURIComponent(safePostAuthRedirect)}`;
+      }
+
+      setTimeout(() => {
+        window.location.href = deepLinkUrl;
+      }, 1000);
+      return;
+    }
+
+    onSuccess?.();
+    redirectAfterLogin?.(selectedPlan);
   };
 
   const handleAppleSignIn = async () => {
+    if (isSignInPending.current) return;
+    isSignInPending.current = true;
+
     try {
-      if (!window.AppleID) {
-        throw new Error("Apple Sign In SDK not loaded");
-      }
+      await initializeAppleAuth();
 
-      // Initialize Apple Auth if not already initialized
-      if (!appleAuthInitialized.current) {
-        await initializeAppleAuth();
-        appleAuthInitialized.current = true;
-      }
-
-      // This will open a popup for Apple authentication
-      // Add additional handling to be more robust
+      // Programmatic Apple sign-in returns one promise that resolves on success and rejects on
+      // failure. It is the only completion channel; document events are intentionally unused.
       const authResult = await window.AppleID.auth.signIn();
-
-      // Some implementations might return the data directly
-      if (authResult && authResult.authorization && authResult.authorization.code) {
-        const code = authResult.authorization.code;
-        const state = authResult.authorization.state;
-
-        if (code && state) {
-          // Validate state for CSRF protection
-          // TODO: Fix state validation later
-          // const storedState = sessionStorage.getItem("apple_auth_state");
-          // if (state !== storedState) {
-          //   throw new Error("Invalid state parameter - potential CSRF attack");
-          // }
-
-          // Clear the stored state after validation
-          sessionStorage.removeItem("apple_auth_state");
-
-          // Call the OpenSecret SDK to handle the authentication
-          await os.handleAppleCallback(code, state, inviteCode || "");
-
-          // Clear any existing billing token to prevent session mixing
-          try {
-            getBillingService().clearToken();
-          } catch (billingError) {
-            console.warn("Failed to clear billing token:", billingError);
-          }
-
-          // Check if this is a Tauri app auth flow (desktop or mobile)
-          const isTauriAuth = localStorage.getItem("redirect-to-native") === "true";
-
-          if (isTauriAuth) {
-            // Clear the flag
-            localStorage.removeItem("redirect-to-native");
-
-            // Handle Tauri redirect - redirect back to desktop app
-            const accessToken = localStorage.getItem("access_token") || "";
-            const refreshToken = localStorage.getItem("refresh_token");
-
-            let deepLinkUrl = `cloud.opensecret.maple://auth?access_token=${encodeURIComponent(accessToken)}`;
-
-            if (refreshToken) {
-              deepLinkUrl += `&refresh_token=${encodeURIComponent(refreshToken)}`;
-            }
-
-            const postAuthRedirect = sessionStorage.getItem("post_auth_redirect");
-            sessionStorage.removeItem("post_auth_redirect");
-            const safePostAuthRedirect = getSafeInternalRedirect(postAuthRedirect);
-
-            if (!selectedPlan && safePostAuthRedirect) {
-              deepLinkUrl += `&next=${encodeURIComponent(safePostAuthRedirect)}`;
-            }
-
-            setTimeout(() => {
-              window.location.href = deepLinkUrl;
-            }, 1000);
-
-            return;
-          }
-
-          // Handle web flow - regular navigation
-          if (onSuccess) {
-            onSuccess();
-          }
-
-          if (redirectAfterLogin) {
-            redirectAfterLogin(selectedPlan);
-          }
-        }
+      const authorization = authResult?.authorization;
+      if (!authorization?.code || !authorization.state) {
+        throw new Error("Missing required authentication data");
       }
-      // If not returned directly, it will be handled by the event listener
+
+      await completeAuthorization(authorization);
     } catch (error) {
-      console.error("[Apple Auth] Sign In failed:", error);
+      const signInError = getAppleAuthError(error);
+      console.error("[Apple Auth] Sign In failed:", signInError);
 
-      // Don't show error for user closing the popup
-      if (error instanceof Error && error.message === "popup_closed_by_user") {
-        return;
+      if (!isAppleAuthCancellation(signInError)) {
+        onError?.(signInError);
       }
-
-      if (onError && error instanceof Error) {
-        onError(error);
-      }
+    } finally {
+      isSignInPending.current = false;
     }
   };
 
-  // Skip rendering on Tauri (iOS will use native button)
   if (window.location.protocol === "tauri:") {
     return null;
   }
 
-  // Render Apple Sign In button for web
   return children ? (
     <div onClick={handleAppleSignIn} className={className}>
       {children}


### PR DESCRIPTION
## Summary

- use the documented AppleID.auth.signIn promise as the single completion channel
- remove the parallel document-event handlers that submitted the same Apple authorization twice and leaked across mounts
- prevent overlapping clicks while an Apple attempt is pending
- create fresh backend state and nonce for each genuine retry
- preserve silent handling for both documented and legacy Apple cancellation codes

## Why

Apple popup mode emits DOM events, while a programmatic AppleID.auth.signIn call also returns a promise for the same authorization. AppleAuthProvider consumed both channels and called handleAppleCallback twice. A consume-once OAuth backend accepts the first callback and correctly rejects the replay, which can surface a false login failure after authentication already succeeded.

Maple always starts this flow by explicitly calling AppleID.auth.signIn, and Apple documents that this promise resolves on success and rejects on failure. Using that one standard channel removes the race rather than deduplicating two independently scheduled callbacks.

Apple documentation: https://developer.apple.com/documentation/signinwithapple/configuring-your-webpage-for-sign-in-with-apple

This is frontend-only and wire-compatible with both older backends and the consume-once behavior in OpenSecretCloud/opensecret#222. It does not change SDK behavior, endpoint payloads, status handling, token storage, hosted native handoff URLs, or native iOS Sign in with Apple.

This complements but is independent from #715, which fixes the separate routed GitHub/Google callback remount.

## Validation

- frontend tests: 386 passed
- focused Apple regression test: 30 assertions passed
- TypeScript typecheck: passed
- production build: passed
- formatting: passed
- lint: 0 errors; 13 pre-existing warnings
- independent security, platform, and cancellation reviews: no remaining actionable findings

A live Apple popup and hosted native handoff smoke test remains recommended after deploying the hosted frontend.