### PR TITLE
Update OpenSecret SDK to 3.3.1

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "3.2.1",
+        "@opensecret/react": "3.3.1",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-avatar": "^1.1.11",
         "@radix-ui/react-checkbox": "^1.3.3",
@@ -236,7 +236,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opensecret/react": ["@opensecret/react@3.2.1", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-lxfjO2arSLcCFULBlc8jLGSF7BLH+P17qFfgCAZOQzDDvfkvJt9z2NTRSvCFVbJAYtOh7AY+dKZ07Mk4w8P/1Q=="],
+    "@opensecret/react": ["@opensecret/react@3.3.1", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-jNdG+ulrRVug8+627ELxrXALUGY1tQBqnmsQwTnQBIX7sFPZUQSTHUnZ4cJ+VevQRBNfli65xxy1YOpr2oWTrw=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -31,7 +31,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@opensecret/react": "3.2.1",
+    "@opensecret/react": "3.3.1",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",


### PR DESCRIPTION
## Summary

- update `@opensecret/react` from 3.2.1 to 3.3.1
- ship the reviewed `createCustomFetch` stale-session recovery before the bounded-session backend rollout
- retain Maple API compatibility; no application code changes are required

The 3.3.0 portion of the version jump is additive provider-neutral web search/extraction API support. The 3.3.1 patch rebuilds and re-encrypts a request once after the backend rejects a stale encryption session, then decrypts the response with the replacement key.

## Supply-chain verification

- npm `gitHead` is `6d51325654fa951e81195c9378db349e2b4fd89f`, directly following SDK PR #94 merge commit `8f1ad22`
- the registry tarball SHA-1 and SHA-512 integrity values were independently reproduced
- the lockfile SRI exactly matches npm
- the packed ES and UMD bundles contain the reviewed recovery branch
- Maple’s seven-day minimum package-age policy remains unchanged; a one-command exception was used for this verified first-party release, and a normal frozen install now succeeds

This is integrity/signature/source-lineage verification, not a Sigstore npm provenance attestation; npm does not publish a `dist.attestations` field for this package.

## Validation

- `nix develop -c bun install --frozen-lockfile --ignore-scripts`
- `nix develop -c bun run format:check`
- `nix develop -c bun run lint` — 0 errors; existing warnings only
- `nix develop -c bun run typecheck`
- `nix develop -c bun test` — 483 passed
- `nix develop -c bun run build`
- published-package full-stack GUI smoke: authenticated paid Chat rendered exactly one decrypted `SDK331-PUBLISHED-SMOKE-OK` response

The SDK retry remains deliberately bounded to one attempt. Because the backend currently returns a generic HTTP 400, any first application 400 can trigger that single replay; this is the accepted SDK PR #94 compatibility behavior.