### PR TITLE
Fix overlapping chat history pagination gestures

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -77,7 +77,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { isLinux, isTauri } from "@/utils/platform";
+import { isLinux, isMacOS, isTauri } from "@/utils/platform";
 import { ConversationProjectPicker } from "@/components/ConversationProjectPicker";
 import {
   CHAT_HISTORY_TOP_MARGIN_PX,
@@ -86,7 +86,8 @@ import {
   requiredChatHistoryBottomCompensation,
   restoredChatHistoryAnchorScrollTop,
   restoredChatHistoryScrollTop,
-  type ChatHistoryScrollSnapshot
+  type ChatHistoryScrollSnapshot,
+  usesFirstCancelableWheelGestureStart
 } from "@/components/chatHistoryPagination";
 import {
   ChatProjectionScrollCoordinator,
@@ -1941,10 +1942,16 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const projectionScrollCoordinatorRef = useRef(
     new ChatProjectionScrollCoordinator<ChatRuntimeKey>()
   );
-  const historyPaginationGateRef = useRef(new ChatHistoryPaginationGate());
+  const historyPaginationLifecycle = useMemo(
+    () => ({ runtimeKey: renderedRuntimeKey, gate: new ChatHistoryPaginationGate() }),
+    [renderedRuntimeKey]
+  );
+  const historyPaginationGate = historyPaginationLifecycle.gate;
   const pendingHistoryScrollRestoreRef = useRef<ChatHistoryScrollSnapshot | null>(null);
   const pendingHistoryScrollRestoreKeyRef = useRef<ChatRuntimeKey | null>(null);
   const wheelGestureEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const macOSWheelGestureStartPendingRef = useRef(false);
+  const macOSPreviousWheelCancelableRef = useRef<boolean | null>(null);
   const touchGestureEndTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const keyIntentTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const previousTouchYRef = useRef<number | null>(null);
@@ -2054,10 +2061,11 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     clearHistoryBottomCompensation();
   }, [renderedRuntimeKey, clearHistoryBottomCompensation]);
 
-  useEffect(() => {
-    historyPaginationGateRef.current.resetIntent();
+  useLayoutEffect(() => {
     pendingHistoryScrollRestoreRef.current = null;
     pendingHistoryScrollRestoreKeyRef.current = null;
+    macOSWheelGestureStartPendingRef.current = false;
+    macOSPreviousWheelCancelableRef.current = null;
     previousTouchYRef.current = null;
     touchHistoryGestureActiveRef.current = false;
     pointerHistoryGestureActiveRef.current = false;
@@ -2077,6 +2085,8 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     }
 
     return () => {
+      macOSWheelGestureStartPendingRef.current = false;
+      macOSPreviousWheelCancelableRef.current = null;
       suppressedHistoryScrollEndsRef.current = 0;
       if (wheelGestureEndTimeoutRef.current) {
         clearTimeout(wheelGestureEndTimeoutRef.current);
@@ -2336,6 +2346,13 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
     if (!isVisible) {
       coordinator.deactivate();
+      historyPaginationGate.resetIntent();
+      macOSWheelGestureStartPendingRef.current = false;
+      macOSPreviousWheelCancelableRef.current = null;
+      if (wheelGestureEndTimeoutRef.current) {
+        clearTimeout(wheelGestureEndTimeoutRef.current);
+        wheelGestureEndTimeoutRef.current = null;
+      }
       return;
     }
 
@@ -2343,7 +2360,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
     if (projectionChanged) {
       clearHistoryBottomCompensation();
-      historyPaginationGateRef.current.resetIntent();
+      historyPaginationGate.resetIntent();
       pendingHistoryScrollRestoreRef.current = null;
       pendingHistoryScrollRestoreKeyRef.current = null;
       isUserScrollingRef.current = false;
@@ -2403,7 +2420,8 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     messages,
     renderedRuntimeKey,
     resolveScrollProjectionKey,
-    runtimeStore
+    runtimeStore,
+    historyPaginationGate
   ]);
 
   // Auto-scroll when user sends a message
@@ -2762,14 +2780,14 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   // Load older messages for pagination
   const loadOlderMessages = useCallback(async () => {
-    const runtimeKey = activeRuntimeKeyRef.current;
+    const { gate: paginationGate, runtimeKey } = historyPaginationLifecycle;
     const snapshot = runtimeStore.get(runtimeKey);
     const conversationId =
       snapshot?.conversation?.id ??
       conversationIdFromChatRuntimeKey(runtimeStore.resolveKey(runtimeKey));
     const requestOldestItemId = snapshot?.composer.pagination.oldestItemId;
     if (!conversationId || !openai || !requestOldestItemId) {
-      historyPaginationGateRef.current.finishLoad();
+      paginationGate.finishLoad();
       return;
     }
 
@@ -2777,6 +2795,8 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       ...composer,
       pagination: { ...composer.pagination, isLoadingOlderMessages: true }
     }));
+
+    let pageProgressed = false;
 
     try {
       // Fetch next 20 older items using the oldest item ID we have
@@ -2857,8 +2877,9 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
             }
           }
         }));
+        pageProgressed = true;
       } else {
-        updateComposerForKey(runtimeKey, (composer) => ({
+        pageProgressed = updateComposerForKey(runtimeKey, (composer) => ({
           ...composer,
           pagination: {
             ...composer.pagination,
@@ -2870,7 +2891,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     } catch (error) {
       console.error("Failed to load older messages:", error);
     } finally {
-      historyPaginationGateRef.current.finishLoad();
+      paginationGate.finishLoad({ preserveQueuedLoad: pageProgressed });
       const current = runtimeStore.get(runtimeKey);
       if (current) {
         updateComposerForKey(runtimeKey, (composer) => ({
@@ -2879,7 +2900,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         }));
       }
     }
-  }, [isRuntimeSelected, openai, runtimeStore, updateComposerForKey]);
+  }, [historyPaginationLifecycle, isRuntimeSelected, openai, runtimeStore, updateComposerForKey]);
 
   // Polling mechanism for conversation updates
   const pollForNewItems = useCallback(
@@ -3091,9 +3112,10 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   const maybeLoadOlderMessages = useCallback(() => {
     const canLoad = Boolean(hasMoreOlderMessages && conversation?.id && openai && oldestItemId);
-    const shouldLoad = historyPaginationGateRef.current.tryStartLoad({
+    const shouldLoad = historyPaginationGate.tryStartLoad({
       canLoad,
-      topBoundaryVisible: isHistoryTopBoundaryNear()
+      topBoundaryVisible: isHistoryTopBoundaryNear(),
+      requestInFlight: isLoadingOlderMessages
     });
 
     if (shouldLoad) {
@@ -3102,7 +3124,31 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   }, [
     conversation?.id,
     hasMoreOlderMessages,
+    historyPaginationGate,
     isHistoryTopBoundaryNear,
+    isLoadingOlderMessages,
+    loadOlderMessages,
+    oldestItemId,
+    openai
+  ]);
+
+  // A second physical wheel gesture can reach the old boundary while the
+  // previous page is still in flight. Once that page has committed and its
+  // visible anchor has been restored, honor the one bounded request already
+  // made at that boundary. This effect runs after the restoration layout
+  // effect above, so consecutive prepends never share an uncommitted anchor.
+  useLayoutEffect(() => {
+    if (isLoadingOlderMessages) return;
+
+    const canLoad = Boolean(hasMoreOlderMessages && conversation?.id && openai && oldestItemId);
+    if (historyPaginationGate.tryStartQueuedLoad({ canLoad })) {
+      void loadOlderMessages();
+    }
+  }, [
+    conversation?.id,
+    hasMoreOlderMessages,
+    historyPaginationGate,
+    isLoadingOlderMessages,
     loadOlderMessages,
     oldestItemId,
     openai
@@ -3110,13 +3156,21 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   // Only direct backward-navigation input can arm history pagination. Intersection,
   // resize, initial positioning, and card expansion merely update boundary visibility.
-  useEffect(() => {
+  useLayoutEffect(() => {
     const container = chatContainerRef.current;
-    if (!container) return;
+    if (!container || !isVisible) return;
 
-    const gate = historyPaginationGateRef.current;
+    const gate = historyPaginationGate;
+    const usesMacOSWheelGestureStart = usesFirstCancelableWheelGestureStart({
+      isTauriEnvironment: isTauriEnv,
+      isMacOSPlatform: isMacOS(),
+      browserPlatform: navigator.platform
+    });
+    const delaysWheelGestureEndAfterScrollEnd = isTauriEnv && isMacOS();
 
     const finishWheelGesture = () => {
+      macOSWheelGestureStartPendingRef.current = false;
+      macOSPreviousWheelCancelableRef.current = null;
       gate.endGesture();
       wheelGestureEndTimeoutRef.current = null;
     };
@@ -3146,11 +3200,18 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
       if (wheelGestureEndTimeoutRef.current) {
         clearTimeout(wheelGestureEndTimeoutRef.current);
-        // WKWebView can also emit `scrollend` between the direct and momentum
-        // phases, or while an anchor restoration is settling. Give the wheel
-        // stream one short quiet period; any residual event cancels this release
-        // before it can re-arm pagination.
-        wheelGestureEndTimeoutRef.current = setTimeout(finishWheelGesture, 80);
+        if (delaysWheelGestureEndAfterScrollEnd) {
+          // WKWebView can also emit `scrollend` between the direct and momentum
+          // phases, or while an anchor restoration is settling. Give only that
+          // WebView path one short quiet period; any residual event cancels this
+          // release before it can re-arm pagination.
+          wheelGestureEndTimeoutRef.current = setTimeout(finishWheelGesture, 80);
+        } else {
+          // Browsers such as Chrome expose `scrollend` as the completed wheel or
+          // trackpad boundary. End immediately so a rapid follow-up gesture can
+          // arm (or queue) the next page before its first wheel event is lost.
+          finishWheelGesture();
+        }
         return;
       }
       if (keyIntentTimeoutRef.current) {
@@ -3168,8 +3229,36 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     };
 
     const handleHistoryWheel = (event: WheelEvent) => {
+      // Chrome represents trackpad pinch-to-zoom as Ctrl+wheel. It is not
+      // backward-navigation intent and must not arm or queue history loading.
+      if (event.ctrlKey) return;
+
+      const startsMacOSWheelGesture =
+        usesMacOSWheelGestureStart &&
+        event.cancelable &&
+        macOSPreviousWheelCancelableRef.current !== true;
+      if (usesMacOSWheelGestureStart) {
+        macOSPreviousWheelCancelableRef.current = event.cancelable;
+      }
+
+      if (usesMacOSWheelGestureStart && event.deltaY === 0) {
+        // A trackpad may expose its zero-delta MayBegin event as the first
+        // cancelable event. Carry that start marker to the first directional
+        // event without treating a finger touch as backward-navigation intent.
+        if (startsMacOSWheelGesture) {
+          macOSWheelGestureStartPendingRef.current = true;
+        }
+        if (wheelGestureEndTimeoutRef.current) {
+          clearTimeout(wheelGestureEndTimeoutRef.current);
+        }
+        wheelGestureEndTimeoutRef.current = setTimeout(finishWheelGesture, 180);
+        return;
+      }
+
       if (event.deltaY >= 0) {
         if (event.deltaY > 0) {
+          macOSWheelGestureStartPendingRef.current = false;
+          macOSPreviousWheelCancelableRef.current = null;
           gate.endGesture();
           clearHistoryBottomCompensation();
           if (wheelGestureEndTimeoutRef.current) {
@@ -3180,8 +3269,21 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         return;
       }
 
-      gate.beginGesture();
-      maybeLoadOlderMessages();
+      if (usesMacOSWheelGestureStart) {
+        const isNewWheelGesture =
+          startsMacOSWheelGesture || macOSWheelGestureStartPendingRef.current;
+        macOSWheelGestureStartPendingRef.current = false;
+        gate.beginWheelGesture(isNewWheelGesture);
+      } else {
+        gate.beginGesture();
+      }
+      // The non-passive macOS boundary probe must stay synchronous, but avoid
+      // forcing sentinel geometry while the user is still far from history's
+      // top. The observer will preserve the armed intent if one large wheel
+      // event crosses directly into this margin.
+      if (container.scrollTop <= CHAT_HISTORY_TOP_MARGIN_PX) {
+        maybeLoadOlderMessages();
+      }
 
       if (wheelGestureEndTimeoutRef.current) {
         clearTimeout(wheelGestureEndTimeoutRef.current);
@@ -3327,7 +3429,13 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       gate.endGesture();
     };
 
-    container.addEventListener("wheel", handleHistoryWheel, { passive: true });
+    // WKWebView and Chrome on macOS expose the first-event cancelability
+    // boundary only when the listener is non-passive. We never prevent the
+    // event, so native scrolling is unchanged. Other platforms retain the
+    // existing passive listener.
+    container.addEventListener("wheel", handleHistoryWheel, {
+      passive: !usesMacOSWheelGestureStart
+    });
     container.addEventListener("touchstart", handleHistoryTouchStart, { passive: true });
     container.addEventListener("touchmove", handleHistoryTouchMove, { passive: true });
     container.addEventListener("touchend", handleHistoryTouchEnd, { passive: true });
@@ -3354,7 +3462,13 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       window.removeEventListener("keydown", handleHistoryKeyDown);
       window.removeEventListener("keyup", handleHistoryKeyUp);
     };
-  }, [clearHistoryBottomCompensation, maybeLoadOlderMessages]);
+  }, [
+    clearHistoryBottomCompensation,
+    historyPaginationGate,
+    isTauriEnv,
+    isVisible,
+    maybeLoadOlderMessages
+  ]);
 
   // Observe a persistent list-top sentinel rather than the first rendered turn. A long
   // assistant turn can overlap the viewport even when its actual top is far above it.

--- a/frontend/src/components/chatHistoryPagination.test.ts
+++ b/frontend/src/components/chatHistoryPagination.test.ts
@@ -5,13 +5,50 @@ import {
   chatHistoryCursorProgressed,
   requiredChatHistoryBottomCompensation,
   restoredChatHistoryAnchorScrollTop,
-  restoredChatHistoryScrollTop
+  restoredChatHistoryScrollTop,
+  usesFirstCancelableWheelGestureStart
 } from "./chatHistoryPagination";
 
 const visibleBoundary = {
   canLoad: true,
   topBoundaryVisible: true
 };
+
+describe("usesFirstCancelableWheelGestureStart", () => {
+  test("uses the cancelability boundary in macOS Tauri and macOS web browsers", () => {
+    expect(
+      usesFirstCancelableWheelGestureStart({
+        isTauriEnvironment: true,
+        isMacOSPlatform: true,
+        browserPlatform: ""
+      })
+    ).toBe(true);
+    expect(
+      usesFirstCancelableWheelGestureStart({
+        isTauriEnvironment: false,
+        isMacOSPlatform: false,
+        browserPlatform: "MacIntel"
+      })
+    ).toBe(true);
+  });
+
+  test("keeps non-macOS Tauri and browser wheel listeners on the passive path", () => {
+    expect(
+      usesFirstCancelableWheelGestureStart({
+        isTauriEnvironment: true,
+        isMacOSPlatform: false,
+        browserPlatform: "MacIntel"
+      })
+    ).toBe(false);
+    expect(
+      usesFirstCancelableWheelGestureStart({
+        isTauriEnvironment: false,
+        isMacOSPlatform: false,
+        browserPlatform: "Win32"
+      })
+    ).toBe(false);
+  });
+});
 
 describe("ChatHistoryPaginationGate", () => {
   test("does not load when the top boundary is visible without user intent", () => {
@@ -149,21 +186,214 @@ describe("ChatHistoryPaginationGate", () => {
     expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
   });
 
-  test("does not queue a gesture that begins while a load is in flight", () => {
+  test("rearms immediately for the first event of a new wheel gesture", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+    gate.finishLoad();
+
+    // Residual direct or momentum events do not create another gesture.
+    gate.beginWheelGesture(false);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+    // A new first wheel event can replace the still-active consumed gesture.
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+  });
+
+  test("queues a new wheel gesture that reaches the top during an in-flight load", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+    // Reaching the boundary is the completed intent. Ending the physical
+    // gesture before the network response must not discard that one request.
+    gate.endGesture();
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(true);
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+
+    gate.finishLoad({ preserveQueuedLoad: true });
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("queues a browser wheel gesture that starts after scrollend during an in-flight load", () => {
     const gate = new ChatHistoryPaginationGate();
 
     gate.beginGesture();
     expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
 
+    // Chrome's scrollend completes the first physical gesture before the next
+    // wheel event arrives, even if the first page request is still pending.
     gate.endGesture();
     gate.beginGesture();
-    gate.finishLoad();
-
     expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
 
     gate.endGesture();
-    gate.beginGesture();
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(true);
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("does not queue residual wheel momentum during an in-flight load", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
     expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    gate.beginWheelGesture(false);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("clears a queued gesture when the active page fails to progress", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+    gate.finishLoad();
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("clears newer armed intent when the active page fails to progress", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    gate.beginWheelGesture(true);
+    expect(
+      gate.tryStartLoad({
+        canLoad: true,
+        topBoundaryVisible: false
+      })
+    ).toBe(false);
+    gate.finishLoad();
+
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+  });
+
+  test("keeps a queued load when its drain races the active request", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(true);
+  });
+
+  test("coalesces multiple overlapping boundary attempts into one queued load", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    for (let gesture = 0; gesture < 3; gesture += 1) {
+      gate.beginWheelGesture(true);
+      expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+    }
+
+    gate.finishLoad({ preserveQueuedLoad: true });
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(true);
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("discards a queued load when there is no older page", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartQueuedLoad({ canLoad: false })).toBe(false);
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("does not duplicate a request owned by a previous runtime projection", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginGesture();
+    expect(
+      gate.tryStartLoad({
+        ...visibleBoundary,
+        requestInFlight: true
+      })
+    ).toBe(false);
+
+    // The discarded projection intent cannot turn into an automatic retry
+    // when the request owned by the previous projection settles.
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+  });
+
+  test("keeps pagination lifecycles independent across runtime projections", () => {
+    const previousRuntimeGate = new ChatHistoryPaginationGate();
+    const nextRuntimeGate = new ChatHistoryPaginationGate();
+
+    previousRuntimeGate.beginGesture();
+    expect(previousRuntimeGate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    nextRuntimeGate.beginGesture();
+    expect(nextRuntimeGate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    previousRuntimeGate.finishLoad();
+    expect(nextRuntimeGate.tryStartLoad(visibleBoundary)).toBe(false);
+  });
+
+  test("loads through page four when each next wheel gesture reaches the top in flight", () => {
+    const gate = new ChatHistoryPaginationGate();
+    let loadCount = 0;
+
+    gate.beginWheelGesture(true);
+    if (gate.tryStartLoad(visibleBoundary)) loadCount += 1;
+
+    for (let page = 2; page <= 4; page += 1) {
+      gate.beginWheelGesture(true);
+
+      // The new gesture is queued, but cannot overlap the active request.
+      expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+      gate.endGesture();
+
+      gate.finishLoad({ preserveQueuedLoad: true });
+      if (gate.tryStartQueuedLoad({ canLoad: true })) loadCount += 1;
+      expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+    }
+
+    expect(loadCount).toBe(4);
+  });
+
+  test("resetIntent clears a queued load for the previous conversation", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
+
+    gate.resetIntent();
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
   });
 
   test("requires fresh intent after a load finishes or fails", () => {

--- a/frontend/src/components/chatHistoryPagination.ts
+++ b/frontend/src/components/chatHistoryPagination.ts
@@ -38,18 +38,41 @@ export function chatHistoryCursorProgressed(
   return Boolean(nextOldestItemId && nextOldestItemId !== currentOldestItemId);
 }
 
+export function usesFirstCancelableWheelGestureStart({
+  isTauriEnvironment,
+  isMacOSPlatform,
+  browserPlatform
+}: {
+  isTauriEnvironment: boolean;
+  isMacOSPlatform: boolean;
+  browserPlatform: string;
+}): boolean {
+  return isTauriEnvironment ? isMacOSPlatform : browserPlatform.startsWith("Mac");
+}
+
 export class ChatHistoryPaginationGate {
   private intentArmed = false;
   private gestureActive = false;
   private loadInFlight = false;
+  private queuedLoad = false;
 
   beginGesture(): void {
     if (this.gestureActive) return;
 
     this.gestureActive = true;
-    if (!this.loadInFlight) {
-      this.intentArmed = true;
-    }
+    this.intentArmed = true;
+  }
+
+  beginWheelGesture(isNewGesture: boolean): void {
+    if (!isNewGesture) return;
+
+    // macOS WKWebView and Chrome make the first wheel event in a hardware
+    // gesture cancelable and later direct/momentum events non-cancelable when
+    // that first event is not prevented. A new first event is therefore
+    // stronger evidence than an arbitrary quiet-period timer and may replace
+    // a still active, already-consumed gesture.
+    this.gestureActive = true;
+    this.intentArmed = true;
   }
 
   endGesture(): void {
@@ -60,26 +83,59 @@ export class ChatHistoryPaginationGate {
   resetIntent(): void {
     this.gestureActive = false;
     this.intentArmed = false;
+    this.queuedLoad = false;
   }
 
   tryStartLoad({
     canLoad,
-    topBoundaryVisible
+    topBoundaryVisible,
+    requestInFlight = false
   }: {
     canLoad: boolean;
     topBoundaryVisible: boolean;
+    requestInFlight?: boolean;
   }): boolean {
-    if (!canLoad || !topBoundaryVisible || !this.intentArmed || this.loadInFlight) {
+    if (!canLoad || !topBoundaryVisible || !this.intentArmed) {
       return false;
     }
 
     this.intentArmed = false;
+
+    if (this.loadInFlight) {
+      // The new gesture already reached the boundary, so preserve exactly one
+      // later page even if that gesture ends before the active prepend settles.
+      this.queuedLoad = true;
+      return false;
+    }
+
+    // A runtime can be projected again while a request owned by its previous
+    // projection is still pending. Do not issue the same cursor twice from the
+    // new gate, and do not turn that discarded intent into a post-failure retry.
+    if (requestInFlight) return false;
+
     this.loadInFlight = true;
     return true;
   }
 
-  finishLoad(): void {
+  finishLoad({ preserveQueuedLoad = false }: { preserveQueuedLoad?: boolean } = {}): void {
     this.loadInFlight = false;
-    this.intentArmed = false;
+    if (!preserveQueuedLoad) {
+      this.queuedLoad = false;
+      this.intentArmed = false;
+    }
+  }
+
+  tryStartQueuedLoad({ canLoad }: { canLoad: boolean }): boolean {
+    if (!this.queuedLoad) return false;
+    if (this.loadInFlight) return false;
+
+    this.queuedLoad = false;
+    if (!canLoad) {
+      this.intentArmed = false;
+      return false;
+    }
+
+    this.loadInFlight = true;
+    return true;
   }
 }


### PR DESCRIPTION
## Summary

- recognize separate rapid macOS gestures in both the native WKWebView and the Chrome web app from each gesture's first cancelable wheel event
- preserve exactly one completed top-boundary request when the next gesture arrives while the prior page is in flight, draining only after cursor progress and anchor restoration
- fence lifecycle and visibility, ignore pinch-to-zoom, and keep non-Mac/browser fast paths passive

This replaces the timing-based approach from #713 and closes #692.

## Chrome reproduction and validation

- reproduced Anthony's video sequence in the actual Chrome app against the local web build: waiting before gesture two worked, while an immediate gesture two stopped after page one before the fix
- after the fix, two immediate gestures loaded responses 25–31 → 12–31; remaining idle did not load page three
- forced 1.8s network latency proved gesture two was queued while page one remained unresolved; after settling, the chat contained exactly responses 12–31 with no idle cascade
- pages three and four loaded one deliberate gesture each (earliest response 5, then 1), with all 31 responses unique and no duplicates
- short-chat navigation and compact thought-row rendering remained correct; the Chrome console was clean

## Automated and full-stack validation

- 403 frontend tests, 1,436 expectations
- TypeScript, Prettier, ESLint (0 errors; 13 existing warnings), production web build, and Git diff checks
- managed-stack smoke: OpenSecret, Postgres, Continuum/Tinfoil health, and Billing
- three fresh review groups covered correctness/tests, lifecycle/performance/security, and UX/cross-platform risk; no high- or critical-severity findings remained, and confirmed lifecycle/performance edges were fixed and re-reviewed

Ready for Anthony to test manually in Chrome on his local machine.
