### PR TITLE
Add chat font and size preferences

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -12,6 +12,7 @@ import { NotFoundFallback } from "./components/NotFoundFallback";
 import { BillingServiceProvider } from "./components/BillingServiceProvider";
 import { DeepLinkHandler } from "./components/DeepLinkHandler";
 import { NotificationProvider } from "./contexts/NotificationContext";
+import { ChatTypographyProvider } from "./contexts/ChatTypographyContext";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import { ProxyEventListener } from "./components/ProxyEventListener";
 import { UpdateEventListener } from "./components/UpdateEventListener";
@@ -103,14 +104,16 @@ export default function App() {
             <OpenAIProvider>
               <QueryClientProvider client={queryClient}>
                 <TooltipProvider>
-                  <TTSProvider>
-                    <BillingServiceProvider>
-                      <ProxyEventListener />
-                      <UpdateEventListener />
-                      <DeepLinkHandler />
-                      <InnerApp />
-                    </BillingServiceProvider>
-                  </TTSProvider>
+                  <ChatTypographyProvider>
+                    <TTSProvider>
+                      <BillingServiceProvider>
+                        <ProxyEventListener />
+                        <UpdateEventListener />
+                        <DeepLinkHandler />
+                        <InnerApp />
+                      </BillingServiceProvider>
+                    </TTSProvider>
+                  </ChatTypographyProvider>
                 </TooltipProvider>
               </QueryClientProvider>
             </OpenAIProvider>

--- a/frontend/src/chat.css
+++ b/frontend/src/chat.css
@@ -1294,3 +1294,81 @@
 .markdown-body .hljs-strong {
   font-weight: 700;
 }
+
+/*
+ * Conversation typography is intentionally scoped to shared chat turns. The
+ * product chrome keeps Maple's normal 14px Manrope treatment while Unified
+ * Chat and Agent Mode consume the same device-local reading preference.
+ */
+.chat-typography {
+  --chat-font-size-sm: calc(var(--chat-font-size, 15px) - 1px);
+  --chat-font-size-xs: calc(var(--chat-font-size, 15px) - 3px);
+  --chat-font-size-tool-title: calc(var(--chat-font-size, 15px) - 2px);
+  --chat-font-size-tool-meta: max(10px, calc(var(--chat-font-size, 15px) - 4px));
+  --chat-font-size-kbd: max(10px, calc(var(--chat-font-size, 15px) - 4px));
+  --chat-line-height-sm: calc(var(--chat-font-size, 15px) + 5px);
+  --chat-line-height-xs: calc(var(--chat-font-size, 15px) + 1px);
+  --chat-line-height-kbd: max(10px, calc(var(--chat-font-size, 15px) - 5px));
+
+  font-family: var(--chat-font-family, var(--app-font-family));
+  font-size: var(--chat-font-size, 15px);
+}
+
+/* Markdown keeps its historical full message size, even inside smaller tool chrome. */
+.chat-typography .markdown-body {
+  font-size: var(--chat-font-size, 15px);
+}
+
+.chat-typography .markdown-body p,
+.chat-typography .markdown-body ul,
+.chat-typography .markdown-body ol,
+.chat-typography .markdown-body li,
+.chat-typography .markdown-body li > p,
+.chat-typography .markdown-body table th,
+.chat-typography .markdown-body table td {
+  font-size: var(--chat-font-size, 15px);
+}
+
+/* Preserve the existing transcript hierarchy while scaling every text tier. */
+.chat-typography :where(.text-sm) {
+  font-size: var(--chat-font-size-sm);
+  line-height: var(--chat-line-height-sm);
+}
+
+.chat-typography :where(.text-xs) {
+  font-size: var(--chat-font-size-xs);
+  line-height: var(--chat-line-height-xs);
+}
+
+.chat-typography :where(.text-\[13px\]) {
+  font-size: var(--chat-font-size-tool-title);
+  line-height: var(--chat-line-height-sm);
+}
+
+.chat-typography :where(.text-\[11px\]) {
+  font-size: var(--chat-font-size-tool-meta);
+  line-height: var(--chat-line-height-sm);
+}
+
+/* The assistant identity is product chrome, not transcript content. */
+.chat-typography .chat-product-label {
+  font-family: var(--app-font-family);
+  font-size: 14px;
+  line-height: 1;
+}
+
+.chat-typography .markdown-body .csv-data td,
+.chat-typography .markdown-body .csv-data th,
+.chat-typography .markdown-body .footnotes {
+  font-size: var(--chat-font-size-xs);
+}
+
+.chat-typography .markdown-body kbd {
+  font-size: var(--chat-font-size-kbd);
+  line-height: var(--chat-line-height-kbd);
+}
+
+/* Selected prose fonts should reach chat actions; code remains monospace. */
+.chat-typography :where(.font-sans) {
+  font-family: inherit;
+}

--- a/frontend/src/components/chat/ChatTurn.test.tsx
+++ b/frontend/src/components/chat/ChatTurn.test.tsx
@@ -1,0 +1,27 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { ChatAssistantTurn, ChatUserTurn } from "./ChatTurn";
+
+describe("shared chat typography scope", () => {
+  test("applies the typography scope to user turns", () => {
+    const markup = renderToStaticMarkup(
+      <ChatUserTurn>
+        <p>User message</p>
+      </ChatUserTurn>
+    );
+
+    expect(markup).toContain("chat-typography");
+    expect(markup).toContain("User message");
+  });
+
+  test("applies the typography scope to assistant, reasoning, and tool content", () => {
+    const markup = renderToStaticMarkup(
+      <ChatAssistantTurn>
+        <div className="text-sm">Tool activity</div>
+      </ChatAssistantTurn>
+    );
+
+    expect(markup).toContain("chat-typography");
+    expect(markup).toContain("Tool activity");
+  });
+});

--- a/frontend/src/components/chat/ChatTurn.tsx
+++ b/frontend/src/components/chat/ChatTurn.tsx
@@ -35,7 +35,10 @@ export function ChatUserTurn({
     <div
       ref={containerRef}
       data-history-anchor-ids={historyAnchorIds}
-      className={cn("group/user flex flex-col items-end py-4 landscape-short:py-1.5", className)}
+      className={cn(
+        "chat-typography group/user flex flex-col items-end py-4 landscape-short:py-1.5",
+        className
+      )}
     >
       <div className="max-w-[min(100%,42rem)] rounded-2xl border border-border bg-muted px-4 py-3 backdrop-blur-lg dark:bg-card landscape-short:px-3 landscape-short:py-2">
         <div className="prose prose-sm max-w-none text-left dark:prose-invert">
@@ -56,18 +59,22 @@ export function ChatAssistantTurn({ children, actions, containerRef, className }
     <div
       ref={containerRef}
       className={cn(
-        "group px-0 py-4 md:p-4 landscape-short:px-2 landscape-short:py-1.5",
+        "chat-typography group px-0 py-4 md:p-4 landscape-short:px-2 landscape-short:py-1.5",
         className
       )}
     >
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-2 md:flex-row md:items-start md:gap-3">
         <div className="flex h-8 shrink-0 items-center gap-2 px-0 md:h-auto md:flex-col md:items-start md:gap-3 landscape-short:h-6">
           <MapleChatAvatar />
-          <div className="text-sm font-semibold leading-none md:hidden">Maple</div>
+          <div className="chat-product-label text-sm font-semibold leading-none md:hidden">
+            Maple
+          </div>
         </div>
         <div className="flex min-w-0 w-full flex-1 flex-col overflow-hidden px-2 md:gap-2 md:px-0">
           <div className="hidden md:block">
-            <div className="text-left text-sm font-semibold leading-none">Maple</div>
+            <div className="chat-product-label text-left text-sm font-semibold leading-none">
+              Maple
+            </div>
           </div>
           <div className="space-y-2">
             {children}

--- a/frontend/src/components/settings/PreferencesSettings.tsx
+++ b/frontend/src/components/settings/PreferencesSettings.tsx
@@ -15,7 +15,14 @@ import {
   SelectValue
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
+import { useChatTypography } from "@/contexts/ChatTypographyContext";
 import { useSettingsNavigationLock } from "@/contexts/SettingsNavigationLockContext";
+import {
+  CHAT_FONT_OPTIONS,
+  CHAT_FONT_SIZE_MAX,
+  CHAT_FONT_SIZE_MIN,
+  CHAT_FONT_SIZE_STEP
+} from "@/services/chatTypographyPreferences";
 import { useTTS } from "@/services/tts/TTSContext";
 import {
   isVoxtralTTSVoice,
@@ -34,6 +41,8 @@ function formatPlaybackSpeed(speed: number): string {
 
 export function PreferencesSettings() {
   const os = useOpenSecret();
+  const { fontFamily, fontSize, setFontFamily, setFontSize, resetTypography, hasCustomTypography } =
+    useChatTypography();
   const {
     playbackSpeed,
     hasCustomPlaybackSpeed,
@@ -42,6 +51,7 @@ export function PreferencesSettings() {
     resetPlaybackSpeed,
     setVoice
   } = useTTS();
+  const selectedFontOption = CHAT_FONT_OPTIONS.find((option) => option.value === fontFamily);
   const [prompt, setPrompt] = useState("");
   const [instructionId, setInstructionId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
@@ -158,6 +168,121 @@ export function PreferencesSettings() {
             </Button>
           </div>
         </form>
+      </SettingsSection>
+      <SettingsSection
+        title="Chat appearance"
+        description="Adjust the reading experience for conversations while keeping Maple's current look as the default."
+      >
+        <div className="space-y-6">
+          <div className="grid gap-2">
+            <Label htmlFor="settings-chat-font">Chat font</Label>
+            <Select
+              value={fontFamily}
+              onValueChange={(value) => {
+                const option = CHAT_FONT_OPTIONS.find((candidate) => candidate.value === value);
+                if (option) setFontFamily(option.value);
+              }}
+            >
+              <SelectTrigger
+                id="settings-chat-font"
+                style={{ fontFamily: selectedFontOption?.cssFontFamily }}
+              >
+                <SelectValue placeholder="Select a font" />
+              </SelectTrigger>
+              <SelectContent>
+                {CHAT_FONT_OPTIONS.map((option) => (
+                  <SelectItem
+                    key={option.value}
+                    value={option.value}
+                    style={{ fontFamily: option.cssFontFamily }}
+                  >
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {selectedFontOption && (
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                {selectedFontOption.description}
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor="settings-chat-font-size">Text size</Label>
+              <output
+                htmlFor="settings-chat-font-size"
+                className="text-sm tabular-nums text-muted-foreground"
+              >
+                {fontSize}px
+              </output>
+            </div>
+            <input
+              id="settings-chat-font-size"
+              type="range"
+              min={CHAT_FONT_SIZE_MIN}
+              max={CHAT_FONT_SIZE_MAX}
+              step={CHAT_FONT_SIZE_STEP}
+              value={fontSize}
+              onChange={(event) => setFontSize(Number(event.currentTarget.value))}
+              className="h-2 w-full cursor-pointer accent-primary"
+              aria-valuetext={`${fontSize} pixels`}
+            />
+            <div className="flex items-center justify-between text-xs text-muted-foreground">
+              <span>{CHAT_FONT_SIZE_MIN}px</span>
+              <span>{CHAT_FONT_SIZE_MAX}px</span>
+            </div>
+          </div>
+
+          <div
+            className="rounded-lg border border-border/70 bg-muted/30 p-4"
+            role="group"
+            aria-labelledby="settings-chat-preview-label"
+          >
+            <p
+              id="settings-chat-preview-label"
+              className="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+            >
+              Live preview
+            </p>
+            <div className="chat-typography mt-3 space-y-3">
+              <div className="max-w-[88%] rounded-lg bg-background px-3 py-2 shadow-sm">
+                <p className="mb-1 text-[0.75em] font-semibold text-muted-foreground">Assistant</p>
+                <p className="leading-[1.65] tracking-[0.1px]">
+                  Clear, comfortable text makes longer conversations easier to follow.
+                </p>
+              </div>
+              <div className="ml-auto max-w-[88%] rounded-lg border border-border bg-muted px-3 py-2">
+                <p className="mb-1 text-[0.75em] font-semibold text-muted-foreground">You</p>
+                <p className="leading-[1.65] tracking-[0.1px]">This size feels just right.</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+            <div className="space-y-1">
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Applies to messages, reasoning, and tool activity in Chat and Agent Mode. Code stays
+                monospace for readability.
+              </p>
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Changes are saved automatically on this device.
+              </p>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={resetTypography}
+              disabled={!hasCustomTypography}
+              className="shrink-0 gap-2"
+            >
+              <RotateCcw className="h-4 w-4" aria-hidden="true" />
+              Reset chat appearance
+            </Button>
+          </div>
+        </div>
       </SettingsSection>
       <SettingsSection
         title="Text-to-speech"

--- a/frontend/src/contexts/ChatTypographyContext.test.tsx
+++ b/frontend/src/contexts/ChatTypographyContext.test.tsx
@@ -1,0 +1,94 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import {
+  CHAT_FONT_FAMILY_STORAGE_KEY,
+  CHAT_FONT_SIZE_STORAGE_KEY
+} from "@/services/chatTypographyPreferences";
+import { ChatTypographyProvider, useChatTypography } from "./ChatTypographyContext";
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+class MemoryStyle {
+  readonly values = new Map<string, string>();
+
+  setProperty(property: string, value: string): void {
+    this.values.set(property, value);
+  }
+}
+
+type ChatTypographySnapshot = ReturnType<typeof useChatTypography>;
+
+function ChatTypographyProbe({ onRender }: { onRender: (value: ChatTypographySnapshot) => void }) {
+  onRender(useChatTypography());
+  return null;
+}
+
+describe("ChatTypographyProvider", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = null;
+    }
+  });
+
+  test("restores, persists, applies, and resets typography immediately", () => {
+    const storage = new MemoryStorage();
+    const style = new MemoryStyle();
+    const renderedContext: { current?: ChatTypographySnapshot } = {};
+    const currentContext = () => {
+      if (!renderedContext.current) throw new Error("Typography context did not render");
+      return renderedContext.current;
+    };
+    storage.setItem(CHAT_FONT_FAMILY_STORAGE_KEY, "serif");
+    storage.setItem(CHAT_FONT_SIZE_STORAGE_KEY, "17");
+
+    act(() => {
+      renderer = create(
+        <ChatTypographyProvider storage={storage} rootStyle={style}>
+          <ChatTypographyProbe onRender={(value) => (renderedContext.current = value)} />
+        </ChatTypographyProvider>
+      );
+    });
+
+    expect(currentContext().fontFamily).toBe("serif");
+    expect(currentContext().fontSize).toBe(17);
+    expect(currentContext().hasCustomTypography).toBe(true);
+    expect(style.values.get("--chat-font-family")).toContain("Georgia");
+    expect(style.values.get("--chat-font-size")).toBe("17px");
+
+    act(() => currentContext().setFontFamily("system"));
+    expect(storage.getItem(CHAT_FONT_FAMILY_STORAGE_KEY)).toBe("system");
+    expect(style.values.get("--chat-font-family")).toContain("system-ui");
+
+    act(() => currentContext().setFontSize(100));
+    expect(currentContext().fontSize).toBe(18);
+    expect(storage.getItem(CHAT_FONT_SIZE_STORAGE_KEY)).toBe("18");
+    expect(style.values.get("--chat-font-size")).toBe("18px");
+
+    act(() => currentContext().resetTypography());
+    expect(currentContext().fontFamily).toBe("manrope");
+    expect(currentContext().fontSize).toBe(15);
+    expect(currentContext().hasCustomTypography).toBe(false);
+    expect(storage.getItem(CHAT_FONT_FAMILY_STORAGE_KEY)).toBeNull();
+    expect(storage.getItem(CHAT_FONT_SIZE_STORAGE_KEY)).toBeNull();
+    expect(style.values.get("--chat-font-family")).toContain("Manrope");
+    expect(style.values.get("--chat-font-size")).toBe("15px");
+  });
+});

--- a/frontend/src/contexts/ChatTypographyContext.tsx
+++ b/frontend/src/contexts/ChatTypographyContext.tsx
@@ -1,0 +1,111 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode
+} from "react";
+
+import {
+  applyChatTypography,
+  DEFAULT_CHAT_FONT_FAMILY,
+  DEFAULT_CHAT_FONT_SIZE,
+  getStoredChatFontFamily,
+  getStoredChatFontSize,
+  rememberChatFontFamily,
+  rememberChatFontSize,
+  resetChatTypographyPreferences,
+  type ChatFontFamily,
+  type ChatTypographyStorage,
+  type ChatTypographyStyle
+} from "@/services/chatTypographyPreferences";
+
+interface ChatTypographyContextValue {
+  fontFamily: ChatFontFamily;
+  fontSize: number;
+  setFontFamily: (fontFamily: ChatFontFamily) => void;
+  setFontSize: (fontSize: number) => void;
+  resetTypography: () => void;
+  hasCustomTypography: boolean;
+}
+
+interface ChatTypographyProviderProps {
+  children: ReactNode;
+  storage?: ChatTypographyStorage | null;
+  rootStyle?: ChatTypographyStyle | null;
+}
+
+const ChatTypographyContext = createContext<ChatTypographyContextValue | null>(null);
+
+export function ChatTypographyProvider({
+  children,
+  storage,
+  rootStyle
+}: ChatTypographyProviderProps) {
+  const [fontFamily, setFontFamilyState] = useState(() => getStoredChatFontFamily(storage));
+  const [fontSize, setFontSizeState] = useState(() => getStoredChatFontSize(storage));
+  const fontFamilyRef = useRef(fontFamily);
+  const fontSizeRef = useRef(fontSize);
+
+  useEffect(() => {
+    applyChatTypography({ fontFamily, fontSize }, rootStyle);
+  }, [fontFamily, fontSize, rootStyle]);
+
+  const setFontFamily = useCallback(
+    (nextFontFamily: ChatFontFamily) => {
+      const safeFontFamily = rememberChatFontFamily(nextFontFamily, storage);
+      fontFamilyRef.current = safeFontFamily;
+      applyChatTypography({ fontFamily: safeFontFamily, fontSize: fontSizeRef.current }, rootStyle);
+      setFontFamilyState(safeFontFamily);
+    },
+    [rootStyle, storage]
+  );
+
+  const setFontSize = useCallback(
+    (nextFontSize: number) => {
+      const safeFontSize = rememberChatFontSize(nextFontSize, storage);
+      fontSizeRef.current = safeFontSize;
+      applyChatTypography({ fontFamily: fontFamilyRef.current, fontSize: safeFontSize }, rootStyle);
+      setFontSizeState(safeFontSize);
+    },
+    [rootStyle, storage]
+  );
+
+  const resetTypography = useCallback(() => {
+    resetChatTypographyPreferences(storage);
+    fontFamilyRef.current = DEFAULT_CHAT_FONT_FAMILY;
+    fontSizeRef.current = DEFAULT_CHAT_FONT_SIZE;
+    applyChatTypography(
+      { fontFamily: DEFAULT_CHAT_FONT_FAMILY, fontSize: DEFAULT_CHAT_FONT_SIZE },
+      rootStyle
+    );
+    setFontFamilyState(DEFAULT_CHAT_FONT_FAMILY);
+    setFontSizeState(DEFAULT_CHAT_FONT_SIZE);
+  }, [rootStyle, storage]);
+
+  const value = useMemo(
+    () => ({
+      fontFamily,
+      fontSize,
+      setFontFamily,
+      setFontSize,
+      resetTypography,
+      hasCustomTypography:
+        fontFamily !== DEFAULT_CHAT_FONT_FAMILY || fontSize !== DEFAULT_CHAT_FONT_SIZE
+    }),
+    [fontFamily, fontSize, resetTypography, setFontFamily, setFontSize]
+  );
+
+  return <ChatTypographyContext.Provider value={value}>{children}</ChatTypographyContext.Provider>;
+}
+
+export function useChatTypography(): ChatTypographyContextValue {
+  const context = useContext(ChatTypographyContext);
+  if (!context) {
+    throw new Error("useChatTypography must be used within a ChatTypographyProvider");
+  }
+  return context;
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -51,6 +51,8 @@
   /* Light mode by default — Neutral scale from Figma */
   :root {
     --app-font-family: "Manrope", sans-serif;
+    --chat-font-family: var(--app-font-family);
+    --chat-font-size: 15px;
 
     /* Base colors — Neutral 50 / Neutral 800 (body text) */
     --background: 0 0% 98%; /* #FAFAFA - Neutral 50 */

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,10 +1,15 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { isTauriDesktop, waitForPlatform } from "@/utils/platform";
+import { restoreChatTypographyAtLaunch } from "@/services/chatTypographyPreferences";
 import { restoreWorkspaceModeAtLaunch } from "@/services/workspaceModePreference";
 
 // Initialize platform detection before rendering
 async function initializeApp() {
+  // Restore transcript typography before any asynchronous platform work so a
+  // refreshed conversation does not briefly render with the default metrics.
+  restoreChatTypographyAtLaunch();
+
   // Wait for platform detection to complete
   // This ensures all platform checks are correct from the first render
   await waitForPlatform();

--- a/frontend/src/services/chatTypographyPreferences.test.ts
+++ b/frontend/src/services/chatTypographyPreferences.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  applyChatTypography,
+  CHAT_FONT_FAMILIES,
+  CHAT_FONT_FAMILY_STORAGE_KEY,
+  CHAT_FONT_OPTIONS,
+  CHAT_FONT_SIZE_MAX,
+  CHAT_FONT_SIZE_MIN,
+  CHAT_FONT_SIZE_STEP,
+  CHAT_FONT_SIZE_STORAGE_KEY,
+  clampChatFontSize,
+  DEFAULT_CHAT_FONT_FAMILY,
+  DEFAULT_CHAT_FONT_SIZE,
+  getStoredChatFontFamily,
+  getStoredChatFontSize,
+  rememberChatFontFamily,
+  rememberChatFontSize,
+  resetChatTypographyPreferences,
+  restoreChatTypographyAtLaunch
+} from "./chatTypographyPreferences";
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+class MemoryStyle {
+  readonly values = new Map<string, string>();
+
+  setProperty(property: string, value: string): void {
+    this.values.set(property, value);
+  }
+}
+
+describe("chat typography preferences", () => {
+  test("defines the restrained product defaults and allowlisted options", () => {
+    const storage = new MemoryStorage();
+
+    expect(DEFAULT_CHAT_FONT_FAMILY).toBe("manrope");
+    expect(DEFAULT_CHAT_FONT_SIZE).toBe(15);
+    expect(CHAT_FONT_SIZE_MIN).toBe(13);
+    expect(CHAT_FONT_SIZE_MAX).toBe(18);
+    expect(CHAT_FONT_SIZE_STEP).toBe(1);
+    expect(CHAT_FONT_FAMILY_STORAGE_KEY).toBe("chatFontFamily");
+    expect(CHAT_FONT_SIZE_STORAGE_KEY).toBe("chatFontSize");
+    expect(CHAT_FONT_OPTIONS.map(({ value }) => value)).toEqual([...CHAT_FONT_FAMILIES]);
+    expect(new Set(CHAT_FONT_OPTIONS.map(({ cssFontFamily }) => cssFontFamily)).size).toBe(
+      CHAT_FONT_FAMILIES.length
+    );
+    expect(getStoredChatFontFamily(storage)).toBe("manrope");
+    expect(getStoredChatFontSize(storage)).toBe(15);
+  });
+
+  test("persists valid font choices and clamps sizes to whole steps", () => {
+    const storage = new MemoryStorage();
+
+    expect(rememberChatFontFamily("system", storage)).toBe("system");
+    expect(rememberChatFontSize(16.6, storage)).toBe(17);
+    expect(getStoredChatFontFamily(storage)).toBe("system");
+    expect(getStoredChatFontSize(storage)).toBe(17);
+
+    expect(clampChatFontSize(4)).toBe(13);
+    expect(clampChatFontSize(100)).toBe(18);
+    expect(clampChatFontSize(Number.NaN)).toBe(15);
+  });
+
+  test("falls back safely from malformed and unavailable storage", () => {
+    const storage = new MemoryStorage();
+    storage.setItem(CHAT_FONT_FAMILY_STORAGE_KEY, "comic-sans");
+    storage.setItem(CHAT_FONT_SIZE_STORAGE_KEY, "huge");
+
+    expect(getStoredChatFontFamily(storage)).toBe(DEFAULT_CHAT_FONT_FAMILY);
+    expect(getStoredChatFontSize(storage)).toBe(DEFAULT_CHAT_FONT_SIZE);
+
+    const unavailableStorage = {
+      getItem: () => {
+        throw new Error("unavailable");
+      },
+      setItem: () => {
+        throw new Error("unavailable");
+      },
+      removeItem: () => {
+        throw new Error("unavailable");
+      }
+    };
+
+    expect(getStoredChatFontFamily(unavailableStorage)).toBe(DEFAULT_CHAT_FONT_FAMILY);
+    expect(getStoredChatFontSize(unavailableStorage)).toBe(DEFAULT_CHAT_FONT_SIZE);
+    expect(() => rememberChatFontFamily("system", unavailableStorage)).not.toThrow();
+    expect(() => rememberChatFontSize(18, unavailableStorage)).not.toThrow();
+    expect(() => resetChatTypographyPreferences(unavailableStorage)).not.toThrow();
+  });
+
+  test("removes both keys on reset", () => {
+    const storage = new MemoryStorage();
+    rememberChatFontFamily("serif", storage);
+    rememberChatFontSize(18, storage);
+
+    resetChatTypographyPreferences(storage);
+
+    expect(storage.getItem(CHAT_FONT_FAMILY_STORAGE_KEY)).toBeNull();
+    expect(storage.getItem(CHAT_FONT_SIZE_STORAGE_KEY)).toBeNull();
+  });
+
+  test("applies safe CSS variables and restores stored values before launch", () => {
+    const storage = new MemoryStorage();
+    const style = new MemoryStyle();
+    rememberChatFontFamily("system", storage);
+    rememberChatFontSize(16, storage);
+
+    expect(restoreChatTypographyAtLaunch(storage, style)).toEqual({
+      fontFamily: "system",
+      fontSize: 16
+    });
+    expect(style.values.get("--chat-font-family")).toContain("-apple-system");
+    expect(style.values.get("--chat-font-size")).toBe("16px");
+
+    expect(
+      applyChatTypography(
+        { fontFamily: "invalid" as never, fontSize: Number.POSITIVE_INFINITY },
+        style
+      )
+    ).toEqual({ fontFamily: "manrope", fontSize: 15 });
+    expect(style.values.get("--chat-font-family")).toContain("Manrope");
+    expect(style.values.get("--chat-font-size")).toBe("15px");
+  });
+});

--- a/frontend/src/services/chatTypographyPreferences.ts
+++ b/frontend/src/services/chatTypographyPreferences.ts
@@ -1,0 +1,211 @@
+export const CHAT_FONT_FAMILIES = ["manrope", "system", "serif"] as const;
+
+export type ChatFontFamily = (typeof CHAT_FONT_FAMILIES)[number];
+
+export interface ChatFontOption {
+  value: ChatFontFamily;
+  label: string;
+  description: string;
+  cssFontFamily: string;
+}
+
+export interface ChatTypographyPreferences {
+  fontFamily: ChatFontFamily;
+  fontSize: number;
+}
+
+export type ChatTypographyStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+export type ChatTypographyStyle = Pick<CSSStyleDeclaration, "setProperty">;
+
+export const CHAT_FONT_OPTIONS: readonly ChatFontOption[] = [
+  {
+    value: "manrope",
+    label: "Manrope",
+    description: "Maple's default, with a compact modern feel.",
+    cssFontFamily: '"Manrope", sans-serif'
+  },
+  {
+    value: "system",
+    label: "System",
+    description: "The familiar interface font for your device.",
+    cssFontFamily: 'system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif'
+  },
+  {
+    value: "serif",
+    label: "Serif",
+    description: "A traditional reading style with distinct letterforms.",
+    cssFontFamily: 'Georgia, "Times New Roman", serif'
+  }
+];
+
+export const DEFAULT_CHAT_FONT_FAMILY: ChatFontFamily = "manrope";
+export const DEFAULT_CHAT_FONT_SIZE = 15;
+export const CHAT_FONT_SIZE_MIN = 13;
+export const CHAT_FONT_SIZE_MAX = 18;
+export const CHAT_FONT_SIZE_STEP = 1;
+
+export const CHAT_FONT_FAMILY_STORAGE_KEY = "chatFontFamily";
+export const CHAT_FONT_SIZE_STORAGE_KEY = "chatFontSize";
+
+const CHAT_FONT_OPTION_BY_FAMILY = new Map(
+  CHAT_FONT_OPTIONS.map((option) => [option.value, option] as const)
+);
+
+function getBrowserStorage(): ChatTypographyStorage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function getDocumentRootStyle(): ChatTypographyStyle | null {
+  if (typeof document === "undefined") return null;
+
+  try {
+    return document.documentElement.style;
+  } catch {
+    return null;
+  }
+}
+
+export function isChatFontFamily(value: unknown): value is ChatFontFamily {
+  return typeof value === "string" && CHAT_FONT_OPTION_BY_FAMILY.has(value as ChatFontFamily);
+}
+
+export function getChatFontOption(fontFamily: ChatFontFamily): ChatFontOption {
+  return (
+    CHAT_FONT_OPTION_BY_FAMILY.get(fontFamily) ??
+    CHAT_FONT_OPTION_BY_FAMILY.get(DEFAULT_CHAT_FONT_FAMILY)!
+  );
+}
+
+export function clampChatFontSize(fontSize: number): number {
+  if (!Number.isFinite(fontSize)) {
+    return DEFAULT_CHAT_FONT_SIZE;
+  }
+
+  const clamped = Math.min(CHAT_FONT_SIZE_MAX, Math.max(CHAT_FONT_SIZE_MIN, fontSize));
+  return (
+    Math.round((clamped - CHAT_FONT_SIZE_MIN) / CHAT_FONT_SIZE_STEP) * CHAT_FONT_SIZE_STEP +
+    CHAT_FONT_SIZE_MIN
+  );
+}
+
+export function getStoredChatFontFamily(
+  storage: ChatTypographyStorage | null = getBrowserStorage()
+): ChatFontFamily {
+  if (!storage) return DEFAULT_CHAT_FONT_FAMILY;
+
+  try {
+    const stored = storage.getItem(CHAT_FONT_FAMILY_STORAGE_KEY);
+    return isChatFontFamily(stored) ? stored : DEFAULT_CHAT_FONT_FAMILY;
+  } catch {
+    return DEFAULT_CHAT_FONT_FAMILY;
+  }
+}
+
+export function getStoredChatFontSize(
+  storage: ChatTypographyStorage | null = getBrowserStorage()
+): number {
+  if (!storage) return DEFAULT_CHAT_FONT_SIZE;
+
+  try {
+    const stored = storage.getItem(CHAT_FONT_SIZE_STORAGE_KEY);
+    if (stored === null || stored.trim() === "") {
+      return DEFAULT_CHAT_FONT_SIZE;
+    }
+    return clampChatFontSize(Number(stored));
+  } catch {
+    return DEFAULT_CHAT_FONT_SIZE;
+  }
+}
+
+export function rememberChatFontFamily(
+  fontFamily: ChatFontFamily,
+  storage: ChatTypographyStorage | null = getBrowserStorage()
+): ChatFontFamily {
+  const safeFontFamily = isChatFontFamily(fontFamily) ? fontFamily : DEFAULT_CHAT_FONT_FAMILY;
+  if (!storage) return safeFontFamily;
+
+  try {
+    storage.setItem(CHAT_FONT_FAMILY_STORAGE_KEY, safeFontFamily);
+  } catch {
+    // Storage failures should not prevent an in-memory preference change.
+  }
+  return safeFontFamily;
+}
+
+export function rememberChatFontSize(
+  fontSize: number,
+  storage: ChatTypographyStorage | null = getBrowserStorage()
+): number {
+  const safeFontSize = clampChatFontSize(fontSize);
+  if (!storage) return safeFontSize;
+
+  try {
+    storage.setItem(CHAT_FONT_SIZE_STORAGE_KEY, String(safeFontSize));
+  } catch {
+    // Storage failures should not prevent an in-memory preference change.
+  }
+  return safeFontSize;
+}
+
+export function resetChatTypographyPreferences(
+  storage: ChatTypographyStorage | null = getBrowserStorage()
+): void {
+  if (!storage) return;
+
+  try {
+    storage.removeItem(CHAT_FONT_FAMILY_STORAGE_KEY);
+  } catch {
+    // Continue so one unavailable key does not block the other reset.
+  }
+
+  try {
+    storage.removeItem(CHAT_FONT_SIZE_STORAGE_KEY);
+  } catch {
+    // Storage failures should not prevent an in-memory preference reset.
+  }
+}
+
+export function applyChatTypography(
+  preferences: ChatTypographyPreferences,
+  style: ChatTypographyStyle | null = getDocumentRootStyle()
+): ChatTypographyPreferences {
+  const safePreferences: ChatTypographyPreferences = {
+    fontFamily: isChatFontFamily(preferences.fontFamily)
+      ? preferences.fontFamily
+      : DEFAULT_CHAT_FONT_FAMILY,
+    fontSize: clampChatFontSize(preferences.fontSize)
+  };
+  if (!style) return safePreferences;
+
+  try {
+    style.setProperty(
+      "--chat-font-family",
+      getChatFontOption(safePreferences.fontFamily).cssFontFamily
+    );
+    style.setProperty("--chat-font-size", `${safePreferences.fontSize}px`);
+  } catch {
+    // CSS application failures should not prevent the app from launching.
+  }
+
+  return safePreferences;
+}
+
+export function restoreChatTypographyAtLaunch(
+  storage: ChatTypographyStorage | null = getBrowserStorage(),
+  style: ChatTypographyStyle | null = getDocumentRootStyle()
+): ChatTypographyPreferences {
+  return applyChatTypography(
+    {
+      fontFamily: getStoredChatFontFamily(storage),
+      fontSize: getStoredChatFontSize(storage)
+    },
+    style
+  );
+}


### PR DESCRIPTION
## Summary

- add device-local Chat appearance preferences for Manrope, the system font, or a serif font, plus a bounded 13–18px text-size control
- keep Manrope at 15px as the default and restore saved choices before first render
- apply typography to shared Chat and Agent Mode turns, including reasoning and tool activity, while keeping code monospace and product chrome unchanged
- safely handle invalid or unavailable local storage, with reset and regression coverage

## Validation

- `nix develop .#ci -c ./scripts/ci/frontend.sh` — 483 passing, 0 failing; formatting, typecheck, and lint completed with 0 errors
- `nix develop -c just build`
- managed full-stack smoke passed OpenSecret, Postgres, Continuum, extended Tinfoil SDK health, and billing
- Chrome UI smoke covered all font choices, 13px/18px limits, narrow layout, refresh/reset persistence, and real web-search tool activity; no console errors
- Agent Mode uses the tested shared `ChatTurn` scope; desktop-only visual confirmation remains for local manual testing
