### PR TITLE
Remove deprecated Starter plan

### DIFF
--- a/docs/conversations-api-implementation.md
+++ b/docs/conversations-api-implementation.md
@@ -1470,7 +1470,7 @@ The refactor is essentially feature-complete except for scroll UX improvements!
    - ModelSelector component integrated in both input areas
    - Support for model switching mid-conversation
    - Auto-switching to vision models when images are added
-   - Billing tier restrictions (Pro/Starter/Team)
+   - Billing tier restrictions (Pro/Team)
    - Upgrade prompts for restricted models
 
 2. **Billing Integration** ✅

--- a/docs/product-redesign-spec.md
+++ b/docs/product-redesign-spec.md
@@ -1200,7 +1200,6 @@ Supported scenarios from the PR:
 | ------------- | -------------------------------------------- |
 | `Coming Soon` | `bg-muted text-muted-foreground`             |
 | `Pro`         | coral-to-tertiary soft gradient + coral text |
-| `Starter`     | `bg-maple-success/10 text-maple-success`     |
 | `New`         | `bg-maple-info/10 text-maple-info`           |
 | `Reasoning`   | `bg-maple-error/10 text-maple-error`         |
 | `Beta`        | `bg-maple-warning/10 text-maple-warning`     |

--- a/docs/unified-chat-refactor.md
+++ b/docs/unified-chat-refactor.md
@@ -216,7 +216,7 @@ The UnifiedChat component now includes these fully working features:
 - **Proper OpenAI format** - Uses `input_text`, `input_image`, `output_text` content types
 
 #### Billing & Access Control
-- **Tier-based features** - Starter (images), Pro/Team (documents)
+- **Tier-based features** - Pro/Team (images and documents)
 - **Upgrade prompts** - Contextual dialogs when accessing restricted features
 - **Model selector integration** - Shows available models based on user's plan
 

--- a/frontend/src/billing/billingAccess.test.ts
+++ b/frontend/src/billing/billingAccess.test.ts
@@ -28,7 +28,7 @@ describe("hasApiAccess", () => {
     expect(hasApiAccess(status)).toBe(false);
   });
 
-  test.each(["Free", "Starter"])("does not allow the %s plan", (productName) => {
+  test.each(["Free", "Unknown"])("does not allow the %s plan", (productName) => {
     expect(hasApiAccess(billingStatus(productName))).toBe(false);
   });
 });
@@ -37,7 +37,7 @@ describe("isKnownFreePlan", () => {
   test("identifies a loaded free plan without treating unknown billing as free", () => {
     expect(isKnownFreePlan(billingStatus("Free"))).toBe(true);
     expect(isKnownFreePlan(billingStatus(""))).toBe(false);
-    expect(isKnownFreePlan(billingStatus("Starter"))).toBe(false);
+    expect(isKnownFreePlan(billingStatus("Unknown"))).toBe(false);
     expect(isKnownFreePlan(billingStatus("Pro"))).toBe(false);
     expect(isKnownFreePlan(null)).toBe(false);
   });

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -3695,21 +3695,7 @@ function AgentModelSelector({
       if (access === "free") return true;
 
       const planName = billingStatus?.product_name?.toLowerCase() || "";
-
-      if (access === "pro") {
-        return planName.includes("pro") || planName.includes("max") || planName.includes("team");
-      }
-
-      if (access === "starter") {
-        return (
-          planName.includes("starter") ||
-          planName.includes("pro") ||
-          planName.includes("max") ||
-          planName.includes("team")
-        );
-      }
-
-      return true;
+      return planName.includes("pro") || planName.includes("max") || planName.includes("team");
     },
     [billingStatus?.product_name, getAccess]
   );
@@ -3747,8 +3733,13 @@ function AgentModelSelector({
   };
 
   const getModelBadges = (modelId: string): string[] => {
-    const badges = modelById.get(modelId)?.badges || [];
-    return badges.filter((badge) => badge !== "Pro" && badge !== "Starter");
+    const selectedModel = modelById.get(modelId);
+    const badges = selectedModel?.badges || [];
+    return badges.filter(
+      (badge) =>
+        badge !== "Pro" &&
+        (selectedModel?.access === "free" || badge.toLowerCase() !== selectedModel?.access)
+    );
   };
 
   const getDisplayName = (modelId: string, showLock = false) => {

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -238,21 +238,7 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
       if (access === "free") return true;
 
       const planName = billingStatus?.product_name?.toLowerCase() || "";
-
-      if (access === "pro") {
-        return planName.includes("pro") || planName.includes("max") || planName.includes("team");
-      }
-
-      if (access === "starter") {
-        return (
-          planName.includes("starter") ||
-          planName.includes("pro") ||
-          planName.includes("max") ||
-          planName.includes("team")
-        );
-      }
-
-      return true;
+      return planName.includes("pro") || planName.includes("max") || planName.includes("team");
     },
     [billingStatus?.product_name, getAccess]
   );
@@ -328,8 +314,13 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
 
   // Get dynamic badges for a model based on billing status
   const getModelBadges = (modelId: string): string[] => {
-    const badges = modelById.get(modelId)?.badges || [];
-    return badges.filter((badge) => badge !== "Pro" && badge !== "Starter");
+    const selectedModel = modelById.get(modelId);
+    const badges = selectedModel?.badges || [];
+    return badges.filter(
+      (badge) =>
+        badge !== "Pro" &&
+        (selectedModel?.access === "free" || badge.toLowerCase() !== selectedModel?.access)
+    );
   };
 
   const getDisplayName = (modelId: string, showLock = false) => {
@@ -349,8 +340,6 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
           } else if (badge === "Pro") {
             badgeClass +=
               " bg-gradient-to-r from-[hsl(var(--maple-primary))]/10 to-[hsl(var(--maple-tertiary))]/10 text-[hsl(var(--maple-primary))]";
-          } else if (badge === "Starter") {
-            badgeClass += " bg-maple-success/10 text-maple-success";
           } else if (badge === "New") {
             badgeClass += " bg-maple-info/10 text-maple-info";
           } else if (badge === "Reasoning") {

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -3530,11 +3530,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       billingStatus.product_name?.toLowerCase().includes("max") ||
       billingStatus.product_name?.toLowerCase().includes("team"));
 
-  const hasStarterAccess =
-    billingStatus &&
-    (billingStatus.product_name?.toLowerCase().includes("starter") || hasProAccess);
-
-  const canUseImages = hasStarterAccess;
+  const canUseImages = hasProAccess;
   const canUseDocuments = hasProAccess;
   const canUseVoice = hasProAccess && localState.hasWhisperModel;
 

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -85,11 +85,11 @@ export function UpgradePromptDialog({
         icon: <Image className="h-8 w-8" />,
         title: "Image Upload",
         description: "Upload and analyze images with AI-powered vision models",
-        requiredPlan: "Starter",
+        requiredPlan: "Pro",
         benefits: [
           "Images stay private with end-to-end encryption",
           "Upload JPEG, PNG, and WebP formats securely",
-          "Use Gemma 4 31B on Starter, plus Kimi K2.6 on Pro and above",
+          "Use Gemma 4 31B and Kimi K2.6 on Pro and above",
           "Analyze diagrams, screenshots, and photos privately",
           "Extract text from images without exposing data"
         ]

--- a/frontend/src/components/settings/BillingSettings.tsx
+++ b/frontend/src/components/settings/BillingSettings.tsx
@@ -15,9 +15,7 @@ export function BillingSettings() {
   const productName = billingStatus?.product_name ?? "";
   const normalizedProductName = productName.toLowerCase();
   const hasStripeAccount = !!billingStatus?.stripe_customer_id;
-  const isPaidPlan = ["starter", "pro", "max", "team"].some((plan) =>
-    normalizedProductName.includes(plan)
-  );
+  const isPaidPlan = ["pro", "max", "team"].some((plan) => normalizedProductName.includes(plan));
   const showManage = isPaidPlan && hasStripeAccount;
   const showUpgrade =
     !normalizedProductName.includes("max") && !normalizedProductName.includes("team");

--- a/frontend/src/config/pricingConfig.tsx
+++ b/frontend/src/config/pricingConfig.tsx
@@ -67,55 +67,6 @@ export const PRICING_PLANS: PricingPlan[] = [
     ctaText: "Start Free"
   },
   {
-    name: "Starter",
-    price: "$5.99",
-    description: "Get started with secure AI chat",
-    features: [
-      {
-        text: "All features from Free",
-        included: true,
-        icon: <Check className="w-4 h-4 text-maple-success" />
-      },
-      {
-        text: "Enough messages for casual use",
-        included: true,
-        icon: <Check className="w-4 h-4 text-maple-success" />
-      },
-      {
-        text: "AI Naming of Chats",
-        included: true,
-        icon: <Check className="w-4 h-4 text-maple-success" />
-      },
-      {
-        text: "Gemma 4 31B",
-        included: true,
-        icon: <Check className="w-4 h-4 text-maple-success" />
-      },
-      {
-        text: "Image Upload",
-        included: true,
-        icon: <Check className="w-4 h-4 text-maple-success" />
-      },
-      {
-        text: "Document Upload (PDF, TXT, MD)",
-        included: false,
-        icon: <X className="w-4 h-4 text-maple-error" />
-      },
-      {
-        text: "Voice Recording (Whisper)",
-        included: false,
-        icon: <X className="w-4 h-4 text-maple-error" />
-      },
-      {
-        text: "GLM 5.2 + Kimi K2.6",
-        included: false,
-        icon: <X className="w-4 h-4 text-maple-error" />
-      },
-      { text: "API Access", included: false, icon: <X className="w-4 h-4 text-maple-error" /> }
-    ],
-    ctaText: "Start Chatting"
-  },
-  {
     name: "Pro",
     price: "$20",
     description: "For power users who need more",

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -839,17 +839,7 @@ function PricingPage() {
         )}
 
         {(() => {
-          const filteredPlans = PRICING_PLANS.filter((plan) => {
-            // Always hide Starter plan unless user is currently on Starter
-            const isStarterPlan = plan.name.toLowerCase() === "starter";
-            const isUserOnStarter = freshBillingStatus?.product_name?.toLowerCase() === "starter";
-
-            if (isStarterPlan && !isUserOnStarter) {
-              return false;
-            }
-
-            return true;
-          });
+          const filteredPlans = PRICING_PLANS;
 
           const gridColumns = filteredPlans.length === 4 ? "lg:grid-cols-4" : "lg:grid-cols-3";
 

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -218,10 +218,7 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
 
     const planName = status.product_name?.toLowerCase() || "";
     const isPaidPlan =
-      planName.includes("pro") ||
-      planName.includes("max") ||
-      planName.includes("team") ||
-      planName.includes("starter");
+      planName.includes("pro") || planName.includes("max") || planName.includes("team");
 
     const isProMaxOrTeam = isProMaxOrTeamPlan(planName);
 
@@ -279,7 +276,7 @@ export const LocalStateProvider = ({ children }: { children: React.ReactNode }) 
             setModelInternal(PAID_DEFAULT_MODEL_ID, true);
           }
         } else {
-          // User downgraded to free/starter — switch back to free model
+          // User downgraded to free — switch back to free model
           // and clear paid defaults so they get re-applied if they upgrade again
           setModelInternal(DEFAULT_MODEL_ID);
           localStorage.removeItem("paidDefaultsApplied");

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -3,7 +3,7 @@ import { BillingStatus } from "@/billing/billingApi";
 import type { Model } from "openai/resources/models.js";
 
 // Extended Model type for OpenSecret API which includes additional properties
-export type ModelAccessTier = "free" | "starter" | "pro";
+export type ModelAccessTier = "free" | "pro";
 
 export type ModelCapabilities = {
   chat?: boolean;


### PR DESCRIPTION
## Summary

- remove the deprecated Starter pricing card, visibility compatibility path, billing recognition, and matching documentation
- move image upsells and access to Pro while preserving Free, Pro, Max, and Team behavior
- treat every non-free model-catalog tier as Pro-gated so stale metadata cannot fall through to Free access
- remove Starter-specific tests, model-tier types, and badge handling

## Validation

- Maple pre-commit hook
- Prettier formatting check
- TypeScript and Vite production build
- 474 frontend tests with 1,629 assertions
- ESLint: 0 errors, 13 pre-existing warnings
- no tracked textual Starter references remain

No Rust files changed, so the pre-commit hook skipped Rust tests.