### PR TITLE
Fix macOS chat history pagination cascade and viewport jump

### DIFF
--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -83,6 +83,7 @@ import {
   CHAT_HISTORY_TOP_MARGIN_PX,
   ChatHistoryPaginationGate,
   chatHistoryCursorProgressed,
+  preferredChatHistoryScrollSnapshot,
   requiredChatHistoryBottomCompensation,
   restoredChatHistoryAnchorScrollTop,
   restoredChatHistoryScrollTop,
@@ -2123,6 +2124,35 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     [runtimeStore]
   );
 
+  const captureHistoryScrollSnapshot = useCallback(
+    (runtimeKey: ChatRuntimeKey): ChatHistoryScrollSnapshot | null => {
+      if (!isRuntimeSelected(runtimeKey)) return null;
+
+      const container = chatContainerRef.current;
+      if (!container) return null;
+
+      const containerRect = container.getBoundingClientRect();
+      const firstVisibleAnchor = Array.from(
+        container.querySelectorAll<HTMLElement>("[data-history-anchor-ids]")
+      ).find((candidate) => {
+        const candidateRect = candidate.getBoundingClientRect();
+        return candidateRect.bottom > containerRect.top && candidateRect.top < containerRect.bottom;
+      });
+      const anchorId = firstVisibleAnchor?.dataset.historyAnchorIds?.split(" ").find(Boolean);
+      const anchorOffset = firstVisibleAnchor
+        ? firstVisibleAnchor.getBoundingClientRect().top - containerRect.top
+        : undefined;
+
+      return {
+        scrollTop: container.scrollTop,
+        scrollHeight: container.scrollHeight,
+        anchorId,
+        anchorOffset
+      };
+    },
+    [isRuntimeSelected]
+  );
+
   const runForProjectedRuntime = useCallback(
     (lease: ChatProjectionScrollLease<ChatRuntimeKey> | null, action: () => void) => {
       if (
@@ -2720,6 +2750,16 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       return;
     }
 
+    // Preserve the last stable viewport before the request yields. A fast
+    // upward gesture can elastically move every message out of WKWebView's
+    // viewport while the network request is pending, leaving nothing reliable
+    // to anchor when the response arrives.
+    const projectionLease = projectionScrollCoordinatorRef.current.captureLease(
+      runtimeKey,
+      resolveScrollProjectionKey
+    );
+    const requestStartScrollSnapshot = captureHistoryScrollSnapshot(runtimeKey);
+
     updateComposerForKey(runtimeKey, (composer) => ({
       ...composer,
       pagination: { ...composer.pagination, isLoadingOlderMessages: true }
@@ -2764,29 +2804,22 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       }
 
       if (olderMessagesInChronologicalOrder.length > 0) {
-        const container = isRuntimeSelected(runtimeKey) ? chatContainerRef.current : null;
-        if (container) {
-          const containerRect = container.getBoundingClientRect();
-          const firstVisibleAnchor = Array.from(
-            container.querySelectorAll<HTMLElement>("[data-history-anchor-ids]")
-          ).find((candidate) => {
-            const candidateRect = candidate.getBoundingClientRect();
-            return (
-              candidateRect.bottom > containerRect.top && candidateRect.top < containerRect.bottom
-            );
+        const stillOwnsStartingProjection = Boolean(
+          projectionLease &&
+          projectionScrollCoordinatorRef.current.ownsLease(
+            projectionLease,
+            resolveScrollProjectionKey
+          )
+        );
+        if (stillOwnsStartingProjection) {
+          const scrollSnapshot = preferredChatHistoryScrollSnapshot({
+            requestStartSnapshot: requestStartScrollSnapshot,
+            commitSnapshot: captureHistoryScrollSnapshot(runtimeKey)
           });
-          const anchorId = firstVisibleAnchor?.dataset.historyAnchorIds?.split(" ").find(Boolean);
-          const anchorOffset = firstVisibleAnchor
-            ? firstVisibleAnchor.getBoundingClientRect().top - containerRect.top
-            : undefined;
-
-          pendingHistoryScrollRestoreRef.current = {
-            scrollTop: container.scrollTop,
-            scrollHeight: container.scrollHeight,
-            anchorId,
-            anchorOffset
-          };
-          pendingHistoryScrollRestoreKeyRef.current = runtimeKey;
+          if (scrollSnapshot) {
+            pendingHistoryScrollRestoreRef.current = scrollSnapshot;
+            pendingHistoryScrollRestoreKeyRef.current = runtimeKey;
+          }
         }
 
         // Prepend older messages while keeping IDs unique. Restore the pending scroll
@@ -2829,7 +2862,14 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         }));
       }
     }
-  }, [historyPaginationLifecycle, isRuntimeSelected, openai, runtimeStore, updateComposerForKey]);
+  }, [
+    captureHistoryScrollSnapshot,
+    historyPaginationLifecycle,
+    openai,
+    resolveScrollProjectionKey,
+    runtimeStore,
+    updateComposerForKey
+  ]);
 
   // Polling mechanism for conversation updates
   const pollForNewItems = useCallback(
@@ -5046,7 +5086,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         <div
           ref={chatContainerRef}
           data-testid="chat-scroll-container"
-          className="flex-1 min-h-0 overflow-y-auto overscroll-y-contain flex flex-col relative"
+          className="flex-1 min-h-0 overflow-y-auto overscroll-y-none flex flex-col relative"
         >
           {isLoadingOlderMessages && (
             <div className="pointer-events-none absolute inset-x-0 top-0 z-10 flex items-center justify-center py-4">

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -3092,7 +3092,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     const gate = historyPaginationGate;
     const usesMacOSWheelGestureStart = usesFirstCancelableWheelGestureStart({
       isTauriEnvironment: isTauriEnv,
-      isMacOSPlatform: isMacOS(),
       browserPlatform: navigator.platform
     });
     const delaysWheelGestureEndAfterScrollEnd = isTauriEnv && isMacOS();
@@ -3358,10 +3357,10 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       gate.endGesture();
     };
 
-    // WKWebView and Chrome on macOS expose the first-event cancelability
-    // boundary only when the listener is non-passive. We never prevent the
-    // event, so native scrolling is unchanged. Other platforms retain the
-    // existing passive listener.
+    // Chrome on macOS exposes the first-event cancelability boundary only when
+    // the listener is non-passive. We never prevent the event, so native
+    // scrolling is unchanged. Tauri and other platforms retain the passive
+    // listener because WKWebView does not provide the same stable boundary.
     container.addEventListener("wheel", handleHistoryWheel, {
       passive: !usesMacOSWheelGestureStart
     });

--- a/frontend/src/components/chatHistoryPagination.test.ts
+++ b/frontend/src/components/chatHistoryPagination.test.ts
@@ -15,35 +15,25 @@ const visibleBoundary = {
 };
 
 describe("usesFirstCancelableWheelGestureStart", () => {
-  test("uses the cancelability boundary in macOS Tauri and macOS web browsers", () => {
-    expect(
-      usesFirstCancelableWheelGestureStart({
-        isTauriEnvironment: true,
-        isMacOSPlatform: true,
-        browserPlatform: ""
-      })
-    ).toBe(true);
+  test("uses the cancelability boundary in macOS web browsers", () => {
     expect(
       usesFirstCancelableWheelGestureStart({
         isTauriEnvironment: false,
-        isMacOSPlatform: false,
         browserPlatform: "MacIntel"
       })
     ).toBe(true);
   });
 
-  test("keeps non-macOS Tauri and browser wheel listeners on the passive path", () => {
+  test("keeps Tauri and non-macOS browser wheel listeners on the passive path", () => {
     expect(
       usesFirstCancelableWheelGestureStart({
         isTauriEnvironment: true,
-        isMacOSPlatform: false,
         browserPlatform: "MacIntel"
       })
     ).toBe(false);
     expect(
       usesFirstCancelableWheelGestureStart({
         isTauriEnvironment: false,
-        isMacOSPlatform: false,
         browserPlatform: "Win32"
       })
     ).toBe(false);
@@ -239,6 +229,28 @@ describe("ChatHistoryPaginationGate", () => {
     gate.finishLoad({ preserveQueuedLoad: true });
 
     expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(true);
+    expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
+  });
+
+  test("clears unconsumed intent when an in-flight page progresses", () => {
+    const gate = new ChatHistoryPaginationGate();
+
+    gate.beginWheelGesture(true);
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(true);
+
+    // A later gesture has started, but has not actually reached the boundary,
+    // so it must not become an observer-driven request after the prepend.
+    gate.beginWheelGesture(true);
+    expect(
+      gate.tryStartLoad({
+        canLoad: true,
+        topBoundaryVisible: false
+      })
+    ).toBe(false);
+
+    gate.finishLoad({ preserveQueuedLoad: true });
+
+    expect(gate.tryStartLoad(visibleBoundary)).toBe(false);
     expect(gate.tryStartQueuedLoad({ canLoad: true })).toBe(false);
   });
 

--- a/frontend/src/components/chatHistoryPagination.test.ts
+++ b/frontend/src/components/chatHistoryPagination.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import {
   ChatHistoryPaginationGate,
   chatHistoryCursorProgressed,
+  normalizedChatHistoryScrollSnapshot,
+  preferredChatHistoryScrollSnapshot,
   requiredChatHistoryBottomCompensation,
   restoredChatHistoryAnchorScrollTop,
   restoredChatHistoryScrollTop,
@@ -492,6 +494,90 @@ describe("restoredChatHistoryScrollTop", () => {
         620
       )
     ).toBe(0);
+  });
+});
+
+describe("preferredChatHistoryScrollSnapshot", () => {
+  const requestStartSnapshot = {
+    scrollTop: 24,
+    scrollHeight: 800,
+    anchorId: "stable-anchor",
+    anchorOffset: 18
+  };
+
+  test("keeps current user movement when the response-time anchor is stable", () => {
+    const commitSnapshot = {
+      scrollTop: 4,
+      scrollHeight: 800,
+      anchorId: "later-anchor",
+      anchorOffset: 6
+    };
+
+    expect(preferredChatHistoryScrollSnapshot({ requestStartSnapshot, commitSnapshot })).toEqual(
+      commitSnapshot
+    );
+  });
+
+  test("falls back to the request-start anchor when elastic overscroll blanks the viewport", () => {
+    expect(
+      preferredChatHistoryScrollSnapshot({
+        requestStartSnapshot,
+        commitSnapshot: {
+          scrollTop: -72,
+          scrollHeight: 800
+        }
+      })
+    ).toEqual(requestStartSnapshot);
+  });
+
+  test("normalizes a response-time anchor that remains visible during elastic overscroll", () => {
+    expect(
+      preferredChatHistoryScrollSnapshot({
+        requestStartSnapshot,
+        commitSnapshot: {
+          scrollTop: -30,
+          scrollHeight: 800,
+          anchorId: "later-anchor",
+          anchorOffset: 42
+        }
+      })
+    ).toEqual({
+      scrollTop: 0,
+      scrollHeight: 800,
+      anchorId: "later-anchor",
+      anchorOffset: 12
+    });
+  });
+
+  test("normalizes an elastic request-start anchor to its stable offset", () => {
+    expect(
+      normalizedChatHistoryScrollSnapshot({
+        scrollTop: -30,
+        scrollHeight: 800,
+        anchorId: "stable-anchor",
+        anchorOffset: 42
+      })
+    ).toEqual({
+      scrollTop: 0,
+      scrollHeight: 800,
+      anchorId: "stable-anchor",
+      anchorOffset: 12
+    });
+  });
+
+  test("uses a normalized response-time fallback when no request-start snapshot exists", () => {
+    expect(
+      preferredChatHistoryScrollSnapshot({
+        requestStartSnapshot: null,
+        commitSnapshot: {
+          scrollTop: -20,
+          scrollHeight: 800
+        }
+      })
+    ).toEqual({
+      scrollTop: 0,
+      scrollHeight: 800
+    });
   });
 });
 

--- a/frontend/src/components/chatHistoryPagination.ts
+++ b/frontend/src/components/chatHistoryPagination.ts
@@ -40,14 +40,15 @@ export function chatHistoryCursorProgressed(
 
 export function usesFirstCancelableWheelGestureStart({
   isTauriEnvironment,
-  isMacOSPlatform,
   browserPlatform
 }: {
   isTauriEnvironment: boolean;
-  isMacOSPlatform: boolean;
   browserPlatform: string;
 }): boolean {
-  return isTauriEnvironment ? isMacOSPlatform : browserPlatform.startsWith("Mac");
+  // `WheelEvent.cancelable` marks Chrome's first event reliably enough for the
+  // rapid follow-up gesture workaround, but WKWebView can make later events
+  // cancelable again while momentum or an anchor restoration is settling.
+  return !isTauriEnvironment && browserPlatform.startsWith("Mac");
 }
 
 export class ChatHistoryPaginationGate {
@@ -66,11 +67,11 @@ export class ChatHistoryPaginationGate {
   beginWheelGesture(isNewGesture: boolean): void {
     if (!isNewGesture) return;
 
-    // macOS WKWebView and Chrome make the first wheel event in a hardware
-    // gesture cancelable and later direct/momentum events non-cancelable when
-    // that first event is not prevented. A new first event is therefore
-    // stronger evidence than an arbitrary quiet-period timer and may replace
-    // a still active, already-consumed gesture.
+    // Chrome makes the first wheel event in a hardware gesture cancelable and
+    // later direct/momentum events non-cancelable when that first event is not
+    // prevented. A new first event is therefore stronger evidence than an
+    // arbitrary quiet-period timer and may replace a still active,
+    // already-consumed gesture.
     this.gestureActive = true;
     this.intentArmed = true;
   }
@@ -121,8 +122,11 @@ export class ChatHistoryPaginationGate {
     this.loadInFlight = false;
     if (!preserveQueuedLoad) {
       this.queuedLoad = false;
-      this.intentArmed = false;
     }
+    // Only a gesture that actually reached the boundary is represented by the
+    // queue. Never let merely armed intent survive a request and become an
+    // observer-driven follow-up after the prepend changes layout.
+    this.intentArmed = false;
   }
 
   tryStartQueuedLoad({ canLoad }: { canLoad: boolean }): boolean {

--- a/frontend/src/components/chatHistoryPagination.ts
+++ b/frontend/src/components/chatHistoryPagination.ts
@@ -7,6 +7,37 @@ export type ChatHistoryScrollSnapshot = {
   anchorOffset?: number;
 };
 
+export function normalizedChatHistoryScrollSnapshot(
+  snapshot: ChatHistoryScrollSnapshot
+): ChatHistoryScrollSnapshot {
+  const elasticTopOffset = Math.min(0, snapshot.scrollTop);
+
+  return {
+    ...snapshot,
+    scrollTop: Math.max(0, snapshot.scrollTop),
+    ...(snapshot.anchorOffset === undefined
+      ? {}
+      : { anchorOffset: snapshot.anchorOffset + elasticTopOffset })
+  };
+}
+
+export function preferredChatHistoryScrollSnapshot({
+  requestStartSnapshot,
+  commitSnapshot
+}: {
+  requestStartSnapshot: ChatHistoryScrollSnapshot | null;
+  commitSnapshot: ChatHistoryScrollSnapshot | null;
+}): ChatHistoryScrollSnapshot | null {
+  const commitHasVisibleAnchor = Boolean(
+    commitSnapshot && commitSnapshot.anchorId && commitSnapshot.anchorOffset !== undefined
+  );
+  const preferredSnapshot = commitHasVisibleAnchor
+    ? commitSnapshot
+    : (requestStartSnapshot ?? commitSnapshot);
+
+  return preferredSnapshot ? normalizedChatHistoryScrollSnapshot(preferredSnapshot) : null;
+}
+
 export function restoredChatHistoryScrollTop(
   snapshot: ChatHistoryScrollSnapshot,
   nextScrollHeight: number


### PR DESCRIPTION
## Summary

- retain the PR #720 WKWebView cascade containment and the existing Chrome rapid-pagination path
- stop elastic overscroll from pulling the chat history viewport into blank space while an older-page request is pending
- capture a semantic anchor before the request yields, prefer the response-time anchor when it remains visible, and fall back to the normalized request-start anchor only when WKWebView has moved every message out of view
- fence restoration to the projection that started the request so navigation and A to B to A revisits cannot move the wrong shared scroller

## Root cause

The latest macOS GUI recording showed the full message list disappearing for roughly 1.0 to 1.55 seconds before a prepend, followed by 42 to 96 CSS pixels of settling drift. The loading indicator is absolutely positioned and existing messages stay mounted, so this was WKWebView elastic overscroll rather than a loading-layout removal. The previous code then captured its anchor only after the request returned, when `scrollTop` could be negative and no message was visible.

The scroll container now uses `overscroll-y-none`. Snapshot selection preserves newer user movement whenever a response-time anchor exists, including normalized negative overscroll coordinates; if the viewport is fully blank, it restores from the last stable request-start anchor.

## Verification

- exact workspace-specific packaged macOS `Maple.app` against local OpenSecret, billing, feature-flag, and database services
- 31-turn fixture spanning four history pages
- temporary 1.8-second diagnostic latency: messages remained visible while pending; two accepted upward inputs loaded exactly two serialized pages; the same visible anchor stayed fixed before, between, and after both prepends; no third page or idle drift
- latency removed and final packaged build repeated single-page and rapid two-input smoke tests; page counts stopped at one and two respectively, with stable settled and idle screenshots
- `bun test`: 474 passed
- `bun run typecheck`
- Prettier, changed-file ESLint, and `git diff --check`
- full pre-commit hook
- packaged Tauri debug build produced the `.app`, DMG, and updater archive; the expected final updater-signing step was skipped because no release private key is present
- fresh correctness, lifecycle/race, and UX/cross-platform reviews found no high, critical, or remaining actionable source defects

## Manual test

Ready for Anthony to reproduce with a physical trackpad on his local macOS machine. The automated macOS app control used here is not equivalent to a physical trackpad stream, so that final hardware-specific confirmation remains intentionally manual.