### PR TITLE
perf(frontend): reduce startup and render fan-out

### DIFF
--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -5,13 +5,13 @@ import { AlertCircle, Settings } from "lucide-react";
 import { getBillingService } from "@/billing/billingService";
 import { CreditUsage } from "@/components/CreditUsage";
 import { useCompactSettingsLayout } from "@/components/settings/useCompactSettingsLayout";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
 import { getTeamSeatMismatch } from "@/utils/teamSeats";
 
 export function AccountMenu() {
   const os = useOpenSecret();
-  const { billingStatus, setBillingStatus } = useLocalState();
+  const { billingStatus, setBillingStatus } = useBillingState();
   const isCompactSettingsLayout = useCompactSettingsLayout();
   const isTeamPlan = billingStatus?.product_name?.toLowerCase().includes("team") ?? false;
 

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -1,4 +1,5 @@
 import {
+  memo,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -156,7 +157,8 @@ import {
   useIsMobile
 } from "@/utils/utils";
 import { isTauriDesktop } from "@/utils/platform";
-import { useLocalState } from "@/state/useLocalState";
+import { useLazyRef } from "@/utils/useLazyRef";
+import { useBillingState, useModelState } from "@/state/useLocalState";
 import {
   usePersistentHomeNavigation,
   usePersistentSidebarState
@@ -292,7 +294,7 @@ export function AgentMode({ userId }: { userId: string }) {
   const openai = useOpenAI();
   const os = useOpenSecret();
   const { availableModels, setAvailableModels, modelAliases, setModelAliases, setHasWhisperModel } =
-    useLocalState();
+    useModelState();
   const { agentSessionSelection } = usePersistentHomeNavigation();
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
@@ -353,18 +355,18 @@ export function AgentMode({ userId }: { userId: string }) {
   );
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const activeSessionIdRef = useRef(activeSessionId);
-  const deletedSessionIdsRef = useRef(new Set<string>());
+  const deletedSessionIdsRef = useLazyRef(() => new Set<string>());
   const shouldAutoScrollRef = useRef(true);
-  const permissionModeUpdateRef = useRef<Promise<void>>(Promise.resolve());
+  const permissionModeUpdateRef = useLazyRef<Promise<void>>(() => Promise.resolve());
   const permissionModeUpdateGenerationRef = useRef(0);
   const selectedModeRef = useRef<AgentPermissionMode>(mode);
   const committedModeRef = useRef<AgentPermissionMode>(mode);
-  const terminalRunIdsRef = useRef(new Set<string>());
-  const pendingSendTokensRef = useRef(new Map<string, number>());
-  const cancelledPendingSendTokensRef = useRef(new Set<number>());
+  const terminalRunIdsRef = useLazyRef(() => new Set<string>());
+  const pendingSendTokensRef = useLazyRef(() => new Map<string, number>());
+  const cancelledPendingSendTokensRef = useLazyRef(() => new Set<number>());
   const nextSendTokenRef = useRef(0);
   const activeRunsBySessionRef = useRef<Record<string, string>>({});
-  const timelineRevisionBySessionRef = useRef(new Map<string, number>());
+  const timelineRevisionBySessionRef = useLazyRef(() => new Map<string, number>());
   const sessionSelectionGenerationRef = useRef(0);
   const pendingSessionSelectionIdRef = useRef<string | null>(null);
   const interactionGenerationRef = useRef(0);
@@ -378,9 +380,11 @@ export function AgentMode({ userId }: { userId: string }) {
   const isAgentModeMountedRef = useRef(true);
   const projectOrderRequestIdRef = useRef(0);
   const projectSkillsTrustGenerationRef = useRef(0);
-  const thoughtPhaseTrackerRef = useRef(new AgentLiveThoughtPhaseTracker());
-  const thoughtLabelFinalRequestRegistryRef = useRef(new AgentThoughtLabelFinalRequestRegistry());
-  const thoughtPhaseSeededRunIdsRef = useRef(new Set<string>());
+  const thoughtPhaseTrackerRef = useLazyRef(() => new AgentLiveThoughtPhaseTracker());
+  const thoughtLabelFinalRequestRegistryRef = useLazyRef(
+    () => new AgentThoughtLabelFinalRequestRegistry()
+  );
+  const thoughtPhaseSeededRunIdsRef = useLazyRef(() => new Set<string>());
   const openaiRef = useRef(openai);
   const openSecretRef = useRef(os);
   const currentAgentModelRef = useRef(model);
@@ -440,10 +444,13 @@ export function AgentMode({ userId }: { userId: string }) {
     });
   }
 
-  const cancelThoughtLabelDisplays = useCallback((sessionId?: string, assistantTurnId?: string) => {
-    thoughtLabelProvisionalSchedulerRef.current?.cancelMatching(sessionId, assistantTurnId);
-    thoughtLabelFinalRequestRegistryRef.current.cancelMatching(sessionId, assistantTurnId);
-  }, []);
+  const cancelThoughtLabelDisplays = useCallback(
+    (sessionId?: string, assistantTurnId?: string) => {
+      thoughtLabelProvisionalSchedulerRef.current?.cancelMatching(sessionId, assistantTurnId);
+      thoughtLabelFinalRequestRegistryRef.current.cancelMatching(sessionId, assistantTurnId);
+    },
+    [thoughtLabelFinalRequestRegistryRef]
+  );
 
   const generateThoughtLabel = useCallback(
     (phase: AgentThoughtPhase, retainedLabel: string | null = null) => {
@@ -489,7 +496,7 @@ export function AgentMode({ userId }: { userId: string }) {
       });
       finalRequest.setCancel(cancelDisplay);
     },
-    [openai]
+    [deletedSessionIdsRef, openai, thoughtLabelFinalRequestRegistryRef]
   );
 
   const completeThoughtPhase = useCallback(
@@ -503,10 +510,13 @@ export function AgentMode({ userId }: { userId: string }) {
     [generateThoughtLabel]
   );
 
-  const observeActiveThoughtPhase = useCallback((sessionId: string) => {
-    const activePhase = thoughtPhaseTrackerRef.current.activePhase(sessionId);
-    if (activePhase) thoughtLabelProvisionalSchedulerRef.current?.observe(activePhase);
-  }, []);
+  const observeActiveThoughtPhase = useCallback(
+    (sessionId: string) => {
+      const activePhase = thoughtPhaseTrackerRef.current.activePhase(sessionId);
+      if (activePhase) thoughtLabelProvisionalSchedulerRef.current?.observe(activePhase);
+    },
+    [thoughtPhaseTrackerRef]
+  );
 
   const seedActiveThoughtPhases = useCallback(
     (activeRuns: Record<string, string>) => {
@@ -548,7 +558,14 @@ export function AgentMode({ userId }: { userId: string }) {
         })();
       }
     },
-    [observeActiveThoughtPhase, userId]
+    [
+      deletedSessionIdsRef,
+      observeActiveThoughtPhase,
+      thoughtPhaseSeededRunIdsRef,
+      thoughtPhaseTrackerRef,
+      timelineRevisionBySessionRef,
+      userId
+    ]
   );
 
   const invalidateThoughtLabelsForTurn = useCallback(
@@ -765,38 +782,47 @@ export function AgentMode({ userId }: { userId: string }) {
     setPendingSessionSelectionId(null);
   }, []);
 
-  const markPendingSend = useCallback((sessionKey: string, token: number) => {
-    pendingSendTokensRef.current.set(sessionKey, token);
-    setPendingSendSessionIds((current) => {
-      if (current.has(sessionKey)) return current;
-      const next = new Set(current);
-      next.add(sessionKey);
-      return next;
-    });
-  }, []);
+  const markPendingSend = useCallback(
+    (sessionKey: string, token: number) => {
+      pendingSendTokensRef.current.set(sessionKey, token);
+      setPendingSendSessionIds((current) => {
+        if (current.has(sessionKey)) return current;
+        const next = new Set(current);
+        next.add(sessionKey);
+        return next;
+      });
+    },
+    [pendingSendTokensRef]
+  );
 
-  const movePendingSend = useCallback((fromKey: string, toKey: string, token: number) => {
-    if (fromKey === toKey || pendingSendTokensRef.current.get(fromKey) !== token) return;
-    pendingSendTokensRef.current.delete(fromKey);
-    pendingSendTokensRef.current.set(toKey, token);
-    setPendingSendSessionIds((current) => {
-      const next = new Set(current);
-      next.delete(fromKey);
-      next.add(toKey);
-      return next;
-    });
-  }, []);
+  const movePendingSend = useCallback(
+    (fromKey: string, toKey: string, token: number) => {
+      if (fromKey === toKey || pendingSendTokensRef.current.get(fromKey) !== token) return;
+      pendingSendTokensRef.current.delete(fromKey);
+      pendingSendTokensRef.current.set(toKey, token);
+      setPendingSendSessionIds((current) => {
+        const next = new Set(current);
+        next.delete(fromKey);
+        next.add(toKey);
+        return next;
+      });
+    },
+    [pendingSendTokensRef]
+  );
 
-  const clearPendingSend = useCallback((sessionKey: string, token?: number) => {
-    if (token !== undefined && pendingSendTokensRef.current.get(sessionKey) !== token) return;
-    if (!pendingSendTokensRef.current.delete(sessionKey)) return;
-    setPendingSendSessionIds((current) => {
-      if (!current.has(sessionKey)) return current;
-      const next = new Set(current);
-      next.delete(sessionKey);
-      return next;
-    });
-  }, []);
+  const clearPendingSend = useCallback(
+    (sessionKey: string, token?: number) => {
+      if (token !== undefined && pendingSendTokensRef.current.get(sessionKey) !== token) return;
+      if (!pendingSendTokensRef.current.delete(sessionKey)) return;
+      setPendingSendSessionIds((current) => {
+        if (!current.has(sessionKey)) return current;
+        const next = new Set(current);
+        next.delete(sessionKey);
+        return next;
+      });
+    },
+    [pendingSendTokensRef]
+  );
 
   const applyRuntimeStatus = useCallback(
     (status: AgentRuntimeStatus, expectedRunStateGeneration?: number) => {
@@ -816,7 +842,7 @@ export function AgentMode({ userId }: { userId: string }) {
       });
       seedActiveThoughtPhases(activeRuns);
     },
-    [seedActiveThoughtPhases]
+    [seedActiveThoughtPhases, thoughtPhaseSeededRunIdsRef]
   );
 
   const recordActiveRun = useCallback((sessionId: string, runId: string) => {
@@ -835,11 +861,14 @@ export function AgentMode({ userId }: { userId: string }) {
     setActiveRunsBySession(next);
   }, []);
 
-  const bumpTimelineRevision = useCallback((sessionId: string): number => {
-    const revision = (timelineRevisionBySessionRef.current.get(sessionId) || 0) + 1;
-    timelineRevisionBySessionRef.current.set(sessionId, revision);
-    return revision;
-  }, []);
+  const bumpTimelineRevision = useCallback(
+    (sessionId: string): number => {
+      const revision = (timelineRevisionBySessionRef.current.get(sessionId) || 0) + 1;
+      timelineRevisionBySessionRef.current.set(sessionId, revision);
+      return revision;
+    },
+    [timelineRevisionBySessionRef]
+  );
 
   const replaceSessionTimeline = useCallback(
     (sessionId: string, items: AgentTimelineItem[], expectedRevision?: number): boolean => {
@@ -855,7 +884,7 @@ export function AgentMode({ userId }: { userId: string }) {
       }
       return true;
     },
-    [bumpTimelineRevision]
+    [bumpTimelineRevision, timelineRevisionBySessionRef]
   );
 
   const mergeSessionTimelineItem = useCallback(
@@ -1048,7 +1077,7 @@ export function AgentMode({ userId }: { userId: string }) {
       setSessions(nextSessions.filter((session) => !deletedSessionIdsRef.current.has(session.id)));
       setIsSessionHistoryReady(true);
     });
-  }, [trackAgentWorkflow, userId]);
+  }, [deletedSessionIdsRef, trackAgentWorkflow, userId]);
 
   const refreshSessions = useCallback(async () => {
     return await trackAgentWorkflow(async () => {
@@ -1514,7 +1543,7 @@ export function AgentMode({ userId }: { userId: string }) {
           }
         });
     },
-    [applyAuthoritativeMode, userId]
+    [applyAuthoritativeMode, permissionModeUpdateRef, userId]
   );
 
   const startRuntime = useCallback(
@@ -1641,6 +1670,7 @@ export function AgentMode({ userId }: { userId: string }) {
       applyAuthoritativeMode,
       agentSessionSelection,
       contextLimitForModel,
+      deletedSessionIdsRef,
       model,
       projectRoot,
       replaceSessionTimeline,
@@ -1712,6 +1742,7 @@ export function AgentMode({ userId }: { userId: string }) {
     agentSessionSelection,
     beginSessionSelection,
     contextLimitForModel,
+    deletedSessionIdsRef,
     finishSessionSelection,
     model,
     projectRoot,
@@ -1815,10 +1846,14 @@ export function AgentMode({ userId }: { userId: string }) {
       agentSessionSelection,
       beginSessionSelection,
       clearCompletedUnreadSession,
+      deletedSessionIdsRef,
       finishSessionSelection,
       observeActiveThoughtPhase,
+      pendingSendTokensRef,
       persistSelectedProjectRoot,
       replaceSessionTimeline,
+      thoughtPhaseTrackerRef,
+      timelineRevisionBySessionRef,
       trackAgentWorkflow,
       userId
     ]
@@ -1952,8 +1987,10 @@ export function AgentMode({ userId }: { userId: string }) {
   }, [
     activeRunsBySession,
     availableModels,
+    cancelledPendingSendTokensRef,
     clearPendingSend,
     contextLimitForModel,
+    deletedSessionIdsRef,
     ensureRuntimeAndSession,
     input,
     isAgentSendLocked,
@@ -1962,8 +1999,12 @@ export function AgentMode({ userId }: { userId: string }) {
     model,
     modelAliases,
     movePendingSend,
+    pendingSendTokensRef,
+    permissionModeUpdateRef,
     recordActiveRun,
     scrollTimelineToBottom,
+    terminalRunIdsRef,
+    thoughtPhaseTrackerRef,
     trackAgentWorkflow,
     userId
   ]);
@@ -1986,7 +2027,7 @@ export function AgentMode({ userId }: { userId: string }) {
         setError(errorMessage(cancelError));
       }
     }
-  }, [activeRunId, userId]);
+  }, [activeRunId, cancelledPendingSendTokensRef, pendingSendTokensRef, userId]);
 
   const respondToPermission = useCallback(
     async (item: AgentTimelineItem, decision: AgentPermissionDecision) => {
@@ -2053,7 +2094,15 @@ export function AgentMode({ userId }: { userId: string }) {
         setInput("");
       }
     },
-    [agentSessionSelection, cancelThoughtLabelDisplays, clearActiveRun, userId]
+    [
+      agentSessionSelection,
+      cancelThoughtLabelDisplays,
+      clearActiveRun,
+      deletedSessionIdsRef,
+      thoughtPhaseTrackerRef,
+      timelineRevisionBySessionRef,
+      userId
+    ]
   );
 
   const deleteSession = useCallback(
@@ -2136,18 +2185,21 @@ export function AgentMode({ userId }: { userId: string }) {
     };
   }, [removeSessionFromState, userId]);
 
-  const upsertSessionSummary = useCallback((summary: AgentSessionSummary) => {
-    if (deletedSessionIdsRef.current.has(summary.id)) return;
-    setSessions((current) => {
-      let replaced = false;
-      const next = current.map((session) => {
-        if (session.id !== summary.id) return session;
-        replaced = true;
-        return summary;
+  const upsertSessionSummary = useCallback(
+    (summary: AgentSessionSummary) => {
+      if (deletedSessionIdsRef.current.has(summary.id)) return;
+      setSessions((current) => {
+        let replaced = false;
+        const next = current.map((session) => {
+          if (session.id !== summary.id) return session;
+          replaced = true;
+          return summary;
+        });
+        return replaced ? next : [summary, ...current];
       });
-      return replaced ? next : [summary, ...current];
-    });
-  }, []);
+    },
+    [deletedSessionIdsRef]
+  );
 
   const observeLiveThoughtItem = useCallback(
     (sessionId: string, item: AgentTimelineItem) => {
@@ -2166,7 +2218,7 @@ export function AgentMode({ userId }: { userId: string }) {
       }
       observeActiveThoughtPhase(sessionId);
     },
-    [completeThoughtPhase, observeActiveThoughtPhase]
+    [completeThoughtPhase, observeActiveThoughtPhase, thoughtPhaseTrackerRef]
   );
 
   const handleAgentEvent = useCallback(
@@ -2314,6 +2366,7 @@ export function AgentMode({ userId }: { userId: string }) {
       clearActiveRun,
       clearCompletedUnreadSession,
       completeThoughtPhase,
+      deletedSessionIdsRef,
       invalidateThoughtLabelsForSession,
       invalidateThoughtLabelsForTurn,
       markCompletedUnreadSession,
@@ -2324,6 +2377,9 @@ export function AgentMode({ userId }: { userId: string }) {
       recordActiveRun,
       refreshSessionMcpServers,
       replaceSessionTimeline,
+      terminalRunIdsRef,
+      thoughtPhaseSeededRunIdsRef,
+      thoughtPhaseTrackerRef,
       upsertSessionSummary,
       userId
     ]
@@ -2355,6 +2411,29 @@ export function AgentMode({ userId }: { userId: string }) {
     };
   }, [handleAgentEvent, userId]);
 
+  const handleCreateSession = useCallback(() => {
+    void createSession();
+  }, [createSession]);
+  const handlePromptProjectRemoval = useCallback((root: RecentProjectRoot) => {
+    setProjectRemovalError(null);
+    setProjectToRemove(root);
+  }, []);
+  const handleSelectSession = useCallback(
+    (sessionId: string) => {
+      void loadSession(sessionId);
+    },
+    [loadSession]
+  );
+  const handleManageMcpServers = useCallback(() => {
+    setIsMcpServersDialogOpen(true);
+  }, []);
+  const handleSendMessage = useCallback(() => {
+    void sendMessage();
+  }, [sendMessage]);
+  const handleToggleAgentFullscreen = useCallback(() => {
+    setIsAgentFullscreen((current) => !current);
+  }, []);
+
   if (!isTauriDesktop()) {
     return (
       <div className="flex h-dvh items-center justify-center bg-background p-6 text-center">
@@ -2378,7 +2457,7 @@ export function AgentMode({ userId }: { userId: string }) {
         isOpen={isSidebarOpen}
         mode="agent"
         navigationContent={
-          <AgentSidebarContent
+          <MemoizedAgentSidebarContent
             activeSessionId={
               pendingSessionSelectionId && pendingSessionSelectionId !== NEW_SESSION_PENDING_KEY
                 ? pendingSessionSelectionId
@@ -2392,18 +2471,15 @@ export function AgentMode({ userId }: { userId: string }) {
             runningSessionIds={runningSessionIds}
             sessions={visibleSessions}
             onChooseProjectRoot={chooseProjectRoot}
-            onCreateSession={() => void createSession()}
+            onCreateSession={handleCreateSession}
             onProjectOrderChange={saveProjectRootOrder}
-            onProjectRemove={(root) => {
-              setProjectRemovalError(null);
-              setProjectToRemove(root);
-            }}
+            onProjectRemove={handlePromptProjectRemoval}
             onProjectRootChange={selectProjectRoot}
             onSessionDelete={setSessionToDelete}
-            onSessionSelect={(sessionId) => void loadSession(sessionId)}
+            onSessionSelect={handleSelectSession}
           />
         }
-        onNewItem={areAgentSettingsLocked || !projectRoot ? undefined : () => void createSession()}
+        onNewItem={areAgentSettingsLocked || !projectRoot ? undefined : handleCreateSession}
         onToggle={toggleSidebar}
       />
 
@@ -2534,7 +2610,7 @@ export function AgentMode({ userId }: { userId: string }) {
           <ChatDesktopConversationHeader
             title={activeSessionTitle}
             isSidebarOpen={isSidebarOpen}
-            onNewChat={() => void createSession()}
+            onNewChat={handleCreateSession}
             newItemLabel="New Task"
           />
         ) : null}
@@ -2583,13 +2659,13 @@ export function AgentMode({ userId }: { userId: string }) {
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={setInput}
                   onKeyDown={handleKeyDown}
-                  onManageMcpServers={() => setIsMcpServersDialogOpen(true)}
+                  onManageMcpServers={handleManageMcpServers}
                   onMcpToggle={toggleMcpServer}
                   onModeChange={selectMode}
                   onModelChange={selectModel}
                   onProjectRootChange={selectProjectRoot}
-                  onSendMessage={() => void sendMessage()}
-                  onToggleExpanded={() => setIsAgentFullscreen((current) => !current)}
+                  onSendMessage={handleSendMessage}
+                  onToggleExpanded={handleToggleAgentFullscreen}
                 />
               ) : (
                 <AgentTimeline
@@ -2607,7 +2683,7 @@ export function AgentMode({ userId }: { userId: string }) {
           {timelineItems.length > 0 ? (
             <div className="shrink-0 bg-background pb-[env(safe-area-inset-bottom)]">
               <div className="mx-auto max-w-4xl px-4 landscape-short:px-3">
-                <AgentComposer
+                <MemoizedAgentComposer
                   activeRootLabel={activeRootLabel}
                   areSettingsDisabled={areAgentSettingsLocked}
                   input={input}
@@ -2626,12 +2702,12 @@ export function AgentMode({ userId }: { userId: string }) {
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={setInput}
                   onKeyDown={handleKeyDown}
-                  onManageMcpServers={() => setIsMcpServersDialogOpen(true)}
+                  onManageMcpServers={handleManageMcpServers}
                   onMcpToggle={toggleMcpServer}
                   onModeChange={selectMode}
                   onModelChange={selectModel}
                   onProjectRootChange={selectProjectRoot}
-                  onSendMessage={() => void sendMessage()}
+                  onSendMessage={handleSendMessage}
                 />
                 <p className="mb-2 mt-1 text-center text-[10px] text-muted-foreground/50 landscape-short:mb-1">
                   AI can make mistakes. Check important info.
@@ -2661,7 +2737,7 @@ function EmptyAgentState(props: AgentComposerProps) {
             Work on anything...
           </h1>
         ) : null}
-        <AgentComposer {...props} />
+        <MemoizedAgentComposer {...props} />
         {!isExpanded ? (
           <p className="flex items-center justify-center gap-1 text-center text-xs text-muted-foreground/60">
             <Lock className="h-3 w-3" />
@@ -2727,11 +2803,11 @@ function AgentSidebarContent({
   onSessionDelete,
   onSessionSelect
 }: AgentSidebarContentProps) {
-  const rowElementsRef = useRef(new Map<string, HTMLElement>());
-  const previousRowTopsRef = useRef(new Map<string, number>());
+  const rowElementsRef = useLazyRef(() => new Map<string, HTMLElement>());
+  const previousRowTopsRef = useLazyRef(() => new Map<string, number>());
   const projectListRef = useRef<HTMLDivElement>(null);
-  const projectGroupElementsRef = useRef(new Map<string, HTMLDivElement>());
-  const projectHeaderElementsRef = useRef(new Map<string, HTMLDivElement>());
+  const projectGroupElementsRef = useLazyRef(() => new Map<string, HTMLDivElement>());
+  const projectHeaderElementsRef = useLazyRef(() => new Map<string, HTMLDivElement>());
   const pendingProjectPointerRef = useRef<PendingProjectPointer | null>(null);
   const projectDragRef = useRef<ProjectDragState | null>(null);
   const autoScrollFrameRef = useRef<number | null>(null);
@@ -2742,13 +2818,16 @@ function AgentSidebarContent({
   const [collapsedProjectRoots, setCollapsedProjectRoots] = useState<Set<string>>(() => new Set());
   const projectRows = recentRoots;
   const sessionsByRoot = useMemo(() => groupAgentSessionsByRoot(sessions), [sessions]);
-  const setAnimatedRowRef = useCallback((key: string, node: HTMLElement | null) => {
-    if (node) {
-      rowElementsRef.current.set(key, node);
-    } else {
-      rowElementsRef.current.delete(key);
-    }
-  }, []);
+  const setAnimatedRowRef = useCallback(
+    (key: string, node: HTMLElement | null) => {
+      if (node) {
+        rowElementsRef.current.set(key, node);
+      } else {
+        rowElementsRef.current.delete(key);
+      }
+    },
+    [rowElementsRef]
+  );
 
   useLayoutEffect(() => {
     const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)").matches;
@@ -2784,7 +2863,7 @@ function AgentSidebarContent({
     }
 
     previousRowTopsRef.current = nextTops;
-  }, [collapsedProjectRoots, projectRows, sessions]);
+  }, [collapsedProjectRoots, previousRowTopsRef, projectRows, rowElementsRef, sessions]);
 
   const setProjectGroupRef = useCallback(
     (path: string, node: HTMLDivElement | null) => {
@@ -2795,16 +2874,19 @@ function AgentSidebarContent({
         projectGroupElementsRef.current.delete(path);
       }
     },
-    [setAnimatedRowRef]
+    [projectGroupElementsRef, setAnimatedRowRef]
   );
 
-  const setProjectHeaderRef = useCallback((path: string, node: HTMLDivElement | null) => {
-    if (node) {
-      projectHeaderElementsRef.current.set(path, node);
-    } else {
-      projectHeaderElementsRef.current.delete(path);
-    }
-  }, []);
+  const setProjectHeaderRef = useCallback(
+    (path: string, node: HTMLDivElement | null) => {
+      if (node) {
+        projectHeaderElementsRef.current.set(path, node);
+      } else {
+        projectHeaderElementsRef.current.delete(path);
+      }
+    },
+    [projectHeaderElementsRef]
+  );
 
   const measureProjectDrop = useCallback(
     (clientX: number, clientY: number, draggedPath: string) => {
@@ -2848,7 +2930,7 @@ function AgentSidebarContent({
         markerTop: Math.max(0, Math.min(listRect.height, markerViewportY - listRect.top))
       };
     },
-    [projectRows]
+    [projectGroupElementsRef, projectHeaderElementsRef, projectRows]
   );
 
   const stopProjectAutoScroll = useCallback(() => {
@@ -3165,7 +3247,7 @@ function AgentSidebarContent({
                 key={root.path}
                 ref={(node) => setProjectGroupRef(root.path, node)}
                 className={cn(
-                  "space-y-2 will-change-transform",
+                  "space-y-2",
                   rootIndex < projectRows.length - 1 && "mb-2",
                   isProjectDragging && "opacity-25"
                 )}
@@ -3282,7 +3364,7 @@ function AgentSidebarContent({
                           <div
                             key={session.id}
                             ref={(node) => setAnimatedRowRef(`session:${session.id}`, node)}
-                            className="group relative isolate flex w-full min-w-0 select-none items-stretch gap-0.5 rounded-2xl will-change-transform"
+                            className="group relative isolate flex w-full min-w-0 select-none items-stretch gap-0.5 rounded-2xl"
                             onContextMenu={(event) => event.preventDefault()}
                           >
                             <button
@@ -3595,6 +3677,9 @@ function AgentComposer({
   );
 }
 
+const MemoizedAgentSidebarContent = memo(AgentSidebarContent);
+const MemoizedAgentComposer = memo(AgentComposer);
+
 function AgentModeSelector({
   disabled,
   mode,
@@ -3648,7 +3733,8 @@ function AgentModelSelector({
   model: string;
   onModelChange: (value: string) => void;
 }) {
-  const { availableModels, modelAliases, billingStatus } = useLocalState();
+  const { availableModels, modelAliases } = useModelState();
+  const { billingStatus } = useBillingState();
   const [upgradeDialogOpen, setUpgradeDialogOpen] = useState(false);
   const [selectedModelName, setSelectedModelName] = useState("");
   const [showAdvanced, setShowAdvanced] = useState(false);

--- a/frontend/src/components/ChatHistoryList.tsx
+++ b/frontend/src/components/ChatHistoryList.tsx
@@ -1,12 +1,4 @@
-import {
-  useState,
-  useMemo,
-  useCallback,
-  useEffect,
-  useRef,
-  useContext,
-  useSyncExternalStore
-} from "react";
+import { useState, useMemo, useCallback, useEffect, useRef, useSyncExternalStore } from "react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   MoreHorizontal,
@@ -45,7 +37,7 @@ import {
   type ConversationProjectListItem
 } from "@opensecret/react";
 import { useRouter } from "@tanstack/react-router";
-import { LocalStateContext } from "@/state/LocalStateContext";
+import { useSelectedProjectState } from "@/state/useLocalState";
 import { ConversationProjectDialog } from "@/components/ConversationProjectDialog";
 import { DeleteConversationProjectDialog } from "@/components/DeleteConversationProjectDialog";
 import { MoveChatsDialog } from "@/components/MoveChatsDialog";
@@ -110,8 +102,7 @@ export function ChatHistoryList({
   const opensecret = useOpenSecret();
   const router = useRouter();
   const queryClient = useQueryClient();
-  const localState = useContext(LocalStateContext);
-  const { selectedProjectId, setSelectedProjectId } = localState;
+  const { selectedProjectId, setSelectedProjectId } = useSelectedProjectState();
   const userId = opensecret.auth.user?.user.id;
   const runtimeStore = useChatRuntimeStore<Conversation, unknown>();
   const activeRunKeys = useSyncExternalStore(

--- a/frontend/src/components/CreditUsage.tsx
+++ b/frontend/src/components/CreditUsage.tsx
@@ -1,4 +1,4 @@
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import { formatResetDate } from "@/utils/dateFormat";
 
 const CREDIT_NUMBER_FORMATTER = new Intl.NumberFormat("en-US");
@@ -81,7 +81,7 @@ function CreditUsageView(p: CreditUsageViewProps) {
 }
 
 export function CreditUsage() {
-  const { billingStatus } = useLocalState();
+  const { billingStatus } = useBillingState();
 
   const totalLive = billingStatus?.total_tokens;
   const usedLive = billingStatus?.used_tokens;

--- a/frontend/src/components/ModelSelector.tsx
+++ b/frontend/src/components/ModelSelector.tsx
@@ -7,7 +7,7 @@ import {
   DropdownMenuTrigger,
   DropdownMenuSeparator
 } from "@/components/ui/dropdown-menu";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState, useModelState } from "@/state/useLocalState";
 import { useOpenSecret } from "@opensecret/react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
@@ -82,9 +82,9 @@ export function ModelSelector({ hasImages = false }: { hasImages?: boolean }) {
     setAvailableModels,
     modelAliases,
     setModelAliases,
-    billingStatus,
     setHasWhisperModel
-  } = useLocalState();
+  } = useModelState();
+  const { billingStatus } = useBillingState();
   const os = useOpenSecret();
   const isFetching = useRef(false);
   const hasFetched = useRef(false);

--- a/frontend/src/components/ProjectDetailView.tsx
+++ b/frontend/src/components/ProjectDetailView.tsx
@@ -16,7 +16,7 @@ import { useOpenSecret, type Conversation } from "@opensecret/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { useIsMobile, useIsLandscapeMobile } from "@/utils/utils";
-import { useLocalState } from "@/state/useLocalState";
+import { useSelectedProjectState } from "@/state/useLocalState";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Label } from "@/components/ui/label";
@@ -159,7 +159,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
-  const { setSelectedProjectId } = useLocalState();
+  const { setSelectedProjectId } = useSelectedProjectState();
   const hasAuthUser = !!os.auth.user;
   const runtimeStore = useChatRuntimeStore<Conversation, unknown>();
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -25,7 +25,11 @@ import { flushSync } from "react-dom";
 import { cn, useClickOutside, useIsMobile, useIsLandscapeMobile } from "@/utils/utils";
 import { MapleWordmark } from "@/components/MapleWordmark";
 import { Input } from "./ui/input";
-import { useLocalState } from "@/state/useLocalState";
+import {
+  useBillingState,
+  useSelectedProjectState,
+  useSidebarSearchState
+} from "@/state/useLocalState";
 import {
   SIDEBAR_LAYOUT_STYLE,
   SIDEBAR_MAX_WIDTH_CLASS,
@@ -67,14 +71,10 @@ export function Sidebar({
   const os = useOpenSecret();
   const runtimeStore = useChatRuntimeStore<unknown, unknown>();
   const userId = os.auth.user?.user.id;
-  const {
-    searchQuery,
-    setSearchQuery,
-    isSearchVisible,
-    setIsSearchVisible,
-    setSelectedProjectId,
-    billingStatus
-  } = useLocalState();
+  const { searchQuery, setSearchQuery, isSearchVisible, setIsSearchVisible } =
+    useSidebarSearchState();
+  const { setSelectedProjectId } = useSelectedProjectState();
+  const { billingStatus } = useBillingState();
   const searchInputRef = useRef<HTMLInputElement>(null);
 
   // Multi-select state
@@ -335,7 +335,7 @@ export function Sidebar({
     >
       <div
         className={cn(
-          "flex h-full min-h-0 min-w-0 flex-col items-stretch overflow-x-hidden border-r border-border/20 bg-muted backdrop-blur-lg dark:bg-[hsl(var(--sidebar))]",
+          "flex h-full min-h-0 min-w-0 flex-col items-stretch overflow-x-hidden border-r border-border/20 bg-muted dark:bg-[hsl(var(--sidebar))]",
           SIDEBAR_WIDTH_CLASS,
           SIDEBAR_MAX_WIDTH_CLASS
         )}

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -4,7 +4,6 @@ import {
   useEffect,
   useLayoutEffect,
   useCallback,
-  useSyncExternalStore,
   memo,
   useMemo,
   useId
@@ -43,6 +42,8 @@ import {
   maybeReadLinuxTauriClipboardImages
 } from "@/utils/imagePaste";
 import { truncateMarkdownPreservingLinks } from "@/utils/markdown";
+import { useLazyRef } from "@/utils/useLazyRef";
+import { useVisibleExternalStore } from "@/utils/useVisibleExternalStore";
 import {
   getDocumentProcessingErrorMessage,
   getSupportedDocumentType,
@@ -61,7 +62,7 @@ import {
 } from "@/components/chat/ChatTurn";
 import { ChatCopyButton } from "@/components/chat/ChatCopyButton";
 import { ModelSelector } from "@/components/ModelSelector";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState, useModelState, useSelectedProjectState } from "@/state/useLocalState";
 import { isKnownFreePlan } from "@/billing/billingAccess";
 import { useOpenSecret } from "@opensecret/react";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
@@ -1575,8 +1576,9 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
   const openai = useOpenAI();
-  const localState = useLocalState();
-  const { selectedProjectId, setSelectedProjectId } = localState;
+  const { model, hasWhisperModel } = useModelState();
+  const { billingStatus } = useBillingState();
+  const { selectedProjectId, setSelectedProjectId } = useSelectedProjectState();
   const os = useOpenSecret();
   const isTauriEnv = isTauri();
   const isLinuxEnv = isLinux();
@@ -1626,7 +1628,8 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     if (!snapshot) throw new Error(`Missing chat runtime for ${renderedRuntimeKey}`);
     return snapshot;
   }, [renderedRuntimeKey, runtimeStore]);
-  const activeRuntime = useSyncExternalStore(
+  const activeRuntime = useVisibleExternalStore(
+    isVisible,
     subscribeToActiveRuntime,
     getActiveRuntimeSnapshot,
     getActiveRuntimeSnapshot
@@ -1801,9 +1804,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const [documentPlatformDialogOpen, setDocumentPlatformDialogOpen] = useState(false);
   const [contextLimitDialogOpen, setContextLimitDialogOpen] = useState(false);
   const ttsAccessDeniedFeature =
-    localState.billingStatus === null || isKnownFreePlan(localState.billingStatus)
-      ? "tts"
-      : "usage";
+    billingStatus === null || isKnownFreePlan(billingStatus) ? "tts" : "usage";
 
   useEffect(() => {
     if (!isVisible) {
@@ -1872,8 +1873,8 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const [isUserScrolling, setIsUserScrolling] = useState(false);
   const isUserScrollingRef = useRef(false);
   const prevStreamingRef = useRef(false);
-  const projectionScrollCoordinatorRef = useRef(
-    new ChatProjectionScrollCoordinator<ChatRuntimeKey>()
+  const projectionScrollCoordinatorRef = useLazyRef(
+    () => new ChatProjectionScrollCoordinator<ChatRuntimeKey>()
   );
   const historyPaginationLifecycle = useMemo(
     () => ({ runtimeKey: renderedRuntimeKey, gate: new ChatHistoryPaginationGate() }),
@@ -1897,7 +1898,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   );
   const recorderRef = useRef<RecordRTC | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
-  const billingRefreshTimeoutsRef = useRef(new Set<ReturnType<typeof setTimeout>>());
+  const billingRefreshTimeoutsRef = useLazyRef(() => new Set<ReturnType<typeof setTimeout>>());
   const fileInputRef = useRef<HTMLInputElement>(null);
   const documentInputRef = useRef<HTMLInputElement>(null);
   const fileInputOwnerKeyRef = useRef<ChatRuntimeKey | null>(null);
@@ -1912,7 +1913,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const chatContainerRef = useRef<HTMLDivElement>(null);
   const historyTopSentinelRef = useRef<HTMLDivElement>(null);
   const historyBottomCompensationRef = useRef<HTMLDivElement>(null);
-  const activeConversationLoadRef = useRef(new Map<ChatRuntimeKey, number>());
+  const activeConversationLoadRef = useLazyRef(() => new Map<ChatRuntimeKey, number>());
 
   const stopRecordingForNavigation = useCallback(
     (destinationKey: ChatRuntimeKey) => {
@@ -2052,7 +2053,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       for (const timeout of billingRefreshTimeouts) clearTimeout(timeout);
       billingRefreshTimeouts.clear();
     };
-  }, []);
+  }, [billingRefreshTimeoutsRef]);
 
   // Auto-focus textbox on desktop (not mobile/landscape-mobile to avoid keyboard popup interrupting reading)
   // Focus when: app launches, new chat, conversation loads, or assistant finishes streaming
@@ -2169,7 +2170,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       action();
       return true;
     },
-    [isRuntimeSelected, resolveScrollProjectionKey]
+    [isRuntimeSelected, projectionScrollCoordinatorRef, resolveScrollProjectionKey]
   );
 
   const lastMessageId = messages.length > 0 ? messages[messages.length - 1].id : null;
@@ -2380,6 +2381,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     isVisible,
     lastMessageId,
     messages,
+    projectionScrollCoordinatorRef,
     renderedRuntimeKey,
     resolveScrollProjectionKey,
     runtimeStore,
@@ -2416,6 +2418,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     isUserScrolling,
     lastMessageId,
     messages,
+    projectionScrollCoordinatorRef,
     renderedRuntimeKey,
     resolveScrollProjectionKey,
     runForProjectedRuntime,
@@ -2458,6 +2461,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   }, [
     hasStreamingMessage,
     isUserScrolling,
+    projectionScrollCoordinatorRef,
     renderedRuntimeKey,
     resolveScrollProjectionKey,
     runForProjectedRuntime
@@ -2480,6 +2484,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     }
   }, [
     newPolledMessagesOwnerKey,
+    projectionScrollCoordinatorRef,
     resolveScrollProjectionKey,
     runForProjectedRuntime,
     scrollToBottom
@@ -2737,6 +2742,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       }
     },
     [
+      activeConversationLoadRef,
       isRuntimeSelected,
       openai,
       runtimeStore,
@@ -2875,6 +2881,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     captureHistoryScrollSnapshot,
     historyPaginationLifecycle,
     openai,
+    projectionScrollCoordinatorRef,
     resolveScrollProjectionKey,
     runtimeStore,
     updateComposerForKey
@@ -3532,7 +3539,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   }, [runtimeStore, selectedProjectId]);
 
   // Check user's billing access
-  const billingStatus = localState.billingStatus;
   const hasProAccess =
     billingStatus &&
     (billingStatus.product_name?.toLowerCase().includes("pro") ||
@@ -3541,7 +3547,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
 
   const canUseImages = hasProAccess;
   const canUseDocuments = hasProAccess;
-  const canUseVoice = hasProAccess && localState.hasWhisperModel;
+  const canUseVoice = hasProAccess && hasWhisperModel;
 
   const setComposerErrorForKey = useCallback(
     (
@@ -4551,7 +4557,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         return;
       }
 
-      const requestModel = localState.model || DEFAULT_MODEL_ID;
+      const requestModel = model || DEFAULT_MODEL_ID;
       const requestWebSearchEnabled = isWebSearchEnabled;
       const billingStatusAtSend = billingStatus;
       const existingConversationId =
@@ -4949,10 +4955,11 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
       }
     },
     [
+      billingRefreshTimeoutsRef,
       billingStatus,
       isRuntimeSelected,
       isWebSearchEnabled,
-      localState.model,
+      model,
       openai,
       processStreamingResponse,
       queryClient,
@@ -5661,7 +5668,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         <ContextLimitDialog
           open={contextLimitDialogOpen}
           onOpenChange={setContextLimitDialogOpen}
-          currentModel={localState.model}
+          currentModel={model}
           hasDocument={!!documentName}
         />
 

--- a/frontend/src/components/UpgradePromptDialog.tsx
+++ b/frontend/src/components/UpgradePromptDialog.tsx
@@ -21,7 +21,7 @@ import {
   AudioLines
 } from "lucide-react";
 import { useNavigate } from "@tanstack/react-router";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import { hasApiAccess } from "@/billing/billingAccess";
 
 interface UpgradePromptDialogProps {
@@ -40,7 +40,7 @@ export function UpgradePromptDialog({
   onStartNewChat
 }: UpgradePromptDialogProps) {
   const navigate = useNavigate();
-  const localState = useLocalState();
+  const { billingStatus } = useBillingState();
 
   const handleUpgrade = () => {
     onOpenChange(false);
@@ -67,11 +67,11 @@ export function UpgradePromptDialog({
   };
 
   // Determine user's current plan and next upgrade tier
-  const currentPlan = localState.billingStatus?.product_name?.toLowerCase() || "free";
-  const isFreeTier = !localState.billingStatus?.product_name || currentPlan === "free";
+  const currentPlan = billingStatus?.product_name?.toLowerCase() || "free";
+  const isFreeTier = !billingStatus?.product_name || currentPlan === "free";
   const isPro = currentPlan.includes("pro") && !currentPlan.includes("max");
   const isMax = currentPlan.includes("max");
-  const userHasApiAccess = hasApiAccess(localState.billingStatus);
+  const userHasApiAccess = hasApiAccess(billingStatus);
 
   const getNextPlan = () => {
     if (isFreeTier) return "Pro";

--- a/frontend/src/components/chat/ChatTurn.tsx
+++ b/frontend/src/components/chat/ChatTurn.tsx
@@ -40,7 +40,7 @@ export function ChatUserTurn({
         className
       )}
     >
-      <div className="max-w-[min(100%,42rem)] rounded-2xl border border-border bg-muted px-4 py-3 backdrop-blur-lg dark:bg-card landscape-short:px-3 landscape-short:py-2">
+      <div className="max-w-[min(100%,42rem)] rounded-2xl border border-border bg-muted px-4 py-3 dark:bg-card landscape-short:px-3 landscape-short:py-2">
         <div className="prose prose-sm max-w-none text-left dark:prose-invert">
           <div className="space-y-3">{children}</div>
         </div>

--- a/frontend/src/components/settings/AccountSettings.tsx
+++ b/frontend/src/components/settings/AccountSettings.tsx
@@ -16,7 +16,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useTheme } from "@/contexts/ThemeContext";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import { SettingsPage, SettingsSection } from "./SettingsPage";
 
 type SettingsLinkRowProps = {
@@ -54,7 +54,7 @@ function SettingsLinkRow({ to, title, description, icon: Icon, danger }: Setting
 
 export function AccountSettings() {
   const os = useOpenSecret();
-  const { billingStatus } = useLocalState();
+  const { billingStatus } = useBillingState();
   const { theme, setTheme } = useTheme();
   const [verificationStatus, setVerificationStatus] = useState<"unverified" | "pending">(
     "unverified"

--- a/frontend/src/components/settings/BillingSettings.tsx
+++ b/frontend/src/components/settings/BillingSettings.tsx
@@ -4,11 +4,11 @@ import { CreditCard, KeyRound, Loader2, Sparkles } from "lucide-react";
 import { openBillingPortal } from "@/billing/billingPortal";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import { SettingsPage, SettingsSection } from "./SettingsPage";
 
 export function BillingSettings() {
-  const { billingStatus } = useLocalState();
+  const { billingStatus } = useBillingState();
   const [isPortalLoading, setIsPortalLoading] = useState(false);
   const [portalError, setPortalError] = useState<string | null>(null);
 

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -35,7 +35,7 @@ import {
   stopAgentRuntimeForUser
 } from "@/services/agentRuntimeService";
 import { resetWorkspaceModePreference } from "@/services/workspaceModePreference";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
 import { isIOS } from "@/utils/platform";
 import { getTeamSeatMismatch } from "@/utils/teamSeats";
@@ -136,7 +136,7 @@ function SettingsLayoutContent() {
   const location = useLocation();
   const queryClient = useQueryClient();
   const { returnToHome } = usePersistentHomeNavigation();
-  const { billingStatus, setBillingStatus } = useLocalState();
+  const { billingStatus, setBillingStatus } = useBillingState();
   const isNavigationLocked = useSettingsNavigationLockState();
   const isCompactViewport = useCompactSettingsLayout();
   const isSettingsRoot = location.pathname === "/settings" || location.pathname === "/settings/";

--- a/frontend/src/components/settings/SettingsNavigationLockProvider.tsx
+++ b/frontend/src/components/settings/SettingsNavigationLockProvider.tsx
@@ -1,25 +1,29 @@
-import { useCallback, useMemo, useRef, useState, type ReactNode } from "react";
+import { useCallback, useMemo, useState, type ReactNode } from "react";
 import {
   SettingsNavigationLockContext,
   type SettingsNavigationLockContextValue
 } from "@/contexts/SettingsNavigationLockContext";
+import { useLazyRef } from "@/utils/useLazyRef";
 
 export function SettingsNavigationLockProvider({ children }: { children: ReactNode }) {
-  const locksRef = useRef(new Set<symbol>());
+  const locksRef = useLazyRef(() => new Set<symbol>());
   const [lockCount, setLockCount] = useState(0);
 
-  const setLock = useCallback((id: symbol, locked: boolean) => {
-    const locks = locksRef.current;
-    const wasLocked = locks.has(id);
+  const setLock = useCallback(
+    (id: symbol, locked: boolean) => {
+      const locks = locksRef.current;
+      const wasLocked = locks.has(id);
 
-    if (locked && !wasLocked) {
-      locks.add(id);
-      setLockCount(locks.size);
-    } else if (!locked && wasLocked) {
-      locks.delete(id);
-      setLockCount(locks.size);
-    }
-  }, []);
+      if (locked && !wasLocked) {
+        locks.add(id);
+        setLockCount(locks.size);
+      } else if (!locked && wasLocked) {
+        locks.delete(id);
+        setLockCount(locks.size);
+      }
+    },
+    [locksRef]
+  );
 
   const value = useMemo<SettingsNavigationLockContextValue>(
     () => ({ isNavigationLocked: lockCount > 0, setLock }),

--- a/frontend/src/components/settings/api/ApiSettingsLayout.tsx
+++ b/frontend/src/components/settings/api/ApiSettingsLayout.tsx
@@ -13,7 +13,7 @@ import { hasApiAccess } from "@/billing/billingAccess";
 import { getBillingService } from "@/billing/billingService";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import { isIOS, isTauriDesktop } from "@/utils/platform";
 import { cn } from "@/utils/utils";
 import { SettingsPage, SettingsSection } from "../SettingsPage";
@@ -63,7 +63,7 @@ function ApiSettingsLoading() {
 }
 
 export function ApiSettingsLayout() {
-  const { billingStatus, setBillingStatus } = useLocalState();
+  const { billingStatus, setBillingStatus } = useBillingState();
   const isIOSPlatform = isIOS();
   const isTauriDesktopPlatform = isTauriDesktop();
 

--- a/frontend/src/components/settings/team/TeamInviteSettings.tsx
+++ b/frontend/src/components/settings/team/TeamInviteSettings.tsx
@@ -21,7 +21,7 @@ import {
   useSettingsNavigationLock,
   useSettingsNavigationLockState
 } from "@/contexts/SettingsNavigationLockContext";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
 import { getTeamSeatMismatch } from "@/utils/teamSeats";
 import { SettingsPage, SettingsSection } from "../SettingsPage";
@@ -51,7 +51,7 @@ function BackToTeamButton() {
 export function TeamInviteSettings() {
   const os = useOpenSecret();
   const queryClient = useQueryClient();
-  const { billingStatus } = useLocalState();
+  const { billingStatus } = useBillingState();
   const [emails, setEmails] = useState("");
   const [isInviting, setIsInviting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/settings/team/TeamSettings.tsx
+++ b/frontend/src/components/settings/team/TeamSettings.tsx
@@ -25,7 +25,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { useSettingsNavigationLock } from "@/contexts/SettingsNavigationLockContext";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
 import {
   formatTeamSeatMismatchMessage,
@@ -250,7 +250,7 @@ function TeamMemberDashboard({ teamStatus }: { teamStatus: TeamStatus }) {
 
 function TeamAdminDashboard({ teamStatus }: { teamStatus: TeamStatus }) {
   const queryClient = useQueryClient();
-  const { billingStatus } = useLocalState();
+  const { billingStatus } = useBillingState();
   const membersSectionRef = useRef<HTMLDivElement>(null);
   const [isEditingName, setIsEditingName] = useState(false);
   const [editedName, setEditedName] = useState("");

--- a/frontend/src/contexts/SettingsNavigationLockContext.ts
+++ b/frontend/src/contexts/SettingsNavigationLockContext.ts
@@ -1,4 +1,5 @@
-import { createContext, useContext, useLayoutEffect, useRef } from "react";
+import { createContext, useContext, useLayoutEffect } from "react";
+import { useLazyRef } from "@/utils/useLazyRef";
 
 export type SettingsNavigationLockContextValue = {
   isNavigationLocked: boolean;
@@ -10,7 +11,7 @@ export const SettingsNavigationLockContext =
 
 export function useSettingsNavigationLock(locked: boolean) {
   const context = useContext(SettingsNavigationLockContext);
-  const lockId = useRef(Symbol("settings-navigation-lock"));
+  const lockId = useLazyRef(() => Symbol("settings-navigation-lock"));
   const setLock = context?.setLock;
 
   useLayoutEffect(() => {
@@ -18,7 +19,7 @@ export function useSettingsNavigationLock(locked: boolean) {
     const id = lockId.current;
     setLock(id, locked);
     return () => setLock(id, false);
-  }, [locked, setLock]);
+  }, [lockId, locked, setLock]);
 
   if (!context) {
     throw new Error("useSettingsNavigationLock must be used within settings");

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,7 +6,7 @@ import { PromoDialog, hasSeenPromo, markPromoAsSeen } from "@/components/PromoDi
 import { useOpenSecret } from "@opensecret/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { getBillingService } from "@/billing/billingService";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import type { DiscountResponse } from "@/billing/billingApi";
 import { appUrl } from "@/config/domains";
 import { useRouteMeta } from "@/utils/routeMeta";
@@ -43,7 +43,7 @@ function Index() {
   const navigate = useNavigate();
   const os = useOpenSecret();
   const queryClient = useQueryClient();
-  const { setBillingStatus, billingStatus } = useLocalState();
+  const { setBillingStatus, billingStatus } = useBillingState();
 
   useRouteMeta({
     title: os.auth.user ? "Maple Research" : "Maple Research | Private AI Workspace",

--- a/frontend/src/routes/pricing.tsx
+++ b/frontend/src/routes/pricing.tsx
@@ -17,7 +17,7 @@ import {
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import type { DiscountResponse } from "@/billing/billingApi";
 import { Badge } from "@/components/ui/badge";
-import { useLocalState } from "@/state/useLocalState";
+import { useBillingState } from "@/state/useLocalState";
 import { Button } from "@/components/ui/button";
 import { Switch } from "@/components/ui/switch";
 import { PRICING_PLANS } from "@/config/pricingConfig";
@@ -245,7 +245,7 @@ function PricingPage() {
   const [pendingTeamProductId, setPendingTeamProductId] = useState<string | null>(null);
   const navigate = useNavigate();
   const os = useOpenSecret();
-  const { setBillingStatus } = useLocalState();
+  const { setBillingStatus } = useBillingState();
   const isLoggedIn = !!os.auth.user;
   const isGuestUser = os.auth.user?.user.login_method?.toLowerCase() === "guest";
   const { selected_plan } = Route.useSearch();

--- a/frontend/src/services/tts/TTSContext.test.tsx
+++ b/frontend/src/services/tts/TTSContext.test.tsx
@@ -30,7 +30,7 @@ const freeBillingStatus: BillingStatus = {
 };
 
 mock.module("@/state/useLocalState", () => ({
-  useLocalState: () => ({ billingStatus: freeBillingStatus })
+  useBillingState: () => ({ billingStatus: freeBillingStatus })
 }));
 
 const { TTSProvider, useTTS } = await import("./TTSContext");

--- a/frontend/src/services/tts/TTSContext.tsx
+++ b/frontend/src/services/tts/TTSContext.tsx
@@ -11,7 +11,8 @@ import {
   type ReactNode
 } from "react";
 import { isIOS } from "@/utils/platform";
-import { useLocalState } from "@/state/useLocalState";
+import { useLazyRef } from "@/utils/useLazyRef";
+import { useBillingState } from "@/state/useLocalState";
 import { isKnownFreePlan } from "@/billing/billingAccess";
 import {
   INITIAL_TTS_PLAYBACK_STATE,
@@ -93,7 +94,7 @@ function errorMessage(error: unknown, fallback: string): string {
 
 export function TTSProvider({ children }: { children: ReactNode }) {
   const { aiCustomFetch, apiUrl } = useOpenSecret();
-  const { billingStatus } = useLocalState();
+  const { billingStatus } = useBillingState();
   const shouldShowTTSUpgrade = isKnownFreePlan(billingStatus);
 
   const [{ isPreparing, isPlaying, currentPlayingId }, dispatchPlayback] = useReducer(
@@ -109,7 +110,7 @@ export function TTSProvider({ children }: { children: ReactNode }) {
   const playbackRequestIdRef = useRef(0);
   const abortControllerRef = useRef<AbortController | null>(null);
   const audioContextRef = useRef<AudioContext | null>(null);
-  const scheduledSourceNodesRef = useRef<Set<AudioBufferSourceNode>>(new Set());
+  const scheduledSourceNodesRef = useLazyRef(() => new Set<AudioBufferSourceNode>());
   const audioSessionPrevTypeRef = useRef<string | null>(null);
   const mediaSessionPrevStateRef = useRef<{
     metadata: MediaMetadata | null;
@@ -166,7 +167,7 @@ export function TTSProvider({ children }: { children: ReactNode }) {
     }
 
     restorePlatformAudioSession();
-  }, [restorePlatformAudioSession]);
+  }, [restorePlatformAudioSession, scheduledSourceNodesRef]);
 
   const stop = useCallback(() => {
     cleanupPlaybackResources();
@@ -429,6 +430,7 @@ export function TTSProvider({ children }: { children: ReactNode }) {
       apiUrl,
       cleanupPlaybackResources,
       playbackSpeed,
+      scheduledSourceNodesRef,
       shouldShowTTSUpgrade,
       stop,
       voice
@@ -452,7 +454,7 @@ export function TTSProvider({ children }: { children: ReactNode }) {
       cleanupPlaybackResources();
       scheduledSources.clear();
     };
-  }, [cleanupPlaybackResources]);
+  }, [cleanupPlaybackResources, scheduledSourceNodesRef]);
 
   const contextValue = useMemo<TTSContextValue>(
     () => ({

--- a/frontend/src/state/LocalStateContext.test.tsx
+++ b/frontend/src/state/LocalStateContext.test.tsx
@@ -1,0 +1,310 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { memo } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import type { BillingStatus } from "@/billing/billingApi";
+import type {
+  BillingState,
+  ModelState,
+  SelectedProjectState,
+  SidebarSearchState
+} from "./LocalStateContextDef";
+import { DEFAULT_MODEL_ID, LocalStateProvider, PAID_DEFAULT_MODEL_ID } from "./LocalStateContext";
+import {
+  useBillingState,
+  useModelState,
+  useSelectedProjectState,
+  useSidebarSearchState
+} from "./useLocalState";
+
+class CountingMemoryStorage {
+  private readonly values = new Map<string, string>();
+  readonly reads = new Map<string, number>();
+
+  getItem(key: string): string | null {
+    this.reads.set(key, (this.reads.get(key) ?? 0) + 1);
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+}
+
+type DomainSnapshots = {
+  model?: ModelState;
+  billing?: BillingState;
+  sidebarSearch?: SidebarSearchState;
+  selectedProject?: SelectedProjectState;
+};
+
+type RenderCounts = {
+  model: number;
+  billing: number;
+  sidebarSearch: number;
+  selectedProject: number;
+};
+
+type ProbeProps = {
+  snapshots: DomainSnapshots;
+  counts: RenderCounts;
+};
+
+const ModelProbe = memo(function ModelProbe({ snapshots, counts }: ProbeProps) {
+  counts.model += 1;
+  snapshots.model = useModelState();
+  return null;
+});
+
+const BillingProbe = memo(function BillingProbe({ snapshots, counts }: ProbeProps) {
+  counts.billing += 1;
+  snapshots.billing = useBillingState();
+  return null;
+});
+
+const SidebarSearchProbe = memo(function SidebarSearchProbe({ snapshots, counts }: ProbeProps) {
+  counts.sidebarSearch += 1;
+  snapshots.sidebarSearch = useSidebarSearchState();
+  return null;
+});
+
+const SelectedProjectProbe = memo(function SelectedProjectProbe({ snapshots, counts }: ProbeProps) {
+  counts.selectedProject += 1;
+  snapshots.selectedProject = useSelectedProjectState();
+  return null;
+});
+
+function DomainProbes(props: ProbeProps) {
+  return (
+    <>
+      <ModelProbe {...props} />
+      <BillingProbe {...props} />
+      <SidebarSearchProbe {...props} />
+      <SelectedProjectProbe {...props} />
+    </>
+  );
+}
+
+function createCounts(): RenderCounts {
+  return { model: 0, billing: 0, sidebarSearch: 0, selectedProject: 0 };
+}
+
+function expectRenderDelta(
+  counts: RenderCounts,
+  before: RenderCounts,
+  expected: Partial<RenderCounts>
+) {
+  expect({
+    model: counts.model - before.model,
+    billing: counts.billing - before.billing,
+    sidebarSearch: counts.sidebarSearch - before.sidebarSearch,
+    selectedProject: counts.selectedProject - before.selectedProject
+  }).toEqual({
+    model: expected.model ?? 0,
+    billing: expected.billing ?? 0,
+    sidebarSearch: expected.sidebarSearch ?? 0,
+    selectedProject: expected.selectedProject ?? 0
+  });
+}
+
+function freeBillingStatus(): BillingStatus {
+  return {
+    is_subscribed: false,
+    stripe_customer_id: null,
+    product_id: "free",
+    product_name: "Free",
+    subscription_status: "inactive",
+    current_period_end: null,
+    can_chat: true,
+    chats_remaining: null,
+    payment_provider: null,
+    total_tokens: null,
+    used_tokens: null,
+    usage_reset_date: null
+  };
+}
+
+function proBillingStatus(): BillingStatus {
+  return {
+    ...freeBillingStatus(),
+    is_subscribed: true,
+    product_id: "pro",
+    product_name: "Pro",
+    subscription_status: "active",
+    payment_provider: "stripe"
+  };
+}
+
+describe("LocalStateProvider", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = null;
+    }
+  });
+
+  test("isolates updates to the domain that changed", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    let before = { ...counts };
+    act(() => snapshots.model?.setModel(PAID_DEFAULT_MODEL_ID));
+    expectRenderDelta(counts, before, { model: 1 });
+
+    before = { ...counts };
+    act(() => snapshots.billing?.setBillingStatus(freeBillingStatus()));
+    expectRenderDelta(counts, before, { billing: 1 });
+
+    before = { ...counts };
+    act(() => {
+      snapshots.sidebarSearch?.setSearchQuery("maple");
+      snapshots.sidebarSearch?.setIsSearchVisible(true);
+    });
+    expectRenderDelta(counts, before, { sidebarSearch: 1 });
+
+    before = { ...counts };
+    act(() => snapshots.selectedProject?.setSelectedProjectId("project-1"));
+    expectRenderDelta(counts, before, { selectedProject: 1 });
+
+    before = { ...counts };
+    act(() => snapshots.selectedProject?.setSelectedProjectId("project-1"));
+    expectRenderDelta(counts, before, {});
+  });
+
+  test("keeps the intentional paid-plan model default scoped to billing and model consumers", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    const before = { ...counts };
+    act(() => snapshots.billing?.setBillingStatus(proBillingStatus()));
+
+    expectRenderDelta(counts, before, { model: 1, billing: 1 });
+    expect(snapshots.model?.model).toBe(PAID_DEFAULT_MODEL_ID);
+  });
+
+  test("preserves an in-memory model choice when storage is unavailable", () => {
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={null}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    act(() => {
+      snapshots.model?.setModel("user-selected-model", {
+        id: "user-selected-model",
+        object: "model",
+        created: 1,
+        owned_by: "opensecret"
+      });
+      snapshots.billing?.setBillingStatus(proBillingStatus());
+    });
+
+    expect(snapshots.model?.model).toBe("user-selected-model");
+  });
+
+  test("persists model choices without making a no-op selection sticky", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    act(() => snapshots.model?.setModel(DEFAULT_MODEL_ID));
+    expect(storage.getItem("selectedModel")).toBeNull();
+
+    act(() => {
+      snapshots.model?.setModel("user-selected-model", {
+        id: "user-selected-model",
+        object: "model",
+        created: 1,
+        owned_by: "opensecret"
+      });
+      snapshots.model?.setModel(DEFAULT_MODEL_ID);
+    });
+
+    expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
+    expect(storage.getItem("selectedModel")).toBe(DEFAULT_MODEL_ID);
+    expect(storage.getItem("selectedModelMetadata")).toBeNull();
+  });
+
+  test("reads cached model state only during lazy provider initialization", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+    storage.setItem("selectedModel", "cached-model");
+    storage.setItem(
+      "selectedModelMetadata",
+      JSON.stringify({
+        id: "cached-model",
+        object: "model",
+        created: 1,
+        owned_by: "opensecret"
+      })
+    );
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    const initialReads = new Map(storage.reads);
+    expect([...initialReads.values()].reduce((sum, reads) => sum + reads, 0)).toBeGreaterThan(0);
+    expect(snapshots.model?.model).toBe("cached-model");
+
+    act(() => {
+      snapshots.sidebarSearch?.setSearchQuery("persist across routes");
+      snapshots.selectedProject?.setSelectedProjectId("project-2");
+    });
+
+    act(() => {
+      renderer?.update(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+          <span>another route</span>
+        </LocalStateProvider>
+      );
+    });
+
+    expect(storage.reads).toEqual(initialReads);
+    expect(snapshots.sidebarSearch?.searchQuery).toBe("persist across routes");
+    expect(snapshots.selectedProject?.selectedProjectId).toBe("project-2");
+  });
+});

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -1,15 +1,35 @@
-import { useCallback, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { BillingStatus } from "@/billing/billingApi";
-import { LocalStateContext, OpenSecretModel, OpenSecretModelAlias } from "./LocalStateContextDef";
+import {
+  BillingStateContext,
+  ModelStateContext,
+  OpenSecretModel,
+  OpenSecretModelAlias,
+  SelectedProjectStateContext,
+  SidebarSearchStateContext,
+  type BillingState,
+  type ModelState,
+  type SelectedProjectState,
+  type SidebarSearchState
+} from "./LocalStateContextDef";
 import { aliasModelName, migrateStickyModelName } from "@/utils/utils";
-
-export { LocalStateContext, type LocalState } from "./LocalStateContextDef";
 
 export const QUICK_MODEL_ALIAS = "auto:quick";
 export const POWERFUL_MODEL_ALIAS = "auto:powerful";
 export const DEFAULT_MODEL_ID = QUICK_MODEL_ALIAS;
 export const PAID_DEFAULT_MODEL_ID = POWERFUL_MODEL_ALIAS;
 const SELECTED_MODEL_METADATA_KEY = "selectedModelMetadata";
+type LocalStateStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
+
+function getBrowserStorage(): LocalStateStorage | null {
+  if (typeof window === "undefined") return null;
+
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
 
 const DEFAULT_MODEL_ALIASES: OpenSecretModelAlias[] = [
   {
@@ -39,18 +59,20 @@ function isProMaxOrTeamPlan(planName: string): boolean {
 
 // Check if paid defaults have already been applied for this user.
 // The value is an ISO date string indicating when defaults were last applied.
-function hasPaidDefaultsBeenApplied(): boolean {
-  return localStorage.getItem("paidDefaultsApplied") !== null;
+function hasPaidDefaultsBeenApplied(storage: LocalStateStorage | null): boolean {
+  return storage?.getItem("paidDefaultsApplied") != null;
 }
 
 // One-time migration: clear stale webSearchEnabled values that were auto-persisted
 // by the old useEffect (not explicit user choices). After this migration, only values
 // written by explicit user toggle clicks are trusted.
-function migrateWebSearchDefault(): void {
+function migrateWebSearchDefault(storage: LocalStateStorage | null): void {
+  if (!storage) return;
+
   try {
-    if (localStorage.getItem("webSearchDefaultMigrated") === null) {
-      localStorage.removeItem("webSearchEnabled");
-      localStorage.setItem("webSearchDefaultMigrated", "true");
+    if (storage.getItem("webSearchDefaultMigrated") === null) {
+      storage.removeItem("webSearchEnabled");
+      storage.setItem("webSearchDefaultMigrated", "true");
     }
   } catch {
     // Ignore storage errors
@@ -59,12 +81,14 @@ function migrateWebSearchDefault(): void {
 
 // Helper to get the initial web search state from localStorage.
 // Web search is on by default for all users, but respects the user's explicit preference.
-export function getInitialWebSearchEnabled(): boolean {
-  migrateWebSearchDefault();
+export function getInitialWebSearchEnabled(
+  storage: LocalStateStorage | null = getBrowserStorage()
+): boolean {
+  migrateWebSearchDefault(storage);
   try {
     // If user has explicitly toggled web search before, respect that
-    const webSearchSetting = localStorage.getItem("webSearchEnabled");
-    if (webSearchSetting !== null) {
+    const webSearchSetting = storage?.getItem("webSearchEnabled");
+    if (webSearchSetting != null) {
       return webSearchSetting === "true";
     }
   } catch (error) {
@@ -75,7 +99,7 @@ export function getInitialWebSearchEnabled(): boolean {
 }
 
 // Helper to get default model based on cached billing status
-function getInitialModel(): string {
+function getInitialModel(storage: LocalStateStorage | null): string {
   // Check for dev override first
   if (import.meta.env.VITE_DEV_MODEL_OVERRIDE) {
     return aliasModelName(import.meta.env.VITE_DEV_MODEL_OVERRIDE);
@@ -83,9 +107,9 @@ function getInitialModel(): string {
 
   try {
     // Priority 1: Check local storage for user's explicit model choice
-    const selectedModel = localStorage.getItem("selectedModel");
+    const selectedModel = storage?.getItem("selectedModel");
     if (selectedModel) {
-      if (getCachedSelectedModelMetadata(selectedModel)) {
+      if (getCachedSelectedModelMetadata(selectedModel, storage)) {
         return selectedModel;
       }
 
@@ -95,12 +119,12 @@ function getInitialModel(): string {
     // Priority 2: Check if paid defaults were already applied
     // (user is returning paid user who got the one-time flip but then
     // cleared selectedModel somehow — unlikely but safe fallback)
-    if (hasPaidDefaultsBeenApplied()) {
+    if (hasPaidDefaultsBeenApplied(storage)) {
       return PAID_DEFAULT_MODEL_ID;
     }
 
     // Priority 3: Check cached billing status for pro/max/team users
-    const cachedBillingStr = localStorage.getItem("cachedBillingStatus");
+    const cachedBillingStr = storage?.getItem("cachedBillingStatus");
     if (cachedBillingStr) {
       const cachedBilling = JSON.parse(cachedBillingStr) as BillingStatus;
       const planName = cachedBilling.product_name?.toLowerCase() || "";
@@ -134,11 +158,14 @@ function isAutoModelAlias(modelId: string): boolean {
   return modelId === QUICK_MODEL_ALIAS || modelId === POWERFUL_MODEL_ALIAS;
 }
 
-function getCachedSelectedModelMetadata(modelId: string): OpenSecretModel | null {
+function getCachedSelectedModelMetadata(
+  modelId: string,
+  storage: LocalStateStorage | null
+): OpenSecretModel | null {
   if (!modelId || isAutoModelAlias(modelId)) return null;
 
   try {
-    const cachedMetadata = localStorage.getItem(SELECTED_MODEL_METADATA_KEY);
+    const cachedMetadata = storage?.getItem(SELECTED_MODEL_METADATA_KEY);
     if (!cachedMetadata) return null;
 
     const parsedMetadata = JSON.parse(cachedMetadata) as OpenSecretModel;
@@ -156,10 +183,16 @@ function getCachedSelectedModelMetadata(modelId: string): OpenSecretModel | null
   }
 }
 
-function cacheSelectedModelMetadata(modelId: string, modelMetadata?: OpenSecretModel | null) {
+function cacheSelectedModelMetadata(
+  modelId: string,
+  storage: LocalStateStorage | null,
+  modelMetadata?: OpenSecretModel | null
+) {
+  if (!storage) return;
+
   try {
     if (!modelMetadata || isAutoModelAlias(modelId)) {
-      localStorage.removeItem(SELECTED_MODEL_METADATA_KEY);
+      storage.removeItem(SELECTED_MODEL_METADATA_KEY);
       return;
     }
 
@@ -171,196 +204,229 @@ function cacheSelectedModelMetadata(modelId: string, modelMetadata?: OpenSecretM
       owned_by: modelMetadata.owned_by || "opensecret"
     };
 
-    localStorage.setItem(SELECTED_MODEL_METADATA_KEY, JSON.stringify(cacheableMetadata));
+    storage.setItem(SELECTED_MODEL_METADATA_KEY, JSON.stringify(cacheableMetadata));
   } catch (error) {
     console.error("Failed to cache selected model metadata:", error);
   }
 }
 
-export const LocalStateProvider = ({ children }: { children: React.ReactNode }) => {
-  const initialModel = getInitialModel();
-  const cachedSelectedModel = getCachedSelectedModelMetadata(initialModel);
+export const LocalStateProvider = ({
+  children,
+  storage = getBrowserStorage()
+}: {
+  children: React.ReactNode;
+  storage?: LocalStateStorage | null;
+}) => {
+  const [modelState, setModelState] = useState(() => {
+    const model = getInitialModel(storage);
+    const cachedSelectedModel = getCachedSelectedModelMetadata(model, storage);
 
-  const [localState, setLocalState] = useState({
-    model: initialModel,
-    availableModels: cachedSelectedModel ? [cachedSelectedModel] : ([] as OpenSecretModel[]),
-    modelAliases: DEFAULT_MODEL_ALIASES,
-    hasWhisperModel: true, // Default to true to avoid hiding button during loading
-    billingStatus: null as BillingStatus | null,
-    searchQuery: "",
-    isSearchVisible: false,
-    selectedProjectId: null as string | null
+    return {
+      model,
+      availableModels: cachedSelectedModel ? [cachedSelectedModel] : ([] as OpenSecretModel[]),
+      modelAliases: DEFAULT_MODEL_ALIASES,
+      hasWhisperModel: true // Default to true to avoid hiding button during loading
+    };
   });
-
-  function setBillingStatus(status: BillingStatus) {
-    setLocalState((prev) => ({ ...prev, billingStatus: status }));
-
-    const planName = status.product_name?.toLowerCase() || "";
-    const isPaidPlan =
-      planName.includes("pro") || planName.includes("max") || planName.includes("team");
-
-    const isProMaxOrTeam = isProMaxOrTeamPlan(planName);
-
-    // Check if billing plan changed from cached version
-    let billingChanged = false;
-    try {
-      const cachedBillingStr = localStorage.getItem("cachedBillingStatus");
-      if (cachedBillingStr) {
-        const cachedBilling = JSON.parse(cachedBillingStr) as BillingStatus;
-        const cachedPlan = cachedBilling.product_name?.toLowerCase() || "";
-        billingChanged = cachedPlan !== planName;
-      }
-    } catch (error) {
-      console.error("Failed to check cached billing:", error);
-    }
-
-    // Cache billing status to localStorage only for paid users
-    try {
-      if (isPaidPlan) {
-        localStorage.setItem("cachedBillingStatus", JSON.stringify(status));
-      } else {
-        // Clear cache for free users
-        localStorage.removeItem("cachedBillingStatus");
-      }
-    } catch (error) {
-      console.error("Failed to cache billing status:", error);
-    }
-
-    // One-time paid defaults: when a user is on pro/max/team and we haven't
-    // applied paid defaults yet, flip model to "Powerful" and web search ON.
-    // This handles both new signups and free-to-paid upgrades.
-    try {
-      if (isProMaxOrTeam && !hasPaidDefaultsBeenApplied()) {
-        // Apply paid defaults — set model to Powerful reasoning model
-        setModelInternal(PAID_DEFAULT_MODEL_ID, true);
-
-        // Mark when we applied paid defaults (ISO date) so we never override again.
-        // Future defaults can check this date to decide whether to re-apply newer defaults.
-        localStorage.setItem("paidDefaultsApplied", new Date().toISOString());
-
-        return;
-      }
-    } catch (error) {
-      console.error("Failed to apply paid defaults:", error);
-    }
-
-    // For users who already had defaults applied: handle plan changes
-    try {
-      if (billingChanged) {
-        if (isProMaxOrTeam) {
-          // Plan changed but still pro-tier — only update model if user
-          // hasn't manually chosen one (selectedModel not in localStorage)
-          const selectedModel = localStorage.getItem("selectedModel");
-          if (!selectedModel) {
-            setModelInternal(PAID_DEFAULT_MODEL_ID, true);
-          }
-        } else {
-          // User downgraded to free — switch back to free model
-          // and clear paid defaults so they get re-applied if they upgrade again
-          setModelInternal(DEFAULT_MODEL_ID);
-          localStorage.removeItem("paidDefaultsApplied");
-          localStorage.removeItem("selectedModel");
-        }
-      }
-    } catch (error) {
-      console.error("Failed to update model based on billing status:", error);
-    }
-  }
-
-  function setSearchQuery(query: string) {
-    setLocalState((prev) => ({ ...prev, searchQuery: query }));
-  }
-
-  function setIsSearchVisible(visible: boolean) {
-    setLocalState((prev) => ({ ...prev, isSearchVisible: visible }));
-  }
-
-  const setSelectedProjectId = useCallback((projectId: string | null) => {
-    setLocalState((prev) => ({ ...prev, selectedProjectId: projectId }));
-  }, []);
+  const [billingStatus, setBillingStatusState] = useState<BillingStatus | null>(null);
+  const [searchQuery, setSearchQueryState] = useState("");
+  const [isSearchVisible, setIsSearchVisibleState] = useState(false);
+  const [selectedProjectId, setSelectedProjectIdState] = useState<string | null>(null);
+  const currentModelRef = useRef(modelState.model);
 
   // Internal model setter — updates state and localStorage but does NOT mark as
   // a user's explicit choice. Used by billing/system logic.
-  function setModelInternal(modelId: string, persist = false) {
-    const aliasedModel = aliasModelName(modelId);
-    setLocalState((prev) => {
-      if (prev.model === aliasedModel) return prev;
-      return { ...prev, model: aliasedModel };
-    });
-    if (persist) {
-      try {
-        localStorage.setItem("selectedModel", aliasedModel);
-        cacheSelectedModelMetadata(aliasedModel);
-      } catch (error) {
-        console.error("Failed to save model to localStorage:", error);
+  const setModelInternal = useCallback(
+    (modelId: string, persist = false) => {
+      const aliasedModel = aliasModelName(modelId);
+      currentModelRef.current = aliasedModel;
+      setModelState((prev) => {
+        if (prev.model === aliasedModel) return prev;
+        return { ...prev, model: aliasedModel };
+      });
+      if (persist) {
+        try {
+          storage?.setItem("selectedModel", aliasedModel);
+          cacheSelectedModelMetadata(aliasedModel, storage);
+        } catch (error) {
+          console.error("Failed to save model to localStorage:", error);
+        }
       }
-    }
-  }
+    },
+    [storage]
+  );
+
+  const setBillingStatus = useCallback(
+    (status: BillingStatus) => {
+      setBillingStatusState(status);
+
+      const planName = status.product_name?.toLowerCase() || "";
+      const isPaidPlan =
+        planName.includes("pro") || planName.includes("max") || planName.includes("team");
+
+      const isProMaxOrTeam = isProMaxOrTeamPlan(planName);
+
+      // Check if billing plan changed from cached version
+      let billingChanged = false;
+      try {
+        const cachedBillingStr = storage?.getItem("cachedBillingStatus");
+        if (cachedBillingStr) {
+          const cachedBilling = JSON.parse(cachedBillingStr) as BillingStatus;
+          const cachedPlan = cachedBilling.product_name?.toLowerCase() || "";
+          billingChanged = cachedPlan !== planName;
+        }
+      } catch (error) {
+        console.error("Failed to check cached billing:", error);
+      }
+
+      // Cache billing status to localStorage only for paid users
+      try {
+        if (isPaidPlan) {
+          storage?.setItem("cachedBillingStatus", JSON.stringify(status));
+        } else {
+          // Clear cache for free users
+          storage?.removeItem("cachedBillingStatus");
+        }
+      } catch (error) {
+        console.error("Failed to cache billing status:", error);
+      }
+
+      // One-time paid defaults: when a user is on pro/max/team and we haven't
+      // applied paid defaults yet, flip model to "Powerful" and web search ON.
+      // This handles both new signups and free-to-paid upgrades.
+      try {
+        if (storage && isProMaxOrTeam && !hasPaidDefaultsBeenApplied(storage)) {
+          // Apply paid defaults — set model to Powerful reasoning model
+          setModelInternal(PAID_DEFAULT_MODEL_ID, true);
+
+          // Mark when we applied paid defaults (ISO date) so we never override again.
+          // Future defaults can check this date to decide whether to re-apply newer defaults.
+          storage?.setItem("paidDefaultsApplied", new Date().toISOString());
+
+          return;
+        }
+      } catch (error) {
+        console.error("Failed to apply paid defaults:", error);
+      }
+
+      // For users who already had defaults applied: handle plan changes
+      try {
+        if (billingChanged) {
+          if (isProMaxOrTeam) {
+            // Plan changed but still pro-tier — only update model if user
+            // hasn't manually chosen one (selectedModel not in localStorage)
+            const selectedModel = storage?.getItem("selectedModel");
+            if (!selectedModel) {
+              setModelInternal(PAID_DEFAULT_MODEL_ID, true);
+            }
+          } else {
+            // User downgraded to free — switch back to free model
+            // and clear paid defaults so they get re-applied if they upgrade again
+            setModelInternal(DEFAULT_MODEL_ID);
+            storage?.removeItem("paidDefaultsApplied");
+            storage?.removeItem("selectedModel");
+          }
+        }
+      } catch (error) {
+        console.error("Failed to update model based on billing status:", error);
+      }
+    },
+    [setModelInternal, storage]
+  );
+
+  const setSearchQuery = useCallback((query: string) => setSearchQueryState(query), []);
+
+  const setIsSearchVisible = useCallback(
+    (visible: boolean) => setIsSearchVisibleState(visible),
+    []
+  );
+
+  const setSelectedProjectId = useCallback((projectId: string | null) => {
+    setSelectedProjectIdState(projectId);
+  }, []);
 
   // Public model setter — records the choice as a user-initiated selection.
   // After this, we won't auto-override their model choice.
-  function setModel(model: string, modelMetadata?: OpenSecretModel | null) {
-    const nextModel = modelMetadata ? model : aliasModelName(model);
-    setLocalState((prev) => {
-      if (prev.model === nextModel && !modelMetadata) return prev;
+  const setModel = useCallback(
+    (model: string, modelMetadata?: OpenSecretModel | null) => {
+      const nextModel = modelMetadata ? model : aliasModelName(model);
+      if (currentModelRef.current === nextModel && !modelMetadata) return;
+      currentModelRef.current = nextModel;
 
-      // Save to localStorage as user's explicit choice
+      // Save to localStorage as user's explicit choice. Keep this outside the
+      // state updater because React may replay updater functions.
       try {
-        localStorage.setItem("selectedModel", nextModel);
-        cacheSelectedModelMetadata(nextModel, modelMetadata);
+        storage?.setItem("selectedModel", nextModel);
+        cacheSelectedModelMetadata(nextModel, storage, modelMetadata);
       } catch (error) {
         console.error("Failed to save model to localStorage:", error);
       }
 
-      const availableModels =
-        modelMetadata && !isAutoModelAlias(nextModel)
-          ? normalizeAvailableModels([modelMetadata, ...prev.availableModels])
-          : prev.availableModels;
+      setModelState((prev) => {
+        const availableModels =
+          modelMetadata && !isAutoModelAlias(nextModel)
+            ? normalizeAvailableModels([modelMetadata, ...prev.availableModels])
+            : prev.availableModels;
 
-      return { ...prev, model: nextModel, availableModels };
-    });
-  }
+        return { ...prev, model: nextModel, availableModels };
+      });
+    },
+    [storage]
+  );
 
-  function setAvailableModels(models: OpenSecretModel[]) {
-    setLocalState((prev) => ({
+  const setAvailableModels = useCallback((models: OpenSecretModel[]) => {
+    setModelState((prev) => ({
       ...prev,
       availableModels: normalizeAvailableModels(models)
     }));
-  }
+  }, []);
 
-  function setModelAliases(aliases: OpenSecretModelAlias[]) {
-    setLocalState((prev) => ({
+  const setModelAliases = useCallback((aliases: OpenSecretModelAlias[]) => {
+    setModelState((prev) => ({
       ...prev,
       modelAliases: aliases.length > 0 ? aliases : DEFAULT_MODEL_ALIASES
     }));
-  }
+  }, []);
 
-  function setHasWhisperModel(hasWhisper: boolean) {
-    setLocalState((prev) => ({ ...prev, hasWhisperModel: hasWhisper }));
-  }
+  const setHasWhisperModel = useCallback((hasWhisper: boolean) => {
+    setModelState((prev) => ({ ...prev, hasWhisperModel: hasWhisper }));
+  }, []);
+
+  const modelValue = useMemo<ModelState>(
+    () => ({
+      model: modelState.model,
+      availableModels: modelState.availableModels,
+      modelAliases: modelState.modelAliases,
+      setModel,
+      setAvailableModels,
+      setModelAliases,
+      hasWhisperModel: modelState.hasWhisperModel,
+      setHasWhisperModel
+    }),
+    [modelState, setAvailableModels, setHasWhisperModel, setModel, setModelAliases]
+  );
+  const billingValue = useMemo<BillingState>(
+    () => ({ billingStatus, setBillingStatus }),
+    [billingStatus, setBillingStatus]
+  );
+  const sidebarSearchValue = useMemo<SidebarSearchState>(
+    () => ({ searchQuery, setSearchQuery, isSearchVisible, setIsSearchVisible }),
+    [isSearchVisible, searchQuery, setIsSearchVisible, setSearchQuery]
+  );
+  const selectedProjectValue = useMemo<SelectedProjectState>(
+    () => ({ selectedProjectId, setSelectedProjectId }),
+    [selectedProjectId, setSelectedProjectId]
+  );
 
   return (
-    <LocalStateContext.Provider
-      value={{
-        model: localState.model,
-        availableModels: localState.availableModels,
-        modelAliases: localState.modelAliases,
-        setModel,
-        setAvailableModels,
-        setModelAliases,
-        hasWhisperModel: localState.hasWhisperModel,
-        setHasWhisperModel,
-        billingStatus: localState.billingStatus,
-        searchQuery: localState.searchQuery,
-        setSearchQuery,
-        isSearchVisible: localState.isSearchVisible,
-        setIsSearchVisible,
-        selectedProjectId: localState.selectedProjectId,
-        setSelectedProjectId,
-        setBillingStatus
-      }}
-    >
-      {children}
-    </LocalStateContext.Provider>
+    <ModelStateContext.Provider value={modelValue}>
+      <BillingStateContext.Provider value={billingValue}>
+        <SidebarSearchStateContext.Provider value={sidebarSearchValue}>
+          <SelectedProjectStateContext.Provider value={selectedProjectValue}>
+            {children}
+          </SelectedProjectStateContext.Provider>
+        </SidebarSearchStateContext.Provider>
+      </BillingStateContext.Provider>
+    </ModelStateContext.Provider>
   );
 };

--- a/frontend/src/state/LocalStateContextDef.ts
+++ b/frontend/src/state/LocalStateContextDef.ts
@@ -61,7 +61,7 @@ export type OpenSecretModelCatalog = {
   };
 };
 
-export type LocalState = {
+export type ModelState = {
   model: string;
   availableModels: OpenSecretModel[];
   modelAliases: OpenSecretModelAlias[];
@@ -71,7 +71,14 @@ export type LocalState = {
   /** Whether the whisper transcription model is available */
   hasWhisperModel: boolean;
   setHasWhisperModel: (hasWhisper: boolean) => void;
+};
+
+export type BillingState = {
   billingStatus: BillingStatus | null;
+  setBillingStatus: (status: BillingStatus) => void;
+};
+
+export type SidebarSearchState = {
   /** Current search query for filtering chat history */
   searchQuery: string;
   /** Updates the current search query */
@@ -80,28 +87,18 @@ export type LocalState = {
   isSearchVisible: boolean;
   /** Controls the visibility of the search input */
   setIsSearchVisible: (visible: boolean) => void;
+};
+
+export type SelectedProjectState = {
   /** Currently selected conversation project for sidebar/composer context */
   selectedProjectId: string | null;
   /** Updates the selected conversation project context */
   setSelectedProjectId: (projectId: string | null) => void;
-  setBillingStatus: (status: BillingStatus) => void;
 };
 
-export const LocalStateContext = createContext<LocalState>({
-  model: "",
-  availableModels: [],
-  modelAliases: [],
-  setModel: () => void 0,
-  setAvailableModels: () => void 0,
-  setModelAliases: () => void 0,
-  hasWhisperModel: true,
-  setHasWhisperModel: () => void 0,
-  billingStatus: null,
-  searchQuery: "",
-  setSearchQuery: () => void 0,
-  isSearchVisible: false,
-  setIsSearchVisible: () => void 0,
-  selectedProjectId: null,
-  setSelectedProjectId: () => void 0,
-  setBillingStatus: () => void 0
-});
+export const ModelStateContext = createContext<ModelState | undefined>(undefined);
+export const BillingStateContext = createContext<BillingState | undefined>(undefined);
+export const SidebarSearchStateContext = createContext<SidebarSearchState | undefined>(undefined);
+export const SelectedProjectStateContext = createContext<SelectedProjectState | undefined>(
+  undefined
+);

--- a/frontend/src/state/useLocalState.tsx
+++ b/frontend/src/state/useLocalState.tsx
@@ -1,10 +1,39 @@
 import { useContext } from "react";
-import { LocalStateContext } from "./LocalStateContext";
+import {
+  BillingStateContext,
+  ModelStateContext,
+  SelectedProjectStateContext,
+  SidebarSearchStateContext
+} from "./LocalStateContextDef";
 
-export const useLocalState = () => {
-  const context = useContext(LocalStateContext);
+export const useModelState = () => {
+  const context = useContext(ModelStateContext);
   if (context === undefined) {
-    throw new Error("useLocalState must be used within a LocalStateProvider");
+    throw new Error("useModelState must be used within a LocalStateProvider");
+  }
+  return context;
+};
+
+export const useBillingState = () => {
+  const context = useContext(BillingStateContext);
+  if (context === undefined) {
+    throw new Error("useBillingState must be used within a LocalStateProvider");
+  }
+  return context;
+};
+
+export const useSidebarSearchState = () => {
+  const context = useContext(SidebarSearchStateContext);
+  if (context === undefined) {
+    throw new Error("useSidebarSearchState must be used within a LocalStateProvider");
+  }
+  return context;
+};
+
+export const useSelectedProjectState = () => {
+  const context = useContext(SelectedProjectStateContext);
+  if (context === undefined) {
+    throw new Error("useSelectedProjectState must be used within a LocalStateProvider");
   }
   return context;
 };

--- a/frontend/src/utils/useLazyRef.test.tsx
+++ b/frontend/src/utils/useLazyRef.test.tsx
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { createRef, forwardRef, useImperativeHandle, type MutableRefObject } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import { useLazyRef } from "./useLazyRef";
+
+interface LazyValue {
+  readonly sequence: number;
+}
+
+interface LazyRefProbeHandle {
+  getRef: () => MutableRefObject<LazyValue>;
+}
+
+const LazyRefProbe = forwardRef<LazyRefProbeHandle, { createValue: () => LazyValue }>(
+  function LazyRefProbe({ createValue }, forwardedRef) {
+    const valueRef = useLazyRef(createValue);
+    useImperativeHandle(forwardedRef, () => ({ getRef: () => valueRef }), [valueRef]);
+    return null;
+  }
+);
+
+function getCurrentRef(probeRef: React.RefObject<LazyRefProbeHandle>) {
+  const handle = probeRef.current;
+  if (!handle) throw new Error("LazyRefProbe is not mounted");
+  return handle.getRef();
+}
+
+function mountProbe(probeRef: React.RefObject<LazyRefProbeHandle>, createValue: () => LazyValue) {
+  return create(<LazyRefProbe ref={probeRef} createValue={createValue} />);
+}
+
+function updateProbe(
+  renderer: ReactTestRenderer,
+  probeRef: React.RefObject<LazyRefProbeHandle>,
+  createValue: () => LazyValue
+) {
+  renderer.update(<LazyRefProbe ref={probeRef} createValue={createValue} />);
+  return null;
+}
+
+describe("useLazyRef", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = null;
+    }
+  });
+
+  test("calls the initializer once per mount across rerenders", () => {
+    let initializerCalls = 0;
+    const createValue = () => ({ sequence: ++initializerCalls });
+    const probeRef = createRef<LazyRefProbeHandle>();
+
+    act(() => {
+      renderer = mountProbe(probeRef, createValue);
+    });
+    const firstRef = getCurrentRef(probeRef);
+    act(() => {
+      if (!renderer) throw new Error("LazyRefProbe renderer is missing");
+      updateProbe(renderer, probeRef, createValue);
+      updateProbe(renderer, probeRef, createValue);
+    });
+
+    expect(initializerCalls).toBe(1);
+    expect(getCurrentRef(probeRef)).toBe(firstRef);
+    expect(getCurrentRef(probeRef).current.sequence).toBe(1);
+
+    act(() => renderer?.unmount());
+    renderer = null;
+
+    act(() => {
+      renderer = mountProbe(probeRef, createValue);
+    });
+
+    expect(initializerCalls).toBe(2);
+    expect(getCurrentRef(probeRef).current.sequence).toBe(2);
+  });
+
+  test("keeps the ref and value identities stable across rerenders", () => {
+    const value: LazyValue = { sequence: 1 };
+    const createValue = () => value;
+    const probeRef = createRef<LazyRefProbeHandle>();
+
+    act(() => {
+      renderer = mountProbe(probeRef, createValue);
+    });
+    const firstRef = getCurrentRef(probeRef);
+    act(() => {
+      if (!renderer) throw new Error("LazyRefProbe renderer is missing");
+      updateProbe(renderer, probeRef, createValue);
+    });
+
+    expect(getCurrentRef(probeRef)).toBe(firstRef);
+    expect(getCurrentRef(probeRef).current).toBe(value);
+  });
+});

--- a/frontend/src/utils/useLazyRef.ts
+++ b/frontend/src/utils/useLazyRef.ts
@@ -1,0 +1,12 @@
+import { useRef, useState, type MutableRefObject } from "react";
+
+/**
+ * Creates a ref value once per component mount.
+ *
+ * Use this instead of passing a newly allocated object directly to `useRef`,
+ * because React evaluates the `useRef` argument again on every render.
+ */
+export function useLazyRef<T extends object | symbol>(factory: () => T): MutableRefObject<T> {
+  const [initialValue] = useState(factory);
+  return useRef(initialValue);
+}

--- a/frontend/src/utils/useVisibleExternalStore.test.tsx
+++ b/frontend/src/utils/useVisibleExternalStore.test.tsx
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Profiler } from "react";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { useVisibleExternalStore } from "./useVisibleExternalStore";
+
+class NumberStore {
+  private value = 0;
+  private readonly listeners = new Set<() => void>();
+
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  readonly getSnapshot = (): number => this.value;
+
+  get subscriberCount(): number {
+    return this.listeners.size;
+  }
+
+  set(value: number): void {
+    this.value = value;
+    for (const listener of this.listeners) listener();
+  }
+}
+
+function StoreProbe({ isVisible, store }: { isVisible: boolean; store: NumberStore }) {
+  const value = useVisibleExternalStore(
+    isVisible,
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot
+  );
+  return <span>{value}</span>;
+}
+
+describe("useVisibleExternalStore", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = null;
+    }
+  });
+
+  test("renders store notifications only while visible and catches up on return", () => {
+    const store = new NumberStore();
+    let renderCount = 0;
+    const probe = (isVisible: boolean) => (
+      <Profiler id="visible-store" onRender={() => renderCount++}>
+        <StoreProbe isVisible={isVisible} store={store} />
+      </Profiler>
+    );
+
+    act(() => {
+      renderer = create(probe(true));
+    });
+    expect(store.subscriberCount).toBe(1);
+
+    act(() => store.set(1));
+    expect(renderer?.toJSON()).toMatchObject({ children: ["1"] });
+
+    act(() => renderer?.update(probe(false)));
+    expect(store.subscriberCount).toBe(0);
+    const hiddenRenderCount = renderCount;
+
+    act(() => store.set(2));
+    expect(renderCount).toBe(hiddenRenderCount);
+    expect(renderer?.toJSON()).toMatchObject({ children: ["1"] });
+
+    act(() => renderer?.update(probe(true)));
+    expect(store.subscriberCount).toBe(1);
+    expect(renderer?.toJSON()).toMatchObject({ children: ["2"] });
+  });
+});

--- a/frontend/src/utils/useVisibleExternalStore.ts
+++ b/frontend/src/utils/useVisibleExternalStore.ts
@@ -1,0 +1,27 @@
+import { useCallback, useSyncExternalStore } from "react";
+
+type ExternalStoreSubscribe = (listener: () => void) => () => void;
+
+const unsubscribeNoop = () => {};
+
+/**
+ * Suppresses store-driven renders while retained UI is hidden without pausing
+ * the store itself. React reads the current snapshot when the UI becomes
+ * visible and re-subscribes, so updates made while hidden are observed then.
+ */
+export function useVisibleExternalStore<T>(
+  isVisible: boolean,
+  subscribe: ExternalStoreSubscribe,
+  getSnapshot: () => T,
+  getServerSnapshot: () => T = getSnapshot
+): T {
+  const subscribeWhileVisible = useCallback(
+    (listener: () => void) => {
+      if (!isVisible) return unsubscribeNoop;
+      return subscribe(listener);
+    },
+    [isVisible, subscribe]
+  );
+
+  return useSyncExternalStore(subscribeWhileVisible, getSnapshot, getServerSnapshot);
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -9,7 +9,7 @@ const ignoreEnvFiles = process.env.MAPLE_IGNORE_VITE_ENV_FILES === "1";
 // https://vitejs.dev/config/
 export default defineConfig({
   envDir: ignoreEnvFiles ? path.resolve(__dirname, "src-tauri") : undefined,
-  plugins: [TanStackRouterVite(), react(), derPlugin()],
+  plugins: [TanStackRouterVite({ autoCodeSplitting: true }), react(), derPlugin()],
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src")


### PR DESCRIPTION
## Summary

This is the draft performance follow-up stacked on #727.

- enable TanStack Router automatic route code splitting so Agent Mode, Settings, Pricing, Proof, and other non-startup routes load on demand
- split the broad local-state context into focused model, billing, sidebar-search, and project contexts so unrelated updates do not fan out through the app
- stop hidden Unified Chat views from subscribing to streaming render notifications while preserving the live runtime and catching up immediately on return
- avoid repeated Set/Map/tracker construction, memoize the Agent sidebar/composer boundary, and remove permanent compositor hints from Agent project/session rows
- remove two backdrop filters whose backgrounds are fully opaque

## Measured impact

Measured against the #727 base with production builds (`gzip -n -9`):

- startup JS: 2,394,000 -> 1,924,563 bytes (-19.61%)
- startup gzip: 687,240 -> 561,003 bytes (-18.37%)
- all-route JS: +1.12% raw / +6.12% gzip due to chunk boundaries
- JS chunks: 6 -> 80

This improves initial loading and defers route code; it does not reduce total bytes if someone visits every route.

React Doctor 0.9.3 moves from 215 diagnostics (9 errors / 206 warnings) on #727 to 188 (8 / 180), with zero additions. Twenty-five removed diagnostics are substantive. Two unversioned-storage warnings also disappear only because storage access is abstracted for tests; those keys remain unversioned and are not claimed as fixes.

## Validation

- frozen Bun install
- Prettier check
- TypeScript build
- ESLint: 0 errors, 13 existing warnings
- Bun tests: 491 passed, 0 failed, 1,716 assertions
- production Vite build
- focused render-isolation, storage edge-case, lazy-ref, and hidden-store tests
- independent semantic, lifecycle, route-splitting, and final-scope reviews
- fully local managed-workspace smoke: Pro login, two chats, multi-turn memory, hidden streaming across Settings navigation, Account/Preferences/Billing/API page switches, sidebar search, model switching, new/reopened chats, Pricing/Proof lazy routes, and browser back/forward

## Scope and draft gates

- OAuth/token handoff and storage architecture are untouched.
- TTS request concurrency/playback behavior is untouched; this only avoids recreating one Set during renders.
- Before marking ready, I would do one exact-Tauri Agent Mode pass with a large session/project sidebar. The web smoke cannot exercise that desktop-only surface.

Unrelated smoke observations, not changed here: the local pass fixture cannot open a Stripe customer portal, Proof's live attestation validation reported a root-certificate mismatch, and Proof logs a nested-`h2` React warning.
