### PR TITLE
fix(agent): retain chat runtime for routed Agent Mode

### DIFF
--- a/frontend/src/components/RootRuntimeLayout.test.tsx
+++ b/frontend/src/components/RootRuntimeLayout.test.tsx
@@ -124,6 +124,42 @@ describe("RootRuntimeLayout", () => {
     act(() => renderer.unmount());
   });
 
+  test("shares the same-account chat store when moving from home to an ordinary route", () => {
+    const homeStores: unknown[] = [];
+    const routeStores: unknown[] = [];
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        <RootRuntimeLayout
+          userId="user-a"
+          pathname="/"
+          authenticatedHome={<ChatStoreProbe onStore={(store) => homeStores.push(store)} />}
+          routeContent={<div />}
+          accountScopedUi={null}
+        />
+      );
+    });
+
+    act(() => {
+      renderer.update(
+        <RootRuntimeLayout
+          userId="user-a"
+          pathname="/agent"
+          authenticatedHome={null}
+          routeContent={<ChatStoreProbe onStore={(store) => routeStores.push(store)} />}
+          accountScopedUi={null}
+        />
+      );
+    });
+
+    expect(homeStores).toHaveLength(1);
+    expect(routeStores).toHaveLength(1);
+    expect(routeStores[0]).toBe(homeStores[0]);
+
+    act(() => renderer.unmount());
+  });
+
   test("retains the same-account chat store while authenticated home is temporarily hidden", () => {
     const stores: unknown[] = [];
     const recordStore = mock((store: unknown) => stores.push(store));

--- a/frontend/src/components/RootRuntimeLayout.tsx
+++ b/frontend/src/components/RootRuntimeLayout.tsx
@@ -21,10 +21,11 @@ function getRouteScopeKey(pathname: string, accountScopeKey: string): string {
 }
 
 /**
- * Keeps account-scoped chat state around the persistent authenticated home only.
- * The OAuth callback route alone survives the signed-out-to-user transition so its
- * one-shot effect cannot replay. Every other route and global account-scoped UI
- * retains the previous account-keyed remount behavior.
+ * Keeps account-scoped chat state around the persistent authenticated home and
+ * ordinary routed content. The OAuth callback route alone stays outside that
+ * provider so it survives the signed-out-to-user transition and its one-shot
+ * effect cannot replay. Global account-scoped UI retains its previous remount
+ * behavior.
  */
 export function RootRuntimeLayout({
   userId,
@@ -35,11 +36,16 @@ export function RootRuntimeLayout({
 }: RootRuntimeLayoutProps) {
   const accountScopeKey = getAccountScopeKey(userId);
   const routeScopeKey = getRouteScopeKey(pathname, accountScopeKey);
+  const isOAuthCallback = OAUTH_CALLBACK_PATH.test(pathname);
+  const keyedRouteContent = <Fragment key={routeScopeKey}>{routeContent}</Fragment>;
 
   return (
     <>
-      <ChatRuntimeProvider key={`chat:${accountScopeKey}`}>{authenticatedHome}</ChatRuntimeProvider>
-      <Fragment key={routeScopeKey}>{routeContent}</Fragment>
+      <ChatRuntimeProvider key={`chat:${accountScopeKey}`}>
+        {authenticatedHome}
+        {!isOAuthCallback ? keyedRouteContent : null}
+      </ChatRuntimeProvider>
+      {isOAuthCallback ? keyedRouteContent : null}
       <Fragment key={`global:${accountScopeKey}`}>{accountScopedUi}</Fragment>
     </>
   );


### PR DESCRIPTION
## Summary

- keep ordinary routed content under the existing account-keyed `ChatRuntimeProvider`
- keep OAuth callback routes outside that provider so the #715 exactly-once behavior is preserved
- add a Home → `/agent` regression test proving both modes share the same account runtime

Fixes #718.

## Root cause

PR #715 moved `ChatRuntimeProvider` around authenticated Home only. `/agent` renders through `routeContent`, so `AgentMode → Sidebar → useChatRuntimeStore()` ran outside the provider and immediately reached the error boundary.

## Validation

- new regression test failed on current master with `useChatRuntimeStore must be used within a ChatRuntimeProvider`, then passed with this fix
- targeted `RootRuntimeLayout` tests: 4/4
- frontend CI-equivalent checks: formatting, lint with 0 errors, typecheck, 468/468 tests
- pre-commit production frontend build and full test suite passed
- managed local OpenSecret, PostgreSQL, Continuum, and billing smoke passed with a verified Pro fixture
- workspace-specific packaged macOS app exercised Agent → Chat → Agent with `agent_mode` forced; `/agent` rendered the complete Agent UI
- two independent fix reviews and a follow-up review by the original OAuth investigation found no actionable OAuth, account-isolation, or lifecycle regression

The fix intentionally does not broaden into unrelated Apple or OAuth changes.