### PR TITLE
Refactor Maple Agent runtime for thin Desktop and ACP adapters

### DIFF
--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -36,7 +36,7 @@ The packaged executable has two entry paths:
 - Normal invocation launches Maple Desktop.
 - `maple acp` connects standard input/output to the already-running desktop process.
 
-Buzz owns the subprocess and supplies its relay context there. Maple Desktop owns authentication, the account-scoped provider, Goose managers, tasks, tools, permission policy, runs, and UI events. The connector sends no inference request itself and does not initialize a second agent runtime.
+Buzz owns the subprocess and supplies its relay context there. Maple Desktop owns authentication, the account-scoped provider, Goose managers, tasks, tools, automatic permission classification, runs, and UI events. The surface that starts a run owns any unresolved interactive permission decision: Tauri for a Desktop run and the connected ACP client for an ACP run. The connector sends no inference request itself and does not initialize a second agent runtime.
 
 The executable path is part of the socket name. This keeps an installed Maple build and independent development builds from accidentally sharing an ACP endpoint.
 
@@ -67,7 +67,7 @@ A provider factory alone is insufficient. Maple also needs to preserve:
 - account-scoped session storage and lifecycle fencing;
 - model locking and session restoration behavior;
 - `MapleDeveloperClient`, Maple web tools, and trust-filtered skills;
-- Maple-local permission classification and approval UI;
+- Maple-local permission classification and surface-scoped approval routing;
 - run cancellation, retained terminal state, and desktop timeline events; and
 - ephemeral per-session tool context supplied by the external harness.
 
@@ -99,8 +99,8 @@ Goose already implements many of these semantics, but at Maple's pinned revision
 | `session/fork`                             | No              | Medium                            | Goose's underlying `SessionManager` already has copy primitives, and its ACP implementation shows copy, optional truncation, and activation. Maple needs an account-scoped wrapper, root/policy validation, fresh transient context, activation, and rollback for partial failures. ACP fork is still unstable, so enabling it also accepts an unstable wire commitment; no Goose fork is otherwise required.                                                                                                                                               |
 | Session mode                               | No              | Medium                            | Maple already changes per-session permission mode. ACP support needs advertised mode state, a handler, update projection, and an explicit rule about whether a client may select unattended approval. This is principally a Maple trust-policy decision.                                                                                                                                                                                                                                                                                                    |
 | Model selection and other config           | No              | Medium–High                       | A Maple model option is feasible before the first prompt using Maple's authenticated catalog. Maple intentionally locks a task's model once it has history, so arbitrary mid-session switching should be rejected or treated as a product change. The native ACP path also needs authoritative vision/context metadata. Goose's config builder cannot be reused because it assumes Goose's global provider inventory rather than Maple's caller-owned `MapleProvider`; provider switching should remain out of scope.                                       |
-| ACP permission requests                    | No              | High                              | Technically supportable, but it changes the trust boundary. Maple already exposes pending one-shot decisions and can feed a response back to Goose. It would need exactly one authoritative broker per session—Maple UI, ACP client, or a deliberately designed hybrid—plus timeout, disconnect, cancellation, and double-response handling. The tested Buzz build automatically chooses `allow_once` for forwarded requests, so delegation would materially weaken the current local-approval boundary. Goose's mapping is not an injectable broker.       |
-| Basic structured tool calls and results    | No              | Low–Medium                        | Maple's timeline already carries stable IDs, title, input, output, status, and errors, which is enough for ordinary ACP `ToolCall` and `ToolCallUpdate` cards. This is mostly projection work. Buzz also treats the initial `tool_call` notification as activity, so projecting tool-call start would reset its idle watchdog during a long otherwise-silent tool, improving liveness as well as UI visibility.                                                                                                                                             |
+| ACP permission requests                    | Yes             | Implemented                       | Maple automatically resolves operations covered by its own policy, then emits a typed, run-scoped request for anything unresolved. ACP offers only `allow_once` and `reject_once`; cancellation, disconnect, transport failure, an unknown option, duplicate response, or reused request ID fails closed. The ACP caller is the sole interactive broker for that run, and Maple Desktop receives no actionable live card. Buzz currently chooses `allow_once` automatically. Maple has no separate non-overridable dangerous-deny policy yet. |
+| Basic structured tool calls and results    | Partial         | Low–Medium                        | A permission request includes a pending ACP `ToolCallUpdate` with stable ID, title, kind, prompt, and raw input. General tool starts, progress, outputs, and results are not yet projected. Maple's timeline already carries most ordinary card fields, so this is mainly projection work, but lifecycle correlation and bounded rich output still need wire tests.                                                                                                                                                                                           |
 | Rich tool/resource/location/MCP projection | No              | Medium–High                       | Rich image/resource content, file locations, progressive MCP notifications, and faithful replay need data below Maple's deliberately summarized UI timeline. A public transport-neutral Goose `AcpEventProjector` would avoid maintaining this nuanced mapping twice.                                                                                                                                                                                                                                                                                       |
 | Terminal and diff parity                   | No              | Medium–High; architectural choice | Goose's terminal handles and diff updates are not projection alone: its ACP filesystem layer replaces/delegates developer operations through ACP-client filesystem and terminal RPCs. Maple currently executes its own local tools. Maple would need either to synthesize bounded metadata from those results or delegate execution to the client, which would change its tool and permission architecture; an event projector by itself is insufficient.                                                                                                   |
 | Usage and context updates                  | No              | Medium                            | Supportable. Goose emits and persists usage, but Maple currently discards ephemeral usage notifications before its public event stream. Maple must retain a protocol-neutral usage event or query post-turn totals, pair usage with the persisted context limit, and define cumulative semantics. ACP cost is optional and should remain absent until it matches Maple billing semantics. Buzz can display standard usage for observability, but its durable turn-accounting path currently consumes a Goose-private cumulative-usage notification instead. |
@@ -116,7 +116,7 @@ This is parity for the tested Maple task path, not parity with Goose's complete 
 
 Two ACP v1 baseline caveats are worth making explicit: agents must accept `ResourceLink` prompt blocks and stdio MCP definitions. The preview handles neither generically. The tested Buzz custom-harness path uses text prompts and does not depend on arbitrary MCP definitions; Maple also contains one exact Buzz compatibility adaptation. Image, audio, and embedded-resource capabilities are correctly advertised as unavailable.
 
-None of the `No` rows blocks the tested Buzz harness. That Buzz build does not call list/load/resume/fork/close, tolerates absent model/config options by using the agent default, and falls back from native steering to cancel-and-merge. Initial `tool_call` notifications would improve Buzz Desktop visibility and reset its idle watchdog during long tools. Standard usage would improve observability, while durable turn metrics currently rely on a Goose-private notification. Its signed channel reply remains a separate tool/CLI path.
+None of the `No` rows blocks the tested Buzz harness. That Buzz build does not call list/load/resume/fork/close, tolerates absent model/config options by using the agent default, and falls back from native steering to cancel-and-merge. General tool lifecycle notifications would improve Buzz Desktop visibility and reset its idle watchdog during long tools. Standard usage would improve observability, while durable turn metrics currently rely on a Goose-private notification. Its signed channel reply remains a separate tool/CLI path.
 
 ## Maple-owned runtime service
 
@@ -126,6 +126,7 @@ The refactor exposes a transport-neutral Maple service around the existing embed
 - create and delete a Maple task;
 - send and cancel a run;
 - consume an isolated, bounded event stream for one exact run;
+- receive typed permission requests and resolve them through an opaque responder bound to that exact account, task, and run;
 - observe a retained terminal result when a run stream closes normally; and
 - install and revoke per-session tool environments.
 
@@ -157,7 +158,7 @@ This preview gate uses only the local `VITE_FORCE_FEATURE_FLAGS` override; the r
 The macOS/Linux desktop settings page is intentionally manual. It can:
 
 - start and stop the local service;
-- select the policy applied to newly created ACP sessions;
+- show that unresolved approvals belong to the connected ACP client;
 - show connected client, session, and active-run counts;
 - copy the exact packaged executable path and `acp` argument;
 - copy a Buzz custom-harness definition;
@@ -166,14 +167,25 @@ The macOS/Linux desktop settings page is intentionally manual. It can:
 
 Maple stops ACP before logout, local Agent-data clearing, Agent-runtime stop or restart, application update restart, and application exit. A saved `enabled` value does not auto-start ACP on the next launch; the user must explicitly start it again.
 
-Permission-mode, allowed-root, and maximum-connection changes require Stop, then change and save, then Start. This prevents a new session from racing a policy update and retaining the previous policy.
+Allowed-root and maximum-connection changes require Stop, then change and save, then Start. This prevents a new session from racing a policy update and retaining the previous policy.
 
 ## Permissions are policy, not confinement
 
-The persisted protocol-facing values currently have these meanings:
+`read_only` is the retained serialized name for caller-mediated `smart_approve`; it is not a literal read-only sandbox. Maple automatically approves operations covered by its own classifier and sends every unresolved tool decision to the ACP client. That client may prompt, reject, or approve automatically. Buzz currently selects `allow_once`, so guarded writes can still run unattended.
 
-- `read_only` means **require local approvals**. Maple maps it to its `smart_approve` path. A write-capable action can still occur after the user approves it in Maple Desktop.
-- `allow_all` is unattended operation. The agent may run commands, modify files, and perform external actions without a second local confirmation.
+The exploratory `allow_all` value previously bypassed the caller through Maple's Auto mode. Current configuration normalization migrates it to `read_only`, and both variants resolve to caller-mediated policy in the native adapter. This preserves old files without retaining a second Maple-owned approval path.
+
+```mermaid
+flowchart LR
+    Tool["Goose tool request"] --> Policy["Maple automatic policy"]
+    Policy -->|"covered locally"| Goose["Exact running Goose Agent"]
+    Policy -->|"unresolved ACP run"| Request["Run-scoped ACP permission request"]
+    Request --> Caller["Connected ACP client"]
+    Caller -->|"allow_once or reject_once"| Responder["Opaque exact-run responder"]
+    Responder --> Goose
+    Caller -->|"cancel, disconnect, invalid response"| Deny["Fail closed and cancel"]
+    Deny --> Goose
+```
 
 Neither mode is an operating-system sandbox.
 
@@ -191,7 +203,7 @@ Maple and Buzz credentials follow different paths:
 - Filtered values remain in the ACP connection's in-memory context and are copied into per-session tool context. Session installation revalidates the six-key allowlist and enforces the 16-KiB-per-value and 32-KiB-total bounds.
 - The context is revoked during session and connection cleanup. Credential-bearing shells terminate their Unix process group or Windows Job Object immediately after each command to limit descendant retention. Forced async-task shutdown uses the same containment handle.
 
-This design keeps Buzz credentials out of saved harness JSON, Maple configuration, argv, and Maple's process-global environment. It does **not** make the credentials invisible to the trusted agent or commands it runs. The shell needs the signing identity to publish a durable Buzz reply, and a command with that environment can inspect or transmit it. `allow_all` should therefore be enabled only for trusted clients, prompts, projects, and toolchains.
+This design keeps Buzz credentials out of saved harness JSON, Maple configuration, argv, and Maple's process-global environment. It does **not** make the credentials invisible to the trusted agent or commands it runs. The shell needs the signing identity to publish a durable Buzz reply, and a command with that environment can inspect or transmit it. Because Buzz currently auto-selects `allow_once`, use this integration only with trusted clients, prompts, projects, and toolchains.
 
 Unix process groups are not a complete sandbox: a command can deliberately call `setsid` or otherwise move a descendant into another process group before cleanup. Windows Job Objects provide stronger descendant containment. A hard Maple process crash or `SIGKILL` also bypasses Maple's in-process cleanup on both platforms, so a surviving descendant may retain an already copied credential. A portable hard credential boundary would require keeping the Buzz signing key out of arbitrary shell environments and exposing only a revocable Maple-owned broker or dedicated tool; that is outside this preview.
 
@@ -219,7 +231,7 @@ The exploratory validation used:
 - a packaged arm64 macOS Maple development app;
 - ACP v1;
 - Buzz owner-only channel admission and parallelism `1`; and
-- Maple's unattended `allow_all` policy.
+- Maple's then-current unattended `allow_all` policy (historical; current builds migrate this value to caller-mediated approval).
 
 Two Buzz GUI tasks completed:
 
@@ -233,14 +245,14 @@ The second run took roughly two to three minutes and ended with zero active runs
 - macOS is the only platform validated end to end.
 - Windows, mobile, and web are unsupported; non-Flatpak Linux remains unvalidated.
 - Service activation is manual after every Maple launch.
-- The local-approval mode publishes the ACP task and permission cards to Maple Desktop, which remains the authoritative approval broker. An unattended Buzz task can therefore wait for approval in Maple.
+- ACP runs keep transient events isolated from Maple Desktop. Unresolved permissions are sent only to the connected ACP caller, and Buzz currently auto-selects `allow_once`.
 - Each ACP run has an isolated bounded event queue. If any event is dropped, Maple emits an explicit terminal error message and cancels the underlying run. It settles the already-admitted ACP turn without a JSON-RPC error because Buzz treats post-start agent errors as retryable and could otherwise repeat non-idempotent work; missed chunks are not reconstructed.
-- Maple applies connection-wide backpressure to streamed `session/update` notifications: at most 256 updates and roughly 4 MiB may be in flight, and credit returns only after the complete line is written to the real local socket. A stalled client therefore blocks the adapter and eventually trips the core run's bounded event queue instead of growing the ACP dependency's internal notification queues. A single update larger than the byte limit is rejected and cancels that run. Ordinary JSON-RPC responses still bypass this Maple tracker and use `agent-client-protocol` 1.0.1's internally unbounded outgoing path, so a general release would still need an upstream bounded transport API or a request-admission limit; the validated same-user Buzz configuration uses parallelism `1`.
+- Maple applies connection-wide admission to streamed `session/update` notifications and outbound permission requests: at most 256 admitted events and roughly 4 MiB may be in flight. Notification credit returns after the complete line is written to the real local socket; permission-request credit remains held until the caller responds or the connection closes, including after local turn cancellation. A stalled client therefore backpressures the adapter instead of accumulating permission frames or orphaned SDK correlations. A single oversized update or request is rejected and cancels that run. Ordinary JSON-RPC responses still use `agent-client-protocol` 1.0.1's internal outgoing path.
 - An idle same-user socket can occupy the default one-connection limit; there is no initialization or idle timeout yet.
 - Disconnecting keeps the Maple task, but ACP cannot reload it. Repeated connections can accumulate `Buzz ACP` tasks.
-- Permission, root, and maximum-connection policy changes are rejected while the listener is running.
+- Root and maximum-connection policy changes are rejected while the listener is running.
 - The UI polls service status instead of subscribing to lifecycle events.
-- There is no checked-in wire-level, socket-lifecycle, reconnect, permission, or Buzz GUI integration fixture yet.
+- Permission mapping and ownership have focused unit coverage, but there is no checked-in full wire-level, socket-lifecycle, reconnect, or Buzz GUI integration fixture yet.
 - The adapter intentionally omits much of Goose's ACP event and capability surface.
 
 ## Maintenance recommendation
@@ -264,7 +276,7 @@ Before broadening the local adapter, the preferred path is to pursue reusable Go
 1. construct ACP around existing `AgentManager`, `SessionManager`, and `PermissionManager` handles;
 2. use an injectable provider resolver for new, restored, and reconfigured sessions;
 3. add host session-admission, activation, prompt-preparation, and cleanup hooks;
-4. make permission routing pluggable between the host UI, ACP client, or a hybrid policy;
+4. accept an invocation-scoped permission responder so the host can bind each run to exactly one calling surface;
 5. let a host preserve its installed developer/tool clients;
 6. support transient ACP-provided session context with explicit cleanup;
 7. extract the Goose-event-to-ACP projection for use without runtime ownership; and

--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -141,7 +141,7 @@ flowchart LR
     Service --> Goose["embedded Goose runtime"]
 ```
 
-Tauri remains a thin projection of the existing Desktop contract: the original command names, arguments, result DTOs, `agent-event` envelopes, and frontend Agent Mode behavior are unchanged. ACP independently projects the same service operations and run events into ACP requests, notifications, and stop reasons. Socket ownership, protocol negotiation, connection leases, and `BUZZ_*` parsing remain adapter concerns.
+Tauri remains a thin projection of the Desktop contract: the original command names, arguments, and `agent-event` envelopes are unchanged. Stop and restart now return a small host-lifecycle outcome containing the authoritative runtime status plus any ACP cleanup warning; the frontend unwraps it without changing normal Agent Mode behavior. ACP independently projects the same service operations and run events into ACP requests, notifications, and stop reasons. Socket ownership, protocol negotiation, connection leases, and `BUZZ_*` parsing remain adapter concerns.
 
 This keeps Maple's domain model a useful superset instead of forcing Maple, Tauri, and ACP into exact wire parity. Neither adapter calls through the other, and the core service imports no Tauri or ACP types.
 
@@ -165,7 +165,7 @@ The macOS/Linux desktop settings page is intentionally manual. It can:
 - show protocol, endpoint, and Buzz credential diagnostics; and
 - warn that Buzz's default parallelism must be reduced to Maple's current default of one connection.
 
-Maple stops ACP before logout, local Agent-data clearing, Agent-runtime stop or restart, application update restart, and application exit. A saved `enabled` value does not auto-start ACP on the next launch; the user must explicitly start it again.
+Maple's composite host lifecycle attempts ACP shutdown before Agent-runtime stop or restart, and it always attempts the core runtime operation even if ACP cleanup reports an error. Desktop receives both the authoritative runtime result and any ACP cleanup warning, so it can resynchronize successful runtime changes while logout and credential cleanup still fail closed. Local Agent-data/history clearing remains stricter: it proceeds only after ACP has stopped successfully. Application update restart and exit also report failure if either surface cannot shut down. A saved `enabled` value does not auto-start ACP on the next launch; the user must explicitly start it again.
 
 Allowed-root and maximum-connection changes require Stop, then change and save, then Start. This prevents a new session from racing a policy update and retaining the previous policy.
 

--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -13,7 +13,7 @@ flowchart LR
     Connector["maple acp\nstdio connector"]
     Socket["owner-only\nUnix socket"]
     Adapter["Maple ACP adapter"]
-    Runtime["Maple Agent runtime facade"]
+    Runtime["MapleAgentService\nAgentRuntimeHandle"]
     Goose["embedded Goose AgentManager"]
     Provider["MapleProvider + MapleApiSession"]
     Tools["Maple developer, web, and skills clients"]
@@ -118,20 +118,41 @@ Two ACP v1 baseline caveats are worth making explicit: agents must accept `Resou
 
 None of the `No` rows blocks the tested Buzz harness. That Buzz build does not call list/load/resume/fork/close, tolerates absent model/config options by using the agent default, and falls back from native steering to cancel-and-merge. Initial `tool_call` notifications would improve Buzz Desktop visibility and reset its idle watchdog during long tools. Standard usage would improve observability, while durable turn metrics currently rely on a Goose-private notification. Its signed channel reply remains a separate tool/CLI path.
 
-## Runtime facade
+## Maple-owned runtime service
 
-The integration exposes a small non-UI interface around Maple Agent's existing runtime:
+The refactor exposes a transport-neutral Maple service around the existing embedded runtime:
 
 - ensure the account-scoped runtime exists;
 - create and delete a Maple task;
 - send and cancel a run;
-- subscribe to Maple Agent events;
-- observe a retained terminal result even if the bounded event stream lags; and
+- consume an isolated, bounded event stream for one exact run;
+- observe a retained terminal result when a run stream closes normally; and
 - install and revoke per-session tool environments.
 
-These are useful host capabilities independent of ACP. Protocol types remain in the ACP adapter rather than becoming Maple Agent domain types.
+These are useful host capabilities independent of ACP. Protocol types remain in the ACP adapter rather than becoming Maple Agent domain types. The service owns account and shutdown admission fences, atomic session creation plus transient tool context, one active run per session, cancellation, cleanup, typed warnings/errors, and an ordered per-run event stream with a retained terminal result.
+
+```mermaid
+flowchart LR
+    UI["Maple UI"] --> Tauri["Tauri command and event projector"]
+    ACP["ACP clients"] --> Adapter["ACP adapter and Buzz compatibility"]
+    Tauri --> Service["MapleAgentService\ntyped operations, leases, and per-run events"]
+    Adapter --> Service
+    Service --> Goose["embedded Goose runtime"]
+```
+
+Tauri remains a thin projection of the existing Desktop contract: the original command names, arguments, result DTOs, `agent-event` envelopes, and frontend Agent Mode behavior are unchanged. ACP independently projects the same service operations and run events into ACP requests, notifications, and stop reasons. Socket ownership, protocol negotiation, connection leases, and `BUZZ_*` parsing remain adapter concerns.
+
+This keeps Maple's domain model a useful superset instead of forcing Maple, Tauri, and ACP into exact wire parity. Neither adapter calls through the other, and the core service imports no Tauri or ACP types.
 
 ## Lifecycle and desktop configuration
+
+The Agent connections settings surface is fail-closed and hidden by default. To expose it in a macOS or Linux Tauri Desktop development build, set the local Vite override in `frontend/.env.local` (or the build environment) and restart the frontend dev server:
+
+```dotenv
+VITE_FORCE_FEATURE_FLAGS=agent_connections
+```
+
+This preview gate uses only the local `VITE_FORCE_FEATURE_FLAGS` override; the remote feature-flag service cannot enable it. Web, mobile, and Windows builds keep both the navigation item and direct route unavailable even when the override is present.
 
 The macOS/Linux desktop settings page is intentionally manual. It can:
 
@@ -145,7 +166,7 @@ The macOS/Linux desktop settings page is intentionally manual. It can:
 
 Maple stops ACP before logout, local Agent-data clearing, Agent-runtime stop or restart, application update restart, and application exit. A saved `enabled` value does not auto-start ACP on the next launch; the user must explicitly start it again.
 
-Permission-mode changes require Stop, then change and save, then Start. This prevents a new session from racing a restrictive policy update and retaining the previous policy.
+Permission-mode, allowed-root, and maximum-connection changes require Stop, then change and save, then Start. This prevents a new session from racing a policy update and retaining the previous policy.
 
 ## Permissions are policy, not confinement
 
@@ -168,9 +189,11 @@ Maple and Buzz credentials follow different paths:
 - Buzz relay credentials begin in the Buzz-owned connector process. The connector sends an internal `_maple/bridge/hello` notification over the local socket before normal ACP traffic.
 - The bridge filters to five `BUZZ_*` variables plus `PATH`, rejects null bytes, and rejects values over 16 KiB.
 - Filtered values remain in the ACP connection's in-memory context and are copied into per-session tool context. Session installation revalidates the six-key allowlist and enforces the 16-KiB-per-value and 32-KiB-total bounds.
-- The context is revoked during session and connection cleanup. Credential-bearing shell process trees are terminated after each command to limit descendant retention.
+- The context is revoked during session and connection cleanup. Credential-bearing shells terminate their Unix process group or Windows Job Object immediately after each command to limit descendant retention. Forced async-task shutdown uses the same containment handle.
 
 This design keeps Buzz credentials out of saved harness JSON, Maple configuration, argv, and Maple's process-global environment. It does **not** make the credentials invisible to the trusted agent or commands it runs. The shell needs the signing identity to publish a durable Buzz reply, and a command with that environment can inspect or transmit it. `allow_all` should therefore be enabled only for trusted clients, prompts, projects, and toolchains.
+
+Unix process groups are not a complete sandbox: a command can deliberately call `setsid` or otherwise move a descendant into another process group before cleanup. Windows Job Objects provide stronger descendant containment. A hard Maple process crash or `SIGKILL` also bypasses Maple's in-process cleanup on both platforms, so a surviving descendant may retain an already copied credential. A portable hard credential boundary would require keeping the Buzz signing key out of arbitrary shell environments and exposing only a revocable Maple-owned broker or dedicated tool; that is outside this preview.
 
 Credential-bearing Buzz shell execution fails closed inside Flatpak. Host-executable Linux packaging and socket behavior still require end-to-end validation.
 
@@ -210,11 +233,12 @@ The second run took roughly two to three minutes and ended with zero active runs
 - macOS is the only platform validated end to end.
 - Windows, mobile, and web are unsupported; non-Flatpak Linux remains unvalidated.
 - Service activation is manual after every Maple launch.
-- The local-approval mode can leave an unattended Buzz task waiting for approval in Maple.
-- Intermediate ACP output can be truncated if Maple's shared bounded event bus lags; terminal state is retained, but missed chunks are not reconstructed.
+- The local-approval mode publishes the ACP task and permission cards to Maple Desktop, which remains the authoritative approval broker. An unattended Buzz task can therefore wait for approval in Maple.
+- Each ACP run has an isolated bounded event queue. If any event is dropped, Maple emits an explicit terminal error message and cancels the underlying run. It settles the already-admitted ACP turn without a JSON-RPC error because Buzz treats post-start agent errors as retryable and could otherwise repeat non-idempotent work; missed chunks are not reconstructed.
+- Maple applies connection-wide backpressure to streamed `session/update` notifications: at most 256 updates and roughly 4 MiB may be in flight, and credit returns only after the complete line is written to the real local socket. A stalled client therefore blocks the adapter and eventually trips the core run's bounded event queue instead of growing the ACP dependency's internal notification queues. A single update larger than the byte limit is rejected and cancels that run. Ordinary JSON-RPC responses still bypass this Maple tracker and use `agent-client-protocol` 1.0.1's internally unbounded outgoing path, so a general release would still need an upstream bounded transport API or a request-admission limit; the validated same-user Buzz configuration uses parallelism `1`.
 - An idle same-user socket can occupy the default one-connection limit; there is no initialization or idle timeout yet.
 - Disconnecting keeps the Maple task, but ACP cannot reload it. Repeated connections can accumulate `Buzz ACP` tasks.
-- Live changes to the configured maximum do not resize a listener that is already running.
+- Permission, root, and maximum-connection policy changes are rejected while the listener is running.
 - The UI polls service status instead of subscribing to lifecycle events.
 - There is no checked-in wire-level, socket-lifecycle, reconnect, permission, or Buzz GUI integration fixture yet.
 - The adapter intentionally omits much of Goose's ACP event and capability surface.

--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -1,0 +1,249 @@
+# Agent Mode ACP harness preview
+
+This document describes Maple's experimental Agent Client Protocol (ACP) surface. The first tested consumer is [Buzz](https://github.com/block/buzz), but the architectural boundary is Maple-owned: external harnesses adapt into Maple's existing Agent Mode runtime rather than starting a second Goose runtime.
+
+ACP is not Maple Agent's primary internal abstraction. Maple continues to embed Goose directly. The preview exists to answer a narrower question: can another local application control the real, signed-in Maple Agent through a standard agent protocol?
+
+## Architecture
+
+```mermaid
+flowchart LR
+    Buzz["Buzz Desktop"]
+    Harness["Buzz ACP harness"]
+    Connector["maple acp\nstdio connector"]
+    Socket["owner-only\nUnix socket"]
+    Adapter["Maple ACP adapter"]
+    Runtime["Maple Agent runtime facade"]
+    Goose["embedded Goose AgentManager"]
+    Provider["MapleProvider + MapleApiSession"]
+    Tools["Maple developer, web, and skills clients"]
+    BuzzCli["Buzz CLI"]
+
+    Buzz --> Harness
+    Harness -->|"ACP v1 over stdio"| Connector
+    Connector --> Socket
+    Socket --> Adapter
+    Adapter --> Runtime
+    Runtime --> Goose
+    Goose --> Provider
+    Goose --> Tools
+    Tools -->|"session-scoped BUZZ_* environment"| BuzzCli
+    BuzzCli --> Buzz
+```
+
+The packaged executable has two entry paths:
+
+- Normal invocation launches Maple Desktop.
+- `maple acp` connects standard input/output to the already-running desktop process.
+
+Buzz owns the subprocess and supplies its relay context there. Maple Desktop owns authentication, the account-scoped provider, Goose managers, tasks, tools, permission policy, runs, and UI events. The connector sends no inference request itself and does not initialize a second agent runtime.
+
+The executable path is part of the socket name. This keeps an installed Maple build and independent development builds from accidentally sharing an ACP endpoint.
+
+## Why Goose ACP is not used directly
+
+Goose already implements a much broader ACP server, including a reusable byte-stream transport. At Maple's pinned Goose revision, however, `GooseAcpAgent::new` creates and owns fresh session, permission, and agent managers and reads Goose's global configuration. Its public construction path cannot attach the ACP projection to Maple's existing managers.
+
+Starting `goose acp`, enabling `goose serve`, or constructing a `GooseAcpAgent` after Maple initializes would therefore create a second runtime:
+
+```mermaid
+flowchart TB
+    subgraph Separate["Standalone Goose ACP path"]
+        ClientA["ACP client"] --> GooseAcp["new GooseAcpAgent"]
+        GooseAcp --> ManagersA["new managers, config, tools, and permissions"]
+    end
+
+    subgraph MaplePath["Required Maple path"]
+        ClientB["ACP client"] --> MapleAcp["Maple ACP adapter"]
+        MapleAcp --> ManagersB["existing account-scoped Maple runtime"]
+        ManagersB --> Auth["in-memory authenticated Maple provider"]
+        ManagersB --> MapleTools["Maple tools, policy, tasks, and UI events"]
+    end
+```
+
+A provider factory alone is insufficient. Maple also needs to preserve:
+
+- its authenticated `MapleApiSession` and caller-owned `MapleProvider`;
+- account-scoped session storage and lifecycle fencing;
+- model locking and session restoration behavior;
+- `MapleDeveloperClient`, Maple web tools, and trust-filtered skills;
+- Maple-local permission classification and approval UI;
+- run cancellation, retained terminal state, and desktop timeline events; and
+- ephemeral per-session tool context supplied by the external harness.
+
+Sharing a data directory between two managers would not make them one runtime and would introduce conflicting in-memory ownership. The preview therefore uses the standard `agent-client-protocol` crate for a deliberately narrow mapping into Maple-owned operations.
+
+## Current protocol surface
+
+`No` means "not implemented by this preview," not "fundamentally impossible." Effort is relative to the current branch:
+
+- **Low** is primarily ACP dispatch or projection over an existing Maple operation.
+- **Medium** adds an account-scoped Maple runtime-facade operation, richer event contract, or lifecycle tests.
+- **High** changes a security/product boundary or needs a broader structured-content/runtime abstraction. High does not necessarily imply a Buzz or Goose fork.
+
+Goose already implements many of these semantics, but at Maple's pinned revision its history replayer, response builders, tool converters, permission mapping, usage mapping, and handlers are private or `pub(crate)` and operate on concrete `GooseAcpAgent` state. Maple can port that behavior, or Goose could extract it, but Maple cannot currently plug its host-owned runtime into those handlers.
+
+| ACP operation or capability                | Preview support | Remaining effort                  | Feasibility and limiting layer                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------ | --------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `initialize`                               | Yes             | Implemented                       | Negotiates ACP v1 and deliberately advertises only the narrow implemented capability set. New capabilities should be advertised only with their handlers and wire tests.                                                                                                                                                                                                                                                                                                                                                                                    |
+| `session/new`                              | Yes             | Implemented                       | Requires an absolute `cwd` and creates a real Maple task. Optional additional workspace directories and generic ACP-provided MCP servers are graded separately below.                                                                                                                                                                                                                                                                                                                                                                                       |
+| Additional workspace directories           | No              | Medium                            | Supportable, but Maple currently has a single-root task and Skills-trust model. Correct support needs canonical admission against the configured roots, an explicit per-session root set, tool and Skills semantics for those roots, and consistent persistence/reporting across list, load, resume, and fork. This is a Maple workspace-model change, not a Goose loop limitation.                                                                                                                                                                         |
+| `session/prompt` text                      | Yes             | Implemented                       | Accepts text blocks and permits one active prompt per session. Text annotations are not currently preserved.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
+| `session/update` text and thought          | Partial         | Low–Medium                        | Assistant text and thought chunks are projected. Maple could incrementally add actual ACP variants such as user chunks, plans, available commands, modes/config, and session info. Full Goose fidelity is the sum of the richer tool, usage, and media rows below; Goose's mature projector cannot currently be called independently of `GooseAcpAgent`.                                                                                                                                                                                                    |
+| `session/cancel`                           | Yes             | Implemented                       | Cancels Maple's underlying run and retains its terminal state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| `session/list`                             | No              | Low                               | Supportable without rearchitecture. Maple already lists account-scoped persisted tasks and can filter by `cwd`. The adapter needs ACP field mapping and pagination plus a policy decision: may a same-user ACP client enumerate all Desktop tasks, or only ACP-created tasks? Restricting by origin would first require durable provenance because preview tasks are ordinary Maple user tasks.                                                                                                                                                             |
+| `session/resume`                           | No              | Medium                            | Supportable. Attach an existing same-account task without replay, validate its `cwd`, allowed roots, and active-run state, preserve its persisted model, and restore Maple provider/tool/permission state plus the current connection's transient environment. A service-global session lease is needed so two ACP clients cannot overwrite one task's credentials or tool context. This is a Maple lifecycle seam, not an agent-loop redesign.                                                                                                             |
+| `session/load`                             | No              | Medium–High                       | Supportable. This is resume plus the protocol-required ordered replay before responding. Maple already loads a normalized timeline; faithful replay needs a separate ACP history projection for user/assistant/thought/tool rows, stable tool correlation, bounded content, and explicit treatment of media that Maple's UI timeline omits. Goose's existing replayer is useful upstream code to extract, but its activation path owns concrete Goose managers.                                                                                             |
+| `session/close`                            | No              | Low–Medium                        | Supportable. Cancel active work, revoke connection-scoped credentials, release ACP ownership, and detach/unload only what ACP owns while preserving the persisted Maple task. The main work is race-safe cleanup without disrupting the same task if Maple Desktop is using it.                                                                                                                                                                                                                                                                             |
+| `session/delete`                           | No              | Low code; high policy             | Maple already has a deletion operation, so the handler is straightforward. The product decision is consequential: whether ACP may destroy Desktop history, whether deletion is limited to ACP-created tasks, and whether an explicit opt-in is required.                                                                                                                                                                                                                                                                                                    |
+| `session/fork`                             | No              | Medium                            | Goose's underlying `SessionManager` already has copy primitives, and its ACP implementation shows copy, optional truncation, and activation. Maple needs an account-scoped wrapper, root/policy validation, fresh transient context, activation, and rollback for partial failures. ACP fork is still unstable, so enabling it also accepts an unstable wire commitment; no Goose fork is otherwise required.                                                                                                                                               |
+| Session mode                               | No              | Medium                            | Maple already changes per-session permission mode. ACP support needs advertised mode state, a handler, update projection, and an explicit rule about whether a client may select unattended approval. This is principally a Maple trust-policy decision.                                                                                                                                                                                                                                                                                                    |
+| Model selection and other config           | No              | Medium–High                       | A Maple model option is feasible before the first prompt using Maple's authenticated catalog. Maple intentionally locks a task's model once it has history, so arbitrary mid-session switching should be rejected or treated as a product change. The native ACP path also needs authoritative vision/context metadata. Goose's config builder cannot be reused because it assumes Goose's global provider inventory rather than Maple's caller-owned `MapleProvider`; provider switching should remain out of scope.                                       |
+| ACP permission requests                    | No              | High                              | Technically supportable, but it changes the trust boundary. Maple already exposes pending one-shot decisions and can feed a response back to Goose. It would need exactly one authoritative broker per session—Maple UI, ACP client, or a deliberately designed hybrid—plus timeout, disconnect, cancellation, and double-response handling. The tested Buzz build automatically chooses `allow_once` for forwarded requests, so delegation would materially weaken the current local-approval boundary. Goose's mapping is not an injectable broker.       |
+| Basic structured tool calls and results    | No              | Low–Medium                        | Maple's timeline already carries stable IDs, title, input, output, status, and errors, which is enough for ordinary ACP `ToolCall` and `ToolCallUpdate` cards. This is mostly projection work. Buzz also treats the initial `tool_call` notification as activity, so projecting tool-call start would reset its idle watchdog during a long otherwise-silent tool, improving liveness as well as UI visibility.                                                                                                                                             |
+| Rich tool/resource/location/MCP projection | No              | Medium–High                       | Rich image/resource content, file locations, progressive MCP notifications, and faithful replay need data below Maple's deliberately summarized UI timeline. A public transport-neutral Goose `AcpEventProjector` would avoid maintaining this nuanced mapping twice.                                                                                                                                                                                                                                                                                       |
+| Terminal and diff parity                   | No              | Medium–High; architectural choice | Goose's terminal handles and diff updates are not projection alone: its ACP filesystem layer replaces/delegates developer operations through ACP-client filesystem and terminal RPCs. Maple currently executes its own local tools. Maple would need either to synthesize bounded metadata from those results or delegate execution to the client, which would change its tool and permission architecture; an event projector by itself is insufficient.                                                                                                   |
+| Usage and context updates                  | No              | Medium                            | Supportable. Goose emits and persists usage, but Maple currently discards ephemeral usage notifications before its public event stream. Maple must retain a protocol-neutral usage event or query post-turn totals, pair usage with the persisted context limit, and define cumulative semantics. ACP cost is optional and should remain absent until it matches Maple billing semantics. Buzz can display standard usage for observability, but its durable turn-accounting path currently consumes a Goose-private cumulative-usage notification instead. |
+| Prompt images                              | No              | Medium                            | The embedded Goose message model and `MapleProvider` already carry images. Maple's non-UI send facade is text-only and ACP forces `vision_capable: false`; support needs structured prompt input, MIME/base64/size limits, native model-capability resolution, and replay/UI policy. This is mainly a Maple facade change.                                                                                                                                                                                                                                  |
+| Prompt audio                               | No              | High                              | Native audio is not a small adapter change. Pinned Goose has no audio message variant and its ACP conversion ignores audio. Maple could define a transcription-to-text pipeline, but native multimodal audio requires a Goose/provider/message abstraction change. This is the clearest current Goose-level content limitation.                                                                                                                                                                                                                             |
+| Embedded text resources                    | No              | Low–Medium                        | Supportable by flattening bounded content into a clearly labeled, untrusted prompt block while preserving URI/provenance metadata.                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| Embedded binary resources                  | No              | Medium–High                       | Known image or document types could use explicit Maple ingestion paths. Arbitrary blobs have no generic model-facing representation and need type, decoding, size, staging, persistence, and rejection rules.                                                                                                                                                                                                                                                                                                                                               |
+| Resource links                             | No              | Medium–High                       | Supportable with policy work, and currently a baseline ACP v1 gap because resource links have no opt-out capability. Local and remote links need separate scheme, root, symlink, size, encoding, permission, and provenance rules so prompt ingress cannot bypass Maple's filesystem/web controls. Goose's private helper only performs an unbounded local `file://` text read, which Maple should not copy literally.                                                                                                                                      |
+| Arbitrary ACP-provided MCP servers         | No              | High                              | Technically supportable, but production-safe support expands a code-execution and secret boundary. Maple must validate client-supplied commands, URLs, headers, and environments; define authorization and name-collision rules; attach them transiently without persisting secrets; and guarantee per-session process cleanup across close, disconnect, crash, and Flatpak constraints. Generic stdio MCP is an ACP v1 baseline, so the current Buzz-only adaptation is a real conformance gap.                                                            |
+| Goose/Buzz native steering                 | No              | Medium code; high coupling        | Supportable but intentionally non-standard. Buzz uses `_goose/unstable/session/steer`, not an ACP v1 method. Goose's underlying `Agent::steer` queue is public; Maple needs an active-agent/run facade, `expectedRunId` validation, correlation updates, and prompt-end/cancel race tests. Buzz's cancel-and-merge fallback means this is not required for the tested flow, and adopting it would couple Maple to an unstable extension.                                                                                                                    |
+
+This is parity for the tested Maple task path, not parity with Goose's complete ACP implementation.
+
+Two ACP v1 baseline caveats are worth making explicit: agents must accept `ResourceLink` prompt blocks and stdio MCP definitions. The preview handles neither generically. The tested Buzz custom-harness path uses text prompts and does not depend on arbitrary MCP definitions; Maple also contains one exact Buzz compatibility adaptation. Image, audio, and embedded-resource capabilities are correctly advertised as unavailable.
+
+None of the `No` rows blocks the tested Buzz harness. That Buzz build does not call list/load/resume/fork/close, tolerates absent model/config options by using the agent default, and falls back from native steering to cancel-and-merge. Initial `tool_call` notifications would improve Buzz Desktop visibility and reset its idle watchdog during long tools. Standard usage would improve observability, while durable turn metrics currently rely on a Goose-private notification. Its signed channel reply remains a separate tool/CLI path.
+
+## Runtime facade
+
+The integration exposes a small non-UI interface around Maple Agent's existing runtime:
+
+- ensure the account-scoped runtime exists;
+- create and delete a Maple task;
+- send and cancel a run;
+- subscribe to Maple Agent events;
+- observe a retained terminal result even if the bounded event stream lags; and
+- install and revoke per-session tool environments.
+
+These are useful host capabilities independent of ACP. Protocol types remain in the ACP adapter rather than becoming Maple Agent domain types.
+
+## Lifecycle and desktop configuration
+
+The macOS/Linux desktop settings page is intentionally manual. It can:
+
+- start and stop the local service;
+- select the policy applied to newly created ACP sessions;
+- show connected client, session, and active-run counts;
+- copy the exact packaged executable path and `acp` argument;
+- copy a Buzz custom-harness definition;
+- show protocol, endpoint, and Buzz credential diagnostics; and
+- warn that Buzz's default parallelism must be reduced to Maple's current default of one connection.
+
+Maple stops ACP before logout, local Agent-data clearing, Agent-runtime stop or restart, application update restart, and application exit. A saved `enabled` value does not auto-start ACP on the next launch; the user must explicitly start it again.
+
+Permission-mode changes require Stop, then change and save, then Start. This prevents a new session from racing a restrictive policy update and retaining the previous policy.
+
+## Permissions are policy, not confinement
+
+The persisted protocol-facing values currently have these meanings:
+
+- `read_only` means **require local approvals**. Maple maps it to its `smart_approve` path. A write-capable action can still occur after the user approves it in Maple Desktop.
+- `allow_all` is unattended operation. The agent may run commands, modify files, and perform external actions without a second local confirmation.
+
+Neither mode is an operating-system sandbox.
+
+Native configuration supports a list of allowed project roots, but the preview UI does not expose it. An empty list accepts any absolute session working directory available to the Maple process. Even a configured root checks session admission, not every path later accessed by a read, edit, or shell tool. Do not describe this as filesystem confinement.
+
+## Local trust and credentials
+
+The Unix socket is mode `0600`; the Linux runtime directory is owner-checked and mode `0700`. There is no second application-level client credential. While the service is enabled, any process running as the same OS user and able to reach that endpoint is inside the local trust boundary and can use the signed-in Maple Agent.
+
+Maple and Buzz credentials follow different paths:
+
+- Maple access credentials stay inside Maple Desktop's authenticated provider session. They are not written to the ACP harness, command arguments, or child environment.
+- Buzz relay credentials begin in the Buzz-owned connector process. The connector sends an internal `_maple/bridge/hello` notification over the local socket before normal ACP traffic.
+- The bridge filters to five `BUZZ_*` variables plus `PATH`, rejects null bytes, and rejects values over 16 KiB.
+- Filtered values remain in the ACP connection's in-memory context and are copied into per-session tool context. Session installation revalidates the six-key allowlist and enforces the 16-KiB-per-value and 32-KiB-total bounds.
+- The context is revoked during session and connection cleanup. Credential-bearing shell process trees are terminated after each command to limit descendant retention.
+
+This design keeps Buzz credentials out of saved harness JSON, Maple configuration, argv, and Maple's process-global environment. It does **not** make the credentials invisible to the trusted agent or commands it runs. The shell needs the signing identity to publish a durable Buzz reply, and a command with that environment can inspect or transmit it. `allow_all` should therefore be enabled only for trusted clients, prompts, projects, and toolchains.
+
+Credential-bearing Buzz shell execution fails closed inside Flatpak. Host-executable Linux packaging and socket behavior still require end-to-end validation.
+
+## Buzz compatibility behavior
+
+The wire surface is standard ACP v1, but this first adapter includes explicit Buzz compatibility:
+
+- the private bridge hello for subprocess environment transfer;
+- the Buzz relay variable allowlist;
+- recognition of a narrowly shaped absolute `buzz-dev-mcp` stdio definition: matching server name and executable basename, no arguments, and an existing executable file;
+- adaptation of that environment into Maple's existing developer shell instead of launching a second general-purpose shell server;
+- a `Buzz ACP` Maple task title;
+- custom-harness JSON and parallelism guidance in settings.
+
+If this integration is maintained, these concerns should move behind an explicit Buzz adapter rather than expanding Maple's protocol-neutral runtime facade.
+
+## End-to-end proof
+
+The exploratory validation used:
+
+- Maple with Goose pinned to `c3111c71cd682ed1d115741677f0ca9946c51499`;
+- Buzz commit `3a4bf513df0e0c258587bfcbed9463d63723b56b`;
+- a packaged arm64 macOS Maple development app;
+- ACP v1;
+- Buzz owner-only channel admission and parallelism `1`; and
+- Maple's unattended `allow_all` policy.
+
+Two Buzz GUI tasks completed:
+
+1. A deterministic mention returned exactly `MAPLE-GUI-OK`.
+2. A mention asked Maple to read the checkout's real `README.md` and explain the project. Maple used its local file tools and posted a substantive Buzz reply covering the Tauri/Bun architecture, platforms, TTS, PDF OCR, signing and updates, development prerequisites, and platform-specific setup notes.
+
+The second run took roughly two to three minutes and ended with zero active runs. That timing has not been profiled and should not be attributed to ACP. The result is manual compatibility evidence, not a performance, load, conformance, billing, or security test.
+
+## Known limitations
+
+- macOS is the only platform validated end to end.
+- Windows, mobile, and web are unsupported; non-Flatpak Linux remains unvalidated.
+- Service activation is manual after every Maple launch.
+- The local-approval mode can leave an unattended Buzz task waiting for approval in Maple.
+- Intermediate ACP output can be truncated if Maple's shared bounded event bus lags; terminal state is retained, but missed chunks are not reconstructed.
+- An idle same-user socket can occupy the default one-connection limit; there is no initialization or idle timeout yet.
+- Disconnecting keeps the Maple task, but ACP cannot reload it. Repeated connections can accumulate `Buzz ACP` tasks.
+- Live changes to the configured maximum do not resize a listener that is already running.
+- The UI polls service status instead of subscribing to lifecycle events.
+- There is no checked-in wire-level, socket-lifecycle, reconnect, permission, or Buzz GUI integration fixture yet.
+- The adapter intentionally omits much of Goose's ACP event and capability surface.
+
+## Maintenance recommendation
+
+Keep Maple's primary path direct:
+
+```text
+Maple UI -> Maple runtime -> embedded Goose -> MapleProvider
+```
+
+Keep ACP at the edge:
+
+```text
+External harness -> ACP adapter -> Maple runtime facade
+```
+
+Maintaining the bounded adapter is reasonable if Buzz or other external harnesses are strategically useful. Maple should not duplicate Goose's full ACP feature set speculatively, refactor primary Agent Mode around ACP, or fork Goose solely for this preview.
+
+Before broadening the local adapter, the preferred path is to pursue reusable Goose seams:
+
+1. construct ACP around existing `AgentManager`, `SessionManager`, and `PermissionManager` handles;
+2. use an injectable provider resolver for new, restored, and reconfigured sessions;
+3. add host session-admission, activation, prompt-preparation, and cleanup hooks;
+4. make permission routing pluggable between the host UI, ACP client, or a hybrid policy;
+5. let a host preserve its installed developer/tool clients;
+6. support transient ACP-provided session context with explicit cleanup;
+7. extract the Goose-event-to-ACP projection for use without runtime ownership; and
+8. remove global configuration and path assumptions from the embedded path.
+
+Even with those changes, the small `maple acp` connector and local IPC boundary would remain: stdio and the Buzz-owned environment live in a spawned process, while Maple authentication lives in the running desktop process.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -2,5 +2,7 @@
 VITE_CLIENT_ID=ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
 #VITE_OS_FLAGS_BASE_URL=https://flags-dev.opensecret.cloud
+# Comma-separated local preview flags. Agent connections supports macOS/Linux desktop only.
+#VITE_FORCE_FEATURE_FLAGS=agent_connections
 #VITE_MAPLE_BILLING_API_URL=http://127.0.0.1:3001
 #VITE_DEV_MODEL_OVERRIDE=gpt-4o

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4581,6 +4581,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 name = "maple"
 version = "3.3.2"
 dependencies = [
+ "agent-client-protocol",
  "anyhow",
  "async-trait",
  "axum",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ tauri-plugin-single-instance = { version = "=2.4.0", features = ["deep-link"] }
 tauri-plugin-opener = "2.5.4"
 tauri-plugin-os = "2.3.2"
 tauri-plugin-sign-in-with-apple = "1.0.2"
-tokio = { version = "1.0", features = ["io-util", "net", "process", "sync", "rt-multi-thread", "macros", "time"] }
+tokio = { version = "1.0", features = ["io-std", "io-util", "net", "process", "sync", "rt-multi-thread", "macros", "time"] }
 once_cell = "1.18.0"
 maple-proxy = "0.2.0"
 tauri-plugin-fs = "2.5.1"
@@ -64,7 +64,8 @@ rand = "0.8.6"
 async-trait = "0.1"
 rmcp = { version = "=1.4.0", default-features = false }
 tauri-plugin-dialog = "2.7.1"
-tokio-util = { version = "0.7", features = ["codec", "io"] }
+tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
+agent-client-protocol = { version = "=1.0.1", default-features = false }
 httpdate = "1"
 process-wrap = { version = "=9.1.0", default-features = false, features = ["tokio1", "creation-flags", "job-object", "process-group"] }
 pulldown-cmark = { version = "0.13", default-features = false }

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -41,7 +41,7 @@ use std::str::FromStr;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Emitter, Manager, State};
+use tauri::{AppHandle, Manager, State};
 use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 use web_permission::{
@@ -56,7 +56,7 @@ const DEFAULT_GOOSE_MODE: &str = "smart_approve";
 // Keep Goose on its ActionRequired path so Maple can apply the currently selected
 // policy at every tool boundary, including when the user changes it mid-run.
 const GOOSE_PERMISSION_ROUTING_MODE: GooseMode = GooseMode::SmartApprove;
-const AGENT_EVENT_NAME: &str = "agent-event";
+pub(crate) const AGENT_EVENT_NAME: &str = "agent-event";
 const MAPLE_DEVELOPER_TOOLS: [&str; 7] = [
     "read",
     "shell",
@@ -396,7 +396,7 @@ struct ActiveAgentRun {
     token: CancellationToken,
     session_id: String,
     cancelled_permission_ids: CancelledPermissionIds,
-    task_handle: tauri::async_runtime::JoinHandle<()>,
+    task_handle: tokio::task::JoinHandle<()>,
 }
 
 type PendingPermissionKey = (String, String);
@@ -434,15 +434,67 @@ impl AgentRuntime {
     }
 }
 
-pub struct AgentRuntimeState {
+#[derive(Clone)]
+pub(crate) struct AgentPathLayout {
+    config_root: PathBuf,
+    local_data_root: PathBuf,
+}
+
+impl AgentPathLayout {
+    pub(crate) fn from_app_roots(app_config_root: PathBuf, app_local_data_root: PathBuf) -> Self {
+        Self {
+            config_root: app_config_root.join("agent"),
+            local_data_root: app_local_data_root.join("agent"),
+        }
+    }
+}
+
+pub(crate) trait AgentEventSink: Send + Sync + 'static {
+    fn emit(&self, event: &AgentEventEnvelope);
+}
+
+#[derive(Clone)]
+struct AgentEventDispatcher {
+    sender: broadcast::Sender<AgentEventEnvelope>,
+    sink: Arc<dyn AgentEventSink>,
+}
+
+impl AgentEventDispatcher {
+    fn new(sink: Arc<dyn AgentEventSink>) -> Self {
+        let (sender, _) = broadcast::channel(AGENT_EVENT_BROADCAST_CAPACITY);
+        Self { sender, sink }
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct MapleAgentHostResources {
+    paths: AgentPathLayout,
+    events: AgentEventDispatcher,
+}
+
+impl MapleAgentHostResources {
+    pub(crate) fn new(paths: AgentPathLayout, event_sink: Arc<dyn AgentEventSink>) -> Self {
+        Self {
+            paths,
+            events: AgentEventDispatcher::new(event_sink),
+        }
+    }
+}
+
+pub struct MapleAgentService {
+    host: MapleAgentHostResources,
     inner: Arc<Mutex<Option<AgentRuntime>>>,
     runtime_lifecycle: Arc<Mutex<()>>,
     account_generations: Arc<Mutex<HashMap<String, u64>>>,
     session_lifecycle: Arc<Mutex<()>>,
     pending_permissions: PendingPermissions,
     live_timelines: LiveTimelines,
-    event_sender: broadcast::Sender<AgentEventEnvelope>,
 }
+
+// Temporary internal compatibility name while the Tauri command surface is
+// peeled away from the service implementation. New non-Tauri callers use the
+// concrete MapleAgentService name directly.
+type AgentRuntimeState = MapleAgentService;
 
 type LiveTimelines = Arc<Mutex<HashMap<String, LiveTimeline>>>;
 
@@ -478,17 +530,16 @@ impl LiveTimeline {
     }
 }
 
-impl AgentRuntimeState {
-    pub fn new() -> Self {
-        let (event_sender, _) = broadcast::channel(AGENT_EVENT_BROADCAST_CAPACITY);
+impl MapleAgentService {
+    pub(crate) fn new(host: MapleAgentHostResources) -> Self {
         Self {
+            host,
             inner: Arc::new(Mutex::new(None)),
             runtime_lifecycle: Arc::new(Mutex::new(())),
             account_generations: Arc::new(Mutex::new(HashMap::new())),
             session_lifecycle: Arc::new(Mutex::new(())),
             pending_permissions: Arc::new(Mutex::new(HashMap::new())),
             live_timelines: Arc::new(Mutex::new(HashMap::new())),
-            event_sender,
         }
     }
 }
@@ -498,7 +549,9 @@ pub(crate) fn subscribe_agent_events(
 ) -> broadcast::Receiver<AgentEventEnvelope> {
     app_handle
         .state::<AgentRuntimeState>()
-        .event_sender
+        .host
+        .events
+        .sender
         .subscribe()
 }
 
@@ -709,7 +762,7 @@ async fn stop_runtime_inner(
 }
 
 async fn join_agent_tasks(
-    mut task_handles: Vec<tauri::async_runtime::JoinHandle<()>>,
+    mut task_handles: Vec<tokio::task::JoinHandle<()>>,
     graceful_timeout: std::time::Duration,
 ) {
     let graceful = futures_util::future::join_all(task_handles.iter_mut());
@@ -877,7 +930,7 @@ async fn start_runtime_for_user(
         .await
         .map_err(|error| format!("Failed to validate Maple API authentication: {error}"))?;
 
-    let mut agent_config = load_agent_config_inner(&app_handle, &user_id)
+    let mut agent_config = load_agent_config_inner(&state.host.paths, &user_id)
         .map_err(|error| format!("Failed to load Agent config: {error}"))?;
     let request = request.unwrap_or(AgentStartRequest {
         project_root: None,
@@ -895,7 +948,7 @@ async fn start_runtime_for_user(
         .unwrap_or_else(|| DEFAULT_GOOSE_MODE.to_string());
     parse_user_permission_mode(&mode)?;
 
-    let config_dir = agent_config_dir(&app_handle, &user_id).map_err(|e| e.to_string())?;
+    let config_dir = agent_config_dir(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
     let goose_path_root = config_dir.join("goose");
     fs::create_dir_all(goose_path_root.join("data"))
         .map_err(|e| format!("Failed to create Goose data dir: {e}"))?;
@@ -907,7 +960,7 @@ async fn start_runtime_for_user(
     reset_maple_owned_permission_file(&goose_path_root.join("config").join("permission.yaml"))?;
 
     configure_embedded_goose(
-        &agent_root_dir(&app_handle)
+        &agent_root_dir(&state.host.paths)
             .map_err(|e| e.to_string())?
             .join("goose-runtime"),
         &model,
@@ -961,10 +1014,10 @@ async fn start_runtime_for_user(
     // here would incorrectly move that visible project to the top of the manual order.
     agent_config.default_project_root = Some(path_string(&project_root));
     agent_config.default_model = model;
-    let _ = save_agent_config_inner(&app_handle, &user_id, &agent_config);
+    let _ = save_agent_config_inner(&state.host.paths, &user_id, &agent_config);
 
     emit_agent_event(
-        &app_handle,
+        &state.host.events,
         AgentEventEnvelope {
             event_type: "runtimeStatus".to_string(),
             session_id: None,
@@ -1032,14 +1085,14 @@ pub async fn agent_clear_user_data(
     }
 
     let account_dir =
-        account_config_dir_path(&app_handle, &user_id).map_err(|error| error.to_string())?;
+        account_config_dir_path(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
     match fs::remove_dir_all(account_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
         Err(error) => return Err(format!("Failed to clear Agent Mode data: {error}")),
     }
-    let local_account_dir =
-        account_local_data_dir_path(&app_handle, &user_id).map_err(|error| error.to_string())?;
+    let local_account_dir = account_local_data_dir_path(&state.host.paths, &user_id)
+        .map_err(|error| error.to_string())?;
     match fs::remove_dir_all(local_account_dir) {
         Ok(()) => {}
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
@@ -1074,7 +1127,7 @@ pub async fn agent_clear_user_history(
     }
 
     let account_dir =
-        account_config_dir_path(&app_handle, &user_id).map_err(|error| error.to_string())?;
+        account_config_dir_path(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
     clear_agent_history(&account_dir)
         .map_err(|error| format!("Failed to clear Agent Mode history: {error}"))
 }
@@ -1089,7 +1142,7 @@ pub async fn agent_load_config(
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     ensure_account_generation(&state, &account_scope, generation).await?;
-    load_agent_config_inner(&app_handle, &user_id).map_err(|e| e.to_string())
+    load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1105,10 +1158,11 @@ pub async fn agent_save_config(
     ensure_account_generation(&state, &account_scope, generation).await?;
     // MCP definitions have a dedicated mutation command. Preserve them here so
     // a delayed project/model preference save cannot overwrite newer servers.
-    let mut next = load_agent_config_inner(&app_handle, &user_id).map_err(|e| e.to_string())?;
+    let mut next =
+        load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
     next.default_project_root = config.default_project_root;
     next.default_model = config.default_model;
-    save_agent_config_inner(&app_handle, &user_id, &next).map_err(|e| e.to_string())
+    save_agent_config_inner(&state.host.paths, &user_id, &next).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1121,7 +1175,7 @@ pub async fn agent_list_mcp_servers(
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     ensure_account_generation(&state, &account_scope, generation).await?;
-    let config = load_agent_config_inner(&app_handle, &user_id).map_err(|e| e.to_string())?;
+    let config = load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
     normalize_mcp_servers(config.mcp_servers)
 }
 
@@ -1137,9 +1191,10 @@ pub async fn agent_save_mcp_servers(
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     ensure_account_generation(&state, &account_scope, generation).await?;
     let servers = normalize_mcp_servers(servers)?;
-    let mut config = load_agent_config_inner(&app_handle, &user_id).map_err(|e| e.to_string())?;
+    let mut config =
+        load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
     config.mcp_servers = servers.clone();
-    save_agent_config_inner(&app_handle, &user_id, &config).map_err(|e| e.to_string())?;
+    save_agent_config_inner(&state.host.paths, &user_id, &config).map_err(|e| e.to_string())?;
 
     Ok(servers)
 }
@@ -1154,7 +1209,7 @@ pub async fn agent_list_recent_project_roots(
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     ensure_account_generation(&state, &account_scope, generation).await?;
-    load_recent_project_roots_inner(&app_handle, &user_id).map_err(|e| e.to_string())
+    load_recent_project_roots_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1170,16 +1225,16 @@ pub async fn agent_save_recent_project_root(
     ensure_account_generation(&state, &account_scope, generation).await?;
     let project_root = normalize_project_root(Path::new(&path))?;
     let mut config =
-        load_agent_config_inner(&app_handle, &user_id).map_err(|error| error.to_string())?;
+        load_agent_config_inner(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
     let canonical_path = path_string(&project_root);
     let restoring = config
         .removed_project_roots
         .iter()
         .any(|removed| removed == &canonical_path);
     let roots = if restoring {
-        restore_explicit_project_root_inner(&app_handle, &user_id, &project_root)
+        restore_explicit_project_root_inner(&state.host.paths, &user_id, &project_root)
     } else {
-        register_explicit_project_root_inner(&app_handle, &user_id, &project_root)
+        register_explicit_project_root_inner(&state.host.paths, &user_id, &project_root)
     }
     .map_err(|error| error.to_string())?;
 
@@ -1187,12 +1242,17 @@ pub async fn agent_save_recent_project_root(
         .removed_project_roots
         .retain(|removed| removed != &canonical_path);
     config.default_project_root = Some(canonical_path.clone());
-    save_agent_config_inner(&app_handle, &user_id, &config).map_err(|error| error.to_string())?;
+    save_agent_config_inner(&state.host.paths, &user_id, &config)
+        .map_err(|error| error.to_string())?;
     // Clear the device-local tombstone last. If registration or ordinary
     // config persistence fails, the project remains hidden.
     if restoring {
-        save_removed_project_roots_inner(&app_handle, &user_id, &config.removed_project_roots)
-            .map_err(|error| error.to_string())?;
+        save_removed_project_roots_inner(
+            &state.host.paths,
+            &user_id,
+            &config.removed_project_roots,
+        )
+        .map_err(|error| error.to_string())?;
     }
 
     Ok(AgentProjectRootRegistration {
@@ -1244,7 +1304,7 @@ pub async fn agent_remove_project_root(
                 )
             }
             None => (
-                account_session_manager(&app_handle, &user_id)?,
+                account_session_manager(&state.host.paths, &user_id)?,
                 HashSet::new(),
             ),
         }
@@ -1262,13 +1322,13 @@ pub async fn agent_remove_project_root(
     }
 
     let mut config =
-        load_agent_config_inner(&app_handle, &user_id).map_err(|error| error.to_string())?;
+        load_agent_config_inner(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
     apply_project_root_removal(&mut config, &path, fallback_path.as_deref())?;
     // The tombstone is the only persistent removal state. Saving the fallback
     // into roaming config would let this device's removal alter another
     // device. Runtime/UI use the fallback immediately; startup filters the
     // stale hidden default before selecting any project.
-    save_removed_project_roots_inner(&app_handle, &user_id, &config.removed_project_roots)
+    save_removed_project_roots_inner(&state.host.paths, &user_id, &config.removed_project_roots)
         .map_err(|error| error.to_string())?;
 
     let mut runtime = state.inner.lock().await;
@@ -1303,7 +1363,7 @@ pub async fn agent_get_project_skills_trust(
         });
     }
     let project_root = normalize_project_root(requested)?;
-    let config = load_agent_config_inner(&app_handle, &user_id).map_err(|e| e.to_string())?;
+    let config = load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
     Ok(project_skills_trust_status(&config, &project_root, true))
 }
 
@@ -1320,9 +1380,10 @@ pub async fn agent_set_project_skills_trust(
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     ensure_account_generation(&state, &account_scope, generation).await?;
     let project_root = normalize_project_root(Path::new(&path))?;
-    let mut config = load_agent_config_inner(&app_handle, &user_id).map_err(|e| e.to_string())?;
+    let mut config =
+        load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
     apply_project_skills_trust(&mut config, &project_root, trusted)?;
-    save_agent_config_inner(&app_handle, &user_id, &config).map_err(|e| e.to_string())?;
+    save_agent_config_inner(&state.host.paths, &user_id, &config).map_err(|e| e.to_string())?;
     Ok(project_skills_trust_status(&config, &project_root, true))
 }
 
@@ -1337,7 +1398,7 @@ pub async fn agent_save_project_root_order(
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     ensure_account_generation(&state, &account_scope, generation).await?;
-    save_project_root_order_inner(&app_handle, &user_id, paths).map_err(|e| e.to_string())
+    save_project_root_order_inner(&state.host.paths, &user_id, paths).map_err(|e| e.to_string())
 }
 
 #[tauri::command]
@@ -1387,7 +1448,7 @@ pub async fn agent_create_session(
     };
 
     let config =
-        load_agent_config_inner(&app_handle, &user_id).map_err(|error| error.to_string())?;
+        load_agent_config_inner(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
     let root = match request.project_root.as_deref() {
         Some(path) if !path.trim().is_empty() => normalize_project_root(Path::new(path))?,
         _ => runtime_project_root,
@@ -1430,7 +1491,7 @@ pub async fn agent_create_session(
     let setup_result: Result<Vec<AgentMcpConnectionError>, String> = async {
         let (agent, mut mcp_errors) = configure_session_agent(
             AgentSkillsScope {
-                app_handle: &app_handle,
+                paths: &state.host.paths,
                 user_id: &user_id,
             },
             &agent_manager,
@@ -1451,7 +1512,7 @@ pub async fn agent_create_session(
             // Resolve every fallible part of restoring Maple's transient Skills client before
             // Goose persists the MCP mutation. Reattachment after this point is infallible.
             let skills_client =
-                prepare_transient_skills_client(&app_handle, &user_id, &agent, &session)?;
+                prepare_transient_skills_client(&state.host.paths, &user_id, &agent, &session)?;
             detach_transient_skills_client(&agent).await;
             let extension_result = agent
                 .add_extensions_bulk(selected_extensions, &session.id)
@@ -1510,7 +1571,7 @@ pub async fn agent_create_session(
         mcp_errors,
     };
     emit_agent_event(
-        &app_handle,
+        &state.host.events,
         AgentEventEnvelope {
             event_type: "sessionCreated".to_string(),
             session_id: Some(summary.id.clone()),
@@ -1542,7 +1603,7 @@ pub async fn agent_list_sessions(
                 ensure_runtime_account(current, &account_scope)?;
                 Arc::clone(&current.session_manager)
             }
-            None => account_session_manager(&app_handle, &user_id)?,
+            None => account_session_manager(&state.host.paths, &user_id)?,
         };
         let filter_root = project_root
             .as_deref()
@@ -1588,7 +1649,7 @@ pub async fn agent_load_session(
                 ensure_runtime_account(current, &account_scope)?;
                 Arc::clone(&current.session_manager)
             }
-            None => account_session_manager(&app_handle, &user_id)?,
+            None => account_session_manager(&state.host.paths, &user_id)?,
         }
     };
     let session = session_manager
@@ -1628,7 +1689,7 @@ pub async fn agent_list_session_mcp_servers(
                 ensure_runtime_account(current, &account_scope)?;
                 Arc::clone(&current.session_manager)
             }
-            None => account_session_manager(&app_handle, &user_id)?,
+            None => account_session_manager(&state.host.paths, &user_id)?,
         }
     };
     let session = session_manager
@@ -1636,7 +1697,7 @@ pub async fn agent_list_session_mcp_servers(
         .await
         .map_err(|error| format!("Failed to load Agent task: {error}"))?;
     let configured = normalize_mcp_servers(
-        load_agent_config_inner(&app_handle, &user_id)
+        load_agent_config_inner(&state.host.paths, &user_id)
             .map_err(|error| format!("Failed to load MCP servers: {error}"))?
             .mcp_servers,
     )?;
@@ -1680,7 +1741,7 @@ pub async fn agent_set_session_mcp_server_enabled(
         )
     };
     let configured = normalize_mcp_servers(
-        load_agent_config_inner(&app_handle, &user_id)
+        load_agent_config_inner(&state.host.paths, &user_id)
             .map_err(|error| format!("Failed to load MCP servers: {error}"))?
             .mcp_servers,
     )?;
@@ -1707,7 +1768,8 @@ pub async fn agent_set_session_mcp_server_enabled(
     let agent = manager_result.agent;
     // Preflight Skills restoration before detaching the working client or changing persisted MCP
     // state. Reattaching this prepared client after the mutation cannot fail.
-    let skills_client = prepare_transient_skills_client(&app_handle, &user_id, &agent, &session)?;
+    let skills_client =
+        prepare_transient_skills_client(&state.host.paths, &user_id, &agent, &session)?;
     detach_transient_skills_client(&agent).await;
     let active = agent.get_extension_configs().await;
     let active_config = active
@@ -1802,7 +1864,7 @@ pub async fn agent_delete_session(
             }
             None => (
                 None,
-                account_session_manager(&app_handle, &user_id)?,
+                account_session_manager(&state.host.paths, &user_id)?,
                 None,
                 None,
             ),
@@ -2169,7 +2231,7 @@ async fn agent_send_message_inner(
                 .await
                 .map_err(|e| format!("Failed to load named Agent task: {e}"))?;
             emit_agent_event(
-                &app_handle,
+                &state.host.events,
                 AgentEventEnvelope {
                     event_type: "sessionUpdated".to_string(),
                     session_id: Some(session.id.clone()),
@@ -2183,7 +2245,7 @@ async fn agent_send_message_inner(
         }
         let (agent, mcp_errors) = configure_session_agent(
             AgentSkillsScope {
-                app_handle: &app_handle,
+                paths: &state.host.paths,
                 user_id: &user_id,
             },
             &agent_manager,
@@ -2217,7 +2279,7 @@ async fn agent_send_message_inner(
     };
     if !mcp_errors.is_empty() {
         emit_agent_event(
-            &app_handle,
+            &state.host.events,
             AgentEventEnvelope {
                 event_type: "error".to_string(),
                 session_id: None,
@@ -2230,7 +2292,7 @@ async fn agent_send_message_inner(
         );
     }
 
-    let app_handle_for_task = app_handle.clone();
+    let task_events = state.host.events.clone();
     let state_inner = Arc::clone(&state.inner);
     let session_lifecycle = Arc::clone(&state.session_lifecycle);
     let pending_permissions = Arc::clone(&state.pending_permissions);
@@ -2246,7 +2308,7 @@ async fn agent_send_message_inner(
     let task_cancelled_permission_ids = Arc::clone(&cancelled_permission_ids);
     let (start_tx, start_rx) = oneshot::channel();
     let (terminal_tx, terminal_rx) = watch::channel(None);
-    let task = tauri::async_runtime::spawn(async move {
+    let task = tokio::spawn(async move {
         let should_run = tokio::select! {
             biased;
             _ = task_cancel_token.cancelled() => false,
@@ -2256,7 +2318,7 @@ async fn agent_send_message_inner(
             provider::with_run_cancellation(
                 task_cancel_token.clone(),
                 run_agent_prompt(AgentPromptRun {
-                    app_handle: app_handle_for_task.clone(),
+                    events: task_events.clone(),
                     agent,
                     session_manager: Arc::clone(&task_session_manager),
                     live_timelines: live_timelines.clone(),
@@ -2321,7 +2383,7 @@ async fn agent_send_message_inner(
                 apply_failed_prompt_outcome(&mut timelines, &session_id, item.clone());
             }
             emit_agent_event(
-                &app_handle_for_task,
+                &task_events,
                 AgentEventEnvelope {
                     event_type: "error".to_string(),
                     session_id: Some(session_id.clone()),
@@ -2334,7 +2396,7 @@ async fn agent_send_message_inner(
             );
         }
         emit_agent_event(
-            &app_handle_for_task,
+            &task_events,
             AgentEventEnvelope {
                 event_type: "runFinished".to_string(),
                 session_id: Some(session_id),
@@ -2396,7 +2458,7 @@ async fn agent_send_message_inner(
         return Err(error);
     }
     emit_agent_event(
-        &app_handle,
+        &state.host.events,
         AgentEventEnvelope {
             event_type: "runStarted".to_string(),
             session_id: Some(request.session_id.clone()),
@@ -2409,7 +2471,7 @@ async fn agent_send_message_inner(
     );
 
     record_and_emit_timeline_item(
-        &app_handle,
+        &state.host.events,
         &state.live_timelines,
         &request.session_id,
         &run_id,
@@ -2491,7 +2553,7 @@ pub async fn agent_cancel_run(
         )
         .await
         {
-            emit_timeline_item(&app_handle, &session_id, &run_id, item);
+            emit_timeline_item(&state.host.events, &session_id, &run_id, item);
         }
     }
     Ok(())
@@ -2630,7 +2692,7 @@ pub async fn agent_set_permission_mode(
             .await
             {
                 emit_agent_event(
-                    &app_handle,
+                    &state.host.events,
                     AgentEventEnvelope {
                         event_type: "timelineItem".to_string(),
                         session_id: Some(session_id.clone()),
@@ -2650,7 +2712,7 @@ pub async fn agent_set_permission_mode(
     // that is no longer authoritative.
     match session_manager.get_session(&session_id, false).await {
         Ok(session) => emit_agent_event(
-            &app_handle,
+            &state.host.events,
             AgentEventEnvelope {
                 event_type: "sessionUpdated".to_string(),
                 session_id: Some(session_id),
@@ -2720,7 +2782,7 @@ pub async fn agent_permission_respond(
     .await
     {
         emit_agent_event(
-            &app_handle,
+            &state.host.events,
             AgentEventEnvelope {
                 event_type: "timelineItem".to_string(),
                 session_id: Some(session_id.clone()),
@@ -2797,7 +2859,7 @@ pub(crate) async fn cancel_agent_run_for_user(
 }
 
 struct AgentPromptRun {
-    app_handle: AppHandle,
+    events: AgentEventDispatcher,
     agent: Arc<Agent>,
     session_manager: Arc<SessionManager>,
     live_timelines: LiveTimelines,
@@ -3128,7 +3190,7 @@ async fn automatically_handle_permissions(
 
 async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, String> {
     let AgentPromptRun {
-        app_handle,
+        events,
         agent,
         session_manager,
         live_timelines,
@@ -3159,7 +3221,7 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
         .map_err(|e| format!("Failed to load updated Agent task: {e}"))?;
     let working_dir = updated_session.working_dir.clone();
     emit_agent_event(
-        &app_handle,
+        &events,
         AgentEventEnvelope {
             event_type: "sessionUpdated".to_string(),
             session_id: Some(session_id.clone()),
@@ -3276,7 +3338,7 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                 }
                 for item in items {
                     record_and_emit_timeline_item(
-                        &app_handle,
+                        &events,
                         &live_timelines,
                         &session_id,
                         &run_id,
@@ -3302,7 +3364,7 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                 )
                 .await;
                 emit_agent_event(
-                    &app_handle,
+                    &events,
                     AgentEventEnvelope {
                         event_type: "historyReplaced".to_string(),
                         session_id: Some(session_id.clone()),
@@ -3445,8 +3507,8 @@ fn pending_permission_request_id(item: &AgentTimelineItem) -> Option<String> {
     None
 }
 
-fn project_skills_are_trusted(app_handle: &AppHandle, user_id: &str, project_root: &Path) -> bool {
-    match load_agent_config_inner(app_handle, user_id) {
+fn project_skills_are_trusted(paths: &AgentPathLayout, user_id: &str, project_root: &Path) -> bool {
+    match load_agent_config_inner(paths, user_id) {
         Ok(config) => {
             project_skills_trust_status(&config, project_root, true).decision == Some(true)
         }
@@ -3467,11 +3529,11 @@ fn project_skills_root_is_available(project_root: &Path) -> bool {
 }
 
 fn skills_discovery_working_dir(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
     session: &Session,
 ) -> Result<PathBuf, String> {
-    if project_skills_are_trusted(app_handle, user_id, &session.working_dir) {
+    if project_skills_are_trusted(paths, user_id, &session.working_dir) {
         if project_skills_root_is_available(&session.working_dir) {
             return Ok(session.working_dir.clone());
         }
@@ -3481,7 +3543,7 @@ fn skills_discovery_working_dir(
         );
     }
 
-    let root = agent_config_dir(app_handle, user_id)
+    let root = agent_config_dir(paths, user_id)
         .map_err(|error| format!("Failed to locate Maple skills data: {error}"))?
         .join("untrusted-project-skills");
     fs::create_dir_all(&root)
@@ -3526,12 +3588,12 @@ fn skills_client_for_working_dir(
 }
 
 fn prepare_transient_skills_client(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
     agent: &Arc<Agent>,
     session: &Session,
 ) -> Result<SkillsClient, String> {
-    let working_dir = skills_discovery_working_dir(app_handle, user_id, session)?;
+    let working_dir = skills_discovery_working_dir(paths, user_id, session)?;
     skills_client_for_working_dir(agent, session, working_dir)
 }
 
@@ -3549,7 +3611,7 @@ async fn attach_prepared_skills_client(agent: &Arc<Agent>, skills_client: Skills
 }
 
 struct AgentSkillsScope<'a> {
-    app_handle: &'a AppHandle,
+    paths: &'a AgentPathLayout,
     user_id: &'a str,
 }
 
@@ -3678,12 +3740,8 @@ async fn configure_session_agent(
     )
     .await?;
     let agent = manager_result.agent;
-    let skills_client = prepare_transient_skills_client(
-        skills_scope.app_handle,
-        skills_scope.user_id,
-        &agent,
-        session,
-    )?;
+    let skills_client =
+        prepare_transient_skills_client(skills_scope.paths, skills_scope.user_id, &agent, session)?;
     let mcp_errors = mcp_connection_errors(manager_result.extension_results, &session_mcp_keys);
     install_maple_provider(&agent, maple_api_session, session, model, context_limit).await?;
     agent
@@ -4497,13 +4555,13 @@ fn sort_sessions_newest_first(sessions: &mut [AgentSessionSummary]) {
 }
 
 fn emit_timeline_item(
-    app_handle: &AppHandle,
+    events: &AgentEventDispatcher,
     session_id: &str,
     run_id: &str,
     item: AgentTimelineItem,
 ) {
     emit_agent_event(
-        app_handle,
+        events,
         AgentEventEnvelope {
             event_type: "timelineItem".to_string(),
             session_id: Some(session_id.to_string()),
@@ -4517,14 +4575,14 @@ fn emit_timeline_item(
 }
 
 async fn record_and_emit_timeline_item(
-    app_handle: &AppHandle,
+    events: &AgentEventDispatcher,
     live_timelines: &LiveTimelines,
     session_id: &str,
     run_id: &str,
     item: AgentTimelineItem,
 ) {
     record_timeline_item(live_timelines, session_id, item.clone()).await;
-    emit_timeline_item(app_handle, session_id, run_id, item);
+    emit_timeline_item(events, session_id, run_id, item);
 }
 
 async fn record_timeline_item(
@@ -4681,12 +4739,9 @@ async fn update_live_permission_status(
     Some(item.clone())
 }
 
-fn emit_agent_event(app_handle: &AppHandle, event: AgentEventEnvelope) {
-    let state = app_handle.state::<AgentRuntimeState>();
-    let _ = state.event_sender.send(event.clone());
-    if let Err(error) = app_handle.emit(AGENT_EVENT_NAME, event) {
-        log::warn!("Failed to emit Agent Mode event: {error}");
-    }
+fn emit_agent_event(events: &AgentEventDispatcher, event: AgentEventEnvelope) {
+    let _ = events.sender.send(event.clone());
+    events.sink.emit(&event);
 }
 
 fn configure_embedded_goose(goose_path_root: &Path, model: &str, mode: &str) -> Result<(), String> {
@@ -5210,49 +5265,41 @@ fn normalize_project_root(path: &Path) -> Result<PathBuf, String> {
     Ok(canonical)
 }
 
-fn agent_root_dir(app_handle: &AppHandle) -> Result<PathBuf, anyhow::Error> {
-    let base = app_handle
-        .path()
-        .app_config_dir()
-        .map_err(|error| anyhow::anyhow!("Failed to resolve app config dir: {error}"))?;
-    let path = base.join("agent");
+fn agent_root_dir(paths: &AgentPathLayout) -> Result<PathBuf, anyhow::Error> {
+    let path = paths.config_root.clone();
     fs::create_dir_all(&path)?;
     set_owner_only_dir_permissions(&path);
     Ok(path)
 }
 
 fn account_config_dir_path(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
 ) -> Result<PathBuf, anyhow::Error> {
     let scope = account_scope(user_id).map_err(anyhow::Error::msg)?;
-    Ok(agent_root_dir(app_handle)?.join("accounts").join(scope))
+    Ok(agent_root_dir(paths)?.join("accounts").join(scope))
 }
 
 fn account_local_data_dir_path(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
 ) -> Result<PathBuf, anyhow::Error> {
     let scope = account_scope(user_id).map_err(anyhow::Error::msg)?;
-    let base = app_handle
-        .path()
-        .app_local_data_dir()
-        .map_err(|error| anyhow::anyhow!("Failed to resolve app local data dir: {error}"))?;
-    Ok(base.join("agent").join("accounts").join(scope))
+    Ok(paths.local_data_root.join("accounts").join(scope))
 }
 
-fn agent_config_dir(app_handle: &AppHandle, user_id: &str) -> Result<PathBuf, anyhow::Error> {
-    let path = account_config_dir_path(app_handle, user_id)?;
+fn agent_config_dir(paths: &AgentPathLayout, user_id: &str) -> Result<PathBuf, anyhow::Error> {
+    let path = account_config_dir_path(paths, user_id)?;
     fs::create_dir_all(&path)?;
     set_owner_only_dir_permissions(&path);
     Ok(path)
 }
 
 fn account_session_manager(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
 ) -> Result<Arc<SessionManager>, String> {
-    let account_dir = agent_config_dir(app_handle, user_id).map_err(|error| error.to_string())?;
+    let account_dir = agent_config_dir(paths, user_id).map_err(|error| error.to_string())?;
     session_manager_for_account_dir(&account_dir)
 }
 
@@ -5281,12 +5328,12 @@ fn remove_agent_history_path(path: &Path) -> Result<(), anyhow::Error> {
     result.map_err(Into::into)
 }
 fn load_agent_config_inner(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
 ) -> Result<AgentConfig, anyhow::Error> {
-    let path = agent_config_dir(app_handle, user_id)?.join("config.json");
+    let path = agent_config_dir(paths, user_id)?.join("config.json");
     let removed_project_roots_path =
-        account_local_data_dir_path(app_handle, user_id)?.join("removed_project_roots.json");
+        account_local_data_dir_path(paths, user_id)?.join("removed_project_roots.json");
     load_agent_config_files(&path, &removed_project_roots_path)
 }
 
@@ -5328,11 +5375,11 @@ fn migrate_agent_config(config: &mut AgentConfig) -> bool {
 }
 
 fn save_agent_config_inner(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
     config: &AgentConfig,
 ) -> Result<(), anyhow::Error> {
-    let path = agent_config_dir(app_handle, user_id)?.join("config.json");
+    let path = agent_config_dir(paths, user_id)?.join("config.json");
     save_agent_config_file(&path, config)
 }
 
@@ -5356,11 +5403,11 @@ fn load_removed_project_roots_file(path: &Path) -> Result<Vec<String>, anyhow::E
 }
 
 fn save_removed_project_roots_inner(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
     roots: &[String],
 ) -> Result<(), anyhow::Error> {
-    let path = account_local_data_dir_path(app_handle, user_id)?.join("removed_project_roots.json");
+    let path = account_local_data_dir_path(paths, user_id)?.join("removed_project_roots.json");
     write_device_local_json_file(&path, roots)
 }
 
@@ -5406,10 +5453,10 @@ fn apply_project_skills_trust(
 }
 
 fn load_recent_project_roots_inner(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
 ) -> Result<Vec<RecentProjectRoot>, anyhow::Error> {
-    let path = agent_config_dir(app_handle, user_id)?.join("recent_roots.json");
+    let path = agent_config_dir(paths, user_id)?.join("recent_roots.json");
     load_recent_project_roots_file(&path)
 }
 
@@ -5494,11 +5541,11 @@ fn register_explicit_project_root_file(
 }
 
 fn register_explicit_project_root_inner(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
     project_root: &Path,
 ) -> Result<Vec<RecentProjectRoot>, anyhow::Error> {
-    let file_path = agent_config_dir(app_handle, user_id)?.join("recent_roots.json");
+    let file_path = agent_config_dir(paths, user_id)?.join("recent_roots.json");
     register_explicit_project_root_file(&file_path, project_root, unix_ms())
 }
 
@@ -5531,11 +5578,11 @@ fn restore_explicit_project_root_file(
 }
 
 fn restore_explicit_project_root_inner(
-    app_handle: &AppHandle,
+    paths: &AgentPathLayout,
     user_id: &str,
     project_root: &Path,
 ) -> Result<Vec<RecentProjectRoot>, anyhow::Error> {
-    let file_path = agent_config_dir(app_handle, user_id)?.join("recent_roots.json");
+    let file_path = agent_config_dir(paths, user_id)?.join("recent_roots.json");
     restore_explicit_project_root_file(&file_path, project_root, unix_ms())
 }
 
@@ -5591,12 +5638,12 @@ fn save_project_root_order_file(
 }
 
 fn save_project_root_order_inner(
-    app_handle: &AppHandle,
+    layout: &AgentPathLayout,
     user_id: &str,
     mut paths: Vec<String>,
 ) -> Result<Vec<RecentProjectRoot>, anyhow::Error> {
-    let file_path = agent_config_dir(app_handle, user_id)?.join("recent_roots.json");
-    let removed = load_agent_config_inner(app_handle, user_id)?
+    let file_path = agent_config_dir(layout, user_id)?.join("recent_roots.json");
+    let removed = load_agent_config_inner(layout, user_id)?
         .removed_project_roots
         .into_iter()
         .collect::<HashSet<_>>();
@@ -5740,6 +5787,12 @@ fn path_string(path: &Path) -> String {
 mod tests {
     use super::*;
     use rmcp::model::{AnnotateAble, RawTextContent, Role as McpRole};
+
+    struct NoopAgentEventSink;
+
+    impl AgentEventSink for NoopAgentEventSink {
+        fn emit(&self, _event: &AgentEventEnvelope) {}
+    }
 
     struct InertMapleTransport;
 
@@ -8942,7 +8995,7 @@ mod tests {
     #[tokio::test]
     async fn detects_active_run_for_session() {
         let mut active_runs = HashMap::new();
-        let task_handle = tauri::async_runtime::spawn(async {});
+        let task_handle = tokio::spawn(async {});
         active_runs.insert(
             "run-1".to_string(),
             ActiveAgentRun {
@@ -9135,7 +9188,13 @@ mod tests {
 
     #[tokio::test]
     async fn rejects_operations_captured_before_account_clear() {
-        let state = AgentRuntimeState::new();
+        let state = MapleAgentService::new(MapleAgentHostResources::new(
+            AgentPathLayout::from_app_roots(
+                PathBuf::from("unused-config-root"),
+                PathBuf::from("unused-local-root"),
+            ),
+            Arc::new(NoopAgentEventSink),
+        ));
         let scope = account_scope("user-to-clear").unwrap();
         let stale_generation = account_generation(&state, &scope).await;
 
@@ -9171,7 +9230,7 @@ mod tests {
         let dropped = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let (started_tx, started_rx) = oneshot::channel();
         let task_dropped = Arc::clone(&dropped);
-        let task = tauri::async_runtime::spawn(async move {
+        let task = tokio::spawn(async move {
             let _drop_flag = DropFlag(task_dropped);
             let _ = started_tx.send(());
             futures_util::future::pending::<()>().await;

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -300,6 +300,45 @@ pub struct AgentPermissionResponse {
     pub decision: String,
 }
 
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct AgentPermissionRequest {
+    pub request_id: String,
+    pub tool_name: String,
+    pub arguments: serde_json::Map<String, Value>,
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentPermissionDecision {
+    AllowOnce,
+    DenyOnce,
+    Cancel,
+}
+
+impl AgentPermissionDecision {
+    fn status(self) -> &'static str {
+        match self {
+            Self::AllowOnce => "allow_once",
+            Self::DenyOnce => "deny_once",
+            Self::Cancel => "cancelled",
+        }
+    }
+
+    fn goose_permission(self) -> Permission {
+        match self {
+            Self::AllowOnce => Permission::AllowOnce,
+            Self::DenyOnce => Permission::DenyOnce,
+            Self::Cancel => Permission::Cancel,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentPermissionRouting {
+    Desktop,
+    CallingSurface,
+}
+
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentPermissionModeRequest {
@@ -325,6 +364,31 @@ pub(crate) struct AgentRunHandle {
     pub events: mpsc::Receiver<AgentRunEvent>,
     pub terminal: watch::Receiver<Option<AgentRunTerminal>>,
     pub event_overflowed: Arc<AtomicBool>,
+    pub permission_responder: Option<AgentRunPermissionResponder>,
+}
+
+#[derive(Clone)]
+pub(crate) struct AgentRunPermissionResponder {
+    agent: AgentRuntimeHandle,
+    session_id: Arc<str>,
+    run_id: Arc<str>,
+}
+
+impl AgentRunPermissionResponder {
+    pub(crate) async fn respond(
+        &self,
+        request_id: String,
+        decision: AgentPermissionDecision,
+    ) -> Result<(), String> {
+        self.agent
+            .permission_respond_for_run(
+                self.session_id.as_ref(),
+                self.run_id.as_ref(),
+                request_id,
+                decision,
+            )
+            .await
+    }
 }
 
 pub(crate) struct CreatedAgentSession {
@@ -334,9 +398,9 @@ pub(crate) struct CreatedAgentSession {
 
 /// Controls whether a surface's events are also projected into Maple Desktop.
 ///
-/// This is deliberately independent of tool-context ownership. An external
-/// surface may still need Maple Desktop to act as its permission broker, while
-/// an unattended surface can keep its transient run stream isolated.
+/// This is deliberately independent of tool-context ownership. A calling
+/// surface can keep its transient run stream isolated while persisted history
+/// remains available when Maple Desktop later loads the task.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum AgentHostEventPolicy {
     Publish,
@@ -406,6 +470,10 @@ pub(crate) enum AgentRunEvent {
     SessionUpdated(AgentSessionSummary),
     Started,
     TimelineItem(AgentTimelineItem),
+    PermissionRequested {
+        request: AgentPermissionRequest,
+        item: AgentTimelineItem,
+    },
     SetupWarning(String),
     HistoryReplaced,
     Error(AgentTimelineItem),
@@ -476,6 +544,8 @@ pub struct AgentTimelineItem {
 }
 
 struct ActiveAgentRun {
+    agent: Arc<Agent>,
+    permission_routing: AgentPermissionRouting,
     token: CancellationToken,
     tool_context: SharedAgentToolContext,
     session_id: String,
@@ -485,7 +555,19 @@ struct ActiveAgentRun {
 }
 
 type PendingPermissionKey = (String, String);
-type PendingPermissions = Arc<Mutex<HashMap<PendingPermissionKey, ()>>>;
+#[derive(Debug, Clone, PartialEq)]
+struct PendingAgentPermission {
+    run_id: String,
+    routing: AgentPermissionRouting,
+    request: AgentPermissionRequest,
+}
+type PendingPermissions = Arc<Mutex<HashMap<PendingPermissionKey, PendingAgentPermission>>>;
+type IssuedPermissionIds = Arc<Mutex<HashSet<String>>>;
+
+enum AgentPermissionResponseScope {
+    Desktop,
+    CallingSurface { run_id: String },
+}
 type CancelledPermissionIds = Arc<Mutex<HashSet<String>>>;
 type SessionPermissionModes = Arc<Mutex<HashMap<String, GooseMode>>>;
 
@@ -936,69 +1018,117 @@ fn should_name_session_from_prompt(session: &Session) -> bool {
         && session.name == DEFAULT_AGENT_SESSION_TITLE
 }
 
-async fn pending_permissions_for_sessions(
+async fn take_pending_permissions_for_runs(
     pending_permissions: &PendingPermissions,
-    session_ids: &[String],
-) -> Vec<(String, String)> {
-    let pending = pending_permissions.lock().await;
-    pending
+    run_ids: &[String],
+) -> Vec<(PendingPermissionKey, PendingAgentPermission)> {
+    let mut pending = pending_permissions.lock().await;
+    let keys = pending
         .keys()
-        .filter(|(session_id, _)| session_ids.contains(session_id))
-        .map(|(session_id, request_id)| (request_id.clone(), session_id.clone()))
+        .filter(|key| {
+            pending
+                .get(*key)
+                .is_some_and(|request| run_ids.contains(&request.run_id))
+        })
+        .cloned()
+        .collect::<Vec<_>>();
+    keys.into_iter()
+        .filter_map(|key| pending.remove(&key).map(|request| (key, request)))
         .collect()
 }
 
-async fn cancel_pending_permissions_for_sessions(
-    agent_manager: &Arc<AgentManager>,
+async fn cancel_pending_permissions_for_runs(
     pending_permissions: &PendingPermissions,
-    session_ids: &[String],
-) -> Vec<(String, String)> {
+    run_ids: &[String],
+    agents_by_run: &HashMap<String, Arc<Agent>>,
+) -> Vec<(PendingPermissionKey, PendingAgentPermission)> {
     let mut cancelled = Vec::new();
-    for (request_id, session_id) in
-        pending_permissions_for_sessions(pending_permissions, session_ids).await
+    for ((session_id, request_id), request) in
+        take_pending_permissions_for_runs(pending_permissions, run_ids).await
     {
-        match agent_manager.get_or_create_agent(session_id.clone()).await {
-            Ok(agent) => {
-                agent
-                    .handle_confirmation(
-                        request_id.clone(),
-                        PermissionConfirmation {
-                            principal_type: PrincipalType::Tool,
-                            permission: Permission::Cancel,
-                        },
-                    )
-                    .await;
-                let mut pending = pending_permissions.lock().await;
-                pending.remove(&(session_id.clone(), request_id.clone()));
-                cancelled.push((request_id, session_id));
-            }
-            Err(error) => {
-                log::warn!(
-                    "Failed to cancel pending Agent Mode permission for session {session_id}: {error}"
-                );
-            }
+        if let Some(agent) = agents_by_run.get(&request.run_id) {
+            agent
+                .handle_confirmation(
+                    request_id.clone(),
+                    PermissionConfirmation {
+                        principal_type: PrincipalType::Tool,
+                        permission: Permission::Cancel,
+                    },
+                )
+                .await;
+        } else {
+            log::warn!(
+                "Failed to resolve the running Agent for pending permission {request_id} in {session_id}"
+            );
         }
+        cancelled.push(((session_id, request_id), request));
     }
     cancelled
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PendingPermissionRegistration {
+    Registered,
+    Existing,
+    Rejected,
+}
+
 async fn register_pending_permission(
     pending_permissions: &PendingPermissions,
-    request_id: &str,
+    issued_permission_ids: &IssuedPermissionIds,
     session_id: &str,
+    run_id: &str,
+    routing: AgentPermissionRouting,
+    request: AgentPermissionRequest,
     cancel_token: &CancellationToken,
-) -> bool {
+) -> PendingPermissionRegistration {
     if cancel_token.is_cancelled() {
-        return false;
+        return PendingPermissionRegistration::Rejected;
+    }
+    let key = (session_id.to_string(), request.request_id.clone());
+    let pending_request = PendingAgentPermission {
+        run_id: run_id.to_string(),
+        routing,
+        request,
+    };
+    {
+        let mut pending = pending_permissions.lock().await;
+        match pending.get(&key) {
+            Some(existing) if existing == &pending_request => {
+                return PendingPermissionRegistration::Existing;
+            }
+            Some(_) => {
+                // Reusing a Goose request ID with different ownership or payload
+                // invalidates the old capability. Leaving it resolvable would let
+                // a stale caller approve a different operation under the reused ID.
+                pending.remove(&key);
+                return PendingPermissionRegistration::Rejected;
+            }
+            None => {}
+        }
+    }
+    {
+        let mut issued = issued_permission_ids.lock().await;
+        if !issued.insert(key.1.clone()) {
+            pending_permissions.lock().await.remove(&key);
+            return PendingPermissionRegistration::Rejected;
+        }
     }
     let mut pending = pending_permissions.lock().await;
-    let key = (session_id.to_string(), request_id.to_string());
-    pending.insert(key.clone(), ());
+    match pending.entry(key.clone()) {
+        std::collections::hash_map::Entry::Occupied(existing) => {
+            existing.remove();
+            return PendingPermissionRegistration::Rejected;
+        }
+        std::collections::hash_map::Entry::Vacant(entry) => {
+            entry.insert(pending_request);
+        }
+    }
     if cancel_token.is_cancelled() {
         pending.remove(&key);
-        false
+        PendingPermissionRegistration::Rejected
     } else {
-        true
+        PendingPermissionRegistration::Registered
     }
 }
 
@@ -1012,7 +1142,7 @@ async fn stop_runtime_inner(
     requested_scope: Option<&str>,
 ) -> Result<(), String> {
     let session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let (agent_manager, active_runs, web_tool_state, tool_contexts) = {
+    let (active_runs, web_tool_state, tool_contexts) = {
         let mut runtime = state.inner.lock().await;
         let Some(current) = runtime.as_mut() else {
             return Ok(());
@@ -1021,7 +1151,6 @@ async fn stop_runtime_inner(
             ensure_runtime_account(current, account_scope)?;
         }
         (
-            Arc::clone(&current.agent_manager),
             std::mem::take(&mut current.active_runs),
             Arc::clone(&current.web_tool_state),
             std::mem::take(&mut current.session_tool_contexts),
@@ -1032,18 +1161,14 @@ async fn stop_runtime_inner(
         installed.context.revoke();
     }
 
-    let session_ids = active_runs
-        .values()
-        .map(|run| run.session_id.clone())
-        .collect::<Vec<_>>();
-    let cancelled_permission_ids_by_session = active_runs
-        .values()
-        .map(|run| {
-            (
-                run.session_id.clone(),
-                Arc::clone(&run.cancelled_permission_ids),
-            )
-        })
+    let run_ids = active_runs.keys().cloned().collect::<Vec<_>>();
+    let agents_by_run = active_runs
+        .iter()
+        .map(|(run_id, run)| (run_id.clone(), Arc::clone(&run.agent)))
+        .collect::<HashMap<_, _>>();
+    let cancelled_permission_ids_by_run = active_runs
+        .iter()
+        .map(|(run_id, run)| (run_id.clone(), Arc::clone(&run.cancelled_permission_ids)))
         .collect::<HashMap<_, _>>();
     let mut task_handles = Vec::with_capacity(active_runs.len());
     for (_, active_run) in active_runs {
@@ -1052,14 +1177,11 @@ async fn stop_runtime_inner(
         active_run.tool_context.cancel_run(&active_run.token);
         task_handles.push(active_run.task_handle);
     }
-    let cancelled_permissions = cancel_pending_permissions_for_sessions(
-        &agent_manager,
-        &state.pending_permissions,
-        &session_ids,
-    )
-    .await;
-    for (request_id, session_id) in cancelled_permissions {
-        if let Some(cancelled_permission_ids) = cancelled_permission_ids_by_session.get(&session_id)
+    let cancelled_permissions =
+        cancel_pending_permissions_for_runs(&state.pending_permissions, &run_ids, &agents_by_run)
+            .await;
+    for ((_, request_id), pending) in cancelled_permissions {
+        if let Some(cancelled_permission_ids) = cancelled_permission_ids_by_run.get(&pending.run_id)
         {
             cancelled_permission_ids.lock().await.insert(request_id);
         }
@@ -2328,8 +2450,14 @@ impl AgentRuntimeHandle {
         &self,
         request: AgentSendMessageRequest,
     ) -> Result<AgentRunHandle, String> {
-        self.send_message_inner(request, None, None, AgentHostEventPolicy::Publish)
-            .await
+        self.send_message_inner(
+            request,
+            None,
+            None,
+            AgentHostEventPolicy::Publish,
+            AgentPermissionRouting::Desktop,
+        )
+        .await
     }
 
     pub(crate) async fn send_message_with_tool_context(
@@ -2339,8 +2467,14 @@ impl AgentRuntimeHandle {
         surface_lifetime: CancellationToken,
         host_events: AgentHostEventPolicy,
     ) -> Result<AgentRunHandle, String> {
-        self.send_message_inner(request, Some(access), Some(surface_lifetime), host_events)
-            .await
+        self.send_message_inner(
+            request,
+            Some(access),
+            Some(surface_lifetime),
+            host_events,
+            AgentPermissionRouting::CallingSurface,
+        )
+        .await
     }
 
     async fn send_message_inner(
@@ -2349,6 +2483,7 @@ impl AgentRuntimeHandle {
         tool_context_access: Option<AgentToolContextAccess>,
         surface_lifetime: Option<CancellationToken>,
         host_events: AgentHostEventPolicy,
+        permission_routing: AgentPermissionRouting,
     ) -> Result<AgentRunHandle, String> {
         let state = &self.service;
         let user_id = self.user_id.as_ref();
@@ -2561,7 +2696,7 @@ impl AgentRuntimeHandle {
         let task_events = run_events.clone();
         let state_inner = Arc::clone(&state.inner);
         let session_lifecycle = Arc::clone(&state.session_lifecycle);
-        let pending_permissions = Arc::clone(&state.pending_permissions);
+        let task_pending_permissions = Arc::clone(&state.pending_permissions);
         let session_id = request.session_id.clone();
         let task_run_id = run_id.clone();
         let task_agent_manager = Arc::clone(&agent_manager);
@@ -2570,8 +2705,11 @@ impl AgentRuntimeHandle {
         let task_web_tool_state = Arc::clone(&web_tool_state);
         let task_user_message = user_message.clone();
         let task_cancel_token = cancel_token.clone();
+        let task_agent = Arc::clone(&agent);
+        let active_agent = Arc::clone(&agent);
         let cancelled_permission_ids = Arc::new(Mutex::new(HashSet::new()));
         let task_cancelled_permission_ids = Arc::clone(&cancelled_permission_ids);
+        let task_issued_permission_ids = Arc::new(Mutex::new(HashSet::new()));
         let (start_tx, start_rx) = oneshot::channel();
         let (terminal_tx, terminal_rx) = watch::channel(None);
         let task = tokio::spawn(async move {
@@ -2585,7 +2723,7 @@ impl AgentRuntimeHandle {
                     task_cancel_token.clone(),
                     run_agent_prompt(AgentPromptRun {
                         events: task_events.clone(),
-                        agent,
+                        agent: Arc::clone(&task_agent),
                         session_manager: Arc::clone(&task_session_manager),
                         live_timelines: live_timelines.clone(),
                         session_id: session_id.clone(),
@@ -2594,8 +2732,11 @@ impl AgentRuntimeHandle {
                         web_tool_state: Arc::clone(&task_web_tool_state),
                         web_permission_context,
                         cancel_token: task_cancel_token.clone(),
-                        pending_permissions,
+                        pending_permissions: Arc::clone(&task_pending_permissions),
+                        issued_permission_ids: task_issued_permission_ids,
                         cancelled_permission_ids: Arc::clone(&task_cancelled_permission_ids),
+                        run_id: task_run_id.clone(),
+                        permission_routing,
                     }),
                 )
                 .await
@@ -2611,6 +2752,31 @@ impl AgentRuntimeHandle {
             // agent_cancel_run. Whichever side acquires it first owns the terminal
             // result, so Stop cannot succeed against an already-settled run.
             let run_was_cancelled = !should_run || task_cancel_token.is_cancelled();
+            let terminal_permissions = cancel_pending_permissions_for_runs(
+                &task_pending_permissions,
+                std::slice::from_ref(&task_run_id),
+                &HashMap::from([(task_run_id.clone(), Arc::clone(&task_agent))]),
+            )
+            .await;
+            if !terminal_permissions.is_empty() {
+                task_cancelled_permission_ids.lock().await.extend(
+                    terminal_permissions
+                        .iter()
+                        .map(|((_, request_id), _)| request_id.clone()),
+                );
+                for ((permission_session_id, request_id), _) in terminal_permissions {
+                    if let Some(item) = update_live_permission_status(
+                        &live_timelines,
+                        &permission_session_id,
+                        &request_id,
+                        "cancelled",
+                    )
+                    .await
+                    {
+                        task_events.publish(AgentRunEvent::TimelineItem(item)).await;
+                    }
+                }
+            }
             let cancelled_permission_ids = task_cancelled_permission_ids.lock().await.clone();
             let result = if run_was_cancelled {
                 finalize_cancelled_agent_turn(
@@ -2680,6 +2846,8 @@ impl AgentRuntimeHandle {
                         current.active_runs.insert(
                             run_id.clone(),
                             ActiveAgentRun {
+                                agent: active_agent,
+                                permission_routing,
                                 token: cancel_token.clone(),
                                 tool_context: tool_context.clone(),
                                 session_id: request.session_id.clone(),
@@ -2717,11 +2885,20 @@ impl AgentRuntimeHandle {
         // followed by this send path re-appending the cancelled prompt.
         drop(session_lifecycle_guard);
 
+        let permission_responder =
+            matches!(permission_routing, AgentPermissionRouting::CallingSurface).then(|| {
+                AgentRunPermissionResponder {
+                    agent: self.clone(),
+                    session_id: Arc::from(request.session_id.as_str()),
+                    run_id: Arc::from(run_id.as_str()),
+                }
+            });
         Ok(AgentRunHandle {
             run_id,
             events: run_events_rx,
             terminal: terminal_rx,
             event_overflowed: run_events.overflow_flag(),
+            permission_responder,
         })
     }
 
@@ -2734,14 +2911,7 @@ impl AgentRuntimeHandle {
         // terminal event. If the worker settled first, its active-run entry will
         // already be gone by the time this command inspects it.
         let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-        let (
-            agent_manager,
-            session_id,
-            cancel_token,
-            tool_context,
-            run_events,
-            cancelled_permission_ids,
-        ) = {
+        let (agent, cancel_token, tool_context, run_events, cancelled_permission_ids) = {
             let runtime = state.inner.lock().await;
             let Some(current) = runtime.as_ref() else {
                 return Ok(());
@@ -2751,8 +2921,7 @@ impl AgentRuntimeHandle {
                 return Ok(());
             };
             (
-                Arc::clone(&current.agent_manager),
-                active_run.session_id.clone(),
+                Arc::clone(&active_run.agent),
                 active_run.token.clone(),
                 active_run.tool_context.clone(),
                 active_run.events.clone(),
@@ -2760,18 +2929,18 @@ impl AgentRuntimeHandle {
             )
         };
         tool_context.cancel_run(&cancel_token);
-        let cancelled_permissions = cancel_pending_permissions_for_sessions(
-            &agent_manager,
+        let cancelled_permissions = cancel_pending_permissions_for_runs(
             &state.pending_permissions,
-            std::slice::from_ref(&session_id),
+            std::slice::from_ref(&run_id),
+            &HashMap::from([(run_id.clone(), agent)]),
         )
         .await;
         cancelled_permission_ids.lock().await.extend(
             cancelled_permissions
                 .iter()
-                .map(|(request_id, _)| request_id.clone()),
+                .map(|((_, request_id), _)| request_id.clone()),
         );
-        for (request_id, session_id) in cancelled_permissions {
+        for ((session_id, request_id), _) in cancelled_permissions {
             if let Some(item) = update_live_permission_status(
                 &state.live_timelines,
                 &session_id,
@@ -2801,17 +2970,35 @@ impl AgentRuntimeHandle {
             return Err("Agent permission mode update requires a task ID".to_string());
         }
         let goose_mode = parse_user_permission_mode(&request.mode)?;
-        let (agent_manager, session_manager, maple_api_session, permission_modes) = {
+        let (agent_manager, session_manager, maple_api_session, permission_modes, active_agent) = {
             let runtime = state.inner.lock().await;
             let current = runtime
                 .as_ref()
                 .ok_or_else(|| "Agent runtime is not running".to_string())?;
             ensure_runtime_account(current, account_scope)?;
+            if current.active_runs.values().any(|run| {
+                run.session_id == session_id
+                    && run.permission_routing == AgentPermissionRouting::CallingSurface
+            }) || current
+                .session_tool_contexts
+                .get(&session_id)
+                .is_some_and(|installed| installed.owner == AgentToolContextOwner::Leased)
+            {
+                return Err("This Agent task is controlled by another Agent surface".to_string());
+            }
             (
                 Arc::clone(&current.agent_manager),
                 Arc::clone(&current.session_manager),
                 Arc::clone(&current.maple_api_session),
                 Arc::clone(&current.permission_modes),
+                current
+                    .active_runs
+                    .values()
+                    .find(|run| {
+                        run.session_id == session_id
+                            && run.permission_routing == AgentPermissionRouting::Desktop
+                    })
+                    .map(|run| Arc::clone(&run.agent)),
             )
         };
 
@@ -2832,15 +3019,22 @@ impl AgentRuntimeHandle {
                 .get_session(&session_id, false)
                 .await
                 .map_err(|error| format!("Failed to load Agent task: {error}"))?;
-            let agent = get_or_create_session_agent(
-                &agent_manager,
-                &maple_api_session,
-                &session,
-                RuntimeContext::default(),
-            )
-            .await
-            .map_err(|error| format!("Failed to resolve Goose agent for mode update: {error}"))?
-            .agent;
+            let agent = match active_agent {
+                Some(agent) => agent,
+                None => {
+                    get_or_create_session_agent(
+                        &agent_manager,
+                        &maple_api_session,
+                        &session,
+                        RuntimeContext::default(),
+                    )
+                    .await
+                    .map_err(|error| {
+                        format!("Failed to resolve Goose agent for mode update: {error}")
+                    })?
+                    .agent
+                }
+            };
             agent
                 .update_goose_mode(GOOSE_PERMISSION_ROUTING_MODE, &session_id)
                 .await
@@ -2897,9 +3091,12 @@ impl AgentRuntimeHandle {
             let request_ids = {
                 let mut pending = state.pending_permissions.lock().await;
                 let request_ids = pending
-                    .keys()
-                    .filter(|(pending_session_id, _)| pending_session_id == &session_id)
-                    .map(|(_, request_id)| request_id.clone())
+                    .iter()
+                    .filter(|((pending_session_id, _), request)| {
+                        pending_session_id == &session_id
+                            && request.routing == AgentPermissionRouting::Desktop
+                    })
+                    .map(|((_, request_id), _)| request_id.clone())
                     .collect::<Vec<_>>();
                 for request_id in &request_ids {
                     pending.remove(&(session_id.clone(), request_id.clone()));
@@ -2951,65 +3148,154 @@ impl AgentRuntimeHandle {
         &self,
         response: AgentPermissionResponse,
     ) -> Result<(), String> {
+        let decision = permission_decision_from_str(&response.decision)?;
+        let display_status = response.decision.clone();
+        self.resolve_permission(
+            response.session_id,
+            response.request_id,
+            decision,
+            AgentPermissionResponseScope::Desktop,
+            Some(display_status),
+        )
+        .await
+    }
+
+    async fn permission_respond_for_run(
+        &self,
+        session_id: &str,
+        run_id: &str,
+        request_id: String,
+        decision: AgentPermissionDecision,
+    ) -> Result<(), String> {
+        self.resolve_permission(
+            session_id.to_string(),
+            request_id,
+            decision,
+            AgentPermissionResponseScope::CallingSurface {
+                run_id: run_id.to_string(),
+            },
+            None,
+        )
+        .await
+    }
+
+    async fn resolve_permission(
+        &self,
+        session_id: String,
+        request_id: String,
+        decision: AgentPermissionDecision,
+        scope: AgentPermissionResponseScope,
+        display_status: Option<String>,
+    ) -> Result<(), String> {
         let state = &self.service;
         let account_scope = self.account_scope.as_ref();
         let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
         self.verify_generation().await?;
         self.ensure_accepting_new_work()?;
-        let (agent_manager, session_id) = {
+        let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let session_id = session_id.trim().to_string();
+        if session_id.is_empty() {
+            return Err("Agent permission response requires a task ID".to_string());
+        }
+        if request_id.trim().is_empty() {
+            return Err("Agent permission response requires a request ID".to_string());
+        }
+        let (agent, run_id, expected_routing, run_events, cancelled_permission_ids) = {
             let runtime = state.inner.lock().await;
             let current = runtime
                 .as_ref()
                 .ok_or_else(|| "Agent runtime is not running".to_string())?;
             ensure_runtime_account(current, account_scope)?;
-            let session_id = response.session_id.trim().to_string();
-            if session_id.is_empty() {
-                return Err("Agent permission response requires a task ID".to_string());
+            let (run_id, expected_routing, active_run) = match &scope {
+                AgentPermissionResponseScope::Desktop => {
+                    let (run_id, active_run) = current
+                        .active_runs
+                        .iter()
+                        .find(|(_, run)| run.session_id == session_id)
+                        .ok_or_else(|| {
+                            format!(
+                                "No running Agent task found for permission request {request_id}"
+                            )
+                        })?;
+                    (run_id.clone(), AgentPermissionRouting::Desktop, active_run)
+                }
+                AgentPermissionResponseScope::CallingSurface { run_id } => {
+                    let active_run = current.active_runs.get(run_id).ok_or_else(|| {
+                        format!("No running Agent task found for permission request {request_id}")
+                    })?;
+                    if active_run.session_id != session_id {
+                        return Err("Agent permission responder does not own this task".to_string());
+                    }
+                    (
+                        run_id.clone(),
+                        AgentPermissionRouting::CallingSurface,
+                        active_run,
+                    )
+                }
+            };
+            if active_run.token.is_cancelled() {
+                return Err("Agent permission request is already cancelled".to_string());
             }
-            let key = (session_id.clone(), response.request_id.clone());
-            if !state.pending_permissions.lock().await.contains_key(&key) {
-                return Err(format!(
-                    "No pending Agent Mode permission request found for {} in task {}",
-                    response.request_id, session_id
-                ));
-            }
-            (Arc::clone(&current.agent_manager), session_id)
+            (
+                Arc::clone(&active_run.agent),
+                run_id,
+                expected_routing,
+                active_run.events.clone(),
+                Arc::clone(&active_run.cancelled_permission_ids),
+            )
         };
-        let agent = agent_manager
-            .get_or_create_agent(session_id.clone())
-            .await
-            .map_err(|e| format!("Failed to resolve Goose agent for permission response: {e}"))?;
+        let key = (session_id.clone(), request_id.clone());
+        {
+            let mut pending = state.pending_permissions.lock().await;
+            let Some(request) = pending.get(&key) else {
+                return Err(format!(
+                    "No pending Agent Mode permission request found for {request_id} in task {session_id}"
+                ));
+            };
+            if request.run_id != run_id || request.routing != expected_routing {
+                return Err("Agent permission responder does not own this request".to_string());
+            }
+            pending.remove(&key);
+        }
+        if decision == AgentPermissionDecision::Cancel {
+            cancelled_permission_ids
+                .lock()
+                .await
+                .insert(request_id.clone());
+        }
         agent
             .handle_confirmation(
-                response.request_id.clone(),
+                request_id.clone(),
                 PermissionConfirmation {
                     principal_type: PrincipalType::Tool,
-                    permission: permission_from_decision(&response.decision)?,
+                    permission: decision.goose_permission(),
                 },
             )
             .await;
         if let Some(item) = update_live_permission_status(
             &state.live_timelines,
             &session_id,
-            &response.request_id,
-            &response.decision,
+            &request_id,
+            display_status
+                .as_deref()
+                .unwrap_or_else(|| decision.status()),
         )
         .await
         {
-            emit_agent_event(
-                &state.host.events,
-                AgentServiceEvent::TimelineItem {
-                    session_id: session_id.clone(),
-                    run_id: None,
-                    item,
-                },
-            );
+            match scope {
+                AgentPermissionResponseScope::Desktop => emit_agent_event(
+                    &state.host.events,
+                    AgentServiceEvent::TimelineItem {
+                        session_id,
+                        run_id: None,
+                        item,
+                    },
+                ),
+                AgentPermissionResponseScope::CallingSurface { .. } => {
+                    run_events.publish(AgentRunEvent::TimelineItem(item)).await;
+                }
+            }
         }
-        state
-            .pending_permissions
-            .lock()
-            .await
-            .remove(&(session_id, response.request_id));
         Ok(())
     }
 }
@@ -3026,7 +3312,10 @@ struct AgentPromptRun {
     web_permission_context: WebPermissionContext,
     cancel_token: CancellationToken,
     pending_permissions: PendingPermissions,
+    issued_permission_ids: IssuedPermissionIds,
     cancelled_permission_ids: CancelledPermissionIds,
+    run_id: String,
+    permission_routing: AgentPermissionRouting,
 }
 
 #[derive(Default)]
@@ -3343,6 +3632,60 @@ async fn automatically_handle_permissions(
     handled
 }
 
+struct ExtractedToolPermissionRequests {
+    requests: HashMap<String, AgentPermissionRequest>,
+    conflicting_ids: HashSet<String>,
+}
+
+fn tool_permission_requests(message: &Message) -> ExtractedToolPermissionRequests {
+    let mut requests = HashMap::new();
+    let mut conflicting_ids = HashSet::new();
+    for content in &message.content {
+        let MessageContent::ActionRequired(action) = content else {
+            continue;
+        };
+        let ActionRequiredData::ToolConfirmation {
+            id,
+            tool_name,
+            arguments,
+            prompt,
+        } = &action.data
+        else {
+            continue;
+        };
+        if id.trim().is_empty() {
+            conflicting_ids.insert(id.clone());
+            continue;
+        }
+        let request = AgentPermissionRequest {
+            request_id: id.clone(),
+            tool_name: tool_name.clone(),
+            arguments: arguments.clone(),
+            prompt: prompt.clone(),
+        };
+        if conflicting_ids.contains(id) {
+            continue;
+        }
+        match requests.get(id) {
+            Some(_) => {
+                // A request ID is a one-shot capability. Even byte-for-byte
+                // duplicate entries in the same Goose message are ambiguous:
+                // registering one and suppressing the other can accidentally
+                // suppress the only caller-visible prompt. Fail closed instead.
+                requests.remove(id);
+                conflicting_ids.insert(id.clone());
+            }
+            None => {
+                requests.insert(id.clone(), request);
+            }
+        }
+    }
+    ExtractedToolPermissionRequests {
+        requests,
+        conflicting_ids,
+    }
+}
+
 async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, String> {
     let AgentPromptRun {
         events,
@@ -3356,7 +3699,10 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
         web_permission_context,
         cancel_token,
         pending_permissions,
+        issued_permission_ids,
         cancelled_permission_ids,
+        run_id,
+        permission_routing,
     } = run;
     let mut terminal_message = None;
     let session_config = SessionConfig {
@@ -3383,6 +3729,23 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
     while let Some(event) = stream.next().await {
         match event {
             Ok(AgentEvent::Message(message)) => {
+                let extracted_permissions = tool_permission_requests(&message);
+                if !extracted_permissions.conflicting_ids.is_empty() {
+                    for request_id in &extracted_permissions.conflicting_ids {
+                        deliver_tool_permission(&agent, request_id.clone(), Permission::Cancel)
+                            .await;
+                    }
+                    return Err(format!(
+                        "Goose emitted an empty or conflicting permission request ID: {}",
+                        extracted_permissions
+                            .conflicting_ids
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ));
+                }
+                let permission_requests = extracted_permissions.requests;
                 let automatically_handled = automatically_handle_permissions(
                     &agent,
                     &session_id,
@@ -3408,53 +3771,69 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                         .is_none_or(|request_id| !automatically_handled.contains(&request_id))
                 });
                 let mut newly_auto_handled = HashSet::new();
+                let mut duplicate_permissions = HashSet::new();
                 for item in &mut items {
                     if let Some(request_id) = pending_permission_request_id(item) {
-                        if !register_pending_permission(
-                            &pending_permissions,
-                            &request_id,
-                            &session_id,
-                            &cancel_token,
-                        )
-                        .await
-                        {
+                        let Some(request) = permission_requests.get(&request_id).cloned() else {
                             cancelled_permission_ids
                                 .lock()
                                 .await
                                 .insert(request_id.clone());
-                            agent
-                                .handle_confirmation(
-                                    request_id,
-                                    PermissionConfirmation {
-                                        principal_type: PrincipalType::Tool,
-                                        permission: Permission::Cancel,
-                                    },
-                                )
-                                .await;
+                            deliver_tool_permission(&agent, request_id, Permission::Cancel).await;
                             item.status = Some("cancelled".to_string());
-                        } else if claim_pending_permission_if_auto(
-                            &agent,
-                            &session_id,
-                            &permission_modes,
+                            continue;
+                        };
+                        match register_pending_permission(
                             &pending_permissions,
-                            &request_id,
+                            &issued_permission_ids,
+                            &session_id,
+                            &run_id,
+                            permission_routing,
+                            request,
                             &cancel_token,
                         )
                         .await
                         {
-                            if cancel_token.is_cancelled() {
+                            PendingPermissionRegistration::Rejected => {
                                 cancelled_permission_ids
                                     .lock()
                                     .await
                                     .insert(request_id.clone());
+                                deliver_tool_permission(&agent, request_id, Permission::Cancel)
+                                    .await;
+                                item.status = Some("cancelled".to_string());
                             }
-                            newly_auto_handled.insert(request_id);
+                            PendingPermissionRegistration::Existing => {
+                                duplicate_permissions.insert(request_id);
+                            }
+                            PendingPermissionRegistration::Registered => {
+                                if claim_pending_permission_if_auto(
+                                    &agent,
+                                    &session_id,
+                                    &permission_modes,
+                                    &pending_permissions,
+                                    &request_id,
+                                    &cancel_token,
+                                )
+                                .await
+                                {
+                                    if cancel_token.is_cancelled() {
+                                        cancelled_permission_ids
+                                            .lock()
+                                            .await
+                                            .insert(request_id.clone());
+                                    }
+                                    newly_auto_handled.insert(request_id);
+                                }
+                            }
                         }
                     }
                 }
                 items.retain(|item| {
-                    pending_permission_request_id(item)
-                        .is_none_or(|request_id| !newly_auto_handled.contains(&request_id))
+                    pending_permission_request_id(item).is_none_or(|request_id| {
+                        !newly_auto_handled.contains(&request_id)
+                            && !duplicate_permissions.contains(&request_id)
+                    })
                 });
                 // Publish a permission card while holding the same claim lock
                 // used by an Allow-all transition. If that transition already
@@ -3484,6 +3863,18 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                     ));
                 }
                 for item in items {
+                    if let Some(request_id) = pending_permission_request_id(&item) {
+                        if let Some(request) = permission_requests.get(&request_id) {
+                            record_timeline_item(&live_timelines, &session_id, item.clone()).await;
+                            events
+                                .publish(AgentRunEvent::PermissionRequested {
+                                    request: request.clone(),
+                                    item,
+                                })
+                                .await;
+                            continue;
+                        }
+                    }
                     record_and_emit_timeline_item(&events, &live_timelines, &session_id, item)
                         .await;
                 }
@@ -4652,16 +5043,21 @@ fn tool_response_title(id: &str) -> Option<String> {
     })
 }
 
-fn permission_from_decision(decision: &str) -> Result<Permission, String> {
+fn permission_decision_from_str(decision: &str) -> Result<AgentPermissionDecision, String> {
     match decision {
-        "allow_once" | "allow" => Ok(Permission::AllowOnce),
-        "deny_once" | "deny" => Ok(Permission::DenyOnce),
-        "cancel" => Ok(Permission::Cancel),
+        "allow_once" | "allow" => Ok(AgentPermissionDecision::AllowOnce),
+        "deny_once" | "deny" => Ok(AgentPermissionDecision::DenyOnce),
+        "cancel" | "cancelled" => Ok(AgentPermissionDecision::Cancel),
         "always_allow" | "always_deny" => {
             Err("Persistent tool permissions are not supported by Maple Agent Mode".to_string())
         }
         other => Err(format!("Unknown permission decision: {other}")),
     }
+}
+
+#[cfg(test)]
+fn permission_from_decision(decision: &str) -> Result<Permission, String> {
+    permission_decision_from_str(decision).map(AgentPermissionDecision::goose_permission)
 }
 
 fn session_summary(session: &Session) -> AgentSessionSummary {
@@ -5907,6 +6303,30 @@ mod tests {
 
     fn recent_root_paths(roots: &[RecentProjectRoot]) -> Vec<String> {
         roots.iter().map(|root| root.path.clone()).collect()
+    }
+
+    fn test_permission_request(request_id: &str) -> AgentPermissionRequest {
+        AgentPermissionRequest {
+            request_id: request_id.to_string(),
+            tool_name: "shell".to_string(),
+            arguments: serde_json::Map::from_iter([(
+                "command".to_string(),
+                Value::String("git status --short".to_string()),
+            )]),
+            prompt: Some("Run this command?".to_string()),
+        }
+    }
+
+    fn test_pending_permission(
+        run_id: &str,
+        routing: AgentPermissionRouting,
+        request_id: &str,
+    ) -> PendingAgentPermission {
+        PendingAgentPermission {
+            run_id: run_id.to_string(),
+            routing,
+            request: test_permission_request(request_id),
+        }
     }
 
     #[test]
@@ -8738,8 +9158,22 @@ mod tests {
             (survivor.id.clone(), LiveTimeline::Streaming(Vec::new())),
         ])));
         let pending_permissions = Arc::new(Mutex::new(HashMap::from([
-            ((target.id.clone(), "target-request".to_string()), ()),
-            ((survivor.id.clone(), "survivor-request".to_string()), ()),
+            (
+                (target.id.clone(), "target-request".to_string()),
+                test_pending_permission(
+                    "target-run",
+                    AgentPermissionRouting::Desktop,
+                    "target-request",
+                ),
+            ),
+            (
+                (survivor.id.clone(), "survivor-request".to_string()),
+                test_pending_permission(
+                    "survivor-run",
+                    AgentPermissionRouting::Desktop,
+                    "survivor-request",
+                ),
+            ),
         ])));
         let web_tool_state = WebToolState::default();
         let provenance_cancel = CancellationToken::new();
@@ -9009,32 +9443,6 @@ mod tests {
             .contains_key(&first_turn_session.id));
 
         let _ = fs::remove_dir_all(test_root);
-    }
-
-    #[tokio::test]
-    async fn detects_active_run_for_session() {
-        let mut active_runs = HashMap::new();
-        let task_handle = tokio::spawn(async {});
-        let (events, _receiver) = AgentRunEventPublisher::new(
-            AgentEventDispatcher::new(Arc::new(NoopAgentEventSink)),
-            "session-1".to_string(),
-            "run-1".to_string(),
-            AgentHostEventPolicy::Publish,
-        );
-        active_runs.insert(
-            "run-1".to_string(),
-            ActiveAgentRun {
-                token: CancellationToken::new(),
-                tool_context: SharedAgentToolContext::new(AgentToolContextSpec::default()),
-                session_id: "session-1".to_string(),
-                events,
-                cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
-                task_handle,
-            },
-        );
-
-        assert!(has_active_session_run(&active_runs, "session-1"));
-        assert!(!has_active_session_run(&active_runs, "session-2"));
     }
 
     #[tokio::test]
@@ -9378,32 +9786,223 @@ mod tests {
         assert!(!title.contains("  "));
     }
 
+    #[test]
+    fn permission_extraction_rejects_empty_and_conflicting_ids() {
+        let status_arguments = serde_json::Map::from_iter([(
+            "command".to_string(),
+            Value::String("git status --short".to_string()),
+        )]);
+        let push_arguments = serde_json::Map::from_iter([(
+            "command".to_string(),
+            Value::String("git push".to_string()),
+        )]);
+        let message = Message::assistant()
+            .with_content(MessageContent::action_required(
+                "request-1",
+                "shell".to_string(),
+                status_arguments,
+                None,
+            ))
+            .with_content(MessageContent::action_required(
+                "request-1",
+                "shell".to_string(),
+                push_arguments,
+                None,
+            ))
+            .with_content(MessageContent::action_required(
+                "",
+                "shell".to_string(),
+                serde_json::Map::new(),
+                None,
+            ));
+
+        let extracted = tool_permission_requests(&message);
+
+        assert!(extracted.requests.is_empty());
+        assert_eq!(
+            extracted.conflicting_ids,
+            HashSet::from(["request-1".to_string(), String::new()])
+        );
+    }
+
+    #[test]
+    fn permission_extraction_rejects_identical_duplicate_ids() {
+        let arguments = serde_json::Map::from_iter([(
+            "command".to_string(),
+            Value::String("git status --short".to_string()),
+        )]);
+        let message = Message::assistant()
+            .with_content(MessageContent::action_required(
+                "request-1",
+                "shell".to_string(),
+                arguments.clone(),
+                None,
+            ))
+            .with_content(MessageContent::action_required(
+                "request-1",
+                "shell".to_string(),
+                arguments,
+                None,
+            ));
+
+        let extracted = tool_permission_requests(&message);
+
+        assert!(extracted.requests.is_empty());
+        assert_eq!(
+            extracted.conflicting_ids,
+            HashSet::from(["request-1".to_string()])
+        );
+    }
+
     #[tokio::test]
     async fn cancelled_permission_is_not_registered() {
         let pending = Arc::new(Mutex::new(HashMap::new()));
+        let issued = Arc::new(Mutex::new(HashSet::new()));
         let cancel_token = CancellationToken::new();
         cancel_token.cancel();
 
-        assert!(
-            !register_pending_permission(&pending, "request-1", "session-1", &cancel_token).await
+        assert_eq!(
+            register_pending_permission(
+                &pending,
+                &issued,
+                "session-1",
+                "run-1",
+                AgentPermissionRouting::Desktop,
+                test_permission_request("request-1"),
+                &cancel_token,
+            )
+            .await,
+            PendingPermissionRegistration::Rejected
         );
         assert!(pending.lock().await.is_empty());
     }
 
     #[tokio::test]
-    async fn pending_permission_ids_are_scoped_by_session() {
+    async fn pending_permissions_are_taken_only_for_the_exact_run() {
         let pending = Arc::new(Mutex::new(HashMap::from([
-            (("session-1".to_string(), "shared-request".to_string()), ()),
-            (("session-2".to_string(), "shared-request".to_string()), ()),
+            (
+                ("session-1".to_string(), "request-1".to_string()),
+                test_pending_permission("run-1", AgentPermissionRouting::Desktop, "request-1"),
+            ),
+            (
+                ("session-1".to_string(), "request-2".to_string()),
+                test_pending_permission(
+                    "run-2",
+                    AgentPermissionRouting::CallingSurface,
+                    "request-2",
+                ),
+            ),
         ])));
 
-        let selected = pending_permissions_for_sessions(&pending, &["session-1".to_string()]).await;
+        let selected = take_pending_permissions_for_runs(&pending, &["run-1".to_string()]).await;
 
+        assert_eq!(selected.len(), 1);
         assert_eq!(
-            selected,
-            vec![("shared-request".to_string(), "session-1".to_string())]
+            selected[0].0,
+            ("session-1".to_string(), "request-1".to_string())
         );
-        assert_eq!(pending.lock().await.len(), 2);
+        assert_eq!(selected[0].1.run_id, "run-1");
+        let remaining = pending.lock().await;
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining.values().next().unwrap().run_id, "run-2");
+    }
+
+    #[tokio::test]
+    async fn conflicting_permission_registration_invalidates_the_stale_capability() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let issued = Arc::new(Mutex::new(HashSet::new()));
+        let cancel_token = CancellationToken::new();
+        let original = test_permission_request("request-1");
+        assert_eq!(
+            register_pending_permission(
+                &pending,
+                &issued,
+                "session-1",
+                "run-1",
+                AgentPermissionRouting::CallingSurface,
+                original.clone(),
+                &cancel_token,
+            )
+            .await,
+            PendingPermissionRegistration::Registered
+        );
+        assert_eq!(
+            register_pending_permission(
+                &pending,
+                &issued,
+                "session-1",
+                "run-1",
+                AgentPermissionRouting::CallingSurface,
+                original,
+                &cancel_token,
+            )
+            .await,
+            PendingPermissionRegistration::Existing
+        );
+
+        let mut conflicting = test_permission_request("request-1");
+        conflicting
+            .arguments
+            .insert("command".to_string(), Value::String("git push".to_string()));
+        assert_eq!(
+            register_pending_permission(
+                &pending,
+                &issued,
+                "session-1",
+                "run-1",
+                AgentPermissionRouting::CallingSurface,
+                conflicting,
+                &cancel_token,
+            )
+            .await,
+            PendingPermissionRegistration::Rejected
+        );
+        assert!(pending.lock().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resolved_permission_ids_cannot_be_reissued_within_a_run() {
+        let pending = Arc::new(Mutex::new(HashMap::new()));
+        let issued = Arc::new(Mutex::new(HashSet::new()));
+        let cancel_token = CancellationToken::new();
+        assert_eq!(
+            register_pending_permission(
+                &pending,
+                &issued,
+                "session-1",
+                "run-1",
+                AgentPermissionRouting::Desktop,
+                test_permission_request("request-1"),
+                &cancel_token,
+            )
+            .await,
+            PendingPermissionRegistration::Registered
+        );
+        assert_eq!(
+            take_pending_permissions_for_runs(&pending, &["run-1".to_string()])
+                .await
+                .len(),
+            1
+        );
+
+        let mut reused = test_permission_request("request-1");
+        reused
+            .arguments
+            .insert("command".to_string(), Value::String("git push".to_string()));
+        assert_eq!(
+            register_pending_permission(
+                &pending,
+                &issued,
+                "session-1",
+                "run-1",
+                AgentPermissionRouting::Desktop,
+                reused,
+                &cancel_token,
+            )
+            .await,
+            PendingPermissionRegistration::Rejected
+        );
+        assert!(pending.lock().await.is_empty());
     }
 
     #[test]

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -1,10 +1,11 @@
 mod developer_tools;
 pub(crate) mod provider;
 mod shell_permission;
+mod tool_context;
 mod web_permission;
 mod web_tools;
 
-use crate::maple_api::{account_scope, MapleApiAuthState, MapleApiSession};
+use crate::maple_api::{account_scope, MapleApiSession};
 use developer_tools::MapleDeveloperClient;
 use futures_util::StreamExt;
 use goose::agents::extension::Envs;
@@ -33,17 +34,18 @@ use shell_permission::{
     local_read_image_request_id, local_read_request_id, ShellPermissionClassifier,
     ShellPermissionOutcome, ShellPermissionRequest,
 };
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::str::FromStr;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicU8, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
-use tauri::{AppHandle, Manager, State};
-use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
+use tokio::sync::{mpsc, oneshot, watch, Mutex};
 use tokio_util::sync::CancellationToken;
+pub(crate) use tool_context::AgentToolContextSpec;
+use tool_context::SharedAgentToolContext;
 use web_permission::{
     web_search_request_id, OpenUrlPermissionRequest, WebPermissionClassifier, WebPermissionContext,
     WebPermissionOutcome,
@@ -56,7 +58,6 @@ const DEFAULT_GOOSE_MODE: &str = "smart_approve";
 // Keep Goose on its ActionRequired path so Maple can apply the currently selected
 // policy at every tool boundary, including when the user changes it mid-run.
 const GOOSE_PERMISSION_ROUTING_MODE: GooseMode = GooseMode::SmartApprove;
-pub(crate) const AGENT_EVENT_NAME: &str = "agent-event";
 const MAPLE_DEVELOPER_TOOLS: [&str; 7] = [
     "read",
     "shell",
@@ -92,23 +93,15 @@ const MAX_MCP_CONNECTION_ERRORS: usize = 3;
 const MAX_MCP_SERVER_NAME_CHARS: usize = 64;
 const MAX_MCP_CONNECTION_ERROR_CHARS: usize = 200;
 const MCP_CONNECTION_ERROR_PREFIX: &str = "Some MCP servers could not connect:";
-const AGENT_EVENT_BROADCAST_CAPACITY: usize = 1_024;
-const MAX_AGENT_TOOL_ENV_KEYS: usize = 6;
-const MAX_AGENT_TOOL_ENV_KEY_BYTES: usize = 64;
-const MAX_AGENT_TOOL_ENV_VALUE_BYTES: usize = 16 * 1024;
-const MAX_AGENT_TOOL_ENV_TOTAL_BYTES: usize = 32 * 1024;
-const ALLOWED_AGENT_TOOL_ENV_KEYS: [&str; MAX_AGENT_TOOL_ENV_KEYS] = [
-    "BUZZ_RELAY_URL",
-    "BUZZ_PRIVATE_KEY",
-    "BUZZ_AUTH_TAG",
-    "BUZZ_API_TOKEN",
-    "BUZZ_ACP_DISPLAY_NAME",
-    "PATH",
-];
+const AGENT_RUN_EVENT_CAPACITY: usize = 256;
+const AGENT_SERVICE_OPEN: u8 = 0;
+const AGENT_SERVICE_DRAINING: u8 = 1;
+const AGENT_SERVICE_DRAINING_ERROR: &str =
+    "Maple Agent services are draining and cannot accept new work";
+pub(crate) const AGENT_TOOL_CONTEXT_INACTIVE_ERROR: &str =
+    "Agent tool context access is no longer active";
 static NEXT_RUN_ID: AtomicU64 = AtomicU64::new(1);
-
-pub(crate) type AgentToolEnvironment = BTreeMap<String, String>;
-pub(crate) type SharedAgentToolEnvironment = Arc<RwLock<AgentToolEnvironment>>;
+static NEXT_TOOL_CONTEXT_INSTALLATION_ID: AtomicU64 = AtomicU64::new(1);
 
 fn validate_session_model_lock(
     message_count: usize,
@@ -329,7 +322,115 @@ pub(crate) enum AgentRunTerminal {
 
 pub(crate) struct AgentRunHandle {
     pub run_id: String,
+    pub events: mpsc::Receiver<AgentRunEvent>,
     pub terminal: watch::Receiver<Option<AgentRunTerminal>>,
+    pub event_overflowed: Arc<AtomicBool>,
+}
+
+pub(crate) struct CreatedAgentSession {
+    pub(crate) detail: AgentSessionDetail,
+    pub(crate) tool_context_lease: Option<AgentToolContextLease>,
+}
+
+/// Controls whether a surface's events are also projected into Maple Desktop.
+///
+/// This is deliberately independent of tool-context ownership. An external
+/// surface may still need Maple Desktop to act as its permission broker, while
+/// an unattended surface can keep its transient run stream isolated.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentHostEventPolicy {
+    Publish,
+    Suppress,
+}
+
+impl AgentHostEventPolicy {
+    fn publishes(self) -> bool {
+        matches!(self, Self::Publish)
+    }
+}
+
+pub(crate) struct AgentToolContextLease {
+    service: MapleAgentService,
+    access: AgentToolContextAccess,
+}
+
+#[derive(Clone)]
+pub(crate) struct AgentToolContextAccess {
+    account_scope: Arc<str>,
+    session_id: Arc<str>,
+    installation_id: u64,
+    context: SharedAgentToolContext,
+}
+
+impl AgentToolContextLease {
+    pub(crate) fn access(&self) -> AgentToolContextAccess {
+        self.access.clone()
+    }
+
+    pub(crate) fn revoke(&self) {
+        self.access.context.revoke();
+    }
+
+    pub(crate) async fn release(self) {
+        self.revoke();
+        let _session_lifecycle = self.service.session_lifecycle.lock().await;
+        let removed = {
+            let mut runtime = self.service.inner.lock().await;
+            let Some(current) = runtime.as_mut() else {
+                return;
+            };
+            if current.account_scope != self.access.account_scope.as_ref() {
+                return;
+            }
+            take_matching_tool_context(
+                &mut current.session_tool_contexts,
+                self.access.session_id.as_ref(),
+                self.access.installation_id,
+                &self.access.context,
+            )
+        };
+        if let Some(installed) = removed {
+            installed.context.revoke();
+        }
+    }
+}
+
+impl Drop for AgentToolContextLease {
+    fn drop(&mut self) {
+        self.access.context.revoke();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AgentRunEvent {
+    SessionUpdated(AgentSessionSummary),
+    Started,
+    TimelineItem(AgentTimelineItem),
+    SetupWarning(String),
+    HistoryReplaced,
+    Error(AgentTimelineItem),
+    Finished(AgentRunTerminal),
+}
+
+#[derive(Debug, Clone)]
+pub(crate) enum AgentServiceEvent {
+    RuntimeStatus(AgentRuntimeStatus),
+    SessionCreated(AgentSessionSummary),
+    SessionUpdated {
+        session_id: String,
+        run_id: Option<String>,
+        session: AgentSessionSummary,
+    },
+    TimelineItem {
+        session_id: String,
+        run_id: Option<String>,
+        item: AgentTimelineItem,
+    },
+    Run {
+        session_id: String,
+        run_id: String,
+        event: AgentRunEvent,
+    },
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -374,27 +475,11 @@ pub struct AgentTimelineItem {
     pub merge: String,
 }
 
-#[derive(Debug, Clone, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub struct AgentEventEnvelope {
-    pub event_type: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub run_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub item: Option<AgentTimelineItem>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub status: Option<AgentRuntimeStatus>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub session: Option<AgentSessionSummary>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub message: Option<String>,
-}
-
 struct ActiveAgentRun {
     token: CancellationToken,
+    tool_context: SharedAgentToolContext,
     session_id: String,
+    events: AgentRunEventPublisher,
     cancelled_permission_ids: CancelledPermissionIds,
     task_handle: tokio::task::JoinHandle<()>,
 }
@@ -409,13 +494,117 @@ struct AgentRuntime {
     session_manager: Arc<SessionManager>,
     maple_api_session: Arc<MapleApiSession>,
     active_runs: HashMap<String, ActiveAgentRun>,
-    session_tool_environments: HashMap<String, SharedAgentToolEnvironment>,
+    session_tool_contexts: HashMap<String, InstalledAgentToolContext>,
     permission_modes: SessionPermissionModes,
     web_tool_state: Arc<WebToolState>,
     project_root: PathBuf,
     model: String,
     mode: String,
     account_scope: String,
+}
+
+struct InstalledAgentToolContext {
+    installation_id: u64,
+    context: SharedAgentToolContext,
+    owner: AgentToolContextOwner,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum AgentToolContextOwner {
+    Maple,
+    Leased,
+}
+
+struct PendingAgentToolContextInstallation {
+    context: SharedAgentToolContext,
+    committed: bool,
+}
+
+impl PendingAgentToolContextInstallation {
+    fn new(context: SharedAgentToolContext) -> Self {
+        Self {
+            context,
+            committed: false,
+        }
+    }
+
+    fn commit(&mut self) {
+        self.committed = true;
+    }
+}
+
+impl Drop for PendingAgentToolContextInstallation {
+    fn drop(&mut self) {
+        if !self.committed {
+            self.context.revoke();
+        }
+    }
+}
+
+fn take_matching_tool_context(
+    contexts: &mut HashMap<String, InstalledAgentToolContext>,
+    session_id: &str,
+    installation_id: u64,
+    context: &SharedAgentToolContext,
+) -> Option<InstalledAgentToolContext> {
+    let matches = contexts.get(session_id).is_some_and(|installed| {
+        installed.installation_id == installation_id && installed.context.ptr_eq(context)
+    });
+    matches.then(|| {
+        contexts
+            .remove(session_id)
+            .expect("matching Agent tool context must still exist")
+    })
+}
+
+fn resolve_session_tool_context(
+    contexts: &mut HashMap<String, InstalledAgentToolContext>,
+    account_scope: &str,
+    session_id: &str,
+    access: Option<&AgentToolContextAccess>,
+    default_spec: &AgentToolContextSpec,
+) -> Result<SharedAgentToolContext, String> {
+    if let Some(access) = access {
+        if access.account_scope.as_ref() != account_scope
+            || access.session_id.as_ref() != session_id
+        {
+            return Err("Agent tool context access does not match this task".to_string());
+        }
+        let installed = contexts
+            .get(session_id)
+            .filter(|installed| {
+                installed.owner == AgentToolContextOwner::Leased
+                    && installed.installation_id == access.installation_id
+                    && installed.context.ptr_eq(&access.context)
+                    && !installed.context.is_revoked()
+            })
+            .ok_or_else(|| AGENT_TOOL_CONTEXT_INACTIVE_ERROR.to_string())?;
+        return Ok(installed.context.clone());
+    }
+
+    if contexts
+        .get(session_id)
+        .is_some_and(|installed| installed.context.is_revoked())
+    {
+        contexts.remove(session_id);
+    }
+    if let Some(installed) = contexts.get(session_id) {
+        if installed.owner == AgentToolContextOwner::Leased {
+            return Err("Agent task is controlled by another Agent surface".to_string());
+        }
+        return Ok(installed.context.clone());
+    }
+
+    let context = SharedAgentToolContext::new(default_spec.clone());
+    contexts.insert(
+        session_id.to_string(),
+        InstalledAgentToolContext {
+            installation_id: next_tool_context_installation_id(),
+            context: context.clone(),
+            owner: AgentToolContextOwner::Maple,
+        },
+    );
+    Ok(context)
 }
 
 impl AgentRuntime {
@@ -450,19 +639,80 @@ impl AgentPathLayout {
 }
 
 pub(crate) trait AgentEventSink: Send + Sync + 'static {
-    fn emit(&self, event: &AgentEventEnvelope);
+    fn emit(&self, event: &AgentServiceEvent);
 }
 
 #[derive(Clone)]
 struct AgentEventDispatcher {
-    sender: broadcast::Sender<AgentEventEnvelope>,
     sink: Arc<dyn AgentEventSink>,
 }
 
 impl AgentEventDispatcher {
     fn new(sink: Arc<dyn AgentEventSink>) -> Self {
-        let (sender, _) = broadcast::channel(AGENT_EVENT_BROADCAST_CAPACITY);
-        Self { sender, sink }
+        Self { sink }
+    }
+}
+
+#[derive(Clone)]
+struct AgentRunEventPublisher {
+    dispatcher: AgentEventDispatcher,
+    session_id: Arc<str>,
+    run_id: Arc<str>,
+    sender: mpsc::Sender<AgentRunEvent>,
+    order: Arc<Mutex<()>>,
+    host_events: AgentHostEventPolicy,
+    overflowed: Arc<AtomicBool>,
+}
+
+impl AgentRunEventPublisher {
+    fn new(
+        dispatcher: AgentEventDispatcher,
+        session_id: String,
+        run_id: String,
+        host_events: AgentHostEventPolicy,
+    ) -> (Self, mpsc::Receiver<AgentRunEvent>) {
+        let (sender, receiver) = mpsc::channel(AGENT_RUN_EVENT_CAPACITY);
+        (
+            Self {
+                dispatcher,
+                session_id: Arc::from(session_id),
+                run_id: Arc::from(run_id),
+                sender,
+                order: Arc::new(Mutex::new(())),
+                host_events,
+                overflowed: Arc::new(AtomicBool::new(false)),
+            },
+            receiver,
+        )
+    }
+
+    fn overflow_flag(&self) -> Arc<AtomicBool> {
+        Arc::clone(&self.overflowed)
+    }
+
+    async fn publish(&self, event: AgentRunEvent) {
+        let _order = self.order.lock().await;
+        if self.host_events.publishes() {
+            emit_agent_event(
+                &self.dispatcher,
+                AgentServiceEvent::Run {
+                    session_id: self.session_id.to_string(),
+                    run_id: self.run_id.to_string(),
+                    event: event.clone(),
+                },
+            );
+        }
+        // Desktop deliberately drops this receiver after obtaining the run ID.
+        // ACP retains it as an isolated, bounded stream for the run. A slow
+        // protocol consumer must never backpressure Goose or lifecycle cleanup.
+        // Queue saturation is retained as an explicit error signal so no ACP
+        // caller can mistake a truncated stream for a complete response.
+        match self.sender.try_send(event) {
+            Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.overflowed.store(true, Ordering::Release);
+            }
+        }
     }
 }
 
@@ -470,17 +720,24 @@ impl AgentEventDispatcher {
 pub(crate) struct MapleAgentHostResources {
     paths: AgentPathLayout,
     events: AgentEventDispatcher,
+    default_tool_context: AgentToolContextSpec,
 }
 
 impl MapleAgentHostResources {
-    pub(crate) fn new(paths: AgentPathLayout, event_sink: Arc<dyn AgentEventSink>) -> Self {
+    pub(crate) fn new(
+        paths: AgentPathLayout,
+        event_sink: Arc<dyn AgentEventSink>,
+        default_tool_context: AgentToolContextSpec,
+    ) -> Self {
         Self {
             paths,
             events: AgentEventDispatcher::new(event_sink),
+            default_tool_context,
         }
     }
 }
 
+#[derive(Clone)]
 pub struct MapleAgentService {
     host: MapleAgentHostResources,
     inner: Arc<Mutex<Option<AgentRuntime>>>,
@@ -489,12 +746,16 @@ pub struct MapleAgentService {
     session_lifecycle: Arc<Mutex<()>>,
     pending_permissions: PendingPermissions,
     live_timelines: LiveTimelines,
+    admission: Arc<AtomicU8>,
 }
 
-// Temporary internal compatibility name while the Tauri command surface is
-// peeled away from the service implementation. New non-Tauri callers use the
-// concrete MapleAgentService name directly.
-type AgentRuntimeState = MapleAgentService;
+#[derive(Clone)]
+pub(crate) struct AgentRuntimeHandle {
+    service: MapleAgentService,
+    user_id: Arc<str>,
+    account_scope: Arc<str>,
+    generation: u64,
+}
 
 type LiveTimelines = Arc<Mutex<HashMap<String, LiveTimeline>>>;
 
@@ -540,19 +801,59 @@ impl MapleAgentService {
             session_lifecycle: Arc::new(Mutex::new(())),
             pending_permissions: Arc::new(Mutex::new(HashMap::new())),
             live_timelines: Arc::new(Mutex::new(HashMap::new())),
+            admission: Arc::new(AtomicU8::new(AGENT_SERVICE_OPEN)),
+        }
+    }
+
+    /// Bind subsequent operations to one Maple account and one data generation.
+    ///
+    /// Desktop commands create a fresh handle at their boundary. Long-lived
+    /// adapters such as ACP retain a handle, which makes account clearing an
+    /// explicit revocation point instead of silently rebinding the adapter.
+    pub(crate) async fn handle_for_user(
+        &self,
+        user_id: &str,
+    ) -> Result<AgentRuntimeHandle, String> {
+        let account_scope = account_scope(user_id)?;
+        let generation = account_generation(self, &account_scope).await;
+        Ok(AgentRuntimeHandle {
+            service: self.clone(),
+            user_id: Arc::from(user_id),
+            account_scope: Arc::from(account_scope),
+            generation,
+        })
+    }
+
+    /// Stop admitting mutations before host teardown begins. Existing work and
+    /// cleanup operations remain able to drain through their dedicated paths.
+    pub(crate) fn begin_draining(&self) {
+        self.admission
+            .store(AGENT_SERVICE_DRAINING, Ordering::Release);
+    }
+
+    /// Reopen admission only when a requested update restart was abandoned and
+    /// the current Maple process will continue serving the user.
+    pub(crate) fn reopen_after_failed_shutdown(&self) {
+        self.admission.store(AGENT_SERVICE_OPEN, Ordering::Release);
+    }
+
+    pub(crate) fn ensure_accepting_new_work(&self) -> Result<(), String> {
+        if self.admission.load(Ordering::Acquire) == AGENT_SERVICE_OPEN {
+            Ok(())
+        } else {
+            Err(AGENT_SERVICE_DRAINING_ERROR.to_string())
         }
     }
 }
 
-pub(crate) fn subscribe_agent_events(
-    app_handle: &AppHandle,
-) -> broadcast::Receiver<AgentEventEnvelope> {
-    app_handle
-        .state::<AgentRuntimeState>()
-        .host
-        .events
-        .sender
-        .subscribe()
+impl AgentRuntimeHandle {
+    pub(crate) async fn verify_generation(&self) -> Result<(), String> {
+        ensure_account_generation(&self.service, &self.account_scope, self.generation).await
+    }
+
+    pub(crate) fn ensure_accepting_new_work(&self) -> Result<(), String> {
+        self.service.ensure_accepting_new_work()
+    }
 }
 
 fn ensure_runtime_account(runtime: &AgentRuntime, account_scope: &str) -> Result<(), String> {
@@ -567,7 +868,7 @@ fn ensure_account_scope(current_scope: &str, requested_scope: &str) -> Result<()
     }
 }
 
-async fn account_generation(state: &AgentRuntimeState, account_scope: &str) -> u64 {
+async fn account_generation(state: &MapleAgentService, account_scope: &str) -> u64 {
     *state
         .account_generations
         .lock()
@@ -577,7 +878,7 @@ async fn account_generation(state: &AgentRuntimeState, account_scope: &str) -> u
 }
 
 async fn ensure_account_generation(
-    state: &AgentRuntimeState,
+    state: &MapleAgentService,
     account_scope: &str,
     expected: u64,
 ) -> Result<(), String> {
@@ -588,7 +889,7 @@ async fn ensure_account_generation(
     }
 }
 
-async fn advance_account_generation(state: &AgentRuntimeState, account_scope: &str) -> u64 {
+async fn advance_account_generation(state: &MapleAgentService, account_scope: &str) -> u64 {
     let mut generations = state.account_generations.lock().await;
     let generation = generations.entry(account_scope.to_string()).or_default();
     *generation = generation
@@ -604,6 +905,14 @@ fn next_run_id() -> String {
         })
         .expect("Agent Mode exhausted its run ID sequence");
     format!("run_{}_{sequence}", unix_ms())
+}
+
+fn next_tool_context_installation_id() -> u64 {
+    NEXT_TOOL_CONTEXT_INSTALLATION_ID
+        .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |value| {
+            value.checked_add(1)
+        })
+        .expect("Agent Mode exhausted its tool context installation IDs")
 }
 
 fn session_title_from_prompt(prompt: &str) -> String {
@@ -693,17 +1002,17 @@ async fn register_pending_permission(
     }
 }
 
-async fn stop_runtime_for_user(state: &AgentRuntimeState, user_id: &str) -> Result<(), String> {
+async fn stop_runtime_for_user(state: &MapleAgentService, user_id: &str) -> Result<(), String> {
     let account_scope = account_scope(user_id)?;
     stop_runtime_inner(state, Some(&account_scope)).await
 }
 
 async fn stop_runtime_inner(
-    state: &AgentRuntimeState,
+    state: &MapleAgentService,
     requested_scope: Option<&str>,
 ) -> Result<(), String> {
     let session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let (agent_manager, active_runs, web_tool_state) = {
+    let (agent_manager, active_runs, web_tool_state, tool_contexts) = {
         let mut runtime = state.inner.lock().await;
         let Some(current) = runtime.as_mut() else {
             return Ok(());
@@ -715,8 +1024,13 @@ async fn stop_runtime_inner(
             Arc::clone(&current.agent_manager),
             std::mem::take(&mut current.active_runs),
             Arc::clone(&current.web_tool_state),
+            std::mem::take(&mut current.session_tool_contexts),
         )
     };
+
+    for installed in tool_contexts.into_values() {
+        installed.context.revoke();
+    }
 
     let session_ids = active_runs
         .values()
@@ -735,7 +1049,7 @@ async fn stop_runtime_inner(
     for (_, active_run) in active_runs {
         // Cancel first so an ActionRequired event racing this snapshot will
         // take the immediate-cancel path in register_pending_permission.
-        active_run.token.cancel();
+        active_run.tool_context.cancel_run(&active_run.token);
         task_handles.push(active_run.task_handle);
     }
     let cancelled_permissions = cancel_pending_permissions_for_sessions(
@@ -780,142 +1094,44 @@ async fn join_agent_tasks(
     }
 }
 
-pub async fn shutdown_agent_runtime(app_handle: &AppHandle) -> Result<(), String> {
-    let state = app_handle.state::<AgentRuntimeState>();
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    stop_runtime_inner(&state, None).await
-}
-
-#[tauri::command]
-pub async fn agent_get_runtime_status(
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<AgentRuntimeStatus, String> {
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    let account_scope = account_scope(&user_id)?;
-    let runtime = state.inner.lock().await;
-    if let Some(current) = runtime.as_ref() {
-        ensure_runtime_account(current, &account_scope)?;
-        return Ok(current.status());
+impl MapleAgentService {
+    pub(crate) async fn shutdown_all(&self) -> Result<(), String> {
+        let _runtime_lifecycle_guard = self.runtime_lifecycle.lock().await;
+        stop_runtime_inner(self, None).await
     }
-    Ok(stopped_status())
 }
 
-#[tauri::command]
-pub async fn agent_start_runtime(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    api_auth_state: State<'_, MapleApiAuthState>,
-    user_id: String,
-    request: Option<AgentStartRequest>,
-) -> Result<AgentRuntimeStatus, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    start_runtime_for_user(app_handle, &state, &api_auth_state, user_id, request).await
-}
-
-pub(crate) async fn ensure_agent_runtime_for_user(
-    app_handle: &AppHandle,
-    user_id: String,
-    request: Option<AgentStartRequest>,
-) -> Result<AgentRuntimeStatus, String> {
-    agent_start_runtime(
-        app_handle.clone(),
-        app_handle.state::<AgentRuntimeState>(),
-        app_handle.state::<MapleApiAuthState>(),
-        user_id,
-        request,
-    )
-    .await
-}
-
-pub(crate) async fn set_agent_session_tool_environment(
-    app_handle: &AppHandle,
-    user_id: &str,
-    session_id: &str,
-    environment: HashMap<String, String>,
-) -> Result<SharedAgentToolEnvironment, String> {
-    let environment = normalize_agent_tool_environment(environment)?;
-    let session_id = session_id.trim().to_string();
-    if session_id.is_empty() {
-        return Err("Agent tool environment requires a task ID".to_string());
+impl AgentRuntimeHandle {
+    pub(crate) async fn status(&self) -> Result<AgentRuntimeStatus, String> {
+        let _runtime_lifecycle_guard = self.service.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let runtime = self.service.inner.lock().await;
+        if let Some(current) = runtime.as_ref() {
+            ensure_runtime_account(current, &self.account_scope)?;
+            return Ok(current.status());
+        }
+        Ok(stopped_status())
     }
 
-    let state = app_handle.state::<AgentRuntimeState>();
-    let requested_scope = account_scope(user_id)?;
-    let generation = account_generation(&state, &requested_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &requested_scope, generation).await?;
-    let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let session_manager = {
-        let runtime = state.inner.lock().await;
-        let current = runtime
-            .as_ref()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &requested_scope)?;
-        Arc::clone(&current.session_manager)
-    };
-    session_manager
-        .get_session(&session_id, false)
-        .await
-        .map_err(|error| format!("Failed to load Agent task: {error}"))?;
-
-    let shared_environment = {
-        let mut runtime = state.inner.lock().await;
-        let current = runtime
-            .as_mut()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &requested_scope)?;
-        Arc::clone(
-            current
-                .session_tool_environments
-                .entry(session_id)
-                .or_insert_with(|| Arc::new(RwLock::new(AgentToolEnvironment::new()))),
-        )
-    };
-    *shared_environment.write().await = environment;
-    Ok(shared_environment)
-}
-
-pub(crate) async fn clear_agent_session_tool_environment(
-    app_handle: &AppHandle,
-    user_id: &str,
-    session_id: &str,
-) -> Result<(), String> {
-    let session_id = session_id.trim();
-    if session_id.is_empty() {
-        return Ok(());
+    pub(crate) async fn start(
+        &self,
+        maple_api_session: Arc<MapleApiSession>,
+        request: Option<AgentStartRequest>,
+    ) -> Result<AgentRuntimeStatus, String> {
+        let _runtime_lifecycle_guard = self.service.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        start_runtime_for_user(&self.service, maple_api_session, &self.user_id, request).await
     }
-
-    let state = app_handle.state::<AgentRuntimeState>();
-    let requested_scope = account_scope(user_id)?;
-    let generation = account_generation(&state, &requested_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &requested_scope, generation).await?;
-    let removed = {
-        let mut runtime = state.inner.lock().await;
-        let Some(current) = runtime.as_mut() else {
-            return Ok(());
-        };
-        ensure_runtime_account(current, &requested_scope)?;
-        current.session_tool_environments.remove(session_id)
-    };
-    if let Some(environment) = removed {
-        environment.write().await.clear();
-    }
-    Ok(())
 }
 
 async fn start_runtime_for_user(
-    app_handle: AppHandle,
-    state: &AgentRuntimeState,
-    api_auth_state: &MapleApiAuthState,
-    user_id: String,
+    state: &MapleAgentService,
+    maple_api_session: Arc<MapleApiSession>,
+    user_id: &str,
     request: Option<AgentStartRequest>,
 ) -> Result<AgentRuntimeStatus, String> {
-    let account_scope = account_scope(&user_id)?;
+    let account_scope = account_scope(user_id)?;
     {
         let runtime = state.inner.lock().await;
         if let Some(current) = runtime.as_ref() {
@@ -924,13 +1140,15 @@ async fn start_runtime_for_user(
         }
     }
 
-    let maple_api_session = api_auth_state.session_for(&user_id).await?;
+    ensure_account_scope(maple_api_session.account_scope(), &account_scope).map_err(|_| {
+        "Maple API authentication belongs to a different signed-in account".to_string()
+    })?;
     maple_api_session
         .validate_user()
         .await
         .map_err(|error| format!("Failed to validate Maple API authentication: {error}"))?;
 
-    let mut agent_config = load_agent_config_inner(&state.host.paths, &user_id)
+    let mut agent_config = load_agent_config_inner(&state.host.paths, user_id)
         .map_err(|error| format!("Failed to load Agent config: {error}"))?;
     let request = request.unwrap_or(AgentStartRequest {
         project_root: None,
@@ -948,7 +1166,7 @@ async fn start_runtime_for_user(
         .unwrap_or_else(|| DEFAULT_GOOSE_MODE.to_string());
     parse_user_permission_mode(&mode)?;
 
-    let config_dir = agent_config_dir(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
+    let config_dir = agent_config_dir(&state.host.paths, user_id).map_err(|e| e.to_string())?;
     let goose_path_root = config_dir.join("goose");
     fs::create_dir_all(goose_path_root.join("data"))
         .map_err(|e| format!("Failed to create Goose data dir: {e}"))?;
@@ -994,7 +1212,7 @@ async fn start_runtime_for_user(
         session_manager,
         maple_api_session,
         active_runs: HashMap::new(),
-        session_tool_environments: HashMap::new(),
+        session_tool_contexts: HashMap::new(),
         permission_modes: Arc::new(Mutex::new(HashMap::new())),
         web_tool_state: Arc::new(WebToolState::default()),
         project_root: project_root.clone(),
@@ -1014,895 +1232,876 @@ async fn start_runtime_for_user(
     // here would incorrectly move that visible project to the top of the manual order.
     agent_config.default_project_root = Some(path_string(&project_root));
     agent_config.default_model = model;
-    let _ = save_agent_config_inner(&state.host.paths, &user_id, &agent_config);
+    let _ = save_agent_config_inner(&state.host.paths, user_id, &agent_config);
 
     emit_agent_event(
         &state.host.events,
-        AgentEventEnvelope {
-            event_type: "runtimeStatus".to_string(),
-            session_id: None,
-            run_id: None,
-            item: None,
-            status: Some(status.clone()),
-            session: None,
-            message: None,
-        },
+        AgentServiceEvent::RuntimeStatus(status.clone()),
     );
 
     Ok(status)
 }
 
-#[tauri::command]
-pub async fn agent_stop_runtime(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<AgentRuntimeStatus, String> {
-    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    stop_runtime_for_user(&state, &user_id).await?;
-    Ok(stopped_status())
-}
-
-#[tauri::command]
-pub async fn agent_restart_runtime(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    api_auth_state: State<'_, MapleApiAuthState>,
-    user_id: String,
-    request: Option<AgentStartRequest>,
-) -> Result<AgentRuntimeStatus, String> {
-    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    stop_runtime_for_user(&state, &user_id).await?;
-    start_runtime_for_user(app_handle, &state, &api_auth_state, user_id, request).await
-}
-
-#[tauri::command]
-pub async fn agent_clear_user_data(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<(), String> {
-    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
-    let requested_scope = account_scope(&user_id)?;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    advance_account_generation(&state, &requested_scope).await;
-    let is_running_account = {
-        let runtime = state.inner.lock().await;
-        runtime
-            .as_ref()
-            .is_some_and(|current| current.account_scope == requested_scope)
-    };
-    if is_running_account {
-        stop_runtime_for_user(&state, &user_id).await?;
+impl AgentRuntimeHandle {
+    pub(crate) async fn stop(&self) -> Result<AgentRuntimeStatus, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        stop_runtime_for_user(state, &self.user_id).await?;
+        Ok(stopped_status())
     }
 
-    let account_dir =
-        account_config_dir_path(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
-    match fs::remove_dir_all(account_dir) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => return Err(format!("Failed to clear Agent Mode data: {error}")),
-    }
-    let local_account_dir = account_local_data_dir_path(&state.host.paths, &user_id)
-        .map_err(|error| error.to_string())?;
-    match fs::remove_dir_all(local_account_dir) {
-        Ok(()) => {}
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
-        Err(error) => {
-            return Err(format!(
-                "Failed to clear device-local Agent Mode data: {error}"
-            ))
-        }
-    }
-    crate::agent_acp::clear_agent_acp_config(&app_handle, &user_id)?;
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn agent_clear_user_history(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<(), String> {
-    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
-    let requested_scope = account_scope(&user_id)?;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    advance_account_generation(&state, &requested_scope).await;
-    let is_running_account = {
-        let runtime = state.inner.lock().await;
-        runtime
-            .as_ref()
-            .is_some_and(|current| current.account_scope == requested_scope)
-    };
-    if is_running_account {
-        stop_runtime_for_user(&state, &user_id).await?;
+    pub(crate) async fn restart(
+        &self,
+        maple_api_session: Arc<MapleApiSession>,
+        request: Option<AgentStartRequest>,
+    ) -> Result<AgentRuntimeStatus, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        stop_runtime_for_user(state, &self.user_id).await?;
+        start_runtime_for_user(state, maple_api_session, &self.user_id, request).await
     }
 
-    let account_dir =
-        account_config_dir_path(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
-    clear_agent_history(&account_dir)
-        .map_err(|error| format!("Failed to clear Agent Mode history: {error}"))
-}
-
-#[tauri::command]
-pub async fn agent_load_config(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<AgentConfig, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub async fn agent_save_config(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    config: AgentConfig,
-) -> Result<(), String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    // MCP definitions have a dedicated mutation command. Preserve them here so
-    // a delayed project/model preference save cannot overwrite newer servers.
-    let mut next =
-        load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
-    next.default_project_root = config.default_project_root;
-    next.default_model = config.default_model;
-    save_agent_config_inner(&state.host.paths, &user_id, &next).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub async fn agent_list_mcp_servers(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<Vec<AgentMcpServer>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let config = load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
-    normalize_mcp_servers(config.mcp_servers)
-}
-
-#[tauri::command]
-pub async fn agent_save_mcp_servers(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    servers: Vec<AgentMcpServer>,
-) -> Result<Vec<AgentMcpServer>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let servers = normalize_mcp_servers(servers)?;
-    let mut config =
-        load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
-    config.mcp_servers = servers.clone();
-    save_agent_config_inner(&state.host.paths, &user_id, &config).map_err(|e| e.to_string())?;
-
-    Ok(servers)
-}
-
-#[tauri::command]
-pub async fn agent_list_recent_project_roots(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-) -> Result<Vec<RecentProjectRoot>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    load_recent_project_roots_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub async fn agent_save_recent_project_root(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    path: String,
-) -> Result<AgentProjectRootRegistration, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let project_root = normalize_project_root(Path::new(&path))?;
-    let mut config =
-        load_agent_config_inner(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
-    let canonical_path = path_string(&project_root);
-    let restoring = config
-        .removed_project_roots
-        .iter()
-        .any(|removed| removed == &canonical_path);
-    let roots = if restoring {
-        restore_explicit_project_root_inner(&state.host.paths, &user_id, &project_root)
-    } else {
-        register_explicit_project_root_inner(&state.host.paths, &user_id, &project_root)
-    }
-    .map_err(|error| error.to_string())?;
-
-    config
-        .removed_project_roots
-        .retain(|removed| removed != &canonical_path);
-    config.default_project_root = Some(canonical_path.clone());
-    save_agent_config_inner(&state.host.paths, &user_id, &config)
-        .map_err(|error| error.to_string())?;
-    // Clear the device-local tombstone last. If registration or ordinary
-    // config persistence fails, the project remains hidden.
-    if restoring {
-        save_removed_project_roots_inner(
-            &state.host.paths,
-            &user_id,
-            &config.removed_project_roots,
-        )
-        .map_err(|error| error.to_string())?;
-    }
-
-    Ok(AgentProjectRootRegistration {
-        project_root: canonical_path,
-        roots,
-        config,
-    })
-}
-
-#[tauri::command]
-pub async fn agent_remove_project_root(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    path: String,
-    fallback_path: Option<String>,
-) -> Result<AgentConfig, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-
-    let path = path.trim().to_string();
-    if !structurally_valid_project_root(&path) {
-        return Err("Project path must be an absolute folder path".to_string());
-    }
-    let fallback_path = fallback_path
-        .map(|fallback| fallback.trim().to_string())
-        .filter(|fallback| !fallback.is_empty());
-    if let Some(fallback) = fallback_path.as_deref() {
-        if fallback == path || !structurally_valid_project_root(fallback) {
-            return Err("Project fallback must be a different absolute folder path".to_string());
-        }
-    }
-
-    let (session_manager, active_session_ids) = {
-        let runtime = state.inner.lock().await;
-        match runtime.as_ref() {
-            Some(current) => {
-                ensure_runtime_account(current, &account_scope)?;
-                (
-                    Arc::clone(&current.session_manager),
-                    current
-                        .active_runs
-                        .values()
-                        .map(|run| run.session_id.clone())
-                        .collect::<HashSet<_>>(),
-                )
-            }
-            None => (
-                account_session_manager(&state.host.paths, &user_id)?,
-                HashSet::new(),
-            ),
-        }
-    };
-    let sessions = session_manager
-        .list_all_sessions()
-        .await
-        .map_err(|error| format!("Failed to inspect Agent tasks: {error}"))?;
-    let session_roots = sessions
-        .iter()
-        .map(|session| (session.id.clone(), path_string(&session.working_dir)))
-        .collect::<HashMap<_, _>>();
-    if project_has_active_session_run(&session_roots, &active_session_ids, &path) {
-        return Err("Stop the running agent before removing this project".to_string());
-    }
-
-    let mut config =
-        load_agent_config_inner(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
-    apply_project_root_removal(&mut config, &path, fallback_path.as_deref())?;
-    // The tombstone is the only persistent removal state. Saving the fallback
-    // into roaming config would let this device's removal alter another
-    // device. Runtime/UI use the fallback immediately; startup filters the
-    // stale hidden default before selecting any project.
-    save_removed_project_roots_inner(&state.host.paths, &user_id, &config.removed_project_roots)
-        .map_err(|error| error.to_string())?;
-
-    let mut runtime = state.inner.lock().await;
-    if let Some(current) = runtime.as_mut() {
-        update_runtime_project_root_after_removal(
-            &mut current.project_root,
-            &path,
-            fallback_path.as_deref(),
-        );
-    }
-
-    Ok(config)
-}
-
-#[tauri::command]
-pub async fn agent_get_project_skills_trust(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    path: String,
-) -> Result<AgentProjectSkillsTrustStatus, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let requested = Path::new(path.trim());
-    if !requested.is_dir() {
-        return Ok(AgentProjectSkillsTrustStatus {
-            path: path_string(requested),
-            decision: None,
-            available: false,
-        });
-    }
-    let project_root = normalize_project_root(requested)?;
-    let config = load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
-    Ok(project_skills_trust_status(&config, &project_root, true))
-}
-
-#[tauri::command]
-pub async fn agent_set_project_skills_trust(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    path: String,
-    trusted: bool,
-) -> Result<AgentProjectSkillsTrustStatus, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let project_root = normalize_project_root(Path::new(&path))?;
-    let mut config =
-        load_agent_config_inner(&state.host.paths, &user_id).map_err(|e| e.to_string())?;
-    apply_project_skills_trust(&mut config, &project_root, trusted)?;
-    save_agent_config_inner(&state.host.paths, &user_id, &config).map_err(|e| e.to_string())?;
-    Ok(project_skills_trust_status(&config, &project_root, true))
-}
-
-#[tauri::command]
-pub async fn agent_save_project_root_order(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    paths: Vec<String>,
-) -> Result<Vec<RecentProjectRoot>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    save_project_root_order_inner(&state.host.paths, &user_id, paths).map_err(|e| e.to_string())
-}
-
-#[tauri::command]
-pub async fn agent_create_session(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    request: Option<AgentCreateSessionRequest>,
-) -> Result<AgentSessionDetail, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let request = request.unwrap_or(AgentCreateSessionRequest {
-        project_root: None,
-        title: None,
-        model: None,
-        context_limit: None,
-        mode: None,
-        mcp_server_names: None,
-    });
-    let (
-        agent_manager,
-        session_manager,
-        maple_api_session,
-        permission_modes,
-        web_tool_state,
-        runtime_project_root,
-        runtime_model,
-        runtime_mode,
-    ) = {
-        let runtime = state.inner.lock().await;
-        let current = runtime
-            .as_ref()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        (
-            Arc::clone(&current.agent_manager),
-            Arc::clone(&current.session_manager),
-            Arc::clone(&current.maple_api_session),
-            Arc::clone(&current.permission_modes),
-            Arc::clone(&current.web_tool_state),
-            current.project_root.clone(),
-            current.model.clone(),
-            current.mode.clone(),
-        )
-    };
-
-    let config =
-        load_agent_config_inner(&state.host.paths, &user_id).map_err(|error| error.to_string())?;
-    let root = match request.project_root.as_deref() {
-        Some(path) if !path.trim().is_empty() => normalize_project_root(Path::new(path))?,
-        _ => runtime_project_root,
-    };
-    ensure_session_project_root_is_visible(&root, &config.removed_project_roots)?;
-    let title = request
-        .title
-        .filter(|value| !value.trim().is_empty())
-        .unwrap_or_else(|| DEFAULT_AGENT_SESSION_TITLE.to_string());
-    let mode = request.mode.unwrap_or(runtime_mode);
-    let permission_mode = parse_user_permission_mode(&mode)?;
-    let model = request.model.unwrap_or(runtime_model);
-    let configured_mcp = normalize_mcp_servers(config.mcp_servers)?;
-    let selected_mcp = select_mcp_servers(&configured_mcp, request.mcp_server_names.as_deref())?;
-    let selected_extensions = selected_mcp
-        .iter()
-        .map(mcp_server_to_extension)
-        .collect::<Result<Vec<_>, _>>()?;
-    let selected_extension_keys = mcp_extension_keys(&selected_extensions);
-    let session = session_manager
-        .create_session(root.clone(), title, SessionType::User, permission_mode)
-        .await
-        .map_err(|e| format!("Failed to create Agent task: {e}"))?;
-
-    permission_modes
-        .lock()
-        .await
-        .insert(session.id.clone(), permission_mode);
-    let tool_environment = Arc::new(RwLock::new(AgentToolEnvironment::new()));
-    {
-        let mut runtime = state.inner.lock().await;
-        let current = runtime
-            .as_mut()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        current
-            .session_tool_environments
-            .insert(session.id.clone(), Arc::clone(&tool_environment));
-    }
-    let setup_result: Result<Vec<AgentMcpConnectionError>, String> = async {
-        let (agent, mut mcp_errors) = configure_session_agent(
-            AgentSkillsScope {
-                paths: &state.host.paths,
-                user_id: &user_id,
-            },
-            &agent_manager,
-            &session_manager,
-            &maple_api_session,
-            SessionAgentConfiguration {
-                web_tool_state: &web_tool_state,
-                session: &session,
-                model: &model,
-                context_limit: request.context_limit,
-                mode: &mode,
-                primary_model_supports_vision: false,
-                tool_environment: &tool_environment,
-            },
-        )
-        .await?;
-        if !selected_extensions.is_empty() {
-            // Resolve every fallible part of restoring Maple's transient Skills client before
-            // Goose persists the MCP mutation. Reattachment after this point is infallible.
-            let skills_client =
-                prepare_transient_skills_client(&state.host.paths, &user_id, &agent, &session)?;
-            detach_transient_skills_client(&agent).await;
-            let extension_result = agent
-                .add_extensions_bulk(selected_extensions, &session.id)
-                .await;
-            attach_prepared_skills_client(&agent, skills_client).await;
-            match extension_result {
-                Ok(results) => {
-                    mcp_errors.extend(mcp_connection_errors(results, &selected_extension_keys))
-                }
-                Err(error) => mcp_errors.push(AgentMcpConnectionError {
-                    name: "MCP servers".to_string(),
-                    error: error.to_string(),
-                }),
-            }
-        }
-        Ok(mcp_errors)
-    }
-    .await;
-    let mcp_errors = match setup_result {
-        Ok(mcp_errors) => mcp_errors,
-        Err(error) => {
-            permission_modes.lock().await.remove(&session.id);
-            let removed_tool_environment = {
-                let mut runtime = state.inner.lock().await;
-                if let Some(current) = runtime.as_mut() {
-                    ensure_runtime_account(current, &account_scope)?;
-                    current.session_tool_environments.remove(&session.id)
-                } else {
-                    None
-                }
-            };
-            if let Some(environment) = removed_tool_environment {
-                environment.write().await.clear();
-            }
-            if let Err(cleanup_error) = session_manager.delete_session(&session.id).await {
-                log::warn!(
-                    "Failed to remove Agent task {} after setup error: {cleanup_error}",
-                    session.id
-                );
-            }
-            if let Err(cleanup_error) = agent_manager.remove_session_if_loaded(&session.id).await {
-                log::warn!(
-                    "Failed to unload Agent task {} after setup error: {cleanup_error}",
-                    session.id
-                );
-            }
-            return Err(error);
-        }
-    };
-    let summary = session_summary(&session);
-    // Session creation must not mutate project order. Only explicit folder-add and reorder
-    // commands may change the persisted project list.
-    let detail = AgentSessionDetail {
-        session: summary.clone(),
-        timeline: Vec::new(),
-        mcp_errors,
-    };
-    emit_agent_event(
-        &state.host.events,
-        AgentEventEnvelope {
-            event_type: "sessionCreated".to_string(),
-            session_id: Some(summary.id.clone()),
-            run_id: None,
-            item: None,
-            status: None,
-            session: Some(summary),
-            message: None,
-        },
-    );
-    Ok(detail)
-}
-
-#[tauri::command]
-pub async fn agent_list_sessions(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    project_root: Option<String>,
-) -> Result<Vec<AgentSessionSummary>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let (session_manager, filter_root) = {
-        let runtime = state.inner.lock().await;
-        let session_manager = match runtime.as_ref() {
-            Some(current) => {
-                ensure_runtime_account(current, &account_scope)?;
-                Arc::clone(&current.session_manager)
-            }
-            None => account_session_manager(&state.host.paths, &user_id)?,
+    pub(crate) async fn clear_data(&self) -> Result<(), String> {
+        let state = &self.service;
+        let requested_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        advance_account_generation(state, requested_scope).await;
+        let is_running_account = {
+            let runtime = state.inner.lock().await;
+            runtime
+                .as_ref()
+                .is_some_and(|current| current.account_scope == requested_scope)
         };
-        let filter_root = project_root
-            .as_deref()
-            .filter(|value| !value.trim().is_empty())
-            .map(|path| normalize_project_root(Path::new(path)))
-            .transpose()?;
-        (session_manager, filter_root)
-    };
-
-    let mut sessions = session_manager
-        .list_all_sessions()
-        .await
-        .map_err(|e| format!("Failed to list Agent tasks: {e}"))?
-        .into_iter()
-        .filter(|session| {
-            if let Some(root) = filter_root.as_ref() {
-                session.working_dir == *root
-            } else {
-                true
-            }
-        })
-        .map(|session| session_summary(&session))
-        .collect::<Vec<_>>();
-    sort_sessions_newest_first(&mut sessions);
-    Ok(sessions)
-}
-
-#[tauri::command]
-pub async fn agent_load_session(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    session_id: String,
-) -> Result<AgentSessionDetail, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let session_manager = {
-        let runtime = state.inner.lock().await;
-        match runtime.as_ref() {
-            Some(current) => {
-                ensure_runtime_account(current, &account_scope)?;
-                Arc::clone(&current.session_manager)
-            }
-            None => account_session_manager(&state.host.paths, &user_id)?,
+        if is_running_account {
+            stop_runtime_for_user(state, &self.user_id).await?;
         }
-    };
-    let session = session_manager
-        .get_session(&session_id, true)
-        .await
-        .map_err(|e| format!("Failed to load Agent task: {e}"))?;
-    let conversation = session
-        .conversation
-        .as_ref()
-        .ok_or_else(|| "Agent task history was not loaded".to_string())?;
-    let timeline = conversation_to_timeline_items(conversation);
-    let timeline =
-        overlay_live_timeline(&state.live_timelines, &session_id, conversation, timeline).await;
 
-    Ok(AgentSessionDetail {
-        session: session_summary(&session),
-        timeline,
-        mcp_errors: Vec::new(),
-    })
-}
-
-#[tauri::command]
-pub async fn agent_list_session_mcp_servers(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    session_id: String,
-) -> Result<Vec<AgentSessionMcpServer>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let session_manager = {
-        let runtime = state.inner.lock().await;
-        match runtime.as_ref() {
-            Some(current) => {
-                ensure_runtime_account(current, &account_scope)?;
-                Arc::clone(&current.session_manager)
-            }
-            None => account_session_manager(&state.host.paths, &user_id)?,
+        let account_dir = account_config_dir_path(&state.host.paths, &self.user_id)
+            .map_err(|error| error.to_string())?;
+        match fs::remove_dir_all(account_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => return Err(format!("Failed to clear Agent Mode data: {error}")),
         }
-    };
-    let session = session_manager
-        .get_session(session_id.trim(), false)
-        .await
-        .map_err(|error| format!("Failed to load Agent task: {error}"))?;
-    let configured = normalize_mcp_servers(
-        load_agent_config_inner(&state.host.paths, &user_id)
-            .map_err(|error| format!("Failed to load MCP servers: {error}"))?
-            .mcp_servers,
-    )?;
-    Ok(session_mcp_servers(&configured, &session))
-}
-
-#[tauri::command]
-pub async fn agent_set_session_mcp_server_enabled(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    request: AgentSetSessionMcpServerRequest,
-) -> Result<Vec<AgentSessionMcpServer>, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let session_id = request.session_id.trim().to_string();
-    let requested_key = goose::config::extensions::name_to_key(request.name.trim());
-    if session_id.is_empty() {
-        return Err("Agent task ID cannot be empty".to_string());
-    }
-    if requested_key.is_empty() || maple_reserved_extension_key(&requested_key) {
-        return Err("That MCP server cannot be changed".to_string());
-    }
-
-    let (agent_manager, session_manager, maple_api_session) = {
-        let runtime = state.inner.lock().await;
-        let current = runtime
-            .as_ref()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        if has_active_session_run(&current.active_runs, &session_id) {
-            return Err("Stop the running agent before changing MCP servers".to_string());
-        }
-        (
-            Arc::clone(&current.agent_manager),
-            Arc::clone(&current.session_manager),
-            Arc::clone(&current.maple_api_session),
-        )
-    };
-    let configured = normalize_mcp_servers(
-        load_agent_config_inner(&state.host.paths, &user_id)
-            .map_err(|error| format!("Failed to load MCP servers: {error}"))?
-            .mcp_servers,
-    )?;
-    let session = session_manager
-        .get_session(&session_id, false)
-        .await
-        .map_err(|error| format!("Failed to load Agent task: {error}"))?;
-    let session_mcp_keys = session_mcp_extension_keys(&session);
-    let manager_result = get_or_create_session_agent(
-        &agent_manager,
-        &maple_api_session,
-        &session,
-        RuntimeContext::default(),
-    )
-    .await
-    .map_err(|error| format!("Failed to load Goose agent: {error}"))?;
-    for error in mcp_connection_errors(manager_result.extension_results, &session_mcp_keys) {
-        log::warn!(
-            "Failed to restore MCP server {}: {}",
-            error.name,
-            error.error
-        );
-    }
-    let agent = manager_result.agent;
-    // Preflight Skills restoration before detaching the working client or changing persisted MCP
-    // state. Reattaching this prepared client after the mutation cannot fail.
-    let skills_client =
-        prepare_transient_skills_client(&state.host.paths, &user_id, &agent, &session)?;
-    detach_transient_skills_client(&agent).await;
-    let active = agent.get_extension_configs().await;
-    let active_config = active
-        .iter()
-        .find(|config| mcp_transport_label(config).is_some() && config.key() == requested_key);
-
-    let mutation_result: Result<(), String> = async {
-        if request.enabled {
-            if active_config.is_none() {
-                let server = configured
-                    .iter()
-                    .find(|server| {
-                        goose::config::extensions::name_to_key(&server.name) == requested_key
-                    })
-                    .ok_or_else(|| {
-                        format!(
-                            "MCP server '{}' is no longer configured and cannot be enabled",
-                            request.name.trim()
-                        )
-                    })?;
-                let extension = mcp_server_to_extension(server)?;
-                agent
-                    .add_extension(extension, &session_id)
-                    .await
-                    .map_err(|error| {
-                        format!("Failed to connect MCP server '{}': {error}", server.name)
-                    })?;
+        let local_account_dir = account_local_data_dir_path(&state.host.paths, &self.user_id)
+            .map_err(|error| error.to_string())?;
+        match fs::remove_dir_all(local_account_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!(
+                    "Failed to clear device-local Agent Mode data: {error}"
+                ))
             }
-        } else if let Some(config) = active_config {
-            agent
-                .remove_extension(&config.name(), &session_id)
-                .await
-                .map_err(|error| {
-                    format!(
-                        "Failed to disconnect MCP server '{}': {error}",
-                        request.name.trim()
-                    )
-                })?;
-        } else {
-            // A failed cold restore may already have removed the server from the
-            // live manager. Persist that authoritative state so the UI still gets
-            // a successful, durable disable operation.
-            agent
-                .persist_extension_state(&session_id)
-                .await
-                .map_err(|error| format!("Failed to save task MCP settings: {error}"))?;
         }
         Ok(())
     }
-    .await;
-    attach_prepared_skills_client(&agent, skills_client).await;
-    mutation_result?;
 
-    let refreshed = session_manager
-        .get_session(&session_id, false)
-        .await
-        .map_err(|error| format!("Failed to reload Agent task: {error}"))?;
-    Ok(session_mcp_servers(&configured, &refreshed))
+    pub(crate) async fn clear_history(&self) -> Result<(), String> {
+        let state = &self.service;
+        let requested_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        advance_account_generation(state, requested_scope).await;
+        let is_running_account = {
+            let runtime = state.inner.lock().await;
+            runtime
+                .as_ref()
+                .is_some_and(|current| current.account_scope == requested_scope)
+        };
+        if is_running_account {
+            stop_runtime_for_user(state, &self.user_id).await?;
+        }
+
+        let account_dir = account_config_dir_path(&state.host.paths, &self.user_id)
+            .map_err(|error| error.to_string())?;
+        clear_agent_history(&account_dir)
+            .map_err(|error| format!("Failed to clear Agent Mode history: {error}"))
+    }
 }
 
-#[tauri::command]
-pub async fn agent_delete_session(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    session_id: String,
-) -> Result<(), String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let session_id = session_id.trim().to_string();
-    if session_id.is_empty() {
-        return Err("Agent task ID cannot be empty".to_string());
+impl AgentRuntimeHandle {
+    pub(crate) async fn load_config(&self) -> Result<AgentConfig, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        load_agent_config_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())
     }
 
-    let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let (agent_manager, session_manager, permission_modes, web_tool_state) = {
-        let runtime = state.inner.lock().await;
-        match runtime.as_ref() {
-            Some(current) => {
-                ensure_runtime_account(current, &account_scope)?;
-                if has_active_session_run(&current.active_runs, &session_id) {
-                    return Err("Stop the running agent before deleting this task".to_string());
-                }
-                (
-                    Some(Arc::clone(&current.agent_manager)),
-                    Arc::clone(&current.session_manager),
-                    Some(Arc::clone(&current.permission_modes)),
-                    Some(Arc::clone(&current.web_tool_state)),
-                )
+    pub(crate) async fn save_config(&self, config: AgentConfig) -> Result<(), String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        // MCP definitions have a dedicated mutation command. Preserve them here so
+        // a delayed project/model preference save cannot overwrite newer servers.
+        let mut next =
+            load_agent_config_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())?;
+        next.default_project_root = config.default_project_root;
+        next.default_model = config.default_model;
+        save_agent_config_inner(&state.host.paths, &self.user_id, &next).map_err(|e| e.to_string())
+    }
+
+    pub(crate) async fn list_mcp_servers(&self) -> Result<Vec<AgentMcpServer>, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let config =
+            load_agent_config_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())?;
+        normalize_mcp_servers(config.mcp_servers)
+    }
+
+    pub(crate) async fn save_mcp_servers(
+        &self,
+        servers: Vec<AgentMcpServer>,
+    ) -> Result<Vec<AgentMcpServer>, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let servers = normalize_mcp_servers(servers)?;
+        let mut config =
+            load_agent_config_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())?;
+        config.mcp_servers = servers.clone();
+        save_agent_config_inner(&state.host.paths, &self.user_id, &config)
+            .map_err(|e| e.to_string())?;
+
+        Ok(servers)
+    }
+
+    pub(crate) async fn list_recent_project_roots(&self) -> Result<Vec<RecentProjectRoot>, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        load_recent_project_roots_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())
+    }
+
+    pub(crate) async fn save_recent_project_root(
+        &self,
+        path: String,
+    ) -> Result<AgentProjectRootRegistration, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let project_root = normalize_project_root(Path::new(&path))?;
+        let mut config = load_agent_config_inner(&state.host.paths, &self.user_id)
+            .map_err(|error| error.to_string())?;
+        let canonical_path = path_string(&project_root);
+        let restoring = config
+            .removed_project_roots
+            .iter()
+            .any(|removed| removed == &canonical_path);
+        let roots = if restoring {
+            restore_explicit_project_root_inner(&state.host.paths, &self.user_id, &project_root)
+        } else {
+            register_explicit_project_root_inner(&state.host.paths, &self.user_id, &project_root)
+        }
+        .map_err(|error| error.to_string())?;
+
+        config
+            .removed_project_roots
+            .retain(|removed| removed != &canonical_path);
+        config.default_project_root = Some(canonical_path.clone());
+        save_agent_config_inner(&state.host.paths, &self.user_id, &config)
+            .map_err(|error| error.to_string())?;
+        // Clear the device-local tombstone last. If registration or ordinary
+        // config persistence fails, the project remains hidden.
+        if restoring {
+            save_removed_project_roots_inner(
+                &state.host.paths,
+                &self.user_id,
+                &config.removed_project_roots,
+            )
+            .map_err(|error| error.to_string())?;
+        }
+
+        Ok(AgentProjectRootRegistration {
+            project_root: canonical_path,
+            roots,
+            config,
+        })
+    }
+
+    pub(crate) async fn remove_project_root(
+        &self,
+        path: String,
+        fallback_path: Option<String>,
+    ) -> Result<AgentConfig, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+
+        let path = path.trim().to_string();
+        if !structurally_valid_project_root(&path) {
+            return Err("Project path must be an absolute folder path".to_string());
+        }
+        let fallback_path = fallback_path
+            .map(|fallback| fallback.trim().to_string())
+            .filter(|fallback| !fallback.is_empty());
+        if let Some(fallback) = fallback_path.as_deref() {
+            if fallback == path || !structurally_valid_project_root(fallback) {
+                return Err("Project fallback must be a different absolute folder path".to_string());
             }
-            None => (
-                None,
-                account_session_manager(&state.host.paths, &user_id)?,
-                None,
-                None,
-            ),
         }
-    };
 
-    delete_persisted_agent_session(
-        session_manager.as_ref(),
-        &state.pending_permissions,
-        &state.live_timelines,
-        web_tool_state.as_deref(),
-        &session_id,
-    )
-    .await?;
-    if let Some(agent_manager) = agent_manager {
-        if let Err(error) = agent_manager.remove_session_if_loaded(&session_id).await {
-            log::warn!(
-                "Deleted Goose session {session_id}, but failed to unload its agent: {error}"
-            );
+        let (session_manager, active_session_ids) = {
+            let runtime = state.inner.lock().await;
+            match runtime.as_ref() {
+                Some(current) => {
+                    ensure_runtime_account(current, &self.account_scope)?;
+                    (
+                        Arc::clone(&current.session_manager),
+                        current
+                            .active_runs
+                            .values()
+                            .map(|run| run.session_id.clone())
+                            .collect::<HashSet<_>>(),
+                    )
+                }
+                None => (
+                    account_session_manager(&state.host.paths, &self.user_id)?,
+                    HashSet::new(),
+                ),
+            }
+        };
+        let sessions = session_manager
+            .list_all_sessions()
+            .await
+            .map_err(|error| format!("Failed to inspect Agent tasks: {error}"))?;
+        let session_roots = sessions
+            .iter()
+            .map(|session| (session.id.clone(), path_string(&session.working_dir)))
+            .collect::<HashMap<_, _>>();
+        if project_has_active_session_run(&session_roots, &active_session_ids, &path) {
+            return Err("Stop the running agent before removing this project".to_string());
         }
-    }
-    if let Some(permission_modes) = permission_modes {
-        permission_modes.lock().await.remove(&session_id);
-    }
-    let removed_tool_environment = {
+
+        let mut config = load_agent_config_inner(&state.host.paths, &self.user_id)
+            .map_err(|error| error.to_string())?;
+        apply_project_root_removal(&mut config, &path, fallback_path.as_deref())?;
+        // The tombstone is the only persistent removal state. Saving the fallback
+        // into roaming config would let this device's removal alter another
+        // device. Runtime/UI use the fallback immediately; startup filters the
+        // stale hidden default before selecting any project.
+        save_removed_project_roots_inner(
+            &state.host.paths,
+            &self.user_id,
+            &config.removed_project_roots,
+        )
+        .map_err(|error| error.to_string())?;
+
         let mut runtime = state.inner.lock().await;
         if let Some(current) = runtime.as_mut() {
-            ensure_runtime_account(current, &account_scope)?;
-            current.session_tool_environments.remove(&session_id)
-        } else {
-            None
+            update_runtime_project_root_after_removal(
+                &mut current.project_root,
+                &path,
+                fallback_path.as_deref(),
+            );
         }
-    };
-    if let Some(environment) = removed_tool_environment {
-        environment.write().await.clear();
+
+        Ok(config)
     }
 
-    Ok(())
+    pub(crate) async fn get_project_skills_trust(
+        &self,
+        path: String,
+    ) -> Result<AgentProjectSkillsTrustStatus, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let requested = Path::new(path.trim());
+        if !requested.is_dir() {
+            return Ok(AgentProjectSkillsTrustStatus {
+                path: path_string(requested),
+                decision: None,
+                available: false,
+            });
+        }
+        let project_root = normalize_project_root(requested)?;
+        let config =
+            load_agent_config_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())?;
+        Ok(project_skills_trust_status(&config, &project_root, true))
+    }
+
+    pub(crate) async fn set_project_skills_trust(
+        &self,
+        path: String,
+        trusted: bool,
+    ) -> Result<AgentProjectSkillsTrustStatus, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let project_root = normalize_project_root(Path::new(&path))?;
+        let mut config =
+            load_agent_config_inner(&state.host.paths, &self.user_id).map_err(|e| e.to_string())?;
+        apply_project_skills_trust(&mut config, &project_root, trusted)?;
+        save_agent_config_inner(&state.host.paths, &self.user_id, &config)
+            .map_err(|e| e.to_string())?;
+        Ok(project_skills_trust_status(&config, &project_root, true))
+    }
+
+    pub(crate) async fn save_project_root_order(
+        &self,
+        paths: Vec<String>,
+    ) -> Result<Vec<RecentProjectRoot>, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        save_project_root_order_inner(&state.host.paths, &self.user_id, paths)
+            .map_err(|e| e.to_string())
+    }
+}
+
+impl AgentRuntimeHandle {
+    pub(crate) async fn create_session(
+        &self,
+        request: Option<AgentCreateSessionRequest>,
+    ) -> Result<AgentSessionDetail, String> {
+        Ok(self
+            .create_session_with_tool_context(request, None, AgentHostEventPolicy::Publish)
+            .await?
+            .detail)
+    }
+
+    pub(crate) async fn create_session_with_tool_context(
+        &self,
+        request: Option<AgentCreateSessionRequest>,
+        tool_context: Option<AgentToolContextSpec>,
+        host_events: AgentHostEventPolicy,
+    ) -> Result<CreatedAgentSession, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let has_external_tool_context = tool_context.is_some();
+        let tool_context = SharedAgentToolContext::new(
+            tool_context.unwrap_or_else(|| state.host.default_tool_context.clone()),
+        );
+        let mut tool_context_installation =
+            PendingAgentToolContextInstallation::new(tool_context.clone());
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let request = request.unwrap_or(AgentCreateSessionRequest {
+            project_root: None,
+            title: None,
+            model: None,
+            context_limit: None,
+            mode: None,
+            mcp_server_names: None,
+        });
+        let (
+            agent_manager,
+            session_manager,
+            maple_api_session,
+            permission_modes,
+            web_tool_state,
+            runtime_project_root,
+            runtime_model,
+            runtime_mode,
+        ) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            (
+                Arc::clone(&current.agent_manager),
+                Arc::clone(&current.session_manager),
+                Arc::clone(&current.maple_api_session),
+                Arc::clone(&current.permission_modes),
+                Arc::clone(&current.web_tool_state),
+                current.project_root.clone(),
+                current.model.clone(),
+                current.mode.clone(),
+            )
+        };
+
+        let config = load_agent_config_inner(&state.host.paths, user_id)
+            .map_err(|error| error.to_string())?;
+        let root = match request.project_root.as_deref() {
+            Some(path) if !path.trim().is_empty() => normalize_project_root(Path::new(path))?,
+            _ => runtime_project_root,
+        };
+        ensure_session_project_root_is_visible(&root, &config.removed_project_roots)?;
+        let title = request
+            .title
+            .filter(|value| !value.trim().is_empty())
+            .unwrap_or_else(|| DEFAULT_AGENT_SESSION_TITLE.to_string());
+        let mode = request.mode.unwrap_or(runtime_mode);
+        let permission_mode = parse_user_permission_mode(&mode)?;
+        let model = request.model.unwrap_or(runtime_model);
+        let configured_mcp = normalize_mcp_servers(config.mcp_servers)?;
+        let selected_mcp =
+            select_mcp_servers(&configured_mcp, request.mcp_server_names.as_deref())?;
+        let selected_extensions = selected_mcp
+            .iter()
+            .map(mcp_server_to_extension)
+            .collect::<Result<Vec<_>, _>>()?;
+        let selected_extension_keys = mcp_extension_keys(&selected_extensions);
+        let session = session_manager
+            .create_session(root.clone(), title, SessionType::User, permission_mode)
+            .await
+            .map_err(|e| format!("Failed to create Agent task: {e}"))?;
+
+        let installation_id = next_tool_context_installation_id();
+        let setup_result: Result<Vec<AgentMcpConnectionError>, String> = async {
+            let (agent, mut mcp_errors) = configure_session_agent(
+                AgentSkillsScope {
+                    paths: &state.host.paths,
+                    user_id,
+                },
+                &agent_manager,
+                &session_manager,
+                &maple_api_session,
+                SessionAgentConfiguration {
+                    web_tool_state: &web_tool_state,
+                    session: &session,
+                    model: &model,
+                    context_limit: request.context_limit,
+                    mode: &mode,
+                    primary_model_supports_vision: false,
+                    tool_context: &tool_context,
+                },
+            )
+            .await?;
+            if !selected_extensions.is_empty() {
+                // Resolve every fallible part of restoring Maple's transient Skills client before
+                // Goose persists the MCP mutation. Reattachment after this point is infallible.
+                let skills_client =
+                    prepare_transient_skills_client(&state.host.paths, user_id, &agent, &session)?;
+                detach_transient_skills_client(&agent).await;
+                let extension_result = agent
+                    .add_extensions_bulk(selected_extensions, &session.id)
+                    .await;
+                attach_prepared_skills_client(&agent, skills_client).await;
+                match extension_result {
+                    Ok(results) => {
+                        mcp_errors.extend(mcp_connection_errors(results, &selected_extension_keys))
+                    }
+                    Err(error) => mcp_errors.push(AgentMcpConnectionError {
+                        name: "MCP servers".to_string(),
+                        error: error.to_string(),
+                    }),
+                }
+            }
+            Ok(mcp_errors)
+        }
+        .await;
+        let mcp_errors = match setup_result {
+            Ok(mcp_errors) => mcp_errors,
+            Err(error) => {
+                if let Err(cleanup_error) = session_manager.delete_session(&session.id).await {
+                    log::warn!(
+                        "Failed to remove Agent task {} after setup error: {cleanup_error}",
+                        session.id
+                    );
+                }
+                if let Err(cleanup_error) =
+                    agent_manager.remove_session_if_loaded(&session.id).await
+                {
+                    log::warn!(
+                        "Failed to unload Agent task {} after setup error: {cleanup_error}",
+                        session.id
+                    );
+                }
+                return Err(error);
+            }
+        };
+        let summary = session_summary(&session);
+        // Session creation must not mutate project order. Only explicit folder-add and reorder
+        // commands may change the persisted project list.
+        let detail = AgentSessionDetail {
+            session: summary.clone(),
+            timeline: Vec::new(),
+            mcp_errors,
+        };
+        let tool_context_lease = has_external_tool_context.then(|| AgentToolContextLease {
+            service: state.clone(),
+            access: AgentToolContextAccess {
+                account_scope: Arc::clone(&self.account_scope),
+                session_id: Arc::from(detail.session.id.as_str()),
+                installation_id,
+                context: tool_context.clone(),
+            },
+        });
+
+        // Publish the configured context only after every fallible setup await.
+        // Once inserted, the lease is committed and returned without yielding,
+        // so cancellation cannot strand a secret-bearing registry entry.
+        {
+            let mut runtime = state.inner.lock().await;
+            let current = runtime
+                .as_mut()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            let mut modes = permission_modes.lock().await;
+            if let Some(replaced) = current.session_tool_contexts.insert(
+                session.id.clone(),
+                InstalledAgentToolContext {
+                    installation_id,
+                    context: tool_context,
+                    owner: if has_external_tool_context {
+                        AgentToolContextOwner::Leased
+                    } else {
+                        AgentToolContextOwner::Maple
+                    },
+                },
+            ) {
+                replaced.context.revoke();
+            }
+            modes.insert(session.id.clone(), permission_mode);
+        }
+        tool_context_installation.commit();
+        if host_events.publishes() {
+            emit_agent_event(
+                &state.host.events,
+                AgentServiceEvent::SessionCreated(summary),
+            );
+        }
+        Ok(CreatedAgentSession {
+            detail,
+            tool_context_lease,
+        })
+    }
+
+    pub(crate) async fn list_sessions(
+        &self,
+        project_root: Option<String>,
+    ) -> Result<Vec<AgentSessionSummary>, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let (session_manager, filter_root) = {
+            let runtime = state.inner.lock().await;
+            let session_manager = match runtime.as_ref() {
+                Some(current) => {
+                    ensure_runtime_account(current, account_scope)?;
+                    Arc::clone(&current.session_manager)
+                }
+                None => account_session_manager(&state.host.paths, user_id)?,
+            };
+            let filter_root = project_root
+                .as_deref()
+                .filter(|value| !value.trim().is_empty())
+                .map(|path| normalize_project_root(Path::new(path)))
+                .transpose()?;
+            (session_manager, filter_root)
+        };
+
+        let mut sessions = session_manager
+            .list_all_sessions()
+            .await
+            .map_err(|e| format!("Failed to list Agent tasks: {e}"))?
+            .into_iter()
+            .filter(|session| {
+                if let Some(root) = filter_root.as_ref() {
+                    session.working_dir == *root
+                } else {
+                    true
+                }
+            })
+            .map(|session| session_summary(&session))
+            .collect::<Vec<_>>();
+        sort_sessions_newest_first(&mut sessions);
+        Ok(sessions)
+    }
+
+    pub(crate) async fn load_session(
+        &self,
+        session_id: String,
+    ) -> Result<AgentSessionDetail, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let session_manager = {
+            let runtime = state.inner.lock().await;
+            match runtime.as_ref() {
+                Some(current) => {
+                    ensure_runtime_account(current, account_scope)?;
+                    Arc::clone(&current.session_manager)
+                }
+                None => account_session_manager(&state.host.paths, user_id)?,
+            }
+        };
+        let session = session_manager
+            .get_session(&session_id, true)
+            .await
+            .map_err(|e| format!("Failed to load Agent task: {e}"))?;
+        let conversation = session
+            .conversation
+            .as_ref()
+            .ok_or_else(|| "Agent task history was not loaded".to_string())?;
+        let timeline = conversation_to_timeline_items(conversation);
+        let timeline =
+            overlay_live_timeline(&state.live_timelines, &session_id, conversation, timeline).await;
+
+        Ok(AgentSessionDetail {
+            session: session_summary(&session),
+            timeline,
+            mcp_errors: Vec::new(),
+        })
+    }
+
+    pub(crate) async fn list_session_mcp_servers(
+        &self,
+        session_id: String,
+    ) -> Result<Vec<AgentSessionMcpServer>, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let session_manager = {
+            let runtime = state.inner.lock().await;
+            match runtime.as_ref() {
+                Some(current) => {
+                    ensure_runtime_account(current, account_scope)?;
+                    Arc::clone(&current.session_manager)
+                }
+                None => account_session_manager(&state.host.paths, user_id)?,
+            }
+        };
+        let session = session_manager
+            .get_session(session_id.trim(), false)
+            .await
+            .map_err(|error| format!("Failed to load Agent task: {error}"))?;
+        let configured = normalize_mcp_servers(
+            load_agent_config_inner(&state.host.paths, user_id)
+                .map_err(|error| format!("Failed to load MCP servers: {error}"))?
+                .mcp_servers,
+        )?;
+        Ok(session_mcp_servers(&configured, &session))
+    }
+
+    pub(crate) async fn set_session_mcp_server_enabled(
+        &self,
+        request: AgentSetSessionMcpServerRequest,
+    ) -> Result<Vec<AgentSessionMcpServer>, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let session_id = request.session_id.trim().to_string();
+        let requested_key = goose::config::extensions::name_to_key(request.name.trim());
+        if session_id.is_empty() {
+            return Err("Agent task ID cannot be empty".to_string());
+        }
+        if requested_key.is_empty() || maple_reserved_extension_key(&requested_key) {
+            return Err("That MCP server cannot be changed".to_string());
+        }
+
+        let (agent_manager, session_manager, maple_api_session) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            if has_active_session_run(&current.active_runs, &session_id) {
+                return Err("Stop the running agent before changing MCP servers".to_string());
+            }
+            (
+                Arc::clone(&current.agent_manager),
+                Arc::clone(&current.session_manager),
+                Arc::clone(&current.maple_api_session),
+            )
+        };
+        let configured = normalize_mcp_servers(
+            load_agent_config_inner(&state.host.paths, user_id)
+                .map_err(|error| format!("Failed to load MCP servers: {error}"))?
+                .mcp_servers,
+        )?;
+        let session = session_manager
+            .get_session(&session_id, false)
+            .await
+            .map_err(|error| format!("Failed to load Agent task: {error}"))?;
+        let session_mcp_keys = session_mcp_extension_keys(&session);
+        let manager_result = get_or_create_session_agent(
+            &agent_manager,
+            &maple_api_session,
+            &session,
+            RuntimeContext::default(),
+        )
+        .await
+        .map_err(|error| format!("Failed to load Goose agent: {error}"))?;
+        for error in mcp_connection_errors(manager_result.extension_results, &session_mcp_keys) {
+            log::warn!(
+                "Failed to restore MCP server {}: {}",
+                error.name,
+                error.error
+            );
+        }
+        let agent = manager_result.agent;
+        // Preflight Skills restoration before detaching the working client or changing persisted MCP
+        // state. Reattaching this prepared client after the mutation cannot fail.
+        let skills_client =
+            prepare_transient_skills_client(&state.host.paths, user_id, &agent, &session)?;
+        detach_transient_skills_client(&agent).await;
+        let active = agent.get_extension_configs().await;
+        let active_config = active
+            .iter()
+            .find(|config| mcp_transport_label(config).is_some() && config.key() == requested_key);
+
+        let mutation_result: Result<(), String> = async {
+            if request.enabled {
+                if active_config.is_none() {
+                    let server = configured
+                        .iter()
+                        .find(|server| {
+                            goose::config::extensions::name_to_key(&server.name) == requested_key
+                        })
+                        .ok_or_else(|| {
+                            format!(
+                                "MCP server '{}' is no longer configured and cannot be enabled",
+                                request.name.trim()
+                            )
+                        })?;
+                    let extension = mcp_server_to_extension(server)?;
+                    agent
+                        .add_extension(extension, &session_id)
+                        .await
+                        .map_err(|error| {
+                            format!("Failed to connect MCP server '{}': {error}", server.name)
+                        })?;
+                }
+            } else if let Some(config) = active_config {
+                agent
+                    .remove_extension(&config.name(), &session_id)
+                    .await
+                    .map_err(|error| {
+                        format!(
+                            "Failed to disconnect MCP server '{}': {error}",
+                            request.name.trim()
+                        )
+                    })?;
+            } else {
+                // A failed cold restore may already have removed the server from the
+                // live manager. Persist that authoritative state so the UI still gets
+                // a successful, durable disable operation.
+                agent
+                    .persist_extension_state(&session_id)
+                    .await
+                    .map_err(|error| format!("Failed to save task MCP settings: {error}"))?;
+            }
+            Ok(())
+        }
+        .await;
+        attach_prepared_skills_client(&agent, skills_client).await;
+        mutation_result?;
+
+        let refreshed = session_manager
+            .get_session(&session_id, false)
+            .await
+            .map_err(|error| format!("Failed to reload Agent task: {error}"))?;
+        Ok(session_mcp_servers(&configured, &refreshed))
+    }
+
+    pub(crate) async fn delete_session(&self, session_id: String) -> Result<(), String> {
+        self.delete_session_inner(session_id, true).await
+    }
+
+    /// Remove a session that an adapter failed to publish. This cleanup path is
+    /// intentionally available while the service is draining.
+    pub(crate) async fn discard_session_during_cleanup(
+        &self,
+        session_id: String,
+    ) -> Result<(), String> {
+        self.delete_session_inner(session_id, false).await
+    }
+
+    async fn delete_session_inner(
+        &self,
+        session_id: String,
+        require_admission: bool,
+    ) -> Result<(), String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        if require_admission {
+            self.ensure_accepting_new_work()?;
+        }
+        let session_id = session_id.trim().to_string();
+        if session_id.is_empty() {
+            return Err("Agent task ID cannot be empty".to_string());
+        }
+
+        let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let (agent_manager, session_manager, permission_modes, web_tool_state) = {
+            let runtime = state.inner.lock().await;
+            match runtime.as_ref() {
+                Some(current) => {
+                    ensure_runtime_account(current, account_scope)?;
+                    if has_active_session_run(&current.active_runs, &session_id) {
+                        return Err("Stop the running agent before deleting this task".to_string());
+                    }
+                    (
+                        Some(Arc::clone(&current.agent_manager)),
+                        Arc::clone(&current.session_manager),
+                        Some(Arc::clone(&current.permission_modes)),
+                        Some(Arc::clone(&current.web_tool_state)),
+                    )
+                }
+                None => (
+                    None,
+                    account_session_manager(&state.host.paths, user_id)?,
+                    None,
+                    None,
+                ),
+            }
+        };
+
+        delete_persisted_agent_session(
+            session_manager.as_ref(),
+            &state.pending_permissions,
+            &state.live_timelines,
+            web_tool_state.as_deref(),
+            &session_id,
+        )
+        .await?;
+        if let Some(agent_manager) = agent_manager {
+            if let Err(error) = agent_manager.remove_session_if_loaded(&session_id).await {
+                log::warn!(
+                    "Deleted Goose session {session_id}, but failed to unload its agent: {error}"
+                );
+            }
+        }
+        if let Some(permission_modes) = permission_modes {
+            permission_modes.lock().await.remove(&session_id);
+        }
+        let removed_tool_context = {
+            let mut runtime = state.inner.lock().await;
+            if let Some(current) = runtime.as_mut() {
+                ensure_runtime_account(current, account_scope)?;
+                current.session_tool_contexts.remove(&session_id)
+            } else {
+                None
+            }
+        };
+        if let Some(installed) = removed_tool_context {
+            installed.context.revoke();
+        }
+
+        Ok(())
+    }
 }
 
 async fn delete_persisted_agent_session(
@@ -2124,747 +2323,703 @@ fn is_goose_declined_tool_response(response: &goose::conversation::message::Tool
     })
 }
 
-async fn agent_send_message_inner(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    request: AgentSendMessageRequest,
-) -> Result<AgentRunHandle, String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let text = request.text.trim().to_string();
-    if text.is_empty() {
-        return Err("Prompt cannot be empty".to_string());
-    }
-
-    let session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let run_id = next_run_id();
-    let cancel_token = CancellationToken::new();
-    let prompt_title = session_title_from_prompt(&text);
-    let web_permission_context = WebPermissionContext::from_user_prompt(&text);
-    let user_message = Message::user().with_text(text).with_generated_id();
-    let (
-        agent_manager,
-        session_manager,
-        maple_api_session,
-        permission_modes,
-        web_tool_state,
-        tool_environment,
-        model,
-        mode,
-    ) = {
-        let mut runtime = state.inner.lock().await;
-        let current = runtime
-            .as_mut()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        let tool_environment = Arc::clone(
-            current
-                .session_tool_environments
-                .entry(request.session_id.clone())
-                .or_insert_with(|| Arc::new(RwLock::new(AgentToolEnvironment::new()))),
-        );
-        (
-            Arc::clone(&current.agent_manager),
-            Arc::clone(&current.session_manager),
-            Arc::clone(&current.maple_api_session),
-            Arc::clone(&current.permission_modes),
-            Arc::clone(&current.web_tool_state),
-            tool_environment,
-            request
-                .model
-                .clone()
-                .unwrap_or_else(|| current.model.clone()),
-            request.mode.clone().unwrap_or_else(|| current.mode.clone()),
-        )
-    };
-    let requested_permission_mode = parse_user_permission_mode(&mode)?;
-
-    let user_item = message_to_timeline_items(&user_message, false)
-        .into_iter()
-        .next()
-        .ok_or_else(|| "Failed to create user timeline item".to_string())?;
-    let live_timelines = Arc::clone(&state.live_timelines);
-
-    // Claim the session before changing its title, provider, mode, or
-    // extensions. A duplicate send must not mutate an Agent that is already
-    // serving another run.
-    agent_manager
-        .try_register_cancel_token(&request.session_id, cancel_token.clone())
-        .await
-        .map_err(|e| format!("Agent task is already running: {e}"))?;
-
-    // A rejected or delayed send must not be able to change a live policy that
-    // the mode command already made authoritative. Seed only sessions that do
-    // not yet have runtime policy state, after Goose grants this run its claim.
-    let (permission_mode, seeded_permission_mode) = {
-        let mut modes = permission_modes.lock().await;
-        select_session_permission_mode(&mut modes, &request.session_id, requested_permission_mode)
-    };
-    let effective_mode = permission_mode.to_string();
-
-    let setup_result: Result<(Arc<Agent>, Vec<AgentMcpConnectionError>), String> = async {
-        let mut session = session_manager
-            .get_session(&request.session_id, true)
+impl AgentRuntimeHandle {
+    pub(crate) async fn send_message(
+        &self,
+        request: AgentSendMessageRequest,
+    ) -> Result<AgentRunHandle, String> {
+        self.send_message_inner(request, None, None, AgentHostEventPolicy::Publish)
             .await
-            .map_err(|e| format!("Failed to load Agent task: {e}"))?;
-        validate_session_model_lock(
-            session.message_count,
-            session
-                .model_config
-                .as_ref()
-                .map(|model| model.model_name.as_str()),
-            &model,
-        )?;
-        let should_name_from_prompt = should_name_session_from_prompt(&session);
-        if should_name_from_prompt {
-            session_manager
-                .update(&session.id)
-                .system_generated_name(prompt_title)
-                .apply()
-                .await
-                .map_err(|e| format!("Failed to name Agent task: {e}"))?;
-            session = session_manager
-                .get_session(&session.id, false)
-                .await
-                .map_err(|e| format!("Failed to load named Agent task: {e}"))?;
-            emit_agent_event(
-                &state.host.events,
-                AgentEventEnvelope {
-                    event_type: "sessionUpdated".to_string(),
-                    session_id: Some(session.id.clone()),
-                    run_id: Some(run_id.clone()),
-                    item: None,
-                    status: None,
-                    session: Some(session_summary(&session)),
-                    message: None,
-                },
-            );
-        }
-        let (agent, mcp_errors) = configure_session_agent(
-            AgentSkillsScope {
-                paths: &state.host.paths,
-                user_id: &user_id,
-            },
-            &agent_manager,
-            &session_manager,
-            &maple_api_session,
-            SessionAgentConfiguration {
-                web_tool_state: &web_tool_state,
-                session: &session,
-                model: &model,
-                context_limit: request.context_limit,
-                mode: &effective_mode,
-                primary_model_supports_vision: request.vision_capable,
-                tool_environment: &tool_environment,
-            },
-        )
-        .await?;
-        Ok((agent, mcp_errors))
     }
-    .await;
-    let (agent, mcp_errors) = match setup_result {
-        Ok(setup) => setup,
-        Err(error) => {
+
+    pub(crate) async fn send_message_with_tool_context(
+        &self,
+        request: AgentSendMessageRequest,
+        access: AgentToolContextAccess,
+        surface_lifetime: CancellationToken,
+        host_events: AgentHostEventPolicy,
+    ) -> Result<AgentRunHandle, String> {
+        self.send_message_inner(request, Some(access), Some(surface_lifetime), host_events)
+            .await
+    }
+
+    async fn send_message_inner(
+        &self,
+        request: AgentSendMessageRequest,
+        tool_context_access: Option<AgentToolContextAccess>,
+        surface_lifetime: Option<CancellationToken>,
+        host_events: AgentHostEventPolicy,
+    ) -> Result<AgentRunHandle, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let text = request.text.trim().to_string();
+        if text.is_empty() {
+            return Err("Prompt cannot be empty".to_string());
+        }
+
+        let session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let run_id = next_run_id();
+        let (run_events, run_events_rx) = AgentRunEventPublisher::new(
+            state.host.events.clone(),
+            request.session_id.clone(),
+            run_id.clone(),
+            host_events,
+        );
+        let cancel_token = surface_lifetime
+            .as_ref()
+            .map(CancellationToken::child_token)
+            .unwrap_or_default();
+        if cancel_token.is_cancelled() {
+            return Err("Agent surface closed before the run could start".to_string());
+        }
+        let prompt_title = session_title_from_prompt(&text);
+        let web_permission_context = WebPermissionContext::from_user_prompt(&text);
+        let user_message = Message::user().with_text(text).with_generated_id();
+        let (
+            agent_manager,
+            session_manager,
+            maple_api_session,
+            permission_modes,
+            web_tool_state,
+            model,
+            mode,
+        ) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            (
+                Arc::clone(&current.agent_manager),
+                Arc::clone(&current.session_manager),
+                Arc::clone(&current.maple_api_session),
+                Arc::clone(&current.permission_modes),
+                Arc::clone(&current.web_tool_state),
+                request
+                    .model
+                    .clone()
+                    .unwrap_or_else(|| current.model.clone()),
+                request.mode.clone().unwrap_or_else(|| current.mode.clone()),
+            )
+        };
+        let requested_permission_mode = parse_user_permission_mode(&mode)?;
+
+        let user_item = message_to_timeline_items(&user_message, false)
+            .into_iter()
+            .next()
+            .ok_or_else(|| "Failed to create user timeline item".to_string())?;
+        let live_timelines = Arc::clone(&state.live_timelines);
+
+        // Claim the session before changing its title, provider, mode, or
+        // extensions. A duplicate send must not mutate an Agent that is already
+        // serving another run.
+        agent_manager
+            .try_register_cancel_token(&request.session_id, cancel_token.clone())
+            .await
+            .map_err(|e| format!("Agent task is already running: {e}"))?;
+
+        // A rejected or delayed send must not be able to change a live policy that
+        // the mode command already made authoritative. Seed only sessions that do
+        // not yet have runtime policy state, after Goose grants this run its claim.
+        let (permission_mode, seeded_permission_mode) = {
+            let mut modes = permission_modes.lock().await;
+            select_session_permission_mode(
+                &mut modes,
+                &request.session_id,
+                requested_permission_mode,
+            )
+        };
+        let effective_mode = permission_mode.to_string();
+
+        let setup_result: Result<
+            (
+                Arc<Agent>,
+                Vec<AgentMcpConnectionError>,
+                SharedAgentToolContext,
+            ),
+            String,
+        > = async {
+            // External surfaces present an opaque exact-match capability. Check
+            // it before any persisted-session work so deletion that won the
+            // session lifecycle race is reported as an expired surface task.
+            let external_tool_context = if tool_context_access.is_some() {
+                let mut runtime = state.inner.lock().await;
+                let current = runtime
+                    .as_mut()
+                    .ok_or_else(|| "Agent runtime is not running".to_string())?;
+                ensure_runtime_account(current, account_scope)?;
+                Some(resolve_session_tool_context(
+                    &mut current.session_tool_contexts,
+                    account_scope,
+                    &request.session_id,
+                    tool_context_access.as_ref(),
+                    &state.host.default_tool_context,
+                )?)
+            } else {
+                None
+            };
+            let mut session = session_manager
+                .get_session(&request.session_id, true)
+                .await
+                .map_err(|e| format!("Failed to load Agent task: {e}"))?;
+            validate_session_model_lock(
+                session.message_count,
+                session
+                    .model_config
+                    .as_ref()
+                    .map(|model| model.model_name.as_str()),
+                &model,
+            )?;
+            let tool_context = match external_tool_context {
+                Some(context) => context,
+                None => {
+                    let mut runtime = state.inner.lock().await;
+                    let current = runtime
+                        .as_mut()
+                        .ok_or_else(|| "Agent runtime is not running".to_string())?;
+                    ensure_runtime_account(current, account_scope)?;
+                    resolve_session_tool_context(
+                        &mut current.session_tool_contexts,
+                        account_scope,
+                        &request.session_id,
+                        None,
+                        &state.host.default_tool_context,
+                    )?
+                }
+            };
+            let should_name_from_prompt = should_name_session_from_prompt(&session);
+            if should_name_from_prompt {
+                session_manager
+                    .update(&session.id)
+                    .system_generated_name(prompt_title)
+                    .apply()
+                    .await
+                    .map_err(|e| format!("Failed to name Agent task: {e}"))?;
+                session = session_manager
+                    .get_session(&session.id, false)
+                    .await
+                    .map_err(|e| format!("Failed to load named Agent task: {e}"))?;
+                run_events
+                    .publish(AgentRunEvent::SessionUpdated(session_summary(&session)))
+                    .await;
+            }
+            let (agent, mcp_errors) = configure_session_agent(
+                AgentSkillsScope {
+                    paths: &state.host.paths,
+                    user_id,
+                },
+                &agent_manager,
+                &session_manager,
+                &maple_api_session,
+                SessionAgentConfiguration {
+                    web_tool_state: &web_tool_state,
+                    session: &session,
+                    model: &model,
+                    context_limit: request.context_limit,
+                    mode: &effective_mode,
+                    primary_model_supports_vision: request.vision_capable,
+                    tool_context: &tool_context,
+                },
+            )
+            .await?;
+            Ok((agent, mcp_errors, tool_context))
+        }
+        .await;
+        let (agent, mcp_errors, tool_context) = match setup_result {
+            Ok(setup) => setup,
+            Err(error) => {
+                if seeded_permission_mode {
+                    permission_modes.lock().await.remove(&request.session_id);
+                }
+                agent_manager
+                    .unregister_cancel_token(&request.session_id)
+                    .await;
+                return Err(error);
+            }
+        };
+        if !mcp_errors.is_empty() {
+            run_events
+                .publish(AgentRunEvent::SetupWarning(format_mcp_connection_errors(
+                    &mcp_errors,
+                )))
+                .await;
+        }
+        if cancel_token.is_cancelled() {
             if seeded_permission_mode {
                 permission_modes.lock().await.remove(&request.session_id);
             }
             agent_manager
                 .unregister_cancel_token(&request.session_id)
                 .await;
-            return Err(error);
-        }
-    };
-    if !mcp_errors.is_empty() {
-        emit_agent_event(
-            &state.host.events,
-            AgentEventEnvelope {
-                event_type: "error".to_string(),
-                session_id: None,
-                run_id: Some(run_id.clone()),
-                item: None,
-                status: None,
-                session: None,
-                message: Some(format_mcp_connection_errors(&mcp_errors)),
-            },
-        );
-    }
-
-    let task_events = state.host.events.clone();
-    let state_inner = Arc::clone(&state.inner);
-    let session_lifecycle = Arc::clone(&state.session_lifecycle);
-    let pending_permissions = Arc::clone(&state.pending_permissions);
-    let session_id = request.session_id.clone();
-    let task_run_id = run_id.clone();
-    let task_agent_manager = Arc::clone(&agent_manager);
-    let task_session_manager = Arc::clone(&session_manager);
-    let task_permission_modes = Arc::clone(&permission_modes);
-    let task_web_tool_state = Arc::clone(&web_tool_state);
-    let task_user_message = user_message.clone();
-    let task_cancel_token = cancel_token.clone();
-    let cancelled_permission_ids = Arc::new(Mutex::new(HashSet::new()));
-    let task_cancelled_permission_ids = Arc::clone(&cancelled_permission_ids);
-    let (start_tx, start_rx) = oneshot::channel();
-    let (terminal_tx, terminal_rx) = watch::channel(None);
-    let task = tokio::spawn(async move {
-        let should_run = tokio::select! {
-            biased;
-            _ = task_cancel_token.cancelled() => false,
-            start = start_rx => start.is_ok(),
-        };
-        let result = if should_run {
-            provider::with_run_cancellation(
-                task_cancel_token.clone(),
-                run_agent_prompt(AgentPromptRun {
-                    events: task_events.clone(),
-                    agent,
-                    session_manager: Arc::clone(&task_session_manager),
-                    live_timelines: live_timelines.clone(),
-                    session_id: session_id.clone(),
-                    run_id: task_run_id.clone(),
-                    user_message: task_user_message.clone(),
-                    permission_modes: task_permission_modes,
-                    web_tool_state: Arc::clone(&task_web_tool_state),
-                    web_permission_context,
-                    cancel_token: task_cancel_token.clone(),
-                    pending_permissions,
-                    cancelled_permission_ids: Arc::clone(&task_cancelled_permission_ids),
-                }),
-            )
-            .await
-        } else {
-            Ok(AgentPromptOutcome::default())
-        };
-
-        // Keep deletion serialized until every terminal write and event for
-        // this run has completed. The active-run entry stays visible while
-        // the cleanup is in progress, so deletion continues to reject it.
-        let _session_lifecycle_guard = session_lifecycle.lock().await;
-        // Completion and cancellation linearize under the same lock used by
-        // agent_cancel_run. Whichever side acquires it first owns the terminal
-        // result, so Stop cannot succeed against an already-settled run.
-        let run_was_cancelled = !should_run || task_cancel_token.is_cancelled();
-        let cancelled_permission_ids = task_cancelled_permission_ids.lock().await.clone();
-        let result = if run_was_cancelled {
-            finalize_cancelled_agent_turn(
-                task_session_manager.as_ref(),
-                &live_timelines,
-                task_web_tool_state.as_ref(),
-                &session_id,
-                &task_user_message,
-                &cancelled_permission_ids,
-            )
-            .await
-            .map(|_| AgentPromptOutcome::default())
-        } else {
-            result
-        };
-        task_agent_manager
-            .unregister_cancel_token(&session_id)
-            .await;
-        if !run_was_cancelled {
-            if let Ok(outcome) = &result {
-                let mut timelines = live_timelines.lock().await;
-                apply_successful_prompt_outcome(&mut timelines, &session_id, outcome);
-            }
+            return Err("Agent surface closed before the run could start".to_string());
         }
 
-        let (status, message) = match result {
-            Ok(_) if run_was_cancelled => ("cancelled", None),
-            Ok(_) => ("completed", None),
-            Err(error) => ("failed", Some(error)),
-        };
-        if let Some(error) = message.as_ref() {
-            let item = error_item(error.clone());
-            {
-                let mut timelines = live_timelines.lock().await;
-                apply_failed_prompt_outcome(&mut timelines, &session_id, item.clone());
-            }
-            emit_agent_event(
-                &task_events,
-                AgentEventEnvelope {
-                    event_type: "error".to_string(),
-                    session_id: Some(session_id.clone()),
-                    run_id: Some(task_run_id.clone()),
-                    item: Some(item),
-                    status: None,
-                    session: None,
-                    message: None,
-                },
-            );
-        }
-        emit_agent_event(
-            &task_events,
-            AgentEventEnvelope {
-                event_type: "runFinished".to_string(),
-                session_id: Some(session_id),
-                run_id: Some(task_run_id.clone()),
-                item: None,
-                status: None,
-                session: None,
-                message: Some(status.to_string()),
-            },
-        );
-        // This retained per-run signal is authoritative for non-UI consumers.
-        // It is deliberately published after runFinished so a receiver that
-        // can still drain the broadcast stream observes all timeline chunks
-        // before settling, while a lagged receiver can never miss completion.
-        let terminal = match status {
-            "cancelled" => AgentRunTerminal::Cancelled,
-            "failed" => AgentRunTerminal::Failed,
-            _ => AgentRunTerminal::Completed,
-        };
-        let _ = terminal_tx.send(Some(terminal));
-        // Remove the stored JoinHandle only after the final externally visible
-        // side effect. Stop may otherwise miss this task and return while its
-        // runFinished event is still pending.
-        let mut runtime = state_inner.lock().await;
-        if let Some(current) = runtime.as_mut() {
-            current.active_runs.remove(&task_run_id);
-        }
-    });
-
-    let mut task = Some(task);
-    let insertion_error = {
-        let mut runtime = state.inner.lock().await;
-        match runtime.as_mut() {
-            None => Some("Agent runtime is not running".to_string()),
-            Some(current) => match ensure_runtime_account(current, &account_scope) {
-                Err(error) => Some(error),
-                Ok(()) => {
-                    current.active_runs.insert(
-                        run_id.clone(),
-                        ActiveAgentRun {
-                            token: cancel_token.clone(),
-                            session_id: request.session_id.clone(),
-                            cancelled_permission_ids: Arc::clone(&cancelled_permission_ids),
-                            task_handle: task.take().expect("task handle must be available"),
-                        },
-                    );
-                    None
-                }
-            },
-        }
-    };
-    if let Some(error) = insertion_error {
-        let task = task.expect("failed insertion must retain task handle");
-        task.abort();
-        let _ = task.await;
-        agent_manager
-            .unregister_cancel_token(&request.session_id)
-            .await;
-        return Err(error);
-    }
-    emit_agent_event(
-        &state.host.events,
-        AgentEventEnvelope {
-            event_type: "runStarted".to_string(),
-            session_id: Some(request.session_id.clone()),
-            run_id: Some(run_id.clone()),
-            item: None,
-            status: None,
-            session: None,
-            message: None,
-        },
-    );
-
-    record_and_emit_timeline_item(
-        &state.host.events,
-        &state.live_timelines,
-        &request.session_id,
-        &run_id,
-        user_item.clone(),
-    )
-    .await;
-    let _ = start_tx.send(());
-    // Keep the session claimed until the optimistic timeline item and start
-    // signal are ordered. A cancellation cleanup must not finish and then be
-    // followed by this send path re-appending the cancelled prompt.
-    drop(session_lifecycle_guard);
-
-    Ok(AgentRunHandle {
-        run_id,
-        terminal: terminal_rx,
-    })
-}
-
-#[tauri::command]
-pub async fn agent_send_message(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    request: AgentSendMessageRequest,
-) -> Result<AgentRunResponse, String> {
-    let run = agent_send_message_inner(app_handle, state, user_id, request).await?;
-    Ok(AgentRunResponse { run_id: run.run_id })
-}
-
-#[tauri::command]
-pub async fn agent_cancel_run(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    run_id: String,
-) -> Result<(), String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    // Order permission updates before the worker's authoritative reload and
-    // terminal event. If the worker settled first, its active-run entry will
-    // already be gone by the time this command inspects it.
-    let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-    let (agent_manager, session_id, cancel_token, cancelled_permission_ids) = {
-        let runtime = state.inner.lock().await;
-        let Some(current) = runtime.as_ref() else {
-            return Ok(());
-        };
-        ensure_runtime_account(current, &account_scope)?;
-        let Some(active_run) = current.active_runs.get(&run_id) else {
-            return Ok(());
-        };
-        (
-            Arc::clone(&current.agent_manager),
-            active_run.session_id.clone(),
-            active_run.token.clone(),
-            Arc::clone(&active_run.cancelled_permission_ids),
-        )
-    };
-    cancel_token.cancel();
-    let cancelled_permissions = cancel_pending_permissions_for_sessions(
-        &agent_manager,
-        &state.pending_permissions,
-        std::slice::from_ref(&session_id),
-    )
-    .await;
-    cancelled_permission_ids.lock().await.extend(
-        cancelled_permissions
-            .iter()
-            .map(|(request_id, _)| request_id.clone()),
-    );
-    for (request_id, session_id) in cancelled_permissions {
-        if let Some(item) = update_live_permission_status(
-            &state.live_timelines,
-            &session_id,
-            &request_id,
-            "cancelled",
-        )
-        .await
-        {
-            emit_timeline_item(&state.host.events, &session_id, &run_id, item);
-        }
-    }
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn agent_set_permission_mode(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    request: AgentPermissionModeRequest,
-) -> Result<(), String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-
-    let session_id = request.session_id.trim().to_string();
-    if session_id.is_empty() {
-        return Err("Agent permission mode update requires a task ID".to_string());
-    }
-    let goose_mode = parse_user_permission_mode(&request.mode)?;
-    let (agent_manager, session_manager, maple_api_session, permission_modes) = {
-        let runtime = state.inner.lock().await;
-        let current = runtime
-            .as_ref()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        (
-            Arc::clone(&current.agent_manager),
-            Arc::clone(&current.session_manager),
-            Arc::clone(&current.maple_api_session),
-            Arc::clone(&current.permission_modes),
-        )
-    };
-
-    // Restrictive transitions take effect before any fallible Goose or disk
-    // work. Otherwise the selector could say Read only while a still-live Auto
-    // policy approves the next write. If setup fails, restore the previous
-    // policy so the command and optimistic UI can roll back consistently.
-    let previous_restrictive_mode = if goose_mode == GooseMode::SmartApprove {
-        permission_modes
-            .lock()
-            .await
-            .insert(session_id.clone(), goose_mode)
-    } else {
-        None
-    };
-    let update_result: Result<Arc<Agent>, String> = async {
-        let session = session_manager
-            .get_session(&session_id, false)
-            .await
-            .map_err(|error| format!("Failed to load Agent task: {error}"))?;
-        let agent = get_or_create_session_agent(
-            &agent_manager,
-            &maple_api_session,
-            &session,
-            RuntimeContext::default(),
-        )
-        .await
-        .map_err(|error| format!("Failed to resolve Goose agent for mode update: {error}"))?
-        .agent;
-        agent
-            .update_goose_mode(GOOSE_PERMISSION_ROUTING_MODE, &session_id)
-            .await
-            .map_err(|error| format!("Failed to update Goose mode: {error}"))?;
-        // update_goose_mode already persists SmartApprove, which is both our
-        // internal Goose routing mode and the user-facing Read-only mode. Auto
-        // is Maple-owned, so only that case needs a second persistence step.
-        // Keeping Read-only to one write avoids a failed duplicate write
-        // leaving the persisted session stricter than the live Maple policy.
-        if goose_mode == GooseMode::Auto {
-            session_manager
-                .update(&session_id)
-                .goose_mode(goose_mode)
-                .apply()
+        let task_events = run_events.clone();
+        let state_inner = Arc::clone(&state.inner);
+        let session_lifecycle = Arc::clone(&state.session_lifecycle);
+        let pending_permissions = Arc::clone(&state.pending_permissions);
+        let session_id = request.session_id.clone();
+        let task_run_id = run_id.clone();
+        let task_agent_manager = Arc::clone(&agent_manager);
+        let task_session_manager = Arc::clone(&session_manager);
+        let task_permission_modes = Arc::clone(&permission_modes);
+        let task_web_tool_state = Arc::clone(&web_tool_state);
+        let task_user_message = user_message.clone();
+        let task_cancel_token = cancel_token.clone();
+        let cancelled_permission_ids = Arc::new(Mutex::new(HashSet::new()));
+        let task_cancelled_permission_ids = Arc::clone(&cancelled_permission_ids);
+        let (start_tx, start_rx) = oneshot::channel();
+        let (terminal_tx, terminal_rx) = watch::channel(None);
+        let task = tokio::spawn(async move {
+            let should_run = tokio::select! {
+                biased;
+                _ = task_cancel_token.cancelled() => false,
+                start = start_rx => start.is_ok(),
+            };
+            let result = if should_run {
+                provider::with_run_cancellation(
+                    task_cancel_token.clone(),
+                    run_agent_prompt(AgentPromptRun {
+                        events: task_events.clone(),
+                        agent,
+                        session_manager: Arc::clone(&task_session_manager),
+                        live_timelines: live_timelines.clone(),
+                        session_id: session_id.clone(),
+                        user_message: task_user_message.clone(),
+                        permission_modes: task_permission_modes,
+                        web_tool_state: Arc::clone(&task_web_tool_state),
+                        web_permission_context,
+                        cancel_token: task_cancel_token.clone(),
+                        pending_permissions,
+                        cancelled_permission_ids: Arc::clone(&task_cancelled_permission_ids),
+                    }),
+                )
                 .await
-                .map_err(|error| format!("Failed to persist Agent permission mode: {error}"))?;
-        }
-        Ok(agent)
-    }
-    .await;
-    let agent = match update_result {
-        Ok(agent) => agent,
-        Err(error) => {
-            if goose_mode == GooseMode::SmartApprove {
-                let mut modes = permission_modes.lock().await;
-                match previous_restrictive_mode {
-                    Some(previous) => {
-                        modes.insert(session_id.clone(), previous);
-                    }
-                    None => {
-                        modes.remove(&session_id);
-                    }
+            } else {
+                Ok(AgentPromptOutcome::default())
+            };
+
+            // Keep deletion serialized until every terminal write and event for
+            // this run has completed. The active-run entry stays visible while
+            // the cleanup is in progress, so deletion continues to reject it.
+            let _session_lifecycle_guard = session_lifecycle.lock().await;
+            // Completion and cancellation linearize under the same lock used by
+            // agent_cancel_run. Whichever side acquires it first owns the terminal
+            // result, so Stop cannot succeed against an already-settled run.
+            let run_was_cancelled = !should_run || task_cancel_token.is_cancelled();
+            let cancelled_permission_ids = task_cancelled_permission_ids.lock().await.clone();
+            let result = if run_was_cancelled {
+                finalize_cancelled_agent_turn(
+                    task_session_manager.as_ref(),
+                    &live_timelines,
+                    task_web_tool_state.as_ref(),
+                    &session_id,
+                    &task_user_message,
+                    &cancelled_permission_ids,
+                )
+                .await
+                .map(|_| AgentPromptOutcome::default())
+            } else {
+                result
+            };
+            task_agent_manager
+                .unregister_cancel_token(&session_id)
+                .await;
+            if !run_was_cancelled {
+                if let Ok(outcome) = &result {
+                    let mut timelines = live_timelines.lock().await;
+                    apply_successful_prompt_outcome(&mut timelines, &session_id, outcome);
                 }
             }
+
+            let (status, message) = match result {
+                Ok(_) if run_was_cancelled => ("cancelled", None),
+                Ok(_) => ("completed", None),
+                Err(error) => ("failed", Some(error)),
+            };
+            if let Some(error) = message.as_ref() {
+                let item = error_item(error.clone());
+                {
+                    let mut timelines = live_timelines.lock().await;
+                    apply_failed_prompt_outcome(&mut timelines, &session_id, item.clone());
+                }
+                task_events.publish(AgentRunEvent::Error(item)).await;
+            }
+            // This retained per-run signal is authoritative for non-UI consumers.
+            // It is deliberately published after runFinished so a receiver that
+            // can still drain the broadcast stream observes all timeline chunks
+            // before settling, while a lagged receiver can never miss completion.
+            let terminal = match status {
+                "cancelled" => AgentRunTerminal::Cancelled,
+                "failed" => AgentRunTerminal::Failed,
+                _ => AgentRunTerminal::Completed,
+            };
+            task_events.publish(AgentRunEvent::Finished(terminal)).await;
+            let _ = terminal_tx.send(Some(terminal));
+            // Remove the stored JoinHandle only after the final externally visible
+            // side effect. Stop may otherwise miss this task and return while its
+            // runFinished event is still pending.
+            let mut runtime = state_inner.lock().await;
+            if let Some(current) = runtime.as_mut() {
+                current.active_runs.remove(&task_run_id);
+            }
+        });
+
+        let mut task = Some(task);
+        let insertion_error = {
+            let mut runtime = state.inner.lock().await;
+            match runtime.as_mut() {
+                None => Some("Agent runtime is not running".to_string()),
+                Some(current) => match ensure_runtime_account(current, account_scope) {
+                    Err(error) => Some(error),
+                    Ok(()) => {
+                        current.active_runs.insert(
+                            run_id.clone(),
+                            ActiveAgentRun {
+                                token: cancel_token.clone(),
+                                tool_context: tool_context.clone(),
+                                session_id: request.session_id.clone(),
+                                events: run_events.clone(),
+                                cancelled_permission_ids: Arc::clone(&cancelled_permission_ids),
+                                task_handle: task.take().expect("task handle must be available"),
+                            },
+                        );
+                        None
+                    }
+                },
+            }
+        };
+        if let Some(error) = insertion_error {
+            let task = task.expect("failed insertion must retain task handle");
+            task.abort();
+            let _ = task.await;
+            agent_manager
+                .unregister_cancel_token(&request.session_id)
+                .await;
             return Err(error);
         }
-    };
-    if goose_mode == GooseMode::Auto {
-        permission_modes
-            .lock()
-            .await
-            .insert(session_id.clone(), goose_mode);
-    }
-    {
-        let mut runtime = state.inner.lock().await;
-        let current = runtime
-            .as_mut()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        current.mode = request.mode.clone();
+        run_events.publish(AgentRunEvent::Started).await;
+
+        record_and_emit_timeline_item(
+            &run_events,
+            &state.live_timelines,
+            &request.session_id,
+            user_item.clone(),
+        )
+        .await;
+        let _ = start_tx.send(());
+        // Keep the session claimed until the optimistic timeline item and start
+        // signal are ordered. A cancellation cleanup must not finish and then be
+        // followed by this send path re-appending the cancelled prompt.
+        drop(session_lifecycle_guard);
+
+        Ok(AgentRunHandle {
+            run_id,
+            events: run_events_rx,
+            terminal: terminal_rx,
+            event_overflowed: run_events.overflow_flag(),
+        })
     }
 
-    if goose_mode == GooseMode::Auto {
-        let request_ids = {
-            let mut pending = state.pending_permissions.lock().await;
-            let request_ids = pending
-                .keys()
-                .filter(|(pending_session_id, _)| pending_session_id == &session_id)
-                .map(|(_, request_id)| request_id.clone())
-                .collect::<Vec<_>>();
-            for request_id in &request_ids {
-                pending.remove(&(session_id.clone(), request_id.clone()));
-            }
-            request_ids
+    pub(crate) async fn cancel_run(&self, run_id: String) -> Result<(), String> {
+        let state = &self.service;
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        // Order permission updates before the worker's authoritative reload and
+        // terminal event. If the worker settled first, its active-run entry will
+        // already be gone by the time this command inspects it.
+        let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let (
+            agent_manager,
+            session_id,
+            cancel_token,
+            tool_context,
+            run_events,
+            cancelled_permission_ids,
+        ) = {
+            let runtime = state.inner.lock().await;
+            let Some(current) = runtime.as_ref() else {
+                return Ok(());
+            };
+            ensure_runtime_account(current, account_scope)?;
+            let Some(active_run) = current.active_runs.get(&run_id) else {
+                return Ok(());
+            };
+            (
+                Arc::clone(&current.agent_manager),
+                active_run.session_id.clone(),
+                active_run.token.clone(),
+                active_run.tool_context.clone(),
+                active_run.events.clone(),
+                Arc::clone(&active_run.cancelled_permission_ids),
+            )
         };
-        for request_id in request_ids {
-            deliver_tool_permission(&agent, request_id.clone(), Permission::AllowOnce).await;
+        tool_context.cancel_run(&cancel_token);
+        let cancelled_permissions = cancel_pending_permissions_for_sessions(
+            &agent_manager,
+            &state.pending_permissions,
+            std::slice::from_ref(&session_id),
+        )
+        .await;
+        cancelled_permission_ids.lock().await.extend(
+            cancelled_permissions
+                .iter()
+                .map(|(request_id, _)| request_id.clone()),
+        );
+        for (request_id, session_id) in cancelled_permissions {
             if let Some(item) = update_live_permission_status(
                 &state.live_timelines,
                 &session_id,
                 &request_id,
-                "allow_once",
+                "cancelled",
             )
             .await
             {
-                emit_agent_event(
-                    &state.host.events,
-                    AgentEventEnvelope {
-                        event_type: "timelineItem".to_string(),
-                        session_id: Some(session_id.clone()),
-                        run_id: None,
-                        item: Some(item),
-                        status: None,
-                        session: None,
-                        message: None,
-                    },
-                );
+                run_events.publish(AgentRunEvent::TimelineItem(item)).await;
             }
         }
+        Ok(())
     }
 
-    // The policy is already committed at this point. A best-effort refresh
-    // must not report failure to the selector and make it roll back to a mode
-    // that is no longer authoritative.
-    match session_manager.get_session(&session_id, false).await {
+    pub(crate) async fn set_permission_mode(
+        &self,
+        request: AgentPermissionModeRequest,
+    ) -> Result<(), String> {
+        let state = &self.service;
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+
+        let session_id = request.session_id.trim().to_string();
+        if session_id.is_empty() {
+            return Err("Agent permission mode update requires a task ID".to_string());
+        }
+        let goose_mode = parse_user_permission_mode(&request.mode)?;
+        let (agent_manager, session_manager, maple_api_session, permission_modes) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            (
+                Arc::clone(&current.agent_manager),
+                Arc::clone(&current.session_manager),
+                Arc::clone(&current.maple_api_session),
+                Arc::clone(&current.permission_modes),
+            )
+        };
+
+        // Restrictive transitions take effect before any fallible Goose or disk
+        // work. Otherwise the selector could say Read only while a still-live Auto
+        // policy approves the next write. If setup fails, restore the previous
+        // policy so the command and optimistic UI can roll back consistently.
+        let previous_restrictive_mode = if goose_mode == GooseMode::SmartApprove {
+            permission_modes
+                .lock()
+                .await
+                .insert(session_id.clone(), goose_mode)
+        } else {
+            None
+        };
+        let update_result: Result<Arc<Agent>, String> = async {
+            let session = session_manager
+                .get_session(&session_id, false)
+                .await
+                .map_err(|error| format!("Failed to load Agent task: {error}"))?;
+            let agent = get_or_create_session_agent(
+                &agent_manager,
+                &maple_api_session,
+                &session,
+                RuntimeContext::default(),
+            )
+            .await
+            .map_err(|error| format!("Failed to resolve Goose agent for mode update: {error}"))?
+            .agent;
+            agent
+                .update_goose_mode(GOOSE_PERMISSION_ROUTING_MODE, &session_id)
+                .await
+                .map_err(|error| format!("Failed to update Goose mode: {error}"))?;
+            // update_goose_mode already persists SmartApprove, which is both our
+            // internal Goose routing mode and the user-facing Read-only mode. Auto
+            // is Maple-owned, so only that case needs a second persistence step.
+            // Keeping Read-only to one write avoids a failed duplicate write
+            // leaving the persisted session stricter than the live Maple policy.
+            if goose_mode == GooseMode::Auto {
+                session_manager
+                    .update(&session_id)
+                    .goose_mode(goose_mode)
+                    .apply()
+                    .await
+                    .map_err(|error| format!("Failed to persist Agent permission mode: {error}"))?;
+            }
+            Ok(agent)
+        }
+        .await;
+        let agent = match update_result {
+            Ok(agent) => agent,
+            Err(error) => {
+                if goose_mode == GooseMode::SmartApprove {
+                    let mut modes = permission_modes.lock().await;
+                    match previous_restrictive_mode {
+                        Some(previous) => {
+                            modes.insert(session_id.clone(), previous);
+                        }
+                        None => {
+                            modes.remove(&session_id);
+                        }
+                    }
+                }
+                return Err(error);
+            }
+        };
+        if goose_mode == GooseMode::Auto {
+            permission_modes
+                .lock()
+                .await
+                .insert(session_id.clone(), goose_mode);
+        }
+        {
+            let mut runtime = state.inner.lock().await;
+            let current = runtime
+                .as_mut()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            current.mode = request.mode.clone();
+        }
+
+        if goose_mode == GooseMode::Auto {
+            let request_ids = {
+                let mut pending = state.pending_permissions.lock().await;
+                let request_ids = pending
+                    .keys()
+                    .filter(|(pending_session_id, _)| pending_session_id == &session_id)
+                    .map(|(_, request_id)| request_id.clone())
+                    .collect::<Vec<_>>();
+                for request_id in &request_ids {
+                    pending.remove(&(session_id.clone(), request_id.clone()));
+                }
+                request_ids
+            };
+            for request_id in request_ids {
+                deliver_tool_permission(&agent, request_id.clone(), Permission::AllowOnce).await;
+                if let Some(item) = update_live_permission_status(
+                    &state.live_timelines,
+                    &session_id,
+                    &request_id,
+                    "allow_once",
+                )
+                .await
+                {
+                    emit_agent_event(
+                        &state.host.events,
+                        AgentServiceEvent::TimelineItem {
+                            session_id: session_id.clone(),
+                            run_id: None,
+                            item,
+                        },
+                    );
+                }
+            }
+        }
+
+        // The policy is already committed at this point. A best-effort refresh
+        // must not report failure to the selector and make it roll back to a mode
+        // that is no longer authoritative.
+        match session_manager.get_session(&session_id, false).await {
         Ok(session) => emit_agent_event(
             &state.host.events,
-            AgentEventEnvelope {
-                event_type: "sessionUpdated".to_string(),
-                session_id: Some(session_id),
+            AgentServiceEvent::SessionUpdated {
+                session_id,
                 run_id: None,
-                item: None,
-                status: None,
-                session: Some(session_summary(&session)),
-                message: None,
+                session: session_summary(&session),
             },
         ),
         Err(error) => log::warn!(
             "Agent permission mode was updated, but the refreshed session could not be loaded: {error}"
         ),
     }
-    Ok(())
-}
-
-#[tauri::command]
-pub async fn agent_permission_respond(
-    app_handle: AppHandle,
-    state: State<'_, AgentRuntimeState>,
-    user_id: String,
-    response: AgentPermissionResponse,
-) -> Result<(), String> {
-    let account_scope = account_scope(&user_id)?;
-    let generation = account_generation(&state, &account_scope).await;
-    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
-    ensure_account_generation(&state, &account_scope, generation).await?;
-    let (agent_manager, session_id) = {
-        let runtime = state.inner.lock().await;
-        let current = runtime
-            .as_ref()
-            .ok_or_else(|| "Agent runtime is not running".to_string())?;
-        ensure_runtime_account(current, &account_scope)?;
-        let session_id = response.session_id.trim().to_string();
-        if session_id.is_empty() {
-            return Err("Agent permission response requires a task ID".to_string());
-        }
-        let key = (session_id.clone(), response.request_id.clone());
-        if !state.pending_permissions.lock().await.contains_key(&key) {
-            return Err(format!(
-                "No pending Agent Mode permission request found for {} in task {}",
-                response.request_id, session_id
-            ));
-        }
-        (Arc::clone(&current.agent_manager), session_id)
-    };
-    let agent = agent_manager
-        .get_or_create_agent(session_id.clone())
-        .await
-        .map_err(|e| format!("Failed to resolve Goose agent for permission response: {e}"))?;
-    agent
-        .handle_confirmation(
-            response.request_id.clone(),
-            PermissionConfirmation {
-                principal_type: PrincipalType::Tool,
-                permission: permission_from_decision(&response.decision)?,
-            },
-        )
-        .await;
-    if let Some(item) = update_live_permission_status(
-        &state.live_timelines,
-        &session_id,
-        &response.request_id,
-        &response.decision,
-    )
-    .await
-    {
-        emit_agent_event(
-            &state.host.events,
-            AgentEventEnvelope {
-                event_type: "timelineItem".to_string(),
-                session_id: Some(session_id.clone()),
-                run_id: None,
-                item: Some(item),
-                status: None,
-                session: None,
-                message: None,
-            },
-        );
+        Ok(())
     }
-    state
-        .pending_permissions
-        .lock()
+
+    pub(crate) async fn permission_respond(
+        &self,
+        response: AgentPermissionResponse,
+    ) -> Result<(), String> {
+        let state = &self.service;
+        let account_scope = self.account_scope.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let (agent_manager, session_id) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            let session_id = response.session_id.trim().to_string();
+            if session_id.is_empty() {
+                return Err("Agent permission response requires a task ID".to_string());
+            }
+            let key = (session_id.clone(), response.request_id.clone());
+            if !state.pending_permissions.lock().await.contains_key(&key) {
+                return Err(format!(
+                    "No pending Agent Mode permission request found for {} in task {}",
+                    response.request_id, session_id
+                ));
+            }
+            (Arc::clone(&current.agent_manager), session_id)
+        };
+        let agent = agent_manager
+            .get_or_create_agent(session_id.clone())
+            .await
+            .map_err(|e| format!("Failed to resolve Goose agent for permission response: {e}"))?;
+        agent
+            .handle_confirmation(
+                response.request_id.clone(),
+                PermissionConfirmation {
+                    principal_type: PrincipalType::Tool,
+                    permission: permission_from_decision(&response.decision)?,
+                },
+            )
+            .await;
+        if let Some(item) = update_live_permission_status(
+            &state.live_timelines,
+            &session_id,
+            &response.request_id,
+            &response.decision,
+        )
         .await
-        .remove(&(session_id, response.request_id));
-    Ok(())
-}
-
-pub(crate) async fn create_agent_session_for_user(
-    app_handle: &AppHandle,
-    user_id: String,
-    request: Option<AgentCreateSessionRequest>,
-) -> Result<AgentSessionDetail, String> {
-    agent_create_session(
-        app_handle.clone(),
-        app_handle.state::<AgentRuntimeState>(),
-        user_id,
-        request,
-    )
-    .await
-}
-
-pub(crate) async fn delete_agent_session_for_user(
-    app_handle: &AppHandle,
-    user_id: String,
-    session_id: String,
-) -> Result<(), String> {
-    agent_delete_session(
-        app_handle.clone(),
-        app_handle.state::<AgentRuntimeState>(),
-        user_id,
-        session_id,
-    )
-    .await
-}
-
-pub(crate) async fn send_agent_message_for_user(
-    app_handle: &AppHandle,
-    user_id: String,
-    request: AgentSendMessageRequest,
-) -> Result<AgentRunHandle, String> {
-    agent_send_message_inner(
-        app_handle.clone(),
-        app_handle.state::<AgentRuntimeState>(),
-        user_id,
-        request,
-    )
-    .await
-}
-
-pub(crate) async fn cancel_agent_run_for_user(
-    app_handle: &AppHandle,
-    user_id: String,
-    run_id: String,
-) -> Result<(), String> {
-    agent_cancel_run(
-        app_handle.clone(),
-        app_handle.state::<AgentRuntimeState>(),
-        user_id,
-        run_id,
-    )
-    .await
+        {
+            emit_agent_event(
+                &state.host.events,
+                AgentServiceEvent::TimelineItem {
+                    session_id: session_id.clone(),
+                    run_id: None,
+                    item,
+                },
+            );
+        }
+        state
+            .pending_permissions
+            .lock()
+            .await
+            .remove(&(session_id, response.request_id));
+        Ok(())
+    }
 }
 
 struct AgentPromptRun {
-    events: AgentEventDispatcher,
+    events: AgentRunEventPublisher,
     agent: Arc<Agent>,
     session_manager: Arc<SessionManager>,
     live_timelines: LiveTimelines,
     session_id: String,
-    run_id: String,
     user_message: Message,
     permission_modes: SessionPermissionModes,
     web_tool_state: Arc<WebToolState>,
@@ -3195,7 +3350,6 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
         session_manager,
         live_timelines,
         session_id,
-        run_id,
         user_message,
         permission_modes,
         web_tool_state,
@@ -3220,18 +3374,11 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
         .await
         .map_err(|e| format!("Failed to load updated Agent task: {e}"))?;
     let working_dir = updated_session.working_dir.clone();
-    emit_agent_event(
-        &events,
-        AgentEventEnvelope {
-            event_type: "sessionUpdated".to_string(),
-            session_id: Some(session_id.clone()),
-            run_id: Some(run_id.clone()),
-            item: None,
-            status: None,
-            session: Some(session_summary(&updated_session)),
-            message: None,
-        },
-    );
+    events
+        .publish(AgentRunEvent::SessionUpdated(session_summary(
+            &updated_session,
+        )))
+        .await;
 
     while let Some(event) = stream.next().await {
         match event {
@@ -3337,14 +3484,8 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                     ));
                 }
                 for item in items {
-                    record_and_emit_timeline_item(
-                        &events,
-                        &live_timelines,
-                        &session_id,
-                        &run_id,
-                        item,
-                    )
-                    .await;
+                    record_and_emit_timeline_item(&events, &live_timelines, &session_id, item)
+                        .await;
                 }
                 drop(pending_publication_guard);
             }
@@ -3363,18 +3504,7 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                     &conversation,
                 )
                 .await;
-                emit_agent_event(
-                    &events,
-                    AgentEventEnvelope {
-                        event_type: "historyReplaced".to_string(),
-                        session_id: Some(session_id.clone()),
-                        run_id: Some(run_id.clone()),
-                        item: None,
-                        status: None,
-                        session: None,
-                        message: None,
-                    },
-                );
+                events.publish(AgentRunEvent::HistoryReplaced).await;
             }
             Err(error) => {
                 return Err(format!("Goose stream failed: {error}"));
@@ -3622,7 +3752,7 @@ struct SessionAgentConfiguration<'a> {
     context_limit: Option<usize>,
     mode: &'a str,
     primary_model_supports_vision: bool,
-    tool_environment: &'a SharedAgentToolEnvironment,
+    tool_context: &'a SharedAgentToolContext,
 }
 
 fn maple_model_config(
@@ -3729,7 +3859,7 @@ async fn configure_session_agent(
         context_limit,
         mode,
         primary_model_supports_vision,
-        tool_environment,
+        tool_context,
     } = configuration;
     let session_mcp_keys = session_mcp_extension_keys(session);
     let manager_result = get_or_create_session_agent(
@@ -3769,7 +3899,7 @@ async fn configure_session_agent(
         primary_model_supports_vision,
         web_transport,
         Arc::clone(web_tool_state),
-        tool_environment.clone(),
+        tool_context.clone(),
     )
     .map_err(|e| format!("Failed to create Maple developer tools: {e}"))?;
     agent
@@ -4554,35 +4684,14 @@ fn sort_sessions_newest_first(sessions: &mut [AgentSessionSummary]) {
     sessions.sort_by(|a, b| b.updated_ms.cmp(&a.updated_ms));
 }
 
-fn emit_timeline_item(
-    events: &AgentEventDispatcher,
-    session_id: &str,
-    run_id: &str,
-    item: AgentTimelineItem,
-) {
-    emit_agent_event(
-        events,
-        AgentEventEnvelope {
-            event_type: "timelineItem".to_string(),
-            session_id: Some(session_id.to_string()),
-            run_id: Some(run_id.to_string()),
-            item: Some(item),
-            status: None,
-            session: None,
-            message: None,
-        },
-    );
-}
-
 async fn record_and_emit_timeline_item(
-    events: &AgentEventDispatcher,
+    events: &AgentRunEventPublisher,
     live_timelines: &LiveTimelines,
     session_id: &str,
-    run_id: &str,
     item: AgentTimelineItem,
 ) {
     record_timeline_item(live_timelines, session_id, item.clone()).await;
-    emit_timeline_item(events, session_id, run_id, item);
+    events.publish(AgentRunEvent::TimelineItem(item)).await;
 }
 
 async fn record_timeline_item(
@@ -4739,8 +4848,7 @@ async fn update_live_permission_status(
     Some(item.clone())
 }
 
-fn emit_agent_event(events: &AgentEventDispatcher, event: AgentEventEnvelope) {
-    let _ = events.sender.send(event.clone());
+fn emit_agent_event(events: &AgentEventDispatcher, event: AgentServiceEvent) {
     events.sink.emit(&event);
 }
 
@@ -4838,52 +4946,6 @@ fn parse_user_permission_mode(mode: &str) -> Result<GooseMode, String> {
         "smart_approve" => Ok(GooseMode::SmartApprove),
         _ => Err(format!("Unsupported Agent permission mode: {mode}")),
     }
-}
-
-fn normalize_agent_tool_environment(
-    environment: HashMap<String, String>,
-) -> Result<AgentToolEnvironment, String> {
-    if environment.len() > MAX_AGENT_TOOL_ENV_KEYS {
-        return Err(format!(
-            "Agent tool environment supports at most {MAX_AGENT_TOOL_ENV_KEYS} variables"
-        ));
-    }
-
-    let mut total_bytes = 0usize;
-    let mut normalized = AgentToolEnvironment::new();
-    for (key, value) in environment {
-        if key.len() > MAX_AGENT_TOOL_ENV_KEY_BYTES {
-            return Err(format!(
-                "Agent tool environment variable names must be at most {MAX_AGENT_TOOL_ENV_KEY_BYTES} bytes"
-            ));
-        }
-        if !ALLOWED_AGENT_TOOL_ENV_KEYS.contains(&key.as_str()) {
-            return Err(format!(
-                "Agent tool environment variable {key} is not allowed"
-            ));
-        }
-        if value.contains('\0') {
-            return Err(format!(
-                "Agent tool environment variable {key} contains an invalid null byte"
-            ));
-        }
-        let value_bytes = value.len();
-        if value_bytes > MAX_AGENT_TOOL_ENV_VALUE_BYTES {
-            return Err(format!(
-                "Agent tool environment variable {key} exceeds the {MAX_AGENT_TOOL_ENV_VALUE_BYTES} byte limit"
-            ));
-        }
-        total_bytes = total_bytes
-            .checked_add(key.len() + value_bytes)
-            .ok_or_else(|| "Agent tool environment size overflowed".to_string())?;
-        if total_bytes > MAX_AGENT_TOOL_ENV_TOTAL_BYTES {
-            return Err(format!(
-                "Agent tool environment exceeds the {MAX_AGENT_TOOL_ENV_TOTAL_BYTES} byte total limit"
-            ));
-        }
-        normalized.insert(key, value);
-    }
-    Ok(normalized)
 }
 
 fn normalize_mcp_servers(mut servers: Vec<AgentMcpServer>) -> Result<Vec<AgentMcpServer>, String> {
@@ -5787,11 +5849,26 @@ fn path_string(path: &Path) -> String {
 mod tests {
     use super::*;
     use rmcp::model::{AnnotateAble, RawTextContent, Role as McpRole};
+    use std::collections::{BTreeMap, BTreeSet};
 
     struct NoopAgentEventSink;
 
     impl AgentEventSink for NoopAgentEventSink {
-        fn emit(&self, _event: &AgentEventEnvelope) {}
+        fn emit(&self, _event: &AgentServiceEvent) {}
+    }
+
+    #[derive(Default)]
+    struct RecordingAgentEventSink {
+        events: std::sync::Mutex<Vec<AgentServiceEvent>>,
+    }
+
+    impl AgentEventSink for RecordingAgentEventSink {
+        fn emit(&self, event: &AgentServiceEvent) {
+            self.events
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(event.clone());
+        }
     }
 
     struct InertMapleTransport;
@@ -5845,64 +5922,6 @@ mod tests {
         assert_eq!(config.default_model, DEFAULT_AGENT_MODEL);
         assert!(config.mcp_servers.is_empty());
         assert!(config.project_skills_trust.is_empty());
-    }
-
-    #[test]
-    fn agent_tool_environment_accepts_only_the_bounded_buzz_allowlist() {
-        let allowed = ALLOWED_AGENT_TOOL_ENV_KEYS
-            .iter()
-            .map(|key| ((*key).to_string(), format!("value-for-{key}")))
-            .collect::<HashMap<_, _>>();
-        let normalized = normalize_agent_tool_environment(allowed).unwrap();
-        assert_eq!(
-            normalized.keys().map(String::as_str).collect::<Vec<_>>(),
-            vec![
-                "BUZZ_ACP_DISPLAY_NAME",
-                "BUZZ_API_TOKEN",
-                "BUZZ_AUTH_TAG",
-                "BUZZ_PRIVATE_KEY",
-                "BUZZ_RELAY_URL",
-                "PATH",
-            ]
-        );
-
-        let unknown = HashMap::from([("HOME".to_string(), "/tmp/not-allowed".to_string())]);
-        assert!(normalize_agent_tool_environment(unknown)
-            .unwrap_err()
-            .contains("HOME is not allowed"));
-
-        let nul = HashMap::from([("BUZZ_AUTH_TAG".to_string(), "bad\0value".to_string())]);
-        assert!(normalize_agent_tool_environment(nul)
-            .unwrap_err()
-            .contains("null byte"));
-    }
-
-    #[test]
-    fn agent_tool_environment_enforces_value_and_total_size_limits() {
-        let oversized_value = HashMap::from([(
-            "BUZZ_PRIVATE_KEY".to_string(),
-            "x".repeat(MAX_AGENT_TOOL_ENV_VALUE_BYTES + 1),
-        )]);
-        assert!(normalize_agent_tool_environment(oversized_value)
-            .unwrap_err()
-            .contains("byte limit"));
-
-        let per_value = (MAX_AGENT_TOOL_ENV_TOTAL_BYTES / 3) + 1;
-        let oversized_total = HashMap::from([
-            ("BUZZ_PRIVATE_KEY".to_string(), "a".repeat(per_value)),
-            ("BUZZ_API_TOKEN".to_string(), "b".repeat(per_value)),
-            ("BUZZ_AUTH_TAG".to_string(), "c".repeat(per_value)),
-        ]);
-        assert!(normalize_agent_tool_environment(oversized_total)
-            .unwrap_err()
-            .contains("total limit"));
-
-        let too_many = (0..=MAX_AGENT_TOOL_ENV_KEYS)
-            .map(|index| (format!("KEY_{index}"), "value".to_string()))
-            .collect::<HashMap<_, _>>();
-        assert!(normalize_agent_tool_environment(too_many)
-            .unwrap_err()
-            .contains("at most"));
     }
 
     #[test]
@@ -8996,11 +9015,19 @@ mod tests {
     async fn detects_active_run_for_session() {
         let mut active_runs = HashMap::new();
         let task_handle = tokio::spawn(async {});
+        let (events, _receiver) = AgentRunEventPublisher::new(
+            AgentEventDispatcher::new(Arc::new(NoopAgentEventSink)),
+            "session-1".to_string(),
+            "run-1".to_string(),
+            AgentHostEventPolicy::Publish,
+        );
         active_runs.insert(
             "run-1".to_string(),
             ActiveAgentRun {
                 token: CancellationToken::new(),
+                tool_context: SharedAgentToolContext::new(AgentToolContextSpec::default()),
                 session_id: "session-1".to_string(),
+                events,
                 cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
                 task_handle,
             },
@@ -9008,6 +9035,236 @@ mod tests {
 
         assert!(has_active_session_run(&active_runs, "session-1"));
         assert!(!has_active_session_run(&active_runs, "session-2"));
+    }
+
+    #[tokio::test]
+    async fn run_event_streams_are_ordered_isolated_and_host_policy_controls_projection() {
+        let sink = Arc::new(RecordingAgentEventSink::default());
+        let dispatcher = AgentEventDispatcher::new(sink.clone());
+        let (first, mut first_events) = AgentRunEventPublisher::new(
+            dispatcher.clone(),
+            "session-1".to_string(),
+            "run-1".to_string(),
+            AgentHostEventPolicy::Publish,
+        );
+        let (second, mut second_events) = AgentRunEventPublisher::new(
+            dispatcher.clone(),
+            "session-2".to_string(),
+            "run-2".to_string(),
+            AgentHostEventPolicy::Publish,
+        );
+        let (external, mut external_events) = AgentRunEventPublisher::new(
+            dispatcher,
+            "session-3".to_string(),
+            "run-3".to_string(),
+            AgentHostEventPolicy::Suppress,
+        );
+
+        first.publish(AgentRunEvent::Started).await;
+        second
+            .publish(AgentRunEvent::SetupWarning("setup warning".to_string()))
+            .await;
+        first
+            .publish(AgentRunEvent::Finished(AgentRunTerminal::Completed))
+            .await;
+        second
+            .publish(AgentRunEvent::Finished(AgentRunTerminal::Failed))
+            .await;
+        external.publish(AgentRunEvent::Started).await;
+
+        assert!(matches!(
+            first_events.recv().await,
+            Some(AgentRunEvent::Started)
+        ));
+        assert!(matches!(
+            first_events.recv().await,
+            Some(AgentRunEvent::Finished(AgentRunTerminal::Completed))
+        ));
+        assert!(first_events.try_recv().is_err());
+
+        assert!(matches!(
+            second_events.recv().await,
+            Some(AgentRunEvent::SetupWarning(message)) if message == "setup warning"
+        ));
+        assert!(matches!(
+            second_events.recv().await,
+            Some(AgentRunEvent::Finished(AgentRunTerminal::Failed))
+        ));
+        assert!(second_events.try_recv().is_err());
+        assert!(matches!(
+            external_events.recv().await,
+            Some(AgentRunEvent::Started)
+        ));
+
+        let emitted = sink
+            .events
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        assert_eq!(emitted.len(), 4);
+        assert!(matches!(
+            &emitted[0],
+            AgentServiceEvent::Run { session_id, run_id, event: AgentRunEvent::Started }
+                if session_id == "session-1" && run_id == "run-1"
+        ));
+        assert!(matches!(
+            &emitted[1],
+            AgentServiceEvent::Run {
+                session_id,
+                run_id,
+                event: AgentRunEvent::SetupWarning(message),
+            } if session_id == "session-2" && run_id == "run-2" && message == "setup warning"
+        ));
+        assert!(matches!(
+            &emitted[2],
+            AgentServiceEvent::Run {
+                event: AgentRunEvent::Finished(AgentRunTerminal::Completed),
+                ..
+            }
+        ));
+        assert!(matches!(
+            &emitted[3],
+            AgentServiceEvent::Run {
+                event: AgentRunEvent::Finished(AgentRunTerminal::Failed),
+                ..
+            }
+        ));
+    }
+
+    #[tokio::test]
+    async fn lagged_run_event_consumer_never_backpressures_the_agent() {
+        let (publisher, events) = AgentRunEventPublisher::new(
+            AgentEventDispatcher::new(Arc::new(NoopAgentEventSink)),
+            "session-1".to_string(),
+            "run-1".to_string(),
+            AgentHostEventPolicy::Suppress,
+        );
+        let overflowed = publisher.overflow_flag();
+
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            for _ in 0..(AGENT_RUN_EVENT_CAPACITY + 32) {
+                publisher.publish(AgentRunEvent::Started).await;
+            }
+            publisher
+                .publish(AgentRunEvent::Finished(AgentRunTerminal::Completed))
+                .await;
+        })
+        .await
+        .expect("a full protocol queue must not block the Agent run");
+
+        assert_eq!(events.len(), AGENT_RUN_EVENT_CAPACITY);
+        assert!(overflowed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn stale_tool_context_identity_cannot_remove_its_replacement() {
+        let original = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "original".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+        let replacement = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "replacement".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+        let mut contexts = HashMap::from([(
+            "session-1".to_string(),
+            InstalledAgentToolContext {
+                installation_id: 2,
+                context: replacement.clone(),
+                owner: AgentToolContextOwner::Leased,
+            },
+        )]);
+
+        assert!(take_matching_tool_context(&mut contexts, "session-1", 1, &original).is_none());
+        assert_eq!(
+            contexts["session-1"].context.snapshot().values["TOKEN"],
+            "replacement"
+        );
+
+        let removed = take_matching_tool_context(&mut contexts, "session-1", 2, &replacement)
+            .expect("the exact replacement lease should remove its context");
+        assert!(removed.context.ptr_eq(&replacement));
+        assert!(contexts.is_empty());
+    }
+
+    #[test]
+    fn leased_tool_context_requires_the_exact_surface_capability() {
+        let leased = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "leased-secret".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+        let mut contexts = HashMap::from([(
+            "session-1".to_string(),
+            InstalledAgentToolContext {
+                installation_id: 7,
+                context: leased.clone(),
+                owner: AgentToolContextOwner::Leased,
+            },
+        )]);
+        let access = AgentToolContextAccess {
+            account_scope: Arc::from("account-1"),
+            session_id: Arc::from("session-1"),
+            installation_id: 7,
+            context: leased.clone(),
+        };
+
+        assert!(resolve_session_tool_context(
+            &mut contexts,
+            "account-1",
+            "session-1",
+            None,
+            &AgentToolContextSpec::default(),
+        )
+        .is_err());
+        assert!(resolve_session_tool_context(
+            &mut contexts,
+            "account-1",
+            "session-1",
+            Some(&access),
+            &AgentToolContextSpec::default(),
+        )
+        .unwrap()
+        .ptr_eq(&leased));
+
+        leased.revoke();
+        let local = resolve_session_tool_context(
+            &mut contexts,
+            "account-1",
+            "session-1",
+            None,
+            &AgentToolContextSpec::default(),
+        )
+        .expect("a revoked external context should be recoverable as a local task");
+        assert!(!local.ptr_eq(&leased));
+        assert_eq!(contexts["session-1"].owner, AgentToolContextOwner::Maple);
+    }
+
+    #[test]
+    fn uncommitted_tool_context_installation_revokes_synchronously() {
+        let context = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+        {
+            let _pending = PendingAgentToolContextInstallation::new(context.clone());
+        }
+        assert!(context.is_revoked());
+        assert!(context.snapshot().values.is_empty());
     }
 
     #[test]
@@ -9026,166 +9283,6 @@ mod tests {
         assert!(ensure_account_scope(&first, &first).is_ok());
         assert!(ensure_account_scope(&first, &second).is_err());
     }
-
-    #[test]
-    fn legacy_agent_event_envelopes_serialize_stably() {
-        let status = AgentRuntimeStatus {
-            running: true,
-            project_root: Some("/tmp/project".to_string()),
-            model: Some("maple-model".to_string()),
-            mode: Some("smart_approve".to_string()),
-            active_runs: HashMap::from([("session-1".to_string(), "run-1".to_string())]),
-        };
-        let session = AgentSessionSummary {
-            id: "session-1".to_string(),
-            title: "Task".to_string(),
-            project_root: "/tmp/project".to_string(),
-            created_ms: 1,
-            updated_ms: 2,
-            message_count: 3,
-            model: Some("maple-model".to_string()),
-            mode: "smart_approve".to_string(),
-        };
-        let item = AgentTimelineItem {
-            id: "message-1".to_string(),
-            item_type: "message".to_string(),
-            role: Some("assistant".to_string()),
-            title: None,
-            text: Some("hello".to_string()),
-            status: None,
-            input: None,
-            output: None,
-            created_ms: 4,
-            merge: "append".to_string(),
-        };
-        let envelope = |event_type: &str| AgentEventEnvelope {
-            event_type: event_type.to_string(),
-            session_id: None,
-            run_id: None,
-            item: None,
-            status: None,
-            session: None,
-            message: None,
-        };
-
-        let mut runtime_status = envelope("runtimeStatus");
-        runtime_status.status = Some(status);
-        let mut session_created = envelope("sessionCreated");
-        session_created.session_id = Some("session-1".to_string());
-        session_created.session = Some(session.clone());
-        let mut session_updated = envelope("sessionUpdated");
-        session_updated.session_id = Some("session-1".to_string());
-        session_updated.run_id = Some("run-1".to_string());
-        session_updated.session = Some(session);
-        let mut run_started = envelope("runStarted");
-        run_started.session_id = Some("session-1".to_string());
-        run_started.run_id = Some("run-1".to_string());
-        let mut timeline_item = envelope("timelineItem");
-        timeline_item.session_id = Some("session-1".to_string());
-        timeline_item.run_id = Some("run-1".to_string());
-        timeline_item.item = Some(item.clone());
-        let mut error = envelope("error");
-        error.session_id = Some("session-1".to_string());
-        error.run_id = Some("run-1".to_string());
-        error.item = Some(item);
-        let mut history_replaced = envelope("historyReplaced");
-        history_replaced.session_id = Some("session-1".to_string());
-        history_replaced.run_id = Some("run-1".to_string());
-        let mut run_finished = envelope("runFinished");
-        run_finished.session_id = Some("session-1".to_string());
-        run_finished.run_id = Some("run-1".to_string());
-        run_finished.message = Some("completed".to_string());
-
-        assert_eq!(
-            serde_json::to_value([
-                runtime_status,
-                session_created,
-                session_updated,
-                run_started,
-                timeline_item,
-                error,
-                history_replaced,
-                run_finished,
-            ])
-            .unwrap(),
-            json!([
-                {
-                    "eventType": "runtimeStatus",
-                    "status": {
-                        "running": true,
-                        "projectRoot": "/tmp/project",
-                        "model": "maple-model",
-                        "mode": "smart_approve",
-                        "activeRuns": { "session-1": "run-1" }
-                    }
-                },
-                {
-                    "eventType": "sessionCreated",
-                    "sessionId": "session-1",
-                    "session": {
-                        "id": "session-1",
-                        "title": "Task",
-                        "projectRoot": "/tmp/project",
-                        "createdMs": 1,
-                        "updatedMs": 2,
-                        "messageCount": 3,
-                        "model": "maple-model",
-                        "mode": "smart_approve"
-                    }
-                },
-                {
-                    "eventType": "sessionUpdated",
-                    "sessionId": "session-1",
-                    "runId": "run-1",
-                    "session": {
-                        "id": "session-1",
-                        "title": "Task",
-                        "projectRoot": "/tmp/project",
-                        "createdMs": 1,
-                        "updatedMs": 2,
-                        "messageCount": 3,
-                        "model": "maple-model",
-                        "mode": "smart_approve"
-                    }
-                },
-                { "eventType": "runStarted", "sessionId": "session-1", "runId": "run-1" },
-                {
-                    "eventType": "timelineItem",
-                    "sessionId": "session-1",
-                    "runId": "run-1",
-                    "item": {
-                        "id": "message-1",
-                        "itemType": "message",
-                        "role": "assistant",
-                        "text": "hello",
-                        "createdMs": 4,
-                        "merge": "append"
-                    }
-                },
-                {
-                    "eventType": "error",
-                    "sessionId": "session-1",
-                    "runId": "run-1",
-                    "item": {
-                        "id": "message-1",
-                        "itemType": "message",
-                        "role": "assistant",
-                        "text": "hello",
-                        "createdMs": 4,
-                        "merge": "append"
-                    }
-                },
-                { "eventType": "historyReplaced", "sessionId": "session-1", "runId": "run-1" },
-                {
-                    "eventType": "runFinished",
-                    "sessionId": "session-1",
-                    "runId": "run-1",
-                    "message": "completed"
-                }
-            ])
-        );
-    }
-
     #[tokio::test]
     async fn rejects_operations_captured_before_account_clear() {
         let state = MapleAgentService::new(MapleAgentHostResources::new(
@@ -9194,20 +9291,46 @@ mod tests {
                 PathBuf::from("unused-local-root"),
             ),
             Arc::new(NoopAgentEventSink),
+            AgentToolContextSpec::default(),
         ));
+        let stale_handle = state.handle_for_user("user-to-clear").await.unwrap();
         let scope = account_scope("user-to-clear").unwrap();
-        let stale_generation = account_generation(&state, &scope).await;
 
-        let current_generation = advance_account_generation(&state, &scope).await;
+        advance_account_generation(&state, &scope).await;
+        let current_handle = state.handle_for_user("user-to-clear").await.unwrap();
 
-        assert!(ensure_account_generation(&state, &scope, stale_generation)
-            .await
-            .is_err());
-        assert!(
-            ensure_account_generation(&state, &scope, current_generation)
-                .await
-                .is_ok()
+        assert!(stale_handle.verify_generation().await.is_err());
+        assert!(current_handle.verify_generation().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn service_drain_rejects_new_work_and_failed_update_can_reopen_it() {
+        let state = MapleAgentService::new(MapleAgentHostResources::new(
+            AgentPathLayout::from_app_roots(
+                PathBuf::from("unused-config-root"),
+                PathBuf::from("unused-local-root"),
+            ),
+            Arc::new(NoopAgentEventSink),
+            AgentToolContextSpec::default(),
+        ));
+        let handle = state.handle_for_user("user-during-shutdown").await.unwrap();
+
+        assert!(state.ensure_accepting_new_work().is_ok());
+        assert!(handle.ensure_accepting_new_work().is_ok());
+
+        state.begin_draining();
+        assert_eq!(
+            state.ensure_accepting_new_work().unwrap_err(),
+            AGENT_SERVICE_DRAINING_ERROR
         );
+        assert_eq!(
+            handle.ensure_accepting_new_work().unwrap_err(),
+            AGENT_SERVICE_DRAINING_ERROR
+        );
+
+        state.reopen_after_failed_shutdown();
+        assert!(state.ensure_accepting_new_work().is_ok());
+        assert!(handle.ensure_accepting_new_work().is_ok());
     }
 
     #[test]

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -241,7 +241,7 @@ pub struct AgentStartRequest {
     pub mode: Option<String>,
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentRuntimeStatus {
     pub running: bool,
@@ -365,6 +365,7 @@ pub(crate) struct AgentRunHandle {
     pub terminal: watch::Receiver<Option<AgentRunTerminal>>,
     pub event_overflowed: Arc<AtomicBool>,
     pub permission_responder: Option<AgentRunPermissionResponder>,
+    pub cancellation: Option<AgentRunCancellation>,
 }
 
 #[derive(Clone)]
@@ -386,6 +387,31 @@ impl AgentRunPermissionResponder {
                 self.run_id.as_ref(),
                 request_id,
                 decision,
+            )
+            .await
+    }
+}
+
+/// Opaque cancellation capability for one run owned by a calling surface.
+///
+/// Unlike the Desktop command boundary, an adapter already has the exact run
+/// identity. Retaining that identity here prevents it from cancelling another
+/// surface's run through a caller-provided run ID.
+#[derive(Clone)]
+pub(crate) struct AgentRunCancellation {
+    agent: AgentRuntimeHandle,
+    session_id: Arc<str>,
+    run_id: Arc<str>,
+    routing: AgentPermissionRouting,
+}
+
+impl AgentRunCancellation {
+    pub(crate) async fn cancel(&self) -> Result<(), String> {
+        self.agent
+            .cancel_run_scoped(
+                self.run_id.as_ref(),
+                Some(self.session_id.as_ref()),
+                self.routing,
             )
             .await
     }
@@ -690,19 +716,33 @@ fn resolve_session_tool_context(
 }
 
 impl AgentRuntime {
-    fn status(&self) -> AgentRuntimeStatus {
+    fn desktop_status(&self) -> AgentRuntimeStatus {
         AgentRuntimeStatus {
             running: true,
             project_root: Some(path_string(&self.project_root)),
             model: Some(self.model.clone()),
             mode: Some(self.mode.clone()),
-            active_runs: self
-                .active_runs
-                .iter()
-                .map(|(run_id, run)| (run.session_id.clone(), run_id.clone()))
-                .collect(),
+            // AgentRuntimeStatus is Maple Desktop's projection. Calling surfaces
+            // retain their own run handles and lifecycle signals instead of
+            // becoming actionable through the Tauri command boundary.
+            active_runs: active_run_status(self.active_runs.iter().map(|(run_id, run)| {
+                (
+                    run_id.as_str(),
+                    run.session_id.as_str(),
+                    run.permission_routing,
+                )
+            })),
         }
     }
+}
+
+fn active_run_status<'a>(
+    runs: impl IntoIterator<Item = (&'a str, &'a str, AgentPermissionRouting)>,
+) -> HashMap<String, String> {
+    runs.into_iter()
+        .filter(|(_, _, routing)| *routing == AgentPermissionRouting::Desktop)
+        .map(|(run_id, session_id, _)| (session_id.to_string(), run_id.to_string()))
+        .collect()
 }
 
 #[derive(Clone)]
@@ -839,7 +879,13 @@ pub(crate) struct AgentRuntimeHandle {
     generation: u64,
 }
 
-type LiveTimelines = Arc<Mutex<HashMap<String, LiveTimeline>>>;
+type LiveTimelines = Arc<Mutex<HashMap<String, LiveTimelineEntry>>>;
+
+#[derive(Clone, Debug, PartialEq)]
+struct LiveTimelineEntry {
+    routing: AgentPermissionRouting,
+    timeline: LiveTimeline,
+}
 
 #[derive(Clone, Debug, PartialEq)]
 enum LiveTimeline {
@@ -1230,7 +1276,7 @@ impl AgentRuntimeHandle {
         let runtime = self.service.inner.lock().await;
         if let Some(current) = runtime.as_ref() {
             ensure_runtime_account(current, &self.account_scope)?;
-            return Ok(current.status());
+            return Ok(current.desktop_status());
         }
         Ok(stopped_status())
     }
@@ -1258,7 +1304,7 @@ async fn start_runtime_for_user(
         let runtime = state.inner.lock().await;
         if let Some(current) = runtime.as_ref() {
             ensure_runtime_account(current, &account_scope)?;
-            return Ok(current.status());
+            return Ok(current.desktop_status());
         }
     }
 
@@ -1342,7 +1388,7 @@ async fn start_runtime_for_user(
         mode: mode.clone(),
         account_scope,
     };
-    let status = runtime.status();
+    let status = runtime.desktop_status();
 
     {
         let mut guard = state.inner.lock().await;
@@ -1969,8 +2015,37 @@ impl AgentRuntimeHandle {
             .as_ref()
             .ok_or_else(|| "Agent task history was not loaded".to_string())?;
         let timeline = conversation_to_timeline_items(conversation);
-        let timeline =
-            overlay_live_timeline(&state.live_timelines, &session_id, conversation, timeline).await;
+        let mut timeline = overlay_live_timeline(
+            &state.live_timelines,
+            &session_id,
+            AgentPermissionRouting::Desktop,
+            conversation,
+            timeline,
+        )
+        .await;
+        // Goose can persist an action-required row before Maple has registered
+        // its responder. Reconcile the final Desktop projection against the
+        // actual surface owner so another caller's request can never acquire
+        // actionable Desktop buttons during that gap or from stale history.
+        let calling_surface_active = {
+            let runtime = state.inner.lock().await;
+            runtime.as_ref().is_some_and(|current| {
+                current.account_scope == account_scope
+                    && current.active_runs.values().any(|run| {
+                        run.session_id == session_id
+                            && run.permission_routing == AgentPermissionRouting::CallingSurface
+                    })
+            })
+        };
+        let pending_routes = state
+            .pending_permissions
+            .lock()
+            .await
+            .iter()
+            .filter(|((pending_session_id, _), _)| pending_session_id == &session_id)
+            .map(|((_, request_id), pending)| (request_id.clone(), pending.routing))
+            .collect::<HashMap<_, _>>();
+        reconcile_desktop_permission_items(&mut timeline, &pending_routes, calling_surface_active);
 
         Ok(AgentSessionDetail {
             session: session_summary(&session),
@@ -2259,6 +2334,7 @@ async fn finalize_cancelled_agent_turn(
     live_timelines: &LiveTimelines,
     web_tool_state: &WebToolState,
     session_id: &str,
+    routing: AgentPermissionRouting,
     user_message: &Message,
     cancelled_permission_ids: &HashSet<String>,
 ) -> Result<(), String> {
@@ -2299,7 +2375,10 @@ async fn finalize_cancelled_agent_turn(
 
     // Goose's persisted conversation is the committed cancellation boundary.
     // Drop Maple's speculative event suffix so reloads project only that history.
-    live_timelines.lock().await.remove(session_id);
+    {
+        let mut timelines = live_timelines.lock().await;
+        remove_live_timeline_for_routing(&mut timelines, session_id, routing);
+    }
     // Search provenance is an in-memory Maple permission convenience, not
     // Goose history. Reset it rather than letting a discarded search result
     // authorize a later open_url call. A cold session already starts empty.
@@ -2768,6 +2847,7 @@ impl AgentRuntimeHandle {
                     if let Some(item) = update_live_permission_status(
                         &live_timelines,
                         &permission_session_id,
+                        permission_routing,
                         &request_id,
                         "cancelled",
                     )
@@ -2784,6 +2864,7 @@ impl AgentRuntimeHandle {
                     &live_timelines,
                     task_web_tool_state.as_ref(),
                     &session_id,
+                    permission_routing,
                     &task_user_message,
                     &cancelled_permission_ids,
                 )
@@ -2798,7 +2879,12 @@ impl AgentRuntimeHandle {
             if !run_was_cancelled {
                 if let Ok(outcome) = &result {
                     let mut timelines = live_timelines.lock().await;
-                    apply_successful_prompt_outcome(&mut timelines, &session_id, outcome);
+                    apply_successful_prompt_outcome(
+                        &mut timelines,
+                        &session_id,
+                        permission_routing,
+                        outcome,
+                    );
                 }
             }
 
@@ -2811,7 +2897,12 @@ impl AgentRuntimeHandle {
                 let item = error_item(error.clone());
                 {
                     let mut timelines = live_timelines.lock().await;
-                    apply_failed_prompt_outcome(&mut timelines, &session_id, item.clone());
+                    apply_failed_prompt_outcome(
+                        &mut timelines,
+                        &session_id,
+                        permission_routing,
+                        item.clone(),
+                    );
                 }
                 task_events.publish(AgentRunEvent::Error(item)).await;
             }
@@ -2876,6 +2967,7 @@ impl AgentRuntimeHandle {
             &run_events,
             &state.live_timelines,
             &request.session_id,
+            permission_routing,
             user_item.clone(),
         )
         .await;
@@ -2893,16 +2985,34 @@ impl AgentRuntimeHandle {
                     run_id: Arc::from(run_id.as_str()),
                 }
             });
+        let cancellation = matches!(permission_routing, AgentPermissionRouting::CallingSurface)
+            .then(|| AgentRunCancellation {
+                agent: self.clone(),
+                session_id: Arc::from(request.session_id.as_str()),
+                run_id: Arc::from(run_id.as_str()),
+                routing: permission_routing,
+            });
         Ok(AgentRunHandle {
             run_id,
             events: run_events_rx,
             terminal: terminal_rx,
             event_overflowed: run_events.overflow_flag(),
             permission_responder,
+            cancellation,
         })
     }
 
-    pub(crate) async fn cancel_run(&self, run_id: String) -> Result<(), String> {
+    pub(crate) async fn cancel_desktop_run(&self, run_id: String) -> Result<(), String> {
+        self.cancel_run_scoped(&run_id, None, AgentPermissionRouting::Desktop)
+            .await
+    }
+
+    async fn cancel_run_scoped(
+        &self,
+        run_id: &str,
+        expected_session_id: Option<&str>,
+        expected_routing: AgentPermissionRouting,
+    ) -> Result<(), String> {
         let state = &self.service;
         let account_scope = self.account_scope.as_ref();
         let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
@@ -2917,9 +3027,15 @@ impl AgentRuntimeHandle {
                 return Ok(());
             };
             ensure_runtime_account(current, account_scope)?;
-            let Some(active_run) = current.active_runs.get(&run_id) else {
+            let Some(active_run) = current.active_runs.get(run_id) else {
                 return Ok(());
             };
+            validate_run_cancellation_scope(
+                active_run.session_id.as_str(),
+                active_run.permission_routing,
+                expected_session_id,
+                expected_routing,
+            )?;
             (
                 Arc::clone(&active_run.agent),
                 active_run.token.clone(),
@@ -2929,6 +3045,7 @@ impl AgentRuntimeHandle {
             )
         };
         tool_context.cancel_run(&cancel_token);
+        let run_id = run_id.to_string();
         let cancelled_permissions = cancel_pending_permissions_for_runs(
             &state.pending_permissions,
             std::slice::from_ref(&run_id),
@@ -2944,6 +3061,7 @@ impl AgentRuntimeHandle {
             if let Some(item) = update_live_permission_status(
                 &state.live_timelines,
                 &session_id,
+                expected_routing,
                 &request_id,
                 "cancelled",
             )
@@ -3108,6 +3226,7 @@ impl AgentRuntimeHandle {
                 if let Some(item) = update_live_permission_status(
                     &state.live_timelines,
                     &session_id,
+                    AgentPermissionRouting::Desktop,
                     &request_id,
                     "allow_once",
                 )
@@ -3275,6 +3394,7 @@ impl AgentRuntimeHandle {
         if let Some(item) = update_live_permission_status(
             &state.live_timelines,
             &session_id,
+            expected_routing,
             &request_id,
             display_status
                 .as_deref()
@@ -3298,6 +3418,21 @@ impl AgentRuntimeHandle {
         }
         Ok(())
     }
+}
+
+fn validate_run_cancellation_scope(
+    actual_session_id: &str,
+    actual_routing: AgentPermissionRouting,
+    expected_session_id: Option<&str>,
+    expected_routing: AgentPermissionRouting,
+) -> Result<(), String> {
+    if actual_routing != expected_routing {
+        return Err("Agent run is controlled by another Agent surface".to_string());
+    }
+    if expected_session_id.is_some_and(|session_id| session_id != actual_session_id) {
+        return Err("Agent run cancellation capability does not own this task".to_string());
+    }
+    Ok(())
 }
 
 struct AgentPromptRun {
@@ -3332,29 +3467,63 @@ struct LiveMessageCandidate {
 }
 
 fn apply_successful_prompt_outcome(
-    timelines: &mut HashMap<String, LiveTimeline>,
+    timelines: &mut HashMap<String, LiveTimelineEntry>,
     session_id: &str,
+    routing: AgentPermissionRouting,
     outcome: &AgentPromptOutcome,
 ) {
+    if routing == AgentPermissionRouting::CallingSurface {
+        remove_live_timeline_for_routing(timelines, session_id, routing);
+        return;
+    }
     match outcome.terminal_message.as_ref() {
         Some(candidate) => {
             timelines.insert(
                 session_id.to_string(),
-                LiveTimeline::Completed(candidate.clone()),
+                LiveTimelineEntry {
+                    routing,
+                    timeline: LiveTimeline::Completed(candidate.clone()),
+                },
             );
         }
         None => {
-            timelines.remove(session_id);
+            remove_live_timeline_for_routing(timelines, session_id, routing);
         }
     }
 }
 
 fn apply_failed_prompt_outcome(
-    timelines: &mut HashMap<String, LiveTimeline>,
+    timelines: &mut HashMap<String, LiveTimelineEntry>,
     session_id: &str,
+    routing: AgentPermissionRouting,
     item: AgentTimelineItem,
 ) {
-    timelines.insert(session_id.to_string(), LiveTimeline::Failed(vec![item]));
+    if routing == AgentPermissionRouting::CallingSurface {
+        remove_live_timeline_for_routing(timelines, session_id, routing);
+        return;
+    }
+    timelines.insert(
+        session_id.to_string(),
+        LiveTimelineEntry {
+            routing,
+            timeline: LiveTimeline::Failed(vec![item]),
+        },
+    );
+}
+
+fn remove_live_timeline_for_routing(
+    timelines: &mut HashMap<String, LiveTimelineEntry>,
+    session_id: &str,
+    routing: AgentPermissionRouting,
+) -> Option<LiveTimelineEntry> {
+    timelines
+        .get(session_id)
+        .is_some_and(|entry| entry.routing == routing)
+        .then(|| {
+            timelines
+                .remove(session_id)
+                .expect("matching live timeline must still exist")
+        })
 }
 
 async fn selected_permission_mode(
@@ -3865,7 +4034,13 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                 for item in items {
                     if let Some(request_id) = pending_permission_request_id(&item) {
                         if let Some(request) = permission_requests.get(&request_id) {
-                            record_timeline_item(&live_timelines, &session_id, item.clone()).await;
+                            record_timeline_item(
+                                &live_timelines,
+                                &session_id,
+                                permission_routing,
+                                item.clone(),
+                            )
+                            .await;
                             events
                                 .publish(AgentRunEvent::PermissionRequested {
                                     request: request.clone(),
@@ -3875,8 +4050,14 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                             continue;
                         }
                     }
-                    record_and_emit_timeline_item(&events, &live_timelines, &session_id, item)
-                        .await;
+                    record_and_emit_timeline_item(
+                        &events,
+                        &live_timelines,
+                        &session_id,
+                        permission_routing,
+                        item,
+                    )
+                    .await;
                 }
                 drop(pending_publication_guard);
             }
@@ -3892,6 +4073,7 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                 reseed_live_timeline_after_history_replaced(
                     &live_timelines,
                     &session_id,
+                    permission_routing,
                     &conversation,
                 )
                 .await;
@@ -4367,6 +4549,11 @@ fn conversation_to_timeline_items(conversation: &Conversation) -> Vec<AgentTimel
                 _ => {}
             }
         }
+        settle_turn_permission_items(
+            &mut items[current_turn_item_start..],
+            &resolved_permission_ids,
+            false,
+        );
 
         let visible_message = message.user_visible_content();
         // Match Goose's own session presentation contract: agent-only grind,
@@ -4412,23 +4599,11 @@ fn conversation_to_timeline_items(conversation: &Conversation) -> Vec<AgentTimel
             false,
             thinking.as_deref(),
         ));
-
-        if is_stopped_notice(message) {
-            for item in &mut items[current_turn_item_start..] {
-                let resolved = item
-                    .id
-                    .strip_prefix("permission-")
-                    .or_else(|| item.id.strip_prefix("elicitation-"))
-                    .is_some_and(|id| resolved_permission_ids.contains(id));
-                if item.item_type == "permission" && item.status.as_deref() == Some("pending") {
-                    item.status = Some(if resolved {
-                        "completed".to_string()
-                    } else {
-                        "cancelled".to_string()
-                    });
-                }
-            }
-        }
+        settle_turn_permission_items(
+            &mut items[current_turn_item_start..],
+            &resolved_permission_ids,
+            is_stopped_notice(message),
+        );
 
         if inference_ends {
             state.surfaced_thinking_in_inference = false;
@@ -4449,6 +4624,52 @@ fn is_stopped_notice(message: &Message) -> bool {
                         && notification.msg == "Stopped by user"
             )
         })
+}
+
+fn settle_turn_permission_items(
+    items: &mut [AgentTimelineItem],
+    resolved_ids: &HashSet<String>,
+    cancel_unresolved: bool,
+) {
+    for item in items {
+        if item.item_type != "permission" || item.status.as_deref() != Some("pending") {
+            continue;
+        }
+        let resolved = item
+            .id
+            .strip_prefix("permission-")
+            .or_else(|| item.id.strip_prefix("elicitation-"))
+            .is_some_and(|id| resolved_ids.contains(id));
+        if resolved {
+            item.status = Some("completed".to_string());
+        } else if cancel_unresolved {
+            item.status = Some("cancelled".to_string());
+        }
+    }
+}
+
+fn reconcile_desktop_permission_items(
+    items: &mut [AgentTimelineItem],
+    pending_routes: &HashMap<String, AgentPermissionRouting>,
+    calling_surface_active: bool,
+) {
+    for item in items {
+        if item.item_type != "permission" || item.status.as_deref() != Some("pending") {
+            continue;
+        }
+        let request_id = item
+            .id
+            .strip_prefix("permission-")
+            .or_else(|| item.id.strip_prefix("elicitation-"));
+        let route = request_id.and_then(|id| pending_routes.get(id));
+        item.status = match (calling_surface_active, route) {
+            (false, Some(AgentPermissionRouting::Desktop)) => continue,
+            (true, _) | (_, Some(AgentPermissionRouting::CallingSurface)) => {
+                Some("controlled_externally".to_string())
+            }
+            (false, None) => Some("cancelled".to_string()),
+        };
+    }
 }
 
 fn is_real_user_message(message: &Message, role: &str) -> bool {
@@ -5084,35 +5305,51 @@ async fn record_and_emit_timeline_item(
     events: &AgentRunEventPublisher,
     live_timelines: &LiveTimelines,
     session_id: &str,
+    routing: AgentPermissionRouting,
     item: AgentTimelineItem,
 ) {
-    record_timeline_item(live_timelines, session_id, item.clone()).await;
+    record_timeline_item(live_timelines, session_id, routing, item.clone()).await;
     events.publish(AgentRunEvent::TimelineItem(item)).await;
 }
 
 async fn record_timeline_item(
     live_timelines: &LiveTimelines,
     session_id: &str,
+    routing: AgentPermissionRouting,
     item: AgentTimelineItem,
 ) {
     let mut timelines = live_timelines.lock().await;
     let current = match timelines.remove(session_id) {
-        Some(LiveTimeline::Streaming(items)) => items,
+        Some(LiveTimelineEntry {
+            routing: owner,
+            timeline: LiveTimeline::Streaming(items),
+        }) if owner == routing => items,
         // A real user message starts a new live suffix. The preceding terminal
         // row is either already persisted or was a one-turn-only error/notice;
         // carrying it forward could duplicate it on a mid-run session reload.
-        Some(LiveTimeline::Completed(_) | LiveTimeline::Failed(_))
-            if is_user_message_item(&item) =>
-        {
-            Vec::new()
-        }
-        Some(LiveTimeline::Completed(candidate)) => candidate.items,
-        Some(LiveTimeline::Failed(items)) => items,
+        Some(LiveTimelineEntry {
+            routing: owner,
+            timeline: LiveTimeline::Completed(_) | LiveTimeline::Failed(_),
+        }) if owner == routing && is_user_message_item(&item) => Vec::new(),
+        Some(LiveTimelineEntry {
+            routing: owner,
+            timeline: LiveTimeline::Completed(candidate),
+        }) if owner == routing => candidate.items,
+        Some(LiveTimelineEntry {
+            routing: owner,
+            timeline: LiveTimeline::Failed(items),
+        }) if owner == routing => items,
+        // A new surface starts its own transient projection. Persisted Goose
+        // history remains the shared handoff boundary between surfaces.
+        Some(_) => Vec::new(),
         None => Vec::new(),
     };
     timelines.insert(
         session_id.to_string(),
-        LiveTimeline::Streaming(merge_timeline_item(current, item)),
+        LiveTimelineEntry {
+            routing,
+            timeline: LiveTimeline::Streaming(merge_timeline_item(current, item)),
+        },
     );
 }
 
@@ -5124,6 +5361,7 @@ async fn record_timeline_item(
 async fn reseed_live_timeline_after_history_replaced(
     live_timelines: &LiveTimelines,
     session_id: &str,
+    routing: AgentPermissionRouting,
     conversation: &Conversation,
 ) {
     let replacement_boundary = conversation
@@ -5149,8 +5387,9 @@ async fn reseed_live_timeline_after_history_replaced(
             // that compaction or an explicit history command removed.
             let boundary = timelines
                 .get(session_id)
-                .and_then(|items| {
-                    items.items().iter().rev().find(|item| {
+                .filter(|entry| entry.routing == routing)
+                .and_then(|entry| {
+                    entry.timeline.items().iter().rev().find(|item| {
                         is_user_message_item(item) && item.id == replacement_boundary.id
                     })
                 })
@@ -5158,11 +5397,14 @@ async fn reseed_live_timeline_after_history_replaced(
                 .unwrap_or(replacement_boundary);
             timelines.insert(
                 session_id.to_string(),
-                LiveTimeline::Streaming(vec![boundary]),
+                LiveTimelineEntry {
+                    routing,
+                    timeline: LiveTimeline::Streaming(vec![boundary]),
+                },
             );
         }
         None => {
-            timelines.remove(session_id);
+            remove_live_timeline_for_routing(&mut timelines, session_id, routing);
         }
     }
 }
@@ -5170,19 +5412,24 @@ async fn reseed_live_timeline_after_history_replaced(
 async fn overlay_live_timeline(
     live_timelines: &LiveTimelines,
     session_id: &str,
+    routing: AgentPermissionRouting,
     conversation: &Conversation,
     persisted: Vec<AgentTimelineItem>,
 ) -> Vec<AgentTimelineItem> {
     let live_items = {
         let mut timelines = live_timelines.lock().await;
-        match timelines.get(session_id).cloned() {
+        let timeline = timelines
+            .get(session_id)
+            .filter(|entry| entry.routing == routing)
+            .map(|entry| entry.timeline.clone());
+        match timeline {
             Some(LiveTimeline::Streaming(items)) => items,
             Some(LiveTimeline::Completed(candidate)) => {
                 // agent_load_session already paid to load Goose history. Use
                 // that snapshot here instead of deserializing it a second time
                 // at the end of every prompt.
                 if terminal_message_is_persisted(conversation, &candidate) {
-                    timelines.remove(session_id);
+                    remove_live_timeline_for_routing(&mut timelines, session_id, routing);
                     Vec::new()
                 } else {
                     candidate.items
@@ -5232,12 +5479,17 @@ fn live_overlay_item(mut item: AgentTimelineItem) -> AgentTimelineItem {
 async fn update_live_permission_status(
     live_timelines: &LiveTimelines,
     session_id: &str,
+    routing: AgentPermissionRouting,
     request_id: &str,
     decision: &str,
 ) -> Option<AgentTimelineItem> {
     let permission_id = format!("permission-{request_id}");
     let mut timelines = live_timelines.lock().await;
-    let items = timelines.get_mut(session_id)?.items_mut();
+    let entry = timelines.get_mut(session_id)?;
+    if entry.routing != routing {
+        return None;
+    }
+    let items = entry.timeline.items_mut();
     let item = items.iter_mut().find(|item| item.id == permission_id)?;
     item.status = Some(decision.to_string());
     item.merge = "replace".to_string();
@@ -6327,6 +6579,59 @@ mod tests {
             routing,
             request: test_permission_request(request_id),
         }
+    }
+
+    fn test_live_timeline(
+        routing: AgentPermissionRouting,
+        timeline: LiveTimeline,
+    ) -> LiveTimelineEntry {
+        LiveTimelineEntry { routing, timeline }
+    }
+
+    #[test]
+    fn desktop_status_excludes_calling_surface_runs() {
+        let status = active_run_status([
+            (
+                "desktop-run",
+                "desktop-session",
+                AgentPermissionRouting::Desktop,
+            ),
+            (
+                "acp-run",
+                "acp-session",
+                AgentPermissionRouting::CallingSurface,
+            ),
+        ]);
+
+        assert_eq!(
+            status,
+            HashMap::from([("desktop-session".to_string(), "desktop-run".to_string())])
+        );
+    }
+
+    #[test]
+    fn run_cancellation_scope_rejects_cross_surface_and_wrong_session_access() {
+        assert!(validate_run_cancellation_scope(
+            "session-1",
+            AgentPermissionRouting::CallingSurface,
+            None,
+            AgentPermissionRouting::Desktop,
+        )
+        .is_err());
+        assert!(validate_run_cancellation_scope(
+            "session-1",
+            AgentPermissionRouting::CallingSurface,
+            Some("session-2"),
+            AgentPermissionRouting::CallingSurface,
+        )
+        .is_err());
+        assert!(validate_run_cancellation_scope(
+            "session-1",
+            AgentPermissionRouting::CallingSurface,
+            Some("session-1"),
+            AgentPermissionRouting::CallingSurface,
+        )
+        .is_ok());
     }
 
     #[test]
@@ -8085,12 +8390,16 @@ mod tests {
         let reply_candidate = live_message_candidate(&live_reply, &reply_items);
         let live_timelines = Arc::new(Mutex::new(HashMap::from([(
             session_id.to_string(),
-            LiveTimeline::Completed(reply_candidate),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Completed(reply_candidate),
+            ),
         )])));
 
         let loaded = overlay_live_timeline(
             &live_timelines,
             session_id,
+            AgentPermissionRouting::Desktop,
             &persisted_conversation,
             persisted_timeline.clone(),
         )
@@ -8107,6 +8416,7 @@ mod tests {
         apply_successful_prompt_outcome(
             &mut timelines,
             session_id,
+            AgentPermissionRouting::Desktop,
             &AgentPromptOutcome {
                 terminal_message: Some(notice_candidate),
             },
@@ -8115,6 +8425,7 @@ mod tests {
         let loaded = overlay_live_timeline(
             &live_timelines,
             session_id,
+            AgentPermissionRouting::Desktop,
             &persisted_conversation,
             persisted_timeline,
         )
@@ -8125,11 +8436,167 @@ mod tests {
         );
         assert!(matches!(
             live_timelines.lock().await.get(session_id),
-            Some(LiveTimeline::Completed(_))
+            Some(LiveTimelineEntry {
+                routing: AgentPermissionRouting::Desktop,
+                timeline: LiveTimeline::Completed(_),
+            })
         ));
 
         let mut timelines = live_timelines.lock().await;
-        apply_successful_prompt_outcome(&mut timelines, session_id, &AgentPromptOutcome::default());
+        apply_successful_prompt_outcome(
+            &mut timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            &AgentPromptOutcome::default(),
+        );
+        assert!(!timelines.contains_key(session_id));
+    }
+
+    #[tokio::test]
+    async fn calling_surface_timeline_does_not_overlay_desktop_session_load() {
+        let session_id = "calling-surface-session";
+        let persisted_conversation = Conversation::new_unvalidated(vec![
+            Message::user()
+                .with_id("persisted-user")
+                .with_text("Persisted prompt"),
+            Message::assistant()
+                .with_content(MessageContent::action_required(
+                    "persisted-request",
+                    "shell".to_string(),
+                    serde_json::Map::new(),
+                    Some("Run this command?".to_string()),
+                ))
+                .with_generated_id(),
+        ]);
+        let persisted = conversation_to_timeline_items(&persisted_conversation);
+        let permission = AgentTimelineItem {
+            id: "permission-request-1".to_string(),
+            item_type: "permission".to_string(),
+            role: Some("assistant".to_string()),
+            title: Some("shell".to_string()),
+            text: Some("Run this command?".to_string()),
+            status: Some("pending".to_string()),
+            input: Some(json!({ "command": "git status --short" })),
+            output: None,
+            created_ms: 1,
+            merge: "replace".to_string(),
+        };
+        let live_timelines = Arc::new(Mutex::new(HashMap::from([(
+            session_id.to_string(),
+            test_live_timeline(
+                AgentPermissionRouting::CallingSurface,
+                LiveTimeline::Streaming(vec![permission]),
+            ),
+        )])));
+
+        let mut loaded = overlay_live_timeline(
+            &live_timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            &persisted_conversation,
+            persisted.clone(),
+        )
+        .await;
+        reconcile_desktop_permission_items(&mut loaded, &HashMap::new(), true);
+
+        assert_eq!(
+            loaded
+                .iter()
+                .find(|item| item.id == "permission-persisted-request")
+                .and_then(|item| item.status.as_deref()),
+            Some("controlled_externally")
+        );
+        assert!(!loaded.iter().any(|item| {
+            item.item_type == "permission" && item.status.as_deref() == Some("pending")
+        }));
+        assert_eq!(
+            live_timelines.lock().await.get(session_id).unwrap().routing,
+            AgentPermissionRouting::CallingSurface
+        );
+    }
+
+    #[tokio::test]
+    async fn permission_status_updates_only_the_owning_surface_timeline() {
+        let session_id = "permission-owner-session";
+        let permission = AgentTimelineItem {
+            id: "permission-request-1".to_string(),
+            item_type: "permission".to_string(),
+            role: Some("assistant".to_string()),
+            title: Some("shell".to_string()),
+            text: None,
+            status: Some("pending".to_string()),
+            input: None,
+            output: None,
+            created_ms: 1,
+            merge: "replace".to_string(),
+        };
+        let live_timelines = Arc::new(Mutex::new(HashMap::from([(
+            session_id.to_string(),
+            test_live_timeline(
+                AgentPermissionRouting::CallingSurface,
+                LiveTimeline::Streaming(vec![permission]),
+            ),
+        )])));
+
+        assert!(update_live_permission_status(
+            &live_timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            "request-1",
+            "allow_once",
+        )
+        .await
+        .is_none());
+        assert_eq!(
+            update_live_permission_status(
+                &live_timelines,
+                session_id,
+                AgentPermissionRouting::CallingSurface,
+                "request-1",
+                "allow_once",
+            )
+            .await
+            .and_then(|item| item.status),
+            Some("allow_once".to_string())
+        );
+    }
+
+    #[test]
+    fn calling_surface_terminal_cleanup_cannot_remove_desktop_live_state() {
+        let session_id = "terminal-owner-session";
+        let desktop_item = error_item("Desktop-only state".to_string());
+        let mut timelines = HashMap::from([(
+            session_id.to_string(),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Streaming(vec![desktop_item]),
+            ),
+        )]);
+
+        apply_successful_prompt_outcome(
+            &mut timelines,
+            session_id,
+            AgentPermissionRouting::CallingSurface,
+            &AgentPromptOutcome::default(),
+        );
+        assert_eq!(
+            timelines.get(session_id).unwrap().routing,
+            AgentPermissionRouting::Desktop
+        );
+
+        timelines.insert(
+            session_id.to_string(),
+            test_live_timeline(
+                AgentPermissionRouting::CallingSurface,
+                LiveTimeline::Streaming(Vec::new()),
+            ),
+        );
+        apply_successful_prompt_outcome(
+            &mut timelines,
+            session_id,
+            AgentPermissionRouting::CallingSurface,
+            &AgentPromptOutcome::default(),
+        );
         assert!(!timelines.contains_key(session_id));
     }
 
@@ -8142,21 +8609,28 @@ mod tests {
                 .with_text("Prior turn"),
             false,
         );
-        let mut timelines =
-            HashMap::from([(session_id.to_string(), LiveTimeline::Streaming(prior_turn))]);
+        let mut timelines = HashMap::from([(
+            session_id.to_string(),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Streaming(prior_turn),
+            ),
+        )]);
 
         apply_failed_prompt_outcome(
             &mut timelines,
             session_id,
+            AgentPermissionRouting::Desktop,
             error_item("First failure".to_string()),
         );
         apply_failed_prompt_outcome(
             &mut timelines,
             session_id,
+            AgentPermissionRouting::Desktop,
             error_item("Second failure".to_string()),
         );
 
-        let LiveTimeline::Failed(items) = timelines.get(session_id).unwrap() else {
+        let LiveTimeline::Failed(items) = &timelines.get(session_id).unwrap().timeline else {
             panic!("failed run should leave a bounded failed timeline");
         };
         assert_eq!(items.len(), 1);
@@ -8170,9 +8644,15 @@ mod tests {
         .into_iter()
         .next()
         .unwrap();
-        record_timeline_item(&live_timelines, session_id, next_user).await;
+        record_timeline_item(
+            &live_timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            next_user,
+        )
+        .await;
         let timelines = live_timelines.lock().await;
-        let LiveTimeline::Streaming(items) = timelines.get(session_id).unwrap() else {
+        let LiveTimeline::Streaming(items) = &timelines.get(session_id).unwrap().timeline else {
             panic!("a retry should start a fresh streaming timeline");
         };
         assert_eq!(items.len(), 1);
@@ -8377,6 +8857,103 @@ mod tests {
         assert!(items.iter().any(|item| {
             item.id == "elicitation-pending-input" && item.status.as_deref() == Some("cancelled")
         }));
+    }
+
+    #[test]
+    fn persisted_tool_permission_settles_without_stop_notice() {
+        let permission = Message::assistant()
+            .with_content(MessageContent::action_required(
+                "resolved-tool",
+                "shell".to_string(),
+                serde_json::Map::new(),
+                None,
+            ))
+            .with_generated_id();
+        let conversation = Conversation::new_unvalidated(vec![
+            Message::user().with_text("run tool").with_generated_id(),
+            permission,
+            tool_response_message("resolved-response", "resolved-tool"),
+        ]);
+
+        let items = conversation_to_timeline_items(&conversation);
+
+        assert!(items.iter().any(|item| {
+            item.id == "permission-resolved-tool" && item.status.as_deref() == Some("completed")
+        }));
+    }
+
+    #[test]
+    fn persisted_elicitation_settles_from_agent_only_response() {
+        let request = Message::assistant()
+            .with_content(MessageContent::action_required_elicitation(
+                "resolved-input",
+                "Need more input".to_string(),
+                json!({"type": "object"}),
+            ))
+            .with_generated_id();
+        let response = Message::user()
+            .with_content(MessageContent::action_required_elicitation_response(
+                "resolved-input",
+                json!({"answer": "yes"}),
+                rmcp::model::ElicitationAction::Accept,
+            ))
+            .agent_only()
+            .with_generated_id();
+        let conversation = Conversation::new_unvalidated(vec![
+            Message::user().with_text("ask me").with_generated_id(),
+            request,
+            response,
+        ]);
+
+        let items = conversation_to_timeline_items(&conversation);
+
+        assert!(items.iter().any(|item| {
+            item.id == "elicitation-resolved-input" && item.status.as_deref() == Some("completed")
+        }));
+    }
+
+    #[test]
+    fn desktop_permission_reconciliation_preserves_only_desktop_owned_pending_rows() {
+        fn permission(id: &str, status: &str) -> AgentTimelineItem {
+            AgentTimelineItem {
+                id: format!("permission-{id}"),
+                item_type: "permission".to_string(),
+                role: Some("system".to_string()),
+                title: Some("Permission".to_string()),
+                text: None,
+                status: Some(status.to_string()),
+                input: None,
+                output: None,
+                created_ms: 1,
+                merge: "replace".to_string(),
+            }
+        }
+
+        let original_completed = permission("completed", "completed");
+        let mut items = vec![
+            permission("desktop", "pending"),
+            permission("caller", "pending"),
+            permission("orphan", "pending"),
+            original_completed.clone(),
+        ];
+        let routes = HashMap::from([
+            ("desktop".to_string(), AgentPermissionRouting::Desktop),
+            ("caller".to_string(), AgentPermissionRouting::CallingSurface),
+        ]);
+
+        reconcile_desktop_permission_items(&mut items, &routes, false);
+
+        assert_eq!(items[0].status.as_deref(), Some("pending"));
+        assert_eq!(items[1].status.as_deref(), Some("controlled_externally"));
+        assert_eq!(items[2].status.as_deref(), Some("cancelled"));
+        assert_eq!(items[3], original_completed);
+
+        let mut registration_race = vec![permission("not-registered-yet", "pending")];
+        reconcile_desktop_permission_items(&mut registration_race, &HashMap::new(), true);
+        assert_eq!(
+            registration_race[0].status.as_deref(),
+            Some("controlled_externally")
+        );
     }
 
     #[test]
@@ -8857,16 +9434,25 @@ mod tests {
         ));
         let live_timelines = Arc::new(Mutex::new(HashMap::from([(
             session_id.to_string(),
-            LiveTimeline::Streaming(live),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Streaming(live),
+            ),
         )])));
 
-        reseed_live_timeline_after_history_replaced(&live_timelines, session_id, &conversation)
-            .await;
+        reseed_live_timeline_after_history_replaced(
+            &live_timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            &conversation,
+        )
+        .await;
 
         let timelines = live_timelines.lock().await;
         let items = timelines
             .get(session_id)
             .expect("replacement should retain a user boundary")
+            .timeline
             .items();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "current-user-text");
@@ -8896,16 +9482,25 @@ mod tests {
             Conversation::new_unvalidated(vec![current_user.clone(), provider_only_user]);
         let live_timelines = Arc::new(Mutex::new(HashMap::from([(
             session_id.to_string(),
-            LiveTimeline::Streaming(message_to_timeline_items(&current_user, false)),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Streaming(message_to_timeline_items(&current_user, false)),
+            ),
         )])));
 
-        reseed_live_timeline_after_history_replaced(&live_timelines, session_id, &conversation)
-            .await;
+        reseed_live_timeline_after_history_replaced(
+            &live_timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            &conversation,
+        )
+        .await;
 
         let timelines = live_timelines.lock().await;
         let items = timelines
             .get(session_id)
             .expect("the latest visible user boundary should survive")
+            .timeline
             .items();
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "current-user-text");
@@ -8934,8 +9529,13 @@ mod tests {
             current_user.clone(),
         ]);
         let live_timelines = Arc::new(Mutex::new(HashMap::new()));
-        reseed_live_timeline_after_history_replaced(&live_timelines, session_id, &replacement)
-            .await;
+        reseed_live_timeline_after_history_replaced(
+            &live_timelines,
+            session_id,
+            AgentPermissionRouting::Desktop,
+            &replacement,
+        )
+        .await;
 
         let live_response = assistant_tool_message(
             "live-provider-response",
@@ -8944,7 +9544,13 @@ mod tests {
             "",
         );
         for item in message_to_timeline_items(&live_response, true) {
-            record_timeline_item(&live_timelines, session_id, item).await;
+            record_timeline_item(
+                &live_timelines,
+                session_id,
+                AgentPermissionRouting::Desktop,
+                item,
+            )
+            .await;
         }
 
         let persisted_conversation = Conversation::new_unvalidated(vec![
@@ -8968,6 +9574,7 @@ mod tests {
         let overlaid = overlay_live_timeline(
             &live_timelines,
             session_id,
+            AgentPermissionRouting::Desktop,
             &persisted_conversation,
             persisted,
         )
@@ -9154,8 +9761,20 @@ mod tests {
             .expect("surviving session should be created");
 
         let live_timelines = Arc::new(Mutex::new(HashMap::from([
-            (target.id.clone(), LiveTimeline::Streaming(Vec::new())),
-            (survivor.id.clone(), LiveTimeline::Streaming(Vec::new())),
+            (
+                target.id.clone(),
+                test_live_timeline(
+                    AgentPermissionRouting::Desktop,
+                    LiveTimeline::Streaming(Vec::new()),
+                ),
+            ),
+            (
+                survivor.id.clone(),
+                test_live_timeline(
+                    AgentPermissionRouting::Desktop,
+                    LiveTimeline::Streaming(Vec::new()),
+                ),
+            ),
         ])));
         let pending_permissions = Arc::new(Mutex::new(HashMap::from([
             (
@@ -9319,13 +9938,17 @@ mod tests {
 
         let live_timelines = Arc::new(Mutex::new(HashMap::from([(
             session.id.clone(),
-            LiveTimeline::Streaming(vec![error_item("speculative partial event".to_string())]),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Streaming(vec![error_item("speculative partial event".to_string())]),
+            ),
         )])));
         finalize_cancelled_agent_turn(
             &session_manager,
             &live_timelines,
             &web_tool_state,
             &session.id,
+            AgentPermissionRouting::Desktop,
             &stopped_user,
             &HashSet::from(["declined-tool".to_string()]),
         )
@@ -9411,13 +10034,17 @@ mod tests {
             .with_generated_id();
         live_timelines.lock().await.insert(
             first_turn_session.id.clone(),
-            LiveTimeline::Streaming(vec![error_item("optimistic first turn".to_string())]),
+            test_live_timeline(
+                AgentPermissionRouting::Desktop,
+                LiveTimeline::Streaming(vec![error_item("optimistic first turn".to_string())]),
+            ),
         );
         finalize_cancelled_agent_turn(
             &session_manager,
             &live_timelines,
             &web_tool_state,
             &first_turn_session.id,
+            AgentPermissionRouting::Desktop,
             &first_turn_user,
             &HashSet::new(),
         )

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -33,7 +33,7 @@ use shell_permission::{
     local_read_image_request_id, local_read_request_id, ShellPermissionClassifier,
     ShellPermissionOutcome, ShellPermissionRequest,
 };
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -42,7 +42,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use tauri::{AppHandle, Emitter, Manager, State};
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{broadcast, oneshot, watch, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 use web_permission::{
     web_search_request_id, OpenUrlPermissionRequest, WebPermissionClassifier, WebPermissionContext,
@@ -92,7 +92,23 @@ const MAX_MCP_CONNECTION_ERRORS: usize = 3;
 const MAX_MCP_SERVER_NAME_CHARS: usize = 64;
 const MAX_MCP_CONNECTION_ERROR_CHARS: usize = 200;
 const MCP_CONNECTION_ERROR_PREFIX: &str = "Some MCP servers could not connect:";
+const AGENT_EVENT_BROADCAST_CAPACITY: usize = 1_024;
+const MAX_AGENT_TOOL_ENV_KEYS: usize = 6;
+const MAX_AGENT_TOOL_ENV_KEY_BYTES: usize = 64;
+const MAX_AGENT_TOOL_ENV_VALUE_BYTES: usize = 16 * 1024;
+const MAX_AGENT_TOOL_ENV_TOTAL_BYTES: usize = 32 * 1024;
+const ALLOWED_AGENT_TOOL_ENV_KEYS: [&str; MAX_AGENT_TOOL_ENV_KEYS] = [
+    "BUZZ_RELAY_URL",
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_DISPLAY_NAME",
+    "PATH",
+];
 static NEXT_RUN_ID: AtomicU64 = AtomicU64::new(1);
+
+pub(crate) type AgentToolEnvironment = BTreeMap<String, String>;
+pub(crate) type SharedAgentToolEnvironment = Arc<RwLock<AgentToolEnvironment>>;
 
 fn validate_session_model_lock(
     message_count: usize,
@@ -304,6 +320,18 @@ pub struct AgentRunResponse {
     pub run_id: String,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AgentRunTerminal {
+    Completed,
+    Cancelled,
+    Failed,
+}
+
+pub(crate) struct AgentRunHandle {
+    pub run_id: String,
+    pub terminal: watch::Receiver<Option<AgentRunTerminal>>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct AgentSessionSummary {
@@ -381,6 +409,7 @@ struct AgentRuntime {
     session_manager: Arc<SessionManager>,
     maple_api_session: Arc<MapleApiSession>,
     active_runs: HashMap<String, ActiveAgentRun>,
+    session_tool_environments: HashMap<String, SharedAgentToolEnvironment>,
     permission_modes: SessionPermissionModes,
     web_tool_state: Arc<WebToolState>,
     project_root: PathBuf,
@@ -412,6 +441,7 @@ pub struct AgentRuntimeState {
     session_lifecycle: Arc<Mutex<()>>,
     pending_permissions: PendingPermissions,
     live_timelines: LiveTimelines,
+    event_sender: broadcast::Sender<AgentEventEnvelope>,
 }
 
 type LiveTimelines = Arc<Mutex<HashMap<String, LiveTimeline>>>;
@@ -450,6 +480,7 @@ impl LiveTimeline {
 
 impl AgentRuntimeState {
     pub fn new() -> Self {
+        let (event_sender, _) = broadcast::channel(AGENT_EVENT_BROADCAST_CAPACITY);
         Self {
             inner: Arc::new(Mutex::new(None)),
             runtime_lifecycle: Arc::new(Mutex::new(())),
@@ -457,8 +488,18 @@ impl AgentRuntimeState {
             session_lifecycle: Arc::new(Mutex::new(())),
             pending_permissions: Arc::new(Mutex::new(HashMap::new())),
             live_timelines: Arc::new(Mutex::new(HashMap::new())),
+            event_sender,
         }
     }
+}
+
+pub(crate) fn subscribe_agent_events(
+    app_handle: &AppHandle,
+) -> broadcast::Receiver<AgentEventEnvelope> {
+    app_handle
+        .state::<AgentRuntimeState>()
+        .event_sender
+        .subscribe()
 }
 
 fn ensure_runtime_account(runtime: &AgentRuntime, account_scope: &str) -> Result<(), String> {
@@ -722,6 +763,98 @@ pub async fn agent_start_runtime(
     start_runtime_for_user(app_handle, &state, &api_auth_state, user_id, request).await
 }
 
+pub(crate) async fn ensure_agent_runtime_for_user(
+    app_handle: &AppHandle,
+    user_id: String,
+    request: Option<AgentStartRequest>,
+) -> Result<AgentRuntimeStatus, String> {
+    agent_start_runtime(
+        app_handle.clone(),
+        app_handle.state::<AgentRuntimeState>(),
+        app_handle.state::<MapleApiAuthState>(),
+        user_id,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn set_agent_session_tool_environment(
+    app_handle: &AppHandle,
+    user_id: &str,
+    session_id: &str,
+    environment: HashMap<String, String>,
+) -> Result<SharedAgentToolEnvironment, String> {
+    let environment = normalize_agent_tool_environment(environment)?;
+    let session_id = session_id.trim().to_string();
+    if session_id.is_empty() {
+        return Err("Agent tool environment requires a task ID".to_string());
+    }
+
+    let state = app_handle.state::<AgentRuntimeState>();
+    let requested_scope = account_scope(user_id)?;
+    let generation = account_generation(&state, &requested_scope).await;
+    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+    ensure_account_generation(&state, &requested_scope, generation).await?;
+    let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+    let session_manager = {
+        let runtime = state.inner.lock().await;
+        let current = runtime
+            .as_ref()
+            .ok_or_else(|| "Agent runtime is not running".to_string())?;
+        ensure_runtime_account(current, &requested_scope)?;
+        Arc::clone(&current.session_manager)
+    };
+    session_manager
+        .get_session(&session_id, false)
+        .await
+        .map_err(|error| format!("Failed to load Agent task: {error}"))?;
+
+    let shared_environment = {
+        let mut runtime = state.inner.lock().await;
+        let current = runtime
+            .as_mut()
+            .ok_or_else(|| "Agent runtime is not running".to_string())?;
+        ensure_runtime_account(current, &requested_scope)?;
+        Arc::clone(
+            current
+                .session_tool_environments
+                .entry(session_id)
+                .or_insert_with(|| Arc::new(RwLock::new(AgentToolEnvironment::new()))),
+        )
+    };
+    *shared_environment.write().await = environment;
+    Ok(shared_environment)
+}
+
+pub(crate) async fn clear_agent_session_tool_environment(
+    app_handle: &AppHandle,
+    user_id: &str,
+    session_id: &str,
+) -> Result<(), String> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Ok(());
+    }
+
+    let state = app_handle.state::<AgentRuntimeState>();
+    let requested_scope = account_scope(user_id)?;
+    let generation = account_generation(&state, &requested_scope).await;
+    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+    ensure_account_generation(&state, &requested_scope, generation).await?;
+    let removed = {
+        let mut runtime = state.inner.lock().await;
+        let Some(current) = runtime.as_mut() else {
+            return Ok(());
+        };
+        ensure_runtime_account(current, &requested_scope)?;
+        current.session_tool_environments.remove(session_id)
+    };
+    if let Some(environment) = removed {
+        environment.write().await.clear();
+    }
+    Ok(())
+}
+
 async fn start_runtime_for_user(
     app_handle: AppHandle,
     state: &AgentRuntimeState,
@@ -808,6 +941,7 @@ async fn start_runtime_for_user(
         session_manager,
         maple_api_session,
         active_runs: HashMap::new(),
+        session_tool_environments: HashMap::new(),
         permission_modes: Arc::new(Mutex::new(HashMap::new())),
         web_tool_state: Arc::new(WebToolState::default()),
         project_root: project_root.clone(),
@@ -847,9 +981,11 @@ async fn start_runtime_for_user(
 
 #[tauri::command]
 pub async fn agent_stop_runtime(
+    app_handle: AppHandle,
     state: State<'_, AgentRuntimeState>,
     user_id: String,
 ) -> Result<AgentRuntimeStatus, String> {
+    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
     let account_scope = account_scope(&user_id)?;
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
@@ -866,6 +1002,7 @@ pub async fn agent_restart_runtime(
     user_id: String,
     request: Option<AgentStartRequest>,
 ) -> Result<AgentRuntimeStatus, String> {
+    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
     let account_scope = account_scope(&user_id)?;
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
@@ -880,6 +1017,7 @@ pub async fn agent_clear_user_data(
     state: State<'_, AgentRuntimeState>,
     user_id: String,
 ) -> Result<(), String> {
+    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
     let requested_scope = account_scope(&user_id)?;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     advance_account_generation(&state, &requested_scope).await;
@@ -911,6 +1049,7 @@ pub async fn agent_clear_user_data(
             ))
         }
     }
+    crate::agent_acp::clear_agent_acp_config(&app_handle, &user_id)?;
     Ok(())
 }
 
@@ -920,6 +1059,7 @@ pub async fn agent_clear_user_history(
     state: State<'_, AgentRuntimeState>,
     user_id: String,
 ) -> Result<(), String> {
+    crate::agent_acp::shutdown_agent_acp(&app_handle).await?;
     let requested_scope = account_scope(&user_id)?;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
     advance_account_generation(&state, &requested_scope).await;
@@ -1276,6 +1416,17 @@ pub async fn agent_create_session(
         .lock()
         .await
         .insert(session.id.clone(), permission_mode);
+    let tool_environment = Arc::new(RwLock::new(AgentToolEnvironment::new()));
+    {
+        let mut runtime = state.inner.lock().await;
+        let current = runtime
+            .as_mut()
+            .ok_or_else(|| "Agent runtime is not running".to_string())?;
+        ensure_runtime_account(current, &account_scope)?;
+        current
+            .session_tool_environments
+            .insert(session.id.clone(), Arc::clone(&tool_environment));
+    }
     let setup_result: Result<Vec<AgentMcpConnectionError>, String> = async {
         let (agent, mut mcp_errors) = configure_session_agent(
             AgentSkillsScope {
@@ -1292,6 +1443,7 @@ pub async fn agent_create_session(
                 context_limit: request.context_limit,
                 mode: &mode,
                 primary_model_supports_vision: false,
+                tool_environment: &tool_environment,
             },
         )
         .await?;
@@ -1322,6 +1474,18 @@ pub async fn agent_create_session(
         Ok(mcp_errors) => mcp_errors,
         Err(error) => {
             permission_modes.lock().await.remove(&session.id);
+            let removed_tool_environment = {
+                let mut runtime = state.inner.lock().await;
+                if let Some(current) = runtime.as_mut() {
+                    ensure_runtime_account(current, &account_scope)?;
+                    current.session_tool_environments.remove(&session.id)
+                } else {
+                    None
+                }
+            };
+            if let Some(environment) = removed_tool_environment {
+                environment.write().await.clear();
+            }
             if let Err(cleanup_error) = session_manager.delete_session(&session.id).await {
                 log::warn!(
                     "Failed to remove Agent task {} after setup error: {cleanup_error}",
@@ -1663,6 +1827,18 @@ pub async fn agent_delete_session(
     if let Some(permission_modes) = permission_modes {
         permission_modes.lock().await.remove(&session_id);
     }
+    let removed_tool_environment = {
+        let mut runtime = state.inner.lock().await;
+        if let Some(current) = runtime.as_mut() {
+            ensure_runtime_account(current, &account_scope)?;
+            current.session_tool_environments.remove(&session_id)
+        } else {
+            None
+        }
+    };
+    if let Some(environment) = removed_tool_environment {
+        environment.write().await.clear();
+    }
 
     Ok(())
 }
@@ -1886,13 +2062,12 @@ fn is_goose_declined_tool_response(response: &goose::conversation::message::Tool
     })
 }
 
-#[tauri::command]
-pub async fn agent_send_message(
+async fn agent_send_message_inner(
     app_handle: AppHandle,
     state: State<'_, AgentRuntimeState>,
     user_id: String,
     request: AgentSendMessageRequest,
-) -> Result<AgentRunResponse, String> {
+) -> Result<AgentRunHandle, String> {
     let account_scope = account_scope(&user_id)?;
     let generation = account_generation(&state, &account_scope).await;
     let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
@@ -1914,20 +2089,28 @@ pub async fn agent_send_message(
         maple_api_session,
         permission_modes,
         web_tool_state,
+        tool_environment,
         model,
         mode,
     ) = {
-        let runtime = state.inner.lock().await;
+        let mut runtime = state.inner.lock().await;
         let current = runtime
-            .as_ref()
+            .as_mut()
             .ok_or_else(|| "Agent runtime is not running".to_string())?;
         ensure_runtime_account(current, &account_scope)?;
+        let tool_environment = Arc::clone(
+            current
+                .session_tool_environments
+                .entry(request.session_id.clone())
+                .or_insert_with(|| Arc::new(RwLock::new(AgentToolEnvironment::new()))),
+        );
         (
             Arc::clone(&current.agent_manager),
             Arc::clone(&current.session_manager),
             Arc::clone(&current.maple_api_session),
             Arc::clone(&current.permission_modes),
             Arc::clone(&current.web_tool_state),
+            tool_environment,
             request
                 .model
                 .clone()
@@ -2013,6 +2196,7 @@ pub async fn agent_send_message(
                 context_limit: request.context_limit,
                 mode: &effective_mode,
                 primary_model_supports_vision: request.vision_capable,
+                tool_environment: &tool_environment,
             },
         )
         .await?;
@@ -2061,6 +2245,7 @@ pub async fn agent_send_message(
     let cancelled_permission_ids = Arc::new(Mutex::new(HashSet::new()));
     let task_cancelled_permission_ids = Arc::clone(&cancelled_permission_ids);
     let (start_tx, start_rx) = oneshot::channel();
+    let (terminal_tx, terminal_rx) = watch::channel(None);
     let task = tauri::async_runtime::spawn(async move {
         let should_run = tokio::select! {
             biased;
@@ -2160,6 +2345,16 @@ pub async fn agent_send_message(
                 message: Some(status.to_string()),
             },
         );
+        // This retained per-run signal is authoritative for non-UI consumers.
+        // It is deliberately published after runFinished so a receiver that
+        // can still drain the broadcast stream observes all timeline chunks
+        // before settling, while a lagged receiver can never miss completion.
+        let terminal = match status {
+            "cancelled" => AgentRunTerminal::Cancelled,
+            "failed" => AgentRunTerminal::Failed,
+            _ => AgentRunTerminal::Completed,
+        };
+        let _ = terminal_tx.send(Some(terminal));
         // Remove the stored JoinHandle only after the final externally visible
         // side effect. Stop may otherwise miss this task and return while its
         // runFinished event is still pending.
@@ -2227,7 +2422,21 @@ pub async fn agent_send_message(
     // followed by this send path re-appending the cancelled prompt.
     drop(session_lifecycle_guard);
 
-    Ok(AgentRunResponse { run_id })
+    Ok(AgentRunHandle {
+        run_id,
+        terminal: terminal_rx,
+    })
+}
+
+#[tauri::command]
+pub async fn agent_send_message(
+    app_handle: AppHandle,
+    state: State<'_, AgentRuntimeState>,
+    user_id: String,
+    request: AgentSendMessageRequest,
+) -> Result<AgentRunResponse, String> {
+    let run = agent_send_message_inner(app_handle, state, user_id, request).await?;
+    Ok(AgentRunResponse { run_id: run.run_id })
 }
 
 #[tauri::command]
@@ -2529,6 +2738,62 @@ pub async fn agent_permission_respond(
         .await
         .remove(&(session_id, response.request_id));
     Ok(())
+}
+
+pub(crate) async fn create_agent_session_for_user(
+    app_handle: &AppHandle,
+    user_id: String,
+    request: Option<AgentCreateSessionRequest>,
+) -> Result<AgentSessionDetail, String> {
+    agent_create_session(
+        app_handle.clone(),
+        app_handle.state::<AgentRuntimeState>(),
+        user_id,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn delete_agent_session_for_user(
+    app_handle: &AppHandle,
+    user_id: String,
+    session_id: String,
+) -> Result<(), String> {
+    agent_delete_session(
+        app_handle.clone(),
+        app_handle.state::<AgentRuntimeState>(),
+        user_id,
+        session_id,
+    )
+    .await
+}
+
+pub(crate) async fn send_agent_message_for_user(
+    app_handle: &AppHandle,
+    user_id: String,
+    request: AgentSendMessageRequest,
+) -> Result<AgentRunHandle, String> {
+    agent_send_message_inner(
+        app_handle.clone(),
+        app_handle.state::<AgentRuntimeState>(),
+        user_id,
+        request,
+    )
+    .await
+}
+
+pub(crate) async fn cancel_agent_run_for_user(
+    app_handle: &AppHandle,
+    user_id: String,
+    run_id: String,
+) -> Result<(), String> {
+    agent_cancel_run(
+        app_handle.clone(),
+        app_handle.state::<AgentRuntimeState>(),
+        user_id,
+        run_id,
+    )
+    .await
 }
 
 struct AgentPromptRun {
@@ -3295,6 +3560,7 @@ struct SessionAgentConfiguration<'a> {
     context_limit: Option<usize>,
     mode: &'a str,
     primary_model_supports_vision: bool,
+    tool_environment: &'a SharedAgentToolEnvironment,
 }
 
 fn maple_model_config(
@@ -3401,6 +3667,7 @@ async fn configure_session_agent(
         context_limit,
         mode,
         primary_model_supports_vision,
+        tool_environment,
     } = configuration;
     let session_mcp_keys = session_mcp_extension_keys(session);
     let manager_result = get_or_create_session_agent(
@@ -3444,6 +3711,7 @@ async fn configure_session_agent(
         primary_model_supports_vision,
         web_transport,
         Arc::clone(web_tool_state),
+        tool_environment.clone(),
     )
     .map_err(|e| format!("Failed to create Maple developer tools: {e}"))?;
     agent
@@ -4414,6 +4682,8 @@ async fn update_live_permission_status(
 }
 
 fn emit_agent_event(app_handle: &AppHandle, event: AgentEventEnvelope) {
+    let state = app_handle.state::<AgentRuntimeState>();
+    let _ = state.event_sender.send(event.clone());
     if let Err(error) = app_handle.emit(AGENT_EVENT_NAME, event) {
         log::warn!("Failed to emit Agent Mode event: {error}");
     }
@@ -4513,6 +4783,52 @@ fn parse_user_permission_mode(mode: &str) -> Result<GooseMode, String> {
         "smart_approve" => Ok(GooseMode::SmartApprove),
         _ => Err(format!("Unsupported Agent permission mode: {mode}")),
     }
+}
+
+fn normalize_agent_tool_environment(
+    environment: HashMap<String, String>,
+) -> Result<AgentToolEnvironment, String> {
+    if environment.len() > MAX_AGENT_TOOL_ENV_KEYS {
+        return Err(format!(
+            "Agent tool environment supports at most {MAX_AGENT_TOOL_ENV_KEYS} variables"
+        ));
+    }
+
+    let mut total_bytes = 0usize;
+    let mut normalized = AgentToolEnvironment::new();
+    for (key, value) in environment {
+        if key.len() > MAX_AGENT_TOOL_ENV_KEY_BYTES {
+            return Err(format!(
+                "Agent tool environment variable names must be at most {MAX_AGENT_TOOL_ENV_KEY_BYTES} bytes"
+            ));
+        }
+        if !ALLOWED_AGENT_TOOL_ENV_KEYS.contains(&key.as_str()) {
+            return Err(format!(
+                "Agent tool environment variable {key} is not allowed"
+            ));
+        }
+        if value.contains('\0') {
+            return Err(format!(
+                "Agent tool environment variable {key} contains an invalid null byte"
+            ));
+        }
+        let value_bytes = value.len();
+        if value_bytes > MAX_AGENT_TOOL_ENV_VALUE_BYTES {
+            return Err(format!(
+                "Agent tool environment variable {key} exceeds the {MAX_AGENT_TOOL_ENV_VALUE_BYTES} byte limit"
+            ));
+        }
+        total_bytes = total_bytes
+            .checked_add(key.len() + value_bytes)
+            .ok_or_else(|| "Agent tool environment size overflowed".to_string())?;
+        if total_bytes > MAX_AGENT_TOOL_ENV_TOTAL_BYTES {
+            return Err(format!(
+                "Agent tool environment exceeds the {MAX_AGENT_TOOL_ENV_TOTAL_BYTES} byte total limit"
+            ));
+        }
+        normalized.insert(key, value);
+    }
+    Ok(normalized)
 }
 
 fn normalize_mcp_servers(mut servers: Vec<AgentMcpServer>) -> Result<Vec<AgentMcpServer>, String> {
@@ -5476,6 +5792,64 @@ mod tests {
         assert_eq!(config.default_model, DEFAULT_AGENT_MODEL);
         assert!(config.mcp_servers.is_empty());
         assert!(config.project_skills_trust.is_empty());
+    }
+
+    #[test]
+    fn agent_tool_environment_accepts_only_the_bounded_buzz_allowlist() {
+        let allowed = ALLOWED_AGENT_TOOL_ENV_KEYS
+            .iter()
+            .map(|key| ((*key).to_string(), format!("value-for-{key}")))
+            .collect::<HashMap<_, _>>();
+        let normalized = normalize_agent_tool_environment(allowed).unwrap();
+        assert_eq!(
+            normalized.keys().map(String::as_str).collect::<Vec<_>>(),
+            vec![
+                "BUZZ_ACP_DISPLAY_NAME",
+                "BUZZ_API_TOKEN",
+                "BUZZ_AUTH_TAG",
+                "BUZZ_PRIVATE_KEY",
+                "BUZZ_RELAY_URL",
+                "PATH",
+            ]
+        );
+
+        let unknown = HashMap::from([("HOME".to_string(), "/tmp/not-allowed".to_string())]);
+        assert!(normalize_agent_tool_environment(unknown)
+            .unwrap_err()
+            .contains("HOME is not allowed"));
+
+        let nul = HashMap::from([("BUZZ_AUTH_TAG".to_string(), "bad\0value".to_string())]);
+        assert!(normalize_agent_tool_environment(nul)
+            .unwrap_err()
+            .contains("null byte"));
+    }
+
+    #[test]
+    fn agent_tool_environment_enforces_value_and_total_size_limits() {
+        let oversized_value = HashMap::from([(
+            "BUZZ_PRIVATE_KEY".to_string(),
+            "x".repeat(MAX_AGENT_TOOL_ENV_VALUE_BYTES + 1),
+        )]);
+        assert!(normalize_agent_tool_environment(oversized_value)
+            .unwrap_err()
+            .contains("byte limit"));
+
+        let per_value = (MAX_AGENT_TOOL_ENV_TOTAL_BYTES / 3) + 1;
+        let oversized_total = HashMap::from([
+            ("BUZZ_PRIVATE_KEY".to_string(), "a".repeat(per_value)),
+            ("BUZZ_API_TOKEN".to_string(), "b".repeat(per_value)),
+            ("BUZZ_AUTH_TAG".to_string(), "c".repeat(per_value)),
+        ]);
+        assert!(normalize_agent_tool_environment(oversized_total)
+            .unwrap_err()
+            .contains("total limit"));
+
+        let too_many = (0..=MAX_AGENT_TOOL_ENV_KEYS)
+            .map(|index| (format!("KEY_{index}"), "value".to_string()))
+            .collect::<HashMap<_, _>>();
+        assert!(normalize_agent_tool_environment(too_many)
+            .unwrap_err()
+            .contains("at most"));
     }
 
     #[test]

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -8974,6 +8974,165 @@ mod tests {
         assert!(ensure_account_scope(&first, &second).is_err());
     }
 
+    #[test]
+    fn legacy_agent_event_envelopes_serialize_stably() {
+        let status = AgentRuntimeStatus {
+            running: true,
+            project_root: Some("/tmp/project".to_string()),
+            model: Some("maple-model".to_string()),
+            mode: Some("smart_approve".to_string()),
+            active_runs: HashMap::from([("session-1".to_string(), "run-1".to_string())]),
+        };
+        let session = AgentSessionSummary {
+            id: "session-1".to_string(),
+            title: "Task".to_string(),
+            project_root: "/tmp/project".to_string(),
+            created_ms: 1,
+            updated_ms: 2,
+            message_count: 3,
+            model: Some("maple-model".to_string()),
+            mode: "smart_approve".to_string(),
+        };
+        let item = AgentTimelineItem {
+            id: "message-1".to_string(),
+            item_type: "message".to_string(),
+            role: Some("assistant".to_string()),
+            title: None,
+            text: Some("hello".to_string()),
+            status: None,
+            input: None,
+            output: None,
+            created_ms: 4,
+            merge: "append".to_string(),
+        };
+        let envelope = |event_type: &str| AgentEventEnvelope {
+            event_type: event_type.to_string(),
+            session_id: None,
+            run_id: None,
+            item: None,
+            status: None,
+            session: None,
+            message: None,
+        };
+
+        let mut runtime_status = envelope("runtimeStatus");
+        runtime_status.status = Some(status);
+        let mut session_created = envelope("sessionCreated");
+        session_created.session_id = Some("session-1".to_string());
+        session_created.session = Some(session.clone());
+        let mut session_updated = envelope("sessionUpdated");
+        session_updated.session_id = Some("session-1".to_string());
+        session_updated.run_id = Some("run-1".to_string());
+        session_updated.session = Some(session);
+        let mut run_started = envelope("runStarted");
+        run_started.session_id = Some("session-1".to_string());
+        run_started.run_id = Some("run-1".to_string());
+        let mut timeline_item = envelope("timelineItem");
+        timeline_item.session_id = Some("session-1".to_string());
+        timeline_item.run_id = Some("run-1".to_string());
+        timeline_item.item = Some(item.clone());
+        let mut error = envelope("error");
+        error.session_id = Some("session-1".to_string());
+        error.run_id = Some("run-1".to_string());
+        error.item = Some(item);
+        let mut history_replaced = envelope("historyReplaced");
+        history_replaced.session_id = Some("session-1".to_string());
+        history_replaced.run_id = Some("run-1".to_string());
+        let mut run_finished = envelope("runFinished");
+        run_finished.session_id = Some("session-1".to_string());
+        run_finished.run_id = Some("run-1".to_string());
+        run_finished.message = Some("completed".to_string());
+
+        assert_eq!(
+            serde_json::to_value([
+                runtime_status,
+                session_created,
+                session_updated,
+                run_started,
+                timeline_item,
+                error,
+                history_replaced,
+                run_finished,
+            ])
+            .unwrap(),
+            json!([
+                {
+                    "eventType": "runtimeStatus",
+                    "status": {
+                        "running": true,
+                        "projectRoot": "/tmp/project",
+                        "model": "maple-model",
+                        "mode": "smart_approve",
+                        "activeRuns": { "session-1": "run-1" }
+                    }
+                },
+                {
+                    "eventType": "sessionCreated",
+                    "sessionId": "session-1",
+                    "session": {
+                        "id": "session-1",
+                        "title": "Task",
+                        "projectRoot": "/tmp/project",
+                        "createdMs": 1,
+                        "updatedMs": 2,
+                        "messageCount": 3,
+                        "model": "maple-model",
+                        "mode": "smart_approve"
+                    }
+                },
+                {
+                    "eventType": "sessionUpdated",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "session": {
+                        "id": "session-1",
+                        "title": "Task",
+                        "projectRoot": "/tmp/project",
+                        "createdMs": 1,
+                        "updatedMs": 2,
+                        "messageCount": 3,
+                        "model": "maple-model",
+                        "mode": "smart_approve"
+                    }
+                },
+                { "eventType": "runStarted", "sessionId": "session-1", "runId": "run-1" },
+                {
+                    "eventType": "timelineItem",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "item": {
+                        "id": "message-1",
+                        "itemType": "message",
+                        "role": "assistant",
+                        "text": "hello",
+                        "createdMs": 4,
+                        "merge": "append"
+                    }
+                },
+                {
+                    "eventType": "error",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "item": {
+                        "id": "message-1",
+                        "itemType": "message",
+                        "role": "assistant",
+                        "text": "hello",
+                        "createdMs": 4,
+                        "merge": "append"
+                    }
+                },
+                { "eventType": "historyReplaced", "sessionId": "session-1", "runId": "run-1" },
+                {
+                    "eventType": "runFinished",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "message": "completed"
+                }
+            ])
+        );
+    }
+
     #[tokio::test]
     async fn rejects_operations_captured_before_account_clear() {
         let state = AgentRuntimeState::new();

--- a/frontend/src-tauri/src/agent/developer_tools.rs
+++ b/frontend/src-tauri/src/agent/developer_tools.rs
@@ -28,7 +28,9 @@ use rmcp::model::{
 };
 use rmcp::object;
 use serde::{de::Error as SerdeDeError, Deserialize, Deserializer};
-use std::collections::{BTreeMap, HashMap, HashSet};
+#[cfg(test)]
+use std::collections::{BTreeMap, BTreeSet};
+use std::collections::{HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -39,25 +41,19 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt};
 #[cfg(not(windows))]
 use tokio::sync::OnceCell;
-use tokio::sync::{mpsc, Mutex, RwLock};
+use tokio::sync::{mpsc, Mutex};
 use tokio_util::sync::CancellationToken;
 #[cfg(windows)]
 use windows::Win32::System::Threading::CREATE_NO_WINDOW;
 
 use super::shell_permission::{is_remote_file_source, thinking_disabled_request_params};
+use super::tool_context::{AgentToolContextSnapshot, SharedAgentToolContext};
 
 const MAX_READ_LINES: usize = 2_000;
 const MAX_READ_BYTES: usize = 50 * 1024;
 const MAX_EDIT_BYTES: usize = 20 * 1024 * 1024;
 const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
 const MAX_SHELL_OUTPUT_BYTES: usize = 50_000;
-const SESSION_SECRET_ENV_KEYS: [&str; 5] = [
-    "BUZZ_RELAY_URL",
-    "BUZZ_PRIVATE_KEY",
-    "BUZZ_AUTH_TAG",
-    "BUZZ_API_TOKEN",
-    "BUZZ_ACP_DISPLAY_NAME",
-];
 const SHELL_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 const SHELL_PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const IMAGE_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
@@ -139,7 +135,7 @@ pub(crate) struct MapleDeveloperClient {
     goose: DeveloperClient,
     web_transport: Arc<dyn MapleWebTransport>,
     web_state: Arc<WebToolState>,
-    tool_environment: Arc<RwLock<BTreeMap<String, String>>>,
+    tool_context: SharedAgentToolContext,
     contextual_image_context: Option<PlatformExtensionContext>,
     #[cfg(not(windows))]
     login_path_probe: ShellTool,
@@ -153,7 +149,7 @@ impl MapleDeveloperClient {
         primary_model_supports_vision: bool,
         web_transport: Arc<dyn MapleWebTransport>,
         web_state: Arc<WebToolState>,
-        tool_environment: Arc<RwLock<BTreeMap<String, String>>>,
+        tool_context: SharedAgentToolContext,
     ) -> anyhow::Result<Self> {
         let info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("developer", "1.0.0").with_title("Developer"))
@@ -169,7 +165,7 @@ impl MapleDeveloperClient {
             goose: DeveloperClient::new(context)?,
             web_transport,
             web_state,
-            tool_environment,
+            tool_context,
             contextual_image_context,
             #[cfg(not(windows))]
             login_path_probe: ShellTool::new(true)?,
@@ -488,13 +484,13 @@ impl McpClientTrait for MapleDeveloperClient {
                 let login_path = self.login_path().await;
                 #[cfg(windows)]
                 let login_path: Option<String> = None;
-                let tool_environment = self.tool_environment.read().await.clone();
+                let tool_context = self.tool_context.snapshot();
                 return Ok(run_bounded_shell(
                     params,
                     working_dir,
                     login_path.as_deref(),
                     Some(&ctx.session_id),
-                    &tool_environment,
+                    &tool_context,
                     cancel_token,
                 )
                 .await);
@@ -823,12 +819,69 @@ struct BoundedShellExecution {
     cancelled: bool,
 }
 
+/// Keeps OS containment armed across every await in shell execution.
+///
+/// Tokio may drop the whole prompt future during forced runtime shutdown. Raw
+/// `Command::kill_on_drop` only reaches the shell leader; the process-wrap
+/// child reaches the Unix process group or Windows job from this synchronous
+/// drop path as well.
+struct ArmedShellChild {
+    child: Box<dyn ChildWrapper>,
+    armed: bool,
+}
+
+impl ArmedShellChild {
+    fn new(child: Box<dyn ChildWrapper>) -> Self {
+        Self { child, armed: true }
+    }
+
+    fn as_mut(&mut self) -> &mut dyn ChildWrapper {
+        self.child.as_mut()
+    }
+
+    async fn kill_and_wait(&mut self) -> Option<i32> {
+        let kill_succeeded = match self.child.start_kill() {
+            Ok(()) => true,
+            Err(error) => {
+                log::warn!("Failed to terminate shell containment unit: {error}");
+                false
+            }
+        };
+        match self.child.wait().await {
+            Ok(status) => {
+                if kill_succeeded {
+                    self.armed = false;
+                }
+                status.code()
+            }
+            Err(error) => {
+                log::warn!("Failed to reap shell containment unit: {error}");
+                None
+            }
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ArmedShellChild {
+    fn drop(&mut self) {
+        if self.armed {
+            if let Err(error) = self.child.start_kill() {
+                log::warn!("Failed to terminate dropped shell containment unit: {error}");
+            }
+        }
+    }
+}
+
 async fn run_bounded_shell(
     params: ShellParams,
     working_dir: Option<&Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
-    tool_environment: &BTreeMap<String, String>,
+    tool_context: &AgentToolContextSnapshot,
     cancel_token: CancellationToken,
 ) -> CallToolResult {
     if params.command.trim().is_empty() {
@@ -842,7 +895,7 @@ async fn run_bounded_shell(
         working_dir,
         login_path,
         session_id,
-        tool_environment,
+        tool_context,
         cancel_token,
     )
     .await
@@ -867,23 +920,21 @@ async fn execute_bounded_shell(
     working_dir: Option<&Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
-    tool_environment: &BTreeMap<String, String>,
+    tool_context: &AgentToolContextSnapshot,
     cancel_token: CancellationToken,
 ) -> Result<BoundedShellExecution, String> {
-    let credential_bearing = contains_session_secret(tool_environment);
+    let ephemeral = tool_context.ephemeral;
     #[cfg(not(windows))]
-    if Path::new("/.flatpak-info").exists() && credential_bearing {
-        return Err(
-            "Credential-bearing Buzz ACP shell sessions are not supported inside Flatpak"
-                .to_string(),
-        );
+    if Path::new("/.flatpak-info").exists() && ephemeral {
+        return Err("Ephemeral Agent tool contexts are not supported inside Flatpak".to_string());
     }
+    let launch_guard = tool_context.begin_process_launch(&cancel_token)?;
     let mut command = build_bounded_shell_command(
         command_line,
         working_dir,
         login_path,
         session_id,
-        tool_environment,
+        tool_context,
     );
     command
         .stdin(Stdio::null())
@@ -904,14 +955,19 @@ async fn execute_bounded_shell(
         command.wrap(CreationFlags(CREATE_NO_WINDOW));
         command.wrap(JobObject);
     }
-    let mut child = command
-        .spawn()
-        .map_err(|error| format!("Failed to spawn shell command: {error}"))?;
+    let mut child = ArmedShellChild::new(
+        command
+            .spawn()
+            .map_err(|error| format!("Failed to spawn shell command: {error}"))?,
+    );
+    drop(launch_guard);
     let stdout = child
+        .as_mut()
         .stdout()
         .take()
         .ok_or_else(|| "Failed to capture shell stdout".to_string())?;
     let stderr = child
+        .as_mut()
         .stderr()
         .take()
         .ok_or_else(|| "Failed to capture shell stderr".to_string())?;
@@ -941,46 +997,77 @@ async fn execute_bounded_shell(
         biased;
         _ = cancel_token.cancelled() => {
             cancelled = true;
-            terminate_shell_process(child.as_mut()).await
+            terminate_shell_process(&mut child).await
+        }
+        _ = tool_context.revoked.cancelled() => {
+            cancelled = true;
+            terminate_shell_process(&mut child).await
         }
         _ = output_limit_reached.cancelled() => {
-            terminate_shell_process(child.as_mut()).await
+            terminate_shell_process(&mut child).await
         }
         _ = &mut timeout => {
             timed_out = true;
-            terminate_shell_process(child.as_mut()).await
+            terminate_shell_process(&mut child).await
         }
         result = wait_for_shell_parent(child.as_mut()) => match result {
             Ok(status) => status.code(),
             Err(error) => {
                 wait_error = Some(format!("Failed waiting on shell command: {error}"));
-                terminate_shell_process(child.as_mut()).await
+                terminate_shell_process(&mut child).await
             }
         },
     };
 
-    let mut capture =
-        match tokio::time::timeout(SHELL_OUTPUT_DRAIN_TIMEOUT, &mut capture_task).await {
-            Ok(Ok(capture)) => capture,
-            Ok(Err(error)) => BoundedShellCapture {
-                collection_error: Some(format!("Shell output task failed: {error}")),
-                ..BoundedShellCapture::default()
-            },
-            Err(_) => {
-                stdout_task.abort();
-                stderr_task.abort();
-                match capture_task.await {
-                    Ok(mut capture) => {
-                        capture.drain_truncated = true;
-                        capture
-                    }
-                    Err(_) => BoundedShellCapture {
-                        drain_truncated: true,
-                        ..BoundedShellCapture::default()
-                    },
+    // Credential-bearing contexts cannot allow a descendant to outlive the
+    // shell parent even during output draining. On Unix this reaches the
+    // current process group; on Windows it reaches the assigned Job Object.
+    if ephemeral && child.armed {
+        let _ = terminate_shell_process(&mut child).await;
+    }
+
+    let drain_timeout = tokio::time::sleep(SHELL_OUTPUT_DRAIN_TIMEOUT);
+    tokio::pin!(drain_timeout);
+    let capture_result = tokio::select! {
+        biased;
+        _ = cancel_token.cancelled(), if !cancelled => {
+            cancelled = true;
+            let _ = terminate_shell_process(&mut child).await;
+            Some(tokio::time::timeout(SHELL_OUTPUT_DRAIN_TIMEOUT, &mut capture_task).await)
+        }
+        _ = tool_context.revoked.cancelled(), if !cancelled => {
+            cancelled = true;
+            let _ = terminate_shell_process(&mut child).await;
+            Some(tokio::time::timeout(SHELL_OUTPUT_DRAIN_TIMEOUT, &mut capture_task).await)
+        }
+        _ = output_limit_reached.cancelled() => {
+            let _ = terminate_shell_process(&mut child).await;
+            Some(tokio::time::timeout(SHELL_OUTPUT_DRAIN_TIMEOUT, &mut capture_task).await)
+        }
+        result = &mut capture_task => Some(Ok(result)),
+        _ = &mut drain_timeout => None,
+    };
+    let mut capture = match capture_result {
+        Some(Ok(Ok(capture))) => capture,
+        Some(Ok(Err(error))) => BoundedShellCapture {
+            collection_error: Some(format!("Shell output task failed: {error}")),
+            ..BoundedShellCapture::default()
+        },
+        Some(Err(_)) | None => {
+            stdout_task.abort();
+            stderr_task.abort();
+            match capture_task.await {
+                Ok(mut capture) => {
+                    capture.drain_truncated = true;
+                    capture
                 }
+                Err(_) => BoundedShellCapture {
+                    drain_truncated: true,
+                    ..BoundedShellCapture::default()
+                },
             }
-        };
+        }
+    };
     stdout_task.abort();
     stderr_task.abort();
     let _ = stdout_task.await;
@@ -989,14 +1076,17 @@ async fn execute_bounded_shell(
         capture.exceeded_limit = true;
     }
     // The top-level shell can exit before a noisy background descendant reaches
-    // the cap. Keep the wrapped process-tree handle alive and kill it even if
-    // the parent wait already completed. A quiet background job that merely
-    // holds the pipes open follows Pi/Goose semantics and is left running.
-    if capture.exceeded_limit || credential_bearing {
-        let _ = terminate_shell_process(child.as_mut()).await;
+    // the cap. Keep the wrapped containment handle alive and kill the process
+    // group/job even if the parent wait already completed. A quiet ordinary
+    // background job follows Pi/Goose semantics and is left running.
+    if capture.exceeded_limit && child.armed {
+        let _ = terminate_shell_process(&mut child).await;
     }
     if let Some(error) = wait_error {
         return Err(error);
+    }
+    if !timed_out && !cancelled && !capture.exceeded_limit && !ephemeral {
+        child.disarm();
     }
 
     Ok(BoundedShellExecution {
@@ -1005,12 +1095,6 @@ async fn execute_bounded_shell(
         timed_out,
         cancelled,
     })
-}
-
-fn contains_session_secret(tool_environment: &BTreeMap<String, String>) -> bool {
-    SESSION_SECRET_ENV_KEYS
-        .iter()
-        .any(|key| tool_environment.contains_key(*key))
 }
 
 async fn wait_for_shell_parent(child: &mut dyn ChildWrapper) -> std::io::Result<ExitStatus> {
@@ -1090,12 +1174,10 @@ async fn collect_bounded_shell_output(
     capture
 }
 
-async fn terminate_shell_process(child: &mut dyn ChildWrapper) -> Option<i32> {
-    // ProcessGroup and JobObject both override start_kill to terminate the
-    // complete descendant tree. Their wait implementations retain the
-    // top-level exit status and finish reaping the wrapped process container.
-    let _ = child.start_kill();
-    child.wait().await.ok().and_then(|status| status.code())
+async fn terminate_shell_process(child: &mut ArmedShellChild) -> Option<i32> {
+    // ProcessGroup and JobObject both override start_kill. On Unix this
+    // terminates the current process group; on Windows the assigned job.
+    child.kill_and_wait().await
 }
 
 fn build_bounded_shell_command(
@@ -1103,7 +1185,7 @@ fn build_bounded_shell_command(
     working_dir: Option<&Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
-    tool_environment: &BTreeMap<String, String>,
+    tool_context: &AgentToolContextSnapshot,
 ) -> tokio::process::Command {
     #[cfg(windows)]
     let mut command = {
@@ -1131,7 +1213,7 @@ fn build_bounded_shell_command(
         if let Some(path) = login_path {
             command.env("PATH", path);
         }
-        apply_tool_environment(&mut command, tool_environment);
+        apply_tool_context(&mut command, tool_context);
         command
     };
 
@@ -1153,7 +1235,7 @@ fn build_bounded_shell_command(
                 command.arg(format!("--env=PATH={path}"));
             }
             apply_flatpak_session_environment(&mut command, session_id);
-            apply_flatpak_tool_environment(&mut command, tool_environment);
+            apply_flatpak_tool_context(&mut command, tool_context);
             command.arg(shell).args(["-c", command_line]);
             command
         } else {
@@ -1166,7 +1248,7 @@ fn build_bounded_shell_command(
                 command.env("PATH", path);
             }
             apply_session_environment(&mut command, session_id);
-            apply_tool_environment(&mut command, tool_environment);
+            apply_tool_context(&mut command, tool_context);
             command
         }
     };
@@ -1187,14 +1269,14 @@ fn apply_session_environment(command: &mut tokio::process::Command, session_id: 
     }
 }
 
-fn apply_tool_environment(
+fn apply_tool_context(
     command: &mut tokio::process::Command,
-    tool_environment: &BTreeMap<String, String>,
+    tool_context: &AgentToolContextSnapshot,
 ) {
-    for key in SESSION_SECRET_ENV_KEYS {
+    for key in &tool_context.scrub_from_parent {
         command.env_remove(key);
     }
-    command.envs(tool_environment);
+    command.envs(&tool_context.values);
 }
 
 #[cfg(not(windows))]
@@ -1210,14 +1292,14 @@ fn apply_flatpak_session_environment(
 }
 
 #[cfg(not(windows))]
-fn apply_flatpak_tool_environment(
+fn apply_flatpak_tool_context(
     command: &mut tokio::process::Command,
-    tool_environment: &BTreeMap<String, String>,
+    tool_context: &AgentToolContextSnapshot,
 ) {
-    for key in SESSION_SECRET_ENV_KEYS {
+    for key in &tool_context.scrub_from_parent {
         command.arg(format!("--unset-env={key}"));
     }
-    for (key, value) in tool_environment {
+    for (key, value) in &tool_context.values {
         command.arg(format!("--env={key}={value}"));
     }
 }
@@ -1915,13 +1997,14 @@ async fn write_file(
 ) -> CallToolResult {
     let path = resolve_path(&params.path, working_dir);
     let lock = mutation_lock(&path);
-    let _guard = tokio::select! {
+    let guard = tokio::select! {
         biased;
         _ = cancel_token.cancelled() => return error_result("Write cancelled"),
-        guard = lock.lock() => guard,
+        guard = lock.lock_owned() => guard,
     };
     let worker_cancel_token = cancel_token.clone();
     match tokio::task::spawn_blocking(move || {
+        let _guard = guard;
         write_file_blocking(params, path, worker_cancel_token)
     })
     .await
@@ -1989,14 +2072,16 @@ async fn edit_file(
 
     let path = resolve_path(&params.path, working_dir);
     let lock = mutation_lock(&path);
-    let _guard = tokio::select! {
+    let guard = tokio::select! {
         biased;
         _ = cancel_token.cancelled() => return error_result("Edit cancelled"),
-        guard = lock.lock() => guard,
+        guard = lock.lock_owned() => guard,
     };
     let worker_cancel_token = cancel_token.clone();
-    let task =
-        tokio::task::spawn_blocking(move || edit_file_blocking(params, path, worker_cancel_token));
+    let task = tokio::task::spawn_blocking(move || {
+        let _guard = guard;
+        edit_file_blocking(params, path, worker_cancel_token)
+    });
     tokio::select! {
         biased;
         _ = cancel_token.cancelled() => error_result("Edit cancelled"),
@@ -2263,6 +2348,7 @@ fn mutation_key(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::tool_context::AgentToolContextSpec;
     use goose::config::GooseMode;
     use goose::providers::base::{ProviderUsage, Usage};
     use goose::session::SessionManager;
@@ -2327,9 +2413,31 @@ mod tests {
             primary_model_supports_vision,
             Arc::new(TestWebTransport),
             Arc::new(WebToolState::default()),
-            Arc::new(RwLock::new(tool_environment)),
+            test_tool_context(tool_environment, BTreeSet::new(), false),
         )
         .unwrap()
+    }
+
+    fn test_tool_context(
+        values: BTreeMap<String, String>,
+        scrub_from_parent: BTreeSet<String>,
+        ephemeral: bool,
+    ) -> SharedAgentToolContext {
+        SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(values, scrub_from_parent, ephemeral).unwrap(),
+        )
+    }
+
+    fn test_tool_context_snapshot(
+        values: BTreeMap<String, String>,
+        scrub_from_parent: BTreeSet<String>,
+        ephemeral: bool,
+    ) -> AgentToolContextSnapshot {
+        test_tool_context(values, scrub_from_parent, ephemeral).snapshot()
+    }
+
+    fn empty_tool_context_snapshot() -> AgentToolContextSnapshot {
+        test_tool_context_snapshot(BTreeMap::new(), BTreeSet::new(), false)
     }
 
     struct TestDir(PathBuf);
@@ -2456,7 +2564,7 @@ mod tests {
             true,
             Arc::new(TestWebTransport),
             Arc::new(WebToolState::default()),
-            Arc::new(RwLock::new(BTreeMap::new())),
+            test_tool_context(BTreeMap::new(), BTreeSet::new(), false),
         )
         .unwrap();
         let config = goose::agents::ExtensionConfig::Builtin {
@@ -2975,6 +3083,7 @@ mod tests {
     #[cfg(unix)]
     #[tokio::test]
     async fn shell_stops_processes_at_the_combined_output_limit() {
+        let tool_context = empty_tool_context_snapshot();
         let result = tokio::time::timeout(
             Duration::from_secs(5),
             run_bounded_shell(
@@ -2985,7 +3094,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
-                &BTreeMap::new(),
+                &tool_context,
                 CancellationToken::new(),
             ),
         )
@@ -3040,8 +3149,13 @@ mod tests {
             ),
             ("BUZZ_AUTH_TAG".to_string(), "test-auth-tag".to_string()),
         ]);
+        let tool_context = test_tool_context_snapshot(
+            environment.clone(),
+            environment.keys().cloned().collect(),
+            true,
+        );
         let mut command = tokio::process::Command::new("unused");
-        apply_tool_environment(&mut command, &environment);
+        apply_tool_context(&mut command, &tool_context);
 
         let command_environment = command
             .as_std()
@@ -3064,8 +3178,19 @@ mod tests {
             ),
             ("BUZZ_PRIVATE_KEY".to_string(), "key=value".to_string()),
         ]);
+        let tool_context = test_tool_context_snapshot(
+            environment,
+            BTreeSet::from([
+                "BUZZ_RELAY_URL".to_string(),
+                "BUZZ_PRIVATE_KEY".to_string(),
+                "BUZZ_AUTH_TAG".to_string(),
+                "BUZZ_API_TOKEN".to_string(),
+                "BUZZ_ACP_DISPLAY_NAME".to_string(),
+            ]),
+            true,
+        );
         let mut command = tokio::process::Command::new("flatpak-spawn");
-        apply_flatpak_tool_environment(&mut command, &environment);
+        apply_flatpak_tool_context(&mut command, &tool_context);
         let arguments = command
             .as_std()
             .get_args()
@@ -3074,11 +3199,11 @@ mod tests {
         assert_eq!(
             arguments,
             vec![
-                "--unset-env=BUZZ_RELAY_URL",
-                "--unset-env=BUZZ_PRIVATE_KEY",
-                "--unset-env=BUZZ_AUTH_TAG",
-                "--unset-env=BUZZ_API_TOKEN",
                 "--unset-env=BUZZ_ACP_DISPLAY_NAME",
+                "--unset-env=BUZZ_API_TOKEN",
+                "--unset-env=BUZZ_AUTH_TAG",
+                "--unset-env=BUZZ_PRIVATE_KEY",
+                "--unset-env=BUZZ_RELAY_URL",
                 "--env=BUZZ_ACP_DISPLAY_NAME=Maple Agent",
                 "--env=BUZZ_PRIVATE_KEY=key=value",
             ]
@@ -3157,16 +3282,20 @@ mod tests {
     #[tokio::test]
     async fn shell_tool_environment_clear_is_observed_by_an_existing_client() {
         let temp = TestDir::new();
-        let tool_environment = Arc::new(RwLock::new(BTreeMap::from([(
-            "BUZZ_AUTH_TAG".to_string(),
-            "maple-session-auth-tag".to_string(),
-        )])));
+        let tool_context = test_tool_context(
+            BTreeMap::from([(
+                "BUZZ_AUTH_TAG".to_string(),
+                "maple-session-auth-tag".to_string(),
+            )]),
+            BTreeSet::from(["BUZZ_AUTH_TAG".to_string()]),
+            true,
+        );
         let client = MapleDeveloperClient::new(
             test_context(temp.path().join("sessions")),
             true,
             Arc::new(TestWebTransport),
             Arc::new(WebToolState::default()),
-            Arc::clone(&tool_environment),
+            tool_context.clone(),
         )
         .unwrap();
         let context = ToolCallContext::new("maple-clear-test".to_string(), None, None);
@@ -3187,7 +3316,7 @@ mod tests {
             serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
         assert_eq!(output.stdout, "maple-session-auth-tag");
 
-        tool_environment.write().await.clear();
+        tool_context.revoke();
         let result = call_shell().await.unwrap();
         let output: ShellOutput =
             serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
@@ -3200,6 +3329,7 @@ mod tests {
         let temp = TestDir::new();
         let sentinel = temp.path().join("background-completed");
         let command = format!("(sleep 1; printf survived > '{}') &", sentinel.display());
+        let tool_context = empty_tool_context_snapshot();
 
         let result = tokio::time::timeout(
             Duration::from_secs(3),
@@ -3211,7 +3341,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
-                &BTreeMap::new(),
+                &tool_context,
                 CancellationToken::new(),
             ),
         )
@@ -3237,6 +3367,11 @@ mod tests {
             "BUZZ_AUTH_TAG".to_string(),
             "maple-session-auth-tag".to_string(),
         )]);
+        let tool_context = test_tool_context_snapshot(
+            environment,
+            BTreeSet::from(["BUZZ_AUTH_TAG".to_string()]),
+            true,
+        );
 
         let result = tokio::time::timeout(
             Duration::from_secs(3),
@@ -3248,7 +3383,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
-                &environment,
+                &tool_context,
                 CancellationToken::new(),
             ),
         )
@@ -3257,7 +3392,7 @@ mod tests {
         let output: ShellOutput =
             serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
         assert_eq!(result.is_error, Some(false));
-        assert!(output.output_truncated);
+        assert!(!output.timed_out);
 
         tokio::time::sleep(Duration::from_secs(1)).await;
         assert!(
@@ -3275,6 +3410,7 @@ mod tests {
             "((while :; do printf 1234567890; done) & sleep 1; printf survived > '{}') &",
             sentinel.display()
         );
+        let tool_context = empty_tool_context_snapshot();
 
         let result = tokio::time::timeout(
             Duration::from_secs(3),
@@ -3286,7 +3422,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
-                &BTreeMap::new(),
+                &tool_context,
                 CancellationToken::new(),
             ),
         )
@@ -3307,13 +3443,14 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn shell_timeout_kills_the_complete_process_tree() {
+    async fn shell_timeout_kills_the_unix_process_group() {
         let temp = TestDir::new();
         let sentinel = temp.path().join("timed-out-descendant-survived");
         let command = format!(
             "(sleep 2; printf survived > '{}') & sleep 5",
             sentinel.display()
         );
+        let tool_context = empty_tool_context_snapshot();
         let result = run_bounded_shell(
             ShellParams {
                 command,
@@ -3322,7 +3459,7 @@ mod tests {
             None,
             std::env::var("PATH").ok().as_deref(),
             None,
-            &BTreeMap::new(),
+            &tool_context,
             CancellationToken::new(),
         )
         .await;
@@ -3334,13 +3471,13 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(1)).await;
         assert!(
             !sentinel.exists(),
-            "timed-out descendant survived process-tree termination"
+            "timed-out descendant survived process-group termination"
         );
     }
 
     #[cfg(unix)]
     #[tokio::test]
-    async fn shell_cancellation_kills_the_complete_process_tree() {
+    async fn shell_cancellation_kills_the_unix_process_group() {
         let temp = TestDir::new();
         let sentinel = temp.path().join("cancelled-descendant-survived");
         let command = format!(
@@ -3353,6 +3490,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(100)).await;
             cancellation.cancel();
         });
+        let tool_context = empty_tool_context_snapshot();
         let result = run_bounded_shell(
             ShellParams {
                 command,
@@ -3361,7 +3499,7 @@ mod tests {
             None,
             std::env::var("PATH").ok().as_deref(),
             None,
-            &BTreeMap::new(),
+            &tool_context,
             cancel_token,
         )
         .await;
@@ -3372,13 +3510,189 @@ mod tests {
         tokio::time::sleep(Duration::from_secs(1)).await;
         assert!(
             !sentinel.exists(),
-            "cancelled descendant survived process-tree termination"
+            "cancelled descendant survived process-group termination"
         );
     }
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn tool_context_revocation_kills_the_unix_process_group() {
+        let temp = TestDir::new();
+        let sentinel = temp.path().join("revoked-context-descendant-survived");
+        let command = format!(
+            "(sleep 1; printf survived > '{}') & sleep 5",
+            sentinel.display()
+        );
+        let shared_context = test_tool_context(BTreeMap::new(), BTreeSet::new(), false);
+        let tool_context = shared_context.snapshot();
+        let revocation = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            shared_context.revoke();
+        });
+
+        let result = run_bounded_shell(
+            ShellParams {
+                command,
+                timeout_secs: Some(4),
+            },
+            None,
+            std::env::var("PATH").ok().as_deref(),
+            None,
+            &tool_context,
+            CancellationToken::new(),
+        )
+        .await;
+        revocation.await.unwrap();
+        assert_eq!(result.is_error, Some(true));
+        assert!(text(&result).contains("Command cancelled"));
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            !sentinel.exists(),
+            "revoked tool-context descendant survived process-group termination"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn pre_cancelled_shell_cannot_launch_a_process() {
+        let temp = TestDir::new();
+        let sentinel = temp.path().join("pre-cancelled-shell-launched");
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let result = run_bounded_shell(
+            ShellParams {
+                command: format!("printf launched > '{}'", sentinel.display()),
+                timeout_secs: Some(2),
+            },
+            None,
+            std::env::var("PATH").ok().as_deref(),
+            None,
+            &empty_tool_context_snapshot(),
+            cancel_token,
+        )
+        .await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text(&result).contains("cancelled before command launch"));
+        assert!(!sentinel.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn aborting_the_shell_task_kills_its_unix_process_group() {
+        let temp = TestDir::new();
+        let started = temp.path().join("abort-shell-started");
+        let sentinel = temp.path().join("abort-descendant-survived");
+        let command = format!(
+            "printf started > '{}'; (sleep 1; printf survived > '{}') & sleep 5",
+            started.display(),
+            sentinel.display()
+        );
+        let tool_context = test_tool_context_snapshot(BTreeMap::new(), BTreeSet::new(), true);
+        let task = tokio::spawn(async move {
+            run_bounded_shell(
+                ShellParams {
+                    command,
+                    timeout_secs: Some(10),
+                },
+                None,
+                std::env::var("PATH").ok().as_deref(),
+                None,
+                &tool_context,
+                CancellationToken::new(),
+            )
+            .await
+        });
+
+        tokio::time::timeout(Duration::from_secs(2), async {
+            while !started.exists() {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("shell should start before forced task abort");
+        task.abort();
+        assert!(task.await.unwrap_err().is_cancelled());
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            !sentinel.exists(),
+            "forced task abort left a same-group descendant running"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn revocation_after_parent_exit_interrupts_output_drain() {
+        let temp = TestDir::new();
+        let sentinel = temp.path().join("draining-descendant-survived");
+        let shared_context = test_tool_context(BTreeMap::new(), BTreeSet::new(), false);
+        let tool_context = shared_context.snapshot();
+        let revocation = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+            shared_context.revoke();
+        });
+
+        let result = run_bounded_shell(
+            ShellParams {
+                command: format!("(sleep 1; printf survived > '{}') &", sentinel.display()),
+                timeout_secs: Some(3),
+            },
+            None,
+            std::env::var("PATH").ok().as_deref(),
+            None,
+            &tool_context,
+            CancellationToken::new(),
+        )
+        .await;
+        revocation.await.unwrap();
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text(&result).contains("Command cancelled"));
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            !sentinel.exists(),
+            "revocation during output drain left a same-group descendant running"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn snapshot_captured_before_revocation_cannot_launch_a_process() {
+        let temp = TestDir::new();
+        let sentinel = temp.path().join("revoked-context-launched");
+        let shared_context = test_tool_context(
+            BTreeMap::from([("PRIVATE_VALUE".to_string(), "secret".to_string())]),
+            BTreeSet::from(["PRIVATE_VALUE".to_string()]),
+            true,
+        );
+        let tool_context = shared_context.snapshot();
+        shared_context.revoke();
+
+        let result = run_bounded_shell(
+            ShellParams {
+                command: format!("printf launched > '{}'", sentinel.display()),
+                timeout_secs: Some(2),
+            },
+            None,
+            std::env::var("PATH").ok().as_deref(),
+            None,
+            &tool_context,
+            CancellationToken::new(),
+        )
+        .await;
+
+        assert_eq!(result.is_error, Some(true));
+        assert!(text(&result).contains("revoked before command launch"));
+        assert!(!sentinel.exists());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn shell_preserves_small_successful_output() {
+        let tool_context = empty_tool_context_snapshot();
         let result = run_bounded_shell(
             ShellParams {
                 command: "printf hello".to_string(),
@@ -3387,7 +3701,7 @@ mod tests {
             None,
             std::env::var("PATH").ok().as_deref(),
             None,
-            &BTreeMap::new(),
+            &tool_context,
             CancellationToken::new(),
         )
         .await;

--- a/frontend/src-tauri/src/agent/developer_tools.rs
+++ b/frontend/src-tauri/src/agent/developer_tools.rs
@@ -28,7 +28,7 @@ use rmcp::model::{
 };
 use rmcp::object;
 use serde::{de::Error as SerdeDeError, Deserialize, Deserializer};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fs::{self, OpenOptions};
 use std::io::{BufRead, BufReader, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
@@ -39,7 +39,7 @@ use std::time::Duration;
 use tokio::io::{AsyncRead, AsyncReadExt};
 #[cfg(not(windows))]
 use tokio::sync::OnceCell;
-use tokio::sync::{mpsc, Mutex};
+use tokio::sync::{mpsc, Mutex, RwLock};
 use tokio_util::sync::CancellationToken;
 #[cfg(windows)]
 use windows::Win32::System::Threading::CREATE_NO_WINDOW;
@@ -51,6 +51,13 @@ const MAX_READ_BYTES: usize = 50 * 1024;
 const MAX_EDIT_BYTES: usize = 20 * 1024 * 1024;
 const MAX_IMAGE_BYTES: usize = 20 * 1024 * 1024;
 const MAX_SHELL_OUTPUT_BYTES: usize = 50_000;
+const SESSION_SECRET_ENV_KEYS: [&str; 5] = [
+    "BUZZ_RELAY_URL",
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_DISPLAY_NAME",
+];
 const SHELL_OUTPUT_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 const SHELL_PROCESS_POLL_INTERVAL: Duration = Duration::from_millis(10);
 const IMAGE_DOWNLOAD_TIMEOUT: Duration = Duration::from_secs(30);
@@ -132,6 +139,7 @@ pub(crate) struct MapleDeveloperClient {
     goose: DeveloperClient,
     web_transport: Arc<dyn MapleWebTransport>,
     web_state: Arc<WebToolState>,
+    tool_environment: Arc<RwLock<BTreeMap<String, String>>>,
     contextual_image_context: Option<PlatformExtensionContext>,
     #[cfg(not(windows))]
     login_path_probe: ShellTool,
@@ -145,6 +153,7 @@ impl MapleDeveloperClient {
         primary_model_supports_vision: bool,
         web_transport: Arc<dyn MapleWebTransport>,
         web_state: Arc<WebToolState>,
+        tool_environment: Arc<RwLock<BTreeMap<String, String>>>,
     ) -> anyhow::Result<Self> {
         let info = InitializeResult::new(ServerCapabilities::builder().enable_tools().build())
             .with_server_info(Implementation::new("developer", "1.0.0").with_title("Developer"))
@@ -160,6 +169,7 @@ impl MapleDeveloperClient {
             goose: DeveloperClient::new(context)?,
             web_transport,
             web_state,
+            tool_environment,
             contextual_image_context,
             #[cfg(not(windows))]
             login_path_probe: ShellTool::new(true)?,
@@ -478,11 +488,13 @@ impl McpClientTrait for MapleDeveloperClient {
                 let login_path = self.login_path().await;
                 #[cfg(windows)]
                 let login_path: Option<String> = None;
+                let tool_environment = self.tool_environment.read().await.clone();
                 return Ok(run_bounded_shell(
                     params,
                     working_dir,
                     login_path.as_deref(),
                     Some(&ctx.session_id),
+                    &tool_environment,
                     cancel_token,
                 )
                 .await);
@@ -816,6 +828,7 @@ async fn run_bounded_shell(
     working_dir: Option<&Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
+    tool_environment: &BTreeMap<String, String>,
     cancel_token: CancellationToken,
 ) -> CallToolResult {
     if params.command.trim().is_empty() {
@@ -829,6 +842,7 @@ async fn run_bounded_shell(
         working_dir,
         login_path,
         session_id,
+        tool_environment,
         cancel_token,
     )
     .await
@@ -853,10 +867,24 @@ async fn execute_bounded_shell(
     working_dir: Option<&Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
+    tool_environment: &BTreeMap<String, String>,
     cancel_token: CancellationToken,
 ) -> Result<BoundedShellExecution, String> {
-    let mut command =
-        build_bounded_shell_command(command_line, working_dir, login_path, session_id);
+    let credential_bearing = contains_session_secret(tool_environment);
+    #[cfg(not(windows))]
+    if Path::new("/.flatpak-info").exists() && credential_bearing {
+        return Err(
+            "Credential-bearing Buzz ACP shell sessions are not supported inside Flatpak"
+                .to_string(),
+        );
+    }
+    let mut command = build_bounded_shell_command(
+        command_line,
+        working_dir,
+        login_path,
+        session_id,
+        tool_environment,
+    );
     command
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
@@ -964,7 +992,7 @@ async fn execute_bounded_shell(
     // the cap. Keep the wrapped process-tree handle alive and kill it even if
     // the parent wait already completed. A quiet background job that merely
     // holds the pipes open follows Pi/Goose semantics and is left running.
-    if capture.exceeded_limit {
+    if capture.exceeded_limit || credential_bearing {
         let _ = terminate_shell_process(child.as_mut()).await;
     }
     if let Some(error) = wait_error {
@@ -977,6 +1005,12 @@ async fn execute_bounded_shell(
         timed_out,
         cancelled,
     })
+}
+
+fn contains_session_secret(tool_environment: &BTreeMap<String, String>) -> bool {
+    SESSION_SECRET_ENV_KEYS
+        .iter()
+        .any(|key| tool_environment.contains_key(*key))
 }
 
 async fn wait_for_shell_parent(child: &mut dyn ChildWrapper) -> std::io::Result<ExitStatus> {
@@ -1069,6 +1103,7 @@ fn build_bounded_shell_command(
     working_dir: Option<&Path>,
     login_path: Option<&str>,
     session_id: Option<&str>,
+    tool_environment: &BTreeMap<String, String>,
 ) -> tokio::process::Command {
     #[cfg(windows)]
     let mut command = {
@@ -1096,6 +1131,7 @@ fn build_bounded_shell_command(
         if let Some(path) = login_path {
             command.env("PATH", path);
         }
+        apply_tool_environment(&mut command, tool_environment);
         command
     };
 
@@ -1117,6 +1153,7 @@ fn build_bounded_shell_command(
                 command.arg(format!("--env=PATH={path}"));
             }
             apply_flatpak_session_environment(&mut command, session_id);
+            apply_flatpak_tool_environment(&mut command, tool_environment);
             command.arg(shell).args(["-c", command_line]);
             command
         } else {
@@ -1129,6 +1166,7 @@ fn build_bounded_shell_command(
                 command.env("PATH", path);
             }
             apply_session_environment(&mut command, session_id);
+            apply_tool_environment(&mut command, tool_environment);
             command
         }
     };
@@ -1149,6 +1187,16 @@ fn apply_session_environment(command: &mut tokio::process::Command, session_id: 
     }
 }
 
+fn apply_tool_environment(
+    command: &mut tokio::process::Command,
+    tool_environment: &BTreeMap<String, String>,
+) {
+    for key in SESSION_SECRET_ENV_KEYS {
+        command.env_remove(key);
+    }
+    command.envs(tool_environment);
+}
+
 #[cfg(not(windows))]
 fn apply_flatpak_session_environment(
     command: &mut tokio::process::Command,
@@ -1158,6 +1206,19 @@ fn apply_flatpak_session_environment(
         command.arg(format!("--env=AGENT_SESSION_ID={session_id}"));
     } else {
         command.arg("--unset-env=AGENT_SESSION_ID");
+    }
+}
+
+#[cfg(not(windows))]
+fn apply_flatpak_tool_environment(
+    command: &mut tokio::process::Command,
+    tool_environment: &BTreeMap<String, String>,
+) {
+    for key in SESSION_SECRET_ENV_KEYS {
+        command.arg(format!("--unset-env={key}"));
+    }
+    for (key, value) in tool_environment {
+        command.arg(format!("--env={key}={value}"));
     }
 }
 
@@ -2253,11 +2314,20 @@ mod tests {
     }
 
     fn test_client(data_dir: PathBuf, primary_model_supports_vision: bool) -> MapleDeveloperClient {
+        test_client_with_environment(data_dir, primary_model_supports_vision, BTreeMap::new())
+    }
+
+    fn test_client_with_environment(
+        data_dir: PathBuf,
+        primary_model_supports_vision: bool,
+        tool_environment: BTreeMap<String, String>,
+    ) -> MapleDeveloperClient {
         MapleDeveloperClient::new(
             test_context(data_dir),
             primary_model_supports_vision,
             Arc::new(TestWebTransport),
             Arc::new(WebToolState::default()),
+            Arc::new(RwLock::new(tool_environment)),
         )
         .unwrap()
     }
@@ -2386,6 +2456,7 @@ mod tests {
             true,
             Arc::new(TestWebTransport),
             Arc::new(WebToolState::default()),
+            Arc::new(RwLock::new(BTreeMap::new())),
         )
         .unwrap();
         let config = goose::agents::ExtensionConfig::Builtin {
@@ -2914,6 +2985,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
+                &BTreeMap::new(),
                 CancellationToken::new(),
             ),
         )
@@ -2958,6 +3030,61 @@ mod tests {
         assert_eq!(cleared_value, Some(None));
     }
 
+    #[test]
+    fn shell_tool_environment_is_applied_only_to_the_child_command() {
+        let process_value = std::env::var_os("BUZZ_ACP_DISPLAY_NAME");
+        let environment = BTreeMap::from([
+            (
+                "BUZZ_ACP_DISPLAY_NAME".to_string(),
+                "maple-test-agent".to_string(),
+            ),
+            ("BUZZ_AUTH_TAG".to_string(), "test-auth-tag".to_string()),
+        ]);
+        let mut command = tokio::process::Command::new("unused");
+        apply_tool_environment(&mut command, &environment);
+
+        let command_environment = command
+            .as_std()
+            .get_envs()
+            .filter_map(|(key, value)| {
+                Some((key.to_str()?.to_string(), value?.to_str()?.to_string()))
+            })
+            .collect::<BTreeMap<_, _>>();
+        assert_eq!(command_environment, environment);
+        assert_eq!(std::env::var_os("BUZZ_ACP_DISPLAY_NAME"), process_value);
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn flatpak_shell_forwards_each_tool_environment_value_as_one_argument() {
+        let environment = BTreeMap::from([
+            (
+                "BUZZ_ACP_DISPLAY_NAME".to_string(),
+                "Maple Agent".to_string(),
+            ),
+            ("BUZZ_PRIVATE_KEY".to_string(), "key=value".to_string()),
+        ]);
+        let mut command = tokio::process::Command::new("flatpak-spawn");
+        apply_flatpak_tool_environment(&mut command, &environment);
+        let arguments = command
+            .as_std()
+            .get_args()
+            .map(|value| value.to_string_lossy().into_owned())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            arguments,
+            vec![
+                "--unset-env=BUZZ_RELAY_URL",
+                "--unset-env=BUZZ_PRIVATE_KEY",
+                "--unset-env=BUZZ_AUTH_TAG",
+                "--unset-env=BUZZ_API_TOKEN",
+                "--unset-env=BUZZ_ACP_DISPLAY_NAME",
+                "--env=BUZZ_ACP_DISPLAY_NAME=Maple Agent",
+                "--env=BUZZ_PRIVATE_KEY=key=value",
+            ]
+        );
+    }
+
     #[cfg(unix)]
     #[tokio::test]
     async fn shell_tool_forwards_the_current_agent_session_id() {
@@ -2984,6 +3111,91 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn shell_tool_environments_are_isolated_between_maple_sessions() {
+        let temp = TestDir::new();
+        let first = test_client_with_environment(
+            temp.path().join("first-sessions"),
+            true,
+            BTreeMap::from([(
+                "BUZZ_ACP_DISPLAY_NAME".to_string(),
+                "first-maple-agent".to_string(),
+            )]),
+        );
+        let second = test_client_with_environment(
+            temp.path().join("second-sessions"),
+            true,
+            BTreeMap::from([(
+                "BUZZ_ACP_DISPLAY_NAME".to_string(),
+                "second-maple-agent".to_string(),
+            )]),
+        );
+
+        for (client, session_id, expected) in [
+            (&first, "maple-first", "first-maple-agent"),
+            (&second, "maple-second", "second-maple-agent"),
+        ] {
+            let result = client
+                .call_tool(
+                    &ToolCallContext::new(session_id.to_string(), None, None),
+                    "shell",
+                    Some(object!({
+                        "command": "printf %s \"$BUZZ_ACP_DISPLAY_NAME\"",
+                        "timeout_secs": 2
+                    })),
+                    CancellationToken::new(),
+                )
+                .await
+                .unwrap();
+            let output: ShellOutput =
+                serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
+            assert_eq!(result.is_error, Some(false));
+            assert_eq!(output.stdout, expected);
+        }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_tool_environment_clear_is_observed_by_an_existing_client() {
+        let temp = TestDir::new();
+        let tool_environment = Arc::new(RwLock::new(BTreeMap::from([(
+            "BUZZ_AUTH_TAG".to_string(),
+            "maple-session-auth-tag".to_string(),
+        )])));
+        let client = MapleDeveloperClient::new(
+            test_context(temp.path().join("sessions")),
+            true,
+            Arc::new(TestWebTransport),
+            Arc::new(WebToolState::default()),
+            Arc::clone(&tool_environment),
+        )
+        .unwrap();
+        let context = ToolCallContext::new("maple-clear-test".to_string(), None, None);
+        let call_shell = || {
+            client.call_tool(
+                &context,
+                "shell",
+                Some(object!({
+                    "command": "printf %s \"${BUZZ_AUTH_TAG-}\"",
+                    "timeout_secs": 2
+                })),
+                CancellationToken::new(),
+            )
+        };
+
+        let result = call_shell().await.unwrap();
+        let output: ShellOutput =
+            serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
+        assert_eq!(output.stdout, "maple-session-auth-tag");
+
+        tool_environment.write().await.clear();
+        let result = call_shell().await.unwrap();
+        let output: ShellOutput =
+            serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
+        assert_eq!(output.stdout, "");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn shell_returns_without_killing_a_successful_background_job() {
         let temp = TestDir::new();
         let sentinel = temp.path().join("background-completed");
@@ -2999,6 +3211,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
+                &BTreeMap::new(),
                 CancellationToken::new(),
             ),
         )
@@ -3012,6 +3225,45 @@ mod tests {
 
         tokio::time::sleep(Duration::from_secs(1)).await;
         assert_eq!(fs::read_to_string(&sentinel).unwrap(), "survived");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn shell_kills_background_descendants_with_non_private_key_session_secrets() {
+        let temp = TestDir::new();
+        let sentinel = temp.path().join("credential-descendant-survived");
+        let command = format!("(sleep 1; printf survived > '{}') &", sentinel.display());
+        let environment = BTreeMap::from([(
+            "BUZZ_AUTH_TAG".to_string(),
+            "maple-session-auth-tag".to_string(),
+        )]);
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(3),
+            run_bounded_shell(
+                ShellParams {
+                    command,
+                    timeout_secs: Some(2),
+                },
+                None,
+                std::env::var("PATH").ok().as_deref(),
+                None,
+                &environment,
+                CancellationToken::new(),
+            ),
+        )
+        .await
+        .expect("a credential-bearing background tree must be terminated");
+        let output: ShellOutput =
+            serde_json::from_value(result.structured_content.clone().unwrap()).unwrap();
+        assert_eq!(result.is_error, Some(false));
+        assert!(output.output_truncated);
+
+        tokio::time::sleep(Duration::from_secs(1)).await;
+        assert!(
+            !sentinel.exists(),
+            "a background descendant retained a non-private-key session secret"
+        );
     }
 
     #[cfg(unix)]
@@ -3034,6 +3286,7 @@ mod tests {
                 None,
                 std::env::var("PATH").ok().as_deref(),
                 None,
+                &BTreeMap::new(),
                 CancellationToken::new(),
             ),
         )
@@ -3069,6 +3322,7 @@ mod tests {
             None,
             std::env::var("PATH").ok().as_deref(),
             None,
+            &BTreeMap::new(),
             CancellationToken::new(),
         )
         .await;
@@ -3107,6 +3361,7 @@ mod tests {
             None,
             std::env::var("PATH").ok().as_deref(),
             None,
+            &BTreeMap::new(),
             cancel_token,
         )
         .await;
@@ -3132,6 +3387,7 @@ mod tests {
             None,
             std::env::var("PATH").ok().as_deref(),
             None,
+            &BTreeMap::new(),
             CancellationToken::new(),
         )
         .await;

--- a/frontend/src-tauri/src/agent/shell_permission.rs
+++ b/frontend/src-tauri/src/agent/shell_permission.rs
@@ -571,7 +571,7 @@ mod tests {
             request_params.get("chat_template_kwargs"),
             Some(&serde_json::json!({ "enable_thinking": false }))
         );
-        assert!(request_params.get("thinking_effort").is_none());
+        assert!(!request_params.contains_key("thinking_effort"));
     }
 
     #[tokio::test]

--- a/frontend/src-tauri/src/agent/tool_context.rs
+++ b/frontend/src-tauri/src/agent/tool_context.rs
@@ -1,0 +1,260 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::{Arc, Mutex, MutexGuard, RwLock};
+use tokio_util::sync::CancellationToken;
+
+const MAX_TOOL_CONTEXT_KEYS: usize = 16;
+const MAX_TOOL_CONTEXT_KEY_BYTES: usize = 64;
+const MAX_TOOL_CONTEXT_VALUE_BYTES: usize = 16 * 1024;
+const MAX_TOOL_CONTEXT_TOTAL_BYTES: usize = 32 * 1024;
+
+/// Validated, transport-neutral context supplied to Maple's developer tools.
+///
+/// Protocol adapters own their allowlists and decide which values make an
+/// invocation ephemeral. The Agent service owns only validation, installation,
+/// and revocation.
+#[derive(Clone, Default)]
+pub(crate) struct AgentToolContextSpec {
+    values: BTreeMap<String, String>,
+    scrub_from_parent: BTreeSet<String>,
+    ephemeral: bool,
+}
+
+impl AgentToolContextSpec {
+    pub(crate) fn try_new(
+        values: BTreeMap<String, String>,
+        scrub_from_parent: BTreeSet<String>,
+        ephemeral: bool,
+    ) -> Result<Self, String> {
+        if values.len() > MAX_TOOL_CONTEXT_KEYS || scrub_from_parent.len() > MAX_TOOL_CONTEXT_KEYS {
+            return Err(format!(
+                "Agent tool context supports at most {MAX_TOOL_CONTEXT_KEYS} variables"
+            ));
+        }
+
+        let mut total_bytes = 0usize;
+        for key in values.keys().chain(scrub_from_parent.iter()) {
+            validate_key(key)?;
+        }
+        for (key, value) in &values {
+            if value.contains('\0') {
+                return Err(format!(
+                    "Agent tool context variable {key} cannot contain null bytes"
+                ));
+            }
+            let value_bytes = value.len();
+            if value_bytes > MAX_TOOL_CONTEXT_VALUE_BYTES {
+                return Err(format!(
+                    "Agent tool context variable {key} exceeds the {MAX_TOOL_CONTEXT_VALUE_BYTES} byte limit"
+                ));
+            }
+            total_bytes = total_bytes
+                .checked_add(key.len())
+                .and_then(|total| total.checked_add(value_bytes))
+                .ok_or_else(|| "Agent tool context size overflowed".to_string())?;
+            if total_bytes > MAX_TOOL_CONTEXT_TOTAL_BYTES {
+                return Err(format!(
+                    "Agent tool context exceeds the {MAX_TOOL_CONTEXT_TOTAL_BYTES} byte total limit"
+                ));
+            }
+        }
+
+        Ok(Self {
+            values,
+            scrub_from_parent,
+            ephemeral,
+        })
+    }
+}
+
+fn validate_key(key: &str) -> Result<(), String> {
+    if key.is_empty() || key.contains(['=', '\0']) {
+        return Err("Agent tool context variable names are invalid".to_string());
+    }
+    if key.len() > MAX_TOOL_CONTEXT_KEY_BYTES {
+        return Err(format!(
+            "Agent tool context variable names must be at most {MAX_TOOL_CONTEXT_KEY_BYTES} bytes"
+        ));
+    }
+    Ok(())
+}
+
+struct AgentToolContextState {
+    values: BTreeMap<String, String>,
+    scrub_from_parent: BTreeSet<String>,
+    ephemeral: bool,
+}
+
+#[derive(Clone)]
+pub(crate) struct SharedAgentToolContext {
+    state: Arc<RwLock<AgentToolContextState>>,
+    revoked: CancellationToken,
+    launch_gate: Arc<Mutex<()>>,
+}
+
+impl SharedAgentToolContext {
+    pub(crate) fn new(spec: AgentToolContextSpec) -> Self {
+        Self {
+            state: Arc::new(RwLock::new(AgentToolContextState {
+                values: spec.values,
+                scrub_from_parent: spec.scrub_from_parent,
+                ephemeral: spec.ephemeral,
+            })),
+            revoked: CancellationToken::new(),
+            launch_gate: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub(crate) fn snapshot(&self) -> AgentToolContextSnapshot {
+        let state = self
+            .state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        AgentToolContextSnapshot {
+            values: state.values.clone(),
+            scrub_from_parent: state.scrub_from_parent.clone(),
+            ephemeral: state.ephemeral,
+            revoked: self.revoked.clone(),
+            launch_gate: Arc::clone(&self.launch_gate),
+        }
+    }
+
+    pub(crate) fn revoke(&self) {
+        // Linearize revocation with command construction and spawn. Once this
+        // method returns, no snapshot taken before revocation can launch a new
+        // process with its copied values.
+        let _launch = self
+            .launch_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        self.revoked.cancel();
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        state.values.clear();
+        state.ephemeral = false;
+        // Retain inherited-key scrubbing after revocation. A removed explicit
+        // credential must never reveal a same-named ambient process value.
+    }
+
+    pub(crate) fn cancel_run(&self, run: &CancellationToken) {
+        // A run cancellation and a tool launch share the same fence. Once this
+        // method returns, a snapshot from this context cannot cross the launch
+        // boundary for that run.
+        let _launch = self
+            .launch_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        run.cancel();
+    }
+
+    pub(crate) fn ptr_eq(&self, other: &Self) -> bool {
+        Arc::ptr_eq(&self.state, &other.state)
+    }
+
+    pub(crate) fn is_revoked(&self) -> bool {
+        self.revoked.is_cancelled()
+    }
+}
+
+pub(crate) struct AgentToolContextSnapshot {
+    pub(crate) values: BTreeMap<String, String>,
+    pub(crate) scrub_from_parent: BTreeSet<String>,
+    pub(crate) ephemeral: bool,
+    pub(crate) revoked: CancellationToken,
+    launch_gate: Arc<Mutex<()>>,
+}
+
+impl AgentToolContextSnapshot {
+    pub(crate) fn begin_process_launch(
+        &self,
+        run: &CancellationToken,
+    ) -> Result<MutexGuard<'_, ()>, String> {
+        let guard = self
+            .launch_gate
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.revoked.is_cancelled() {
+            Err("Agent tool context was revoked before command launch".to_string())
+        } else if run.is_cancelled() {
+            Err("Agent run was cancelled before command launch".to_string())
+        } else {
+            Ok(guard)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn revocation_clears_values_but_retains_inherited_scrubbing() {
+        let context = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+
+        context.revoke();
+        let snapshot = context.snapshot();
+        assert!(snapshot.values.is_empty());
+        assert_eq!(
+            snapshot.scrub_from_parent,
+            BTreeSet::from(["TOKEN".to_string()])
+        );
+        assert!(!snapshot.ephemeral);
+        assert!(snapshot.revoked.is_cancelled());
+    }
+
+    #[test]
+    fn validation_is_generic_and_bounded() {
+        assert!(AgentToolContextSpec::try_new(
+            BTreeMap::from([("CUSTOM_TOKEN".to_string(), "value".to_string())]),
+            BTreeSet::new(),
+            false,
+        )
+        .is_ok());
+        assert!(AgentToolContextSpec::try_new(
+            BTreeMap::from([("BAD=KEY".to_string(), "value".to_string())]),
+            BTreeSet::new(),
+            false,
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn run_cancellation_returns_only_after_the_process_launch_fence() {
+        let context = SharedAgentToolContext::new(AgentToolContextSpec::default());
+        let snapshot = context.snapshot();
+        let run = CancellationToken::new();
+        let launch = snapshot.begin_process_launch(&run).unwrap();
+        let cancellation_context = context.clone();
+        let cancellation_run = run.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (finished_tx, finished_rx) = std::sync::mpsc::channel();
+        let task = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            cancellation_context.cancel_run(&cancellation_run);
+            finished_tx.send(()).unwrap();
+        });
+
+        started_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("cancellation thread should start");
+        assert!(finished_rx
+            .recv_timeout(std::time::Duration::from_millis(50))
+            .is_err());
+        drop(launch);
+        finished_rx
+            .recv_timeout(std::time::Duration::from_secs(1))
+            .expect("cancellation should finish after launch releases the fence");
+        task.join().unwrap();
+
+        assert!(run.is_cancelled());
+        assert!(snapshot.begin_process_launch(&run).is_err());
+    }
+}

--- a/frontend/src-tauri/src/agent/web_permission.rs
+++ b/frontend/src-tauri/src/agent/web_permission.rs
@@ -499,7 +499,7 @@ mod tests {
             request_params.get("chat_template_kwargs"),
             Some(&serde_json::json!({ "enable_thinking": false }))
         );
-        assert!(request_params.get("thinking_effort").is_none());
+        assert!(!request_params.contains_key("thinking_effort"));
     }
 
     #[tokio::test]

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -1,29 +1,31 @@
 use crate::agent::{
-    cancel_agent_run_for_user, clear_agent_session_tool_environment, create_agent_session_for_user,
-    delete_agent_session_for_user, ensure_agent_runtime_for_user, send_agent_message_for_user,
-    set_agent_session_tool_environment, subscribe_agent_events, AgentCreateSessionRequest,
-    AgentEventEnvelope, AgentRunTerminal, AgentSendMessageRequest, SharedAgentToolEnvironment,
+    AgentCreateSessionRequest, AgentHostEventPolicy, AgentRunEvent, AgentRunTerminal,
+    AgentRuntimeHandle, AgentSendMessageRequest, AgentTimelineItem, AgentToolContextLease,
+    AgentToolContextSpec, MapleAgentService, AGENT_TOOL_CONTEXT_INACTIVE_ERROR,
 };
+use crate::agent_host::AgentHostLifecycle;
+use crate::maple_api::{account_scope, MapleApiAuthState};
 use agent_client_protocol::schema::v1::{
     AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, Implementation,
     InitializeRequest, InitializeResponse, McpServer, NewSessionRequest, NewSessionResponse,
-    PromptCapabilities, PromptRequest, PromptResponse, SessionNotification, SessionUpdate,
-    StopReason, TextContent,
+    PromptCapabilities, PromptRequest, PromptResponse, SessionId, SessionNotification,
+    SessionUpdate, StopReason, TextContent,
 };
 use agent_client_protocol::util::MatchDispatchFrom;
 use agent_client_protocol::{
-    Agent as AcpAgent, ByteStreams, Client, ConnectionTo, Dispatch, HandleDispatchFrom, Handled,
-    JsonRpcNotification, Responder,
+    Agent as AcpAgent, Client, ConnectionTo, Dispatch, HandleDispatchFrom, Handled,
+    JsonRpcNotification, Lines, Responder,
 };
+use futures_util::StreamExt as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::HashMap;
+use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
-use tokio::sync::{Mutex, RwLock, Semaphore};
-use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
+use tokio::sync::{Mutex, OwnedSemaphorePermit, RwLock, Semaphore};
+use tokio_util::codec::{FramedRead, LinesCodec};
 use tokio_util::sync::CancellationToken;
 
 #[cfg(target_os = "linux")]
@@ -37,7 +39,11 @@ const ACP_PROTOCOL_VERSION: u16 = 1;
 const MAX_ACP_CONNECTIONS: usize = 8;
 const MAX_ACP_ERROR_CHARS: usize = 500;
 const MAX_ACP_FRAME_BYTES: usize = 10 * 1024 * 1024;
+const MAX_ACP_OUTBOUND_EVENTS_IN_FLIGHT: usize = 256;
+const MAX_ACP_OUTBOUND_BYTES_IN_FLIGHT: usize = 4 * 1024 * 1024;
+const ACP_OUTBOUND_FRAME_OVERHEAD_BYTES: usize = 256;
 const ACP_CONNECTION_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const ACP_SYNTHETIC_STOP_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const BRIDGE_HELLO_METHOD: &str = "_maple/bridge/hello";
 const ALLOWED_BRIDGE_ENV: [&str; 6] = [
     "BUZZ_RELAY_URL",
@@ -46,6 +52,13 @@ const ALLOWED_BRIDGE_ENV: [&str; 6] = [
     "BUZZ_API_TOKEN",
     "BUZZ_ACP_DISPLAY_NAME",
     "PATH",
+];
+const SENSITIVE_BRIDGE_ENV: [&str; 5] = [
+    "BUZZ_RELAY_URL",
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_DISPLAY_NAME",
 ];
 
 #[cfg(unix)]
@@ -99,6 +112,47 @@ impl<R: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for BoundedLineReader
     }
 }
 
+fn is_session_update_line(line: &str) -> bool {
+    serde_json::from_str::<serde_json::Value>(line)
+        .ok()
+        .and_then(|message| {
+            message
+                .get("method")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_owned)
+        })
+        .as_deref()
+        == Some("session/update")
+}
+
+#[cfg(unix)]
+fn tracked_outgoing_lines<W>(
+    writer: W,
+    outbound: Arc<AcpOutboundTracker>,
+) -> impl futures_util::Sink<String, Error = std::io::Error> + Send
+where
+    W: tokio::io::AsyncWrite + Unpin + Send + 'static,
+{
+    futures_util::sink::unfold(
+        (writer, outbound),
+        |(mut writer, outbound), line: String| async move {
+            use tokio::io::AsyncWriteExt as _;
+
+            let session_update = is_session_update_line(&line);
+            writer.write_all(line.as_bytes()).await?;
+            writer.write_all(b"\n").await?;
+            writer.flush().await?;
+            if session_update {
+                // Credits return only after the real local socket accepted the
+                // complete notification. A peer that stops reading therefore
+                // backpressures Maple instead of growing ACP's internal queues.
+                outbound.acknowledge_session_update();
+            }
+            Ok((writer, outbound))
+        },
+    )
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum AgentAcpPermissionMode {
@@ -111,6 +165,18 @@ impl AgentAcpPermissionMode {
         match self {
             Self::ReadOnly => "smart_approve",
             Self::AllowAll => "auto",
+        }
+    }
+
+    fn host_event_policy(&self) -> AgentHostEventPolicy {
+        match self {
+            // Maple Desktop remains the one authoritative permission broker for
+            // the guarded policy, so its task and permission events must remain
+            // visible there.
+            Self::ReadOnly => AgentHostEventPolicy::Publish,
+            // Unattended ACP runs do not need to contaminate Desktop's live event
+            // stream; their persisted task remains loadable on refresh.
+            Self::AllowAll => AgentHostEventPolicy::Suppress,
         }
     }
 }
@@ -181,7 +247,7 @@ struct AgentAcpStats {
 }
 
 struct RunningAgentAcp {
-    user_id: String,
+    account_scope: String,
     endpoint: PathBuf,
     config: Arc<RwLock<AgentAcpConfig>>,
     stats: Arc<AgentAcpStats>,
@@ -190,14 +256,12 @@ struct RunningAgentAcp {
 }
 
 pub struct AgentAcpState {
-    lifecycle: Mutex<()>,
     running: Mutex<Option<RunningAgentAcp>>,
 }
 
 impl AgentAcpState {
     pub fn new() -> Self {
         Self {
-            lifecycle: Mutex::new(()),
             running: Mutex::new(None),
         }
     }
@@ -210,34 +274,139 @@ struct BridgeHelloNotification {
 }
 
 struct AcpConnectionContext {
-    app_handle: AppHandle,
-    user_id: String,
+    agent: AgentRuntimeHandle,
     config: Arc<RwLock<AgentAcpConfig>>,
     stats: Arc<AgentAcpStats>,
     bridge_environment: Mutex<HashMap<String, String>>,
-    sessions: Mutex<HashMap<String, Option<SharedAgentToolEnvironment>>>,
+    sessions: Mutex<HashMap<String, AgentToolContextLease>>,
     prompt_states: Mutex<HashMap<String, AcpPromptState>>,
     background_tasks: Mutex<tokio::task::JoinSet<()>>,
     finalization: Mutex<()>,
+    lifetime: CancellationToken,
     closed: AtomicBool,
     has_credentials: AtomicBool,
+    outbound: Arc<AcpOutboundTracker>,
 }
 
 enum AcpPromptState {
-    Starting { cancel_requested: bool },
-    Running { run_id: String },
+    Starting {
+        cancellation: CancellationToken,
+    },
+    Running {
+        run_id: String,
+        cancellation: CancellationToken,
+    },
+}
+
+struct AcpOutboundTracker {
+    event_slots: Arc<Semaphore>,
+    byte_slots: Arc<Semaphore>,
+    pending: std::sync::Mutex<VecDeque<AcpOutboundReservation>>,
+}
+
+struct AcpOutboundReservation {
+    _event: OwnedSemaphorePermit,
+    _bytes: OwnedSemaphorePermit,
+}
+
+#[derive(Debug)]
+enum AcpOutboundSendError {
+    UpdateTooLarge,
+    Cancelled,
+    Transport(agent_client_protocol::Error),
+}
+
+impl AcpOutboundTracker {
+    fn new() -> Arc<Self> {
+        Self::with_limits(
+            MAX_ACP_OUTBOUND_EVENTS_IN_FLIGHT,
+            MAX_ACP_OUTBOUND_BYTES_IN_FLIGHT,
+        )
+    }
+
+    fn with_limits(event_limit: usize, byte_limit: usize) -> Arc<Self> {
+        Arc::new(Self {
+            event_slots: Arc::new(Semaphore::new(event_limit)),
+            byte_slots: Arc::new(Semaphore::new(byte_limit)),
+            pending: std::sync::Mutex::new(VecDeque::new()),
+        })
+    }
+
+    async fn reserve(
+        &self,
+        encoded_bytes: usize,
+        cancellation: &CancellationToken,
+    ) -> Result<AcpOutboundReservation, AcpOutboundSendError> {
+        let charged_bytes = encoded_bytes.saturating_add(ACP_OUTBOUND_FRAME_OVERHEAD_BYTES);
+        let Ok(charged_bytes) = u32::try_from(charged_bytes) else {
+            return Err(AcpOutboundSendError::UpdateTooLarge);
+        };
+        if charged_bytes as usize > MAX_ACP_OUTBOUND_BYTES_IN_FLIGHT {
+            return Err(AcpOutboundSendError::UpdateTooLarge);
+        }
+
+        let event = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(AcpOutboundSendError::Cancelled),
+            permit = Arc::clone(&self.event_slots).acquire_owned() => {
+                permit.map_err(|_| AcpOutboundSendError::Cancelled)?
+            }
+        };
+        let bytes = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => return Err(AcpOutboundSendError::Cancelled),
+            permit = Arc::clone(&self.byte_slots).acquire_many_owned(charged_bytes) => {
+                permit.map_err(|_| AcpOutboundSendError::Cancelled)?
+            }
+        };
+        Ok(AcpOutboundReservation {
+            _event: event,
+            _bytes: bytes,
+        })
+    }
+
+    fn enqueue(
+        &self,
+        cx: &ConnectionTo<Client>,
+        notification: SessionNotification,
+        reservation: AcpOutboundReservation,
+    ) -> Result<(), AcpOutboundSendError> {
+        // Serialize reservation order with the protocol enqueue. The socket
+        // writer can then release one exact FIFO credit for each written
+        // session/update line, even when several ACP sessions stream together.
+        let mut pending = self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        pending.push_back(reservation);
+        if let Err(error) = cx.send_notification(notification) {
+            pending.pop_back();
+            return Err(AcpOutboundSendError::Transport(error));
+        }
+        Ok(())
+    }
+
+    fn acknowledge_session_update(&self) {
+        let reservation = self
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .pop_front();
+        if reservation.is_none() {
+            log::warn!("Maple ACP wrote an untracked session/update notification");
+        }
+        drop(reservation);
+    }
 }
 
 impl AcpConnectionContext {
     fn new(
-        app_handle: AppHandle,
-        user_id: String,
+        agent: AgentRuntimeHandle,
         config: Arc<RwLock<AgentAcpConfig>>,
         stats: Arc<AgentAcpStats>,
     ) -> Arc<Self> {
         Arc::new(Self {
-            app_handle,
-            user_id,
+            agent,
             config,
             stats,
             bridge_environment: Mutex::new(HashMap::new()),
@@ -245,8 +414,10 @@ impl AcpConnectionContext {
             prompt_states: Mutex::new(HashMap::new()),
             background_tasks: Mutex::new(tokio::task::JoinSet::new()),
             finalization: Mutex::new(()),
+            lifetime: CancellationToken::new(),
             closed: AtomicBool::new(false),
             has_credentials: AtomicBool::new(false),
+            outbound: AcpOutboundTracker::new(),
         })
     }
 
@@ -278,72 +449,51 @@ impl AcpConnectionContext {
                 .data("ACP session cwd must be an absolute path"));
         }
         let config = self.config.read().await.clone();
-        ensure_allowed_project_root(&request.cwd, &config.allowed_project_roots)
+        let project_root = ensure_allowed_project_root(&request.cwd, &config.allowed_project_roots)
             .map_err(|error| agent_client_protocol::Error::invalid_params().data(error))?;
 
         let mut environment = self.bridge_environment.lock().await.clone();
         merge_mcp_environment(&mut environment, &request.mcp_servers)?;
+        let tool_context = bridge_tool_context_spec(&environment).map_err(internal_acp_error)?;
         let mode = config.permission_mode.maple_mode().to_string();
-        let detail = create_agent_session_for_user(
-            &self.app_handle,
-            self.user_id.clone(),
-            Some(AgentCreateSessionRequest {
-                project_root: Some(request.cwd.to_string_lossy().into_owned()),
-                title: Some("Buzz ACP".to_string()),
-                model: None,
-                context_limit: None,
-                mode: Some(mode),
-                mcp_server_names: None,
-            }),
-        )
-        .await
-        .map_err(internal_acp_error)?;
-        let session_id = detail.session.id;
-        if self
-            .sessions
-            .lock()
+        let created = self
+            .agent
+            .create_session_with_tool_context(
+                Some(AgentCreateSessionRequest {
+                    project_root: Some(project_root.to_string_lossy().into_owned()),
+                    title: Some("Buzz ACP".to_string()),
+                    model: None,
+                    context_limit: None,
+                    mode: Some(mode),
+                    mcp_server_names: None,
+                }),
+                Some(tool_context),
+                config.permission_mode.host_event_policy(),
+            )
             .await
-            .insert(session_id.clone(), None)
-            .is_none()
-        {
-            self.stats.active_sessions.fetch_add(1, Ordering::SeqCst);
-        }
-        if self.closed.load(Ordering::SeqCst) {
-            self.discard_uncommitted_session(&session_id).await;
-            return Err(agent_client_protocol::Error::internal_error()
-                .data("The Maple ACP connection closed while creating the session"));
-        }
-        let tool_environment = match set_agent_session_tool_environment(
-            &self.app_handle,
-            &self.user_id,
-            &session_id,
-            environment.clone(),
-        )
-        .await
-        {
-            Ok(tool_environment) => tool_environment,
-            Err(error) => {
-                self.discard_uncommitted_session(&session_id).await;
-                return Err(internal_acp_error(error));
-            }
-        };
+            .map_err(internal_acp_error)?;
+        let session_id = created.detail.session.id;
+        let lease = created
+            .tool_context_lease
+            .expect("an explicit Agent tool context must return a lease");
         let finalization = self.finalization.lock().await;
         if self.closed.load(Ordering::SeqCst) {
-            tool_environment.write().await.clear();
             drop(finalization);
-            self.discard_uncommitted_session(&session_id).await;
+            self.discard_uncommitted_session(&session_id, lease).await;
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection closed while configuring the session"));
         }
-        let environment_slot = self.sessions.lock().await.get_mut(&session_id).map(|slot| {
-            *slot = Some(tool_environment);
-        });
-        if environment_slot.is_none() {
+        let mut sessions = self.sessions.lock().await;
+        if sessions.contains_key(&session_id) {
+            drop(sessions);
             drop(finalization);
-            self.discard_uncommitted_session(&session_id).await;
+            self.discard_uncommitted_session(&session_id, lease).await;
             return Err(agent_client_protocol::Error::internal_error()
-                .data("The Maple ACP connection lost its new session"));
+                .data("The Maple ACP connection duplicated a new session"));
         }
+        sessions.insert(session_id.clone(), lease);
+        drop(sessions);
+        self.stats.active_sessions.fetch_add(1, Ordering::SeqCst);
         if has_buzz_credentials(&environment) && !self.has_credentials.swap(true, Ordering::SeqCst)
         {
             self.stats
@@ -354,24 +504,26 @@ impl AcpConnectionContext {
         Ok(NewSessionResponse::new(session_id))
     }
 
-    async fn discard_uncommitted_session(&self, session_id: &str) {
-        let _ =
-            clear_agent_session_tool_environment(&self.app_handle, &self.user_id, session_id).await;
-        let _ = delete_agent_session_for_user(
-            &self.app_handle,
-            self.user_id.clone(),
-            session_id.to_string(),
-        )
-        .await;
-        if self.sessions.lock().await.remove(session_id).is_some() {
+    async fn discard_uncommitted_session(&self, session_id: &str, lease: AgentToolContextLease) {
+        lease.release().await;
+        let _ = self
+            .agent
+            .discard_session_during_cleanup(session_id.to_string())
+            .await;
+    }
+
+    async fn retire_session(&self, session_id: &str) {
+        let lease = self.sessions.lock().await.remove(session_id);
+        if let Some(lease) = lease {
             self.stats.active_sessions.fetch_sub(1, Ordering::SeqCst);
+            lease.release().await;
         }
     }
 
     async fn begin_prompt(
         &self,
         request: &PromptRequest,
-    ) -> Result<String, agent_client_protocol::Error> {
+    ) -> Result<(String, CancellationToken), agent_client_protocol::Error> {
         if self.closed.load(Ordering::SeqCst) {
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection is closing"));
@@ -389,173 +541,332 @@ impl AcpConnectionContext {
             return Err(agent_client_protocol::Error::invalid_request()
                 .data("This ACP session already has an active prompt"));
         }
+        let cancellation = self.lifetime.child_token();
         states.insert(
             session_id,
             AcpPromptState::Starting {
-                cancel_requested: false,
+                cancellation: cancellation.clone(),
             },
         );
-        Ok(prompt)
+        Ok((prompt, cancellation))
+    }
+
+    async fn send_session_update(
+        &self,
+        cx: &ConnectionTo<Client>,
+        notification: SessionNotification,
+        cancellation: &CancellationToken,
+    ) -> Result<(), AcpOutboundSendError> {
+        let encoded_bytes = serde_json::to_vec(&notification)
+            .map_err(|error| {
+                AcpOutboundSendError::Transport(
+                    agent_client_protocol::Error::internal_error()
+                        .data(format!("Failed to encode Maple ACP update: {error}")),
+                )
+            })?
+            .len();
+        let reservation = self.outbound.reserve(encoded_bytes, cancellation).await?;
+        self.outbound.enqueue(cx, notification, reservation)
+    }
+
+    async fn send_final_agent_message(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session_id: SessionId,
+        message: &str,
+        cancellation: &CancellationToken,
+    ) -> Result<(), AcpOutboundSendError> {
+        self.send_session_update(
+            cx,
+            SessionNotification::new(
+                session_id,
+                SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
+                    TextContent::new(message.to_string()),
+                ))),
+            ),
+            cancellation,
+        )
+        .await
     }
 
     async fn prompt(
-        &self,
+        self: &Arc<Self>,
         cx: &ConnectionTo<Client>,
         request: PromptRequest,
         prompt: String,
+        prompt_lifetime: CancellationToken,
     ) -> Result<PromptResponse, agent_client_protocol::Error> {
         let session_id = request.session_id.0.to_string();
         let config = self.config.read().await.clone();
-        let mut events = subscribe_agent_events(&self.app_handle);
-        let run = match send_agent_message_for_user(
-            &self.app_handle,
-            self.user_id.clone(),
-            AgentSendMessageRequest {
-                session_id: session_id.clone(),
-                text: prompt,
-                model: None,
-                context_limit: None,
-                mode: Some(config.permission_mode.maple_mode().to_string()),
-                vision_capable: false,
-            },
-        )
-        .await
+        let tool_context_access = match self.sessions.lock().await.get(&session_id) {
+            Some(lease) => lease.access(),
+            None => {
+                self.prompt_states.lock().await.remove(&session_id);
+                return Err(agent_client_protocol::Error::resource_not_found(Some(
+                    session_id.clone(),
+                ))
+                .data("ACP session is no longer owned by this connection"));
+            }
+        };
+        let run = match self
+            .agent
+            .send_message_with_tool_context(
+                AgentSendMessageRequest {
+                    session_id: session_id.clone(),
+                    text: prompt,
+                    model: None,
+                    context_limit: None,
+                    mode: Some(config.permission_mode.maple_mode().to_string()),
+                    vision_capable: false,
+                },
+                tool_context_access,
+                prompt_lifetime.clone(),
+                config.permission_mode.host_event_policy(),
+            )
+            .await
         {
             Ok(run) => run,
+            Err(error) if error == AGENT_TOOL_CONTEXT_INACTIVE_ERROR => {
+                self.prompt_states.lock().await.remove(&session_id);
+                self.retire_session(&session_id).await;
+                return Err(agent_client_protocol::Error::resource_not_found(Some(
+                    session_id.clone(),
+                ))
+                .data("The Maple Agent task was removed outside this ACP connection"));
+            }
             Err(error) => {
                 self.prompt_states.lock().await.remove(&session_id);
                 return Err(internal_acp_error(error));
             }
         };
         let run_id = run.run_id;
+        let mut events = run.events;
         let mut terminal = run.terminal;
-        let cancel_requested = {
+        let event_overflowed = run.event_overflowed;
+        let prompt_registered = {
             let mut states = self.prompt_states.lock().await;
             match states.get_mut(&session_id) {
                 Some(state @ AcpPromptState::Starting { .. }) => {
-                    let requested = match state {
-                        AcpPromptState::Starting { cancel_requested } => *cancel_requested,
-                        AcpPromptState::Running { .. } => unreachable!(),
-                    };
                     *state = AcpPromptState::Running {
                         run_id: run_id.clone(),
+                        cancellation: prompt_lifetime.clone(),
                     };
-                    Some(requested)
+                    true
                 }
-                _ => None,
+                _ => false,
             }
         };
-        let Some(cancel_requested) = cancel_requested else {
-            let _ =
-                cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id.clone())
-                    .await;
+        if !prompt_registered {
+            let _ = self.agent.cancel_run(run_id.clone()).await;
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection closed while starting the prompt"));
-        };
+        }
         self.stats.active_runs.fetch_add(1, Ordering::SeqCst);
-        if cancel_requested {
+        if prompt_lifetime.is_cancelled() {
             // A cancellation failure does not make the active Maple run
             // disappear. Keep listening so its lifecycle remains tracked.
-            let _ =
-                cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id.clone())
-                    .await;
+            let _ = self.agent.cancel_run(run_id.clone()).await;
         }
 
-        let mut observed_terminal = None;
-        let mut event_stream_lagged = false;
+        let mut cancel_after_result = false;
         let result = loop {
-            tokio::select! {
-                event = events.recv() => match event {
-                    Ok(event)
-                        if event.session_id.as_deref() == Some(session_id.as_str())
-                            && event.run_id.as_deref() == Some(run_id.as_str()) =>
-                    {
-                        if event.event_type == "timelineItem" {
-                            if let Some(update) = timeline_update(&event) {
-                                if let Err(error) = cx.send_notification(SessionNotification::new(
+            if event_overflowed.load(Ordering::Acquire) {
+                cancel_after_result = true;
+                let _ = self.agent.cancel_run(run_id.clone()).await;
+                match self
+                    .send_final_agent_message(
+                        cx,
+                        request.session_id.clone(),
+                        "Maple stopped this turn because its bounded ACP event stream overflowed.",
+                        &self.lifetime,
+                    )
+                    .await
+                {
+                    Ok(()) | Err(AcpOutboundSendError::UpdateTooLarge) => {
+                        break Ok(PromptResponse::new(StopReason::EndTurn));
+                    }
+                    Err(AcpOutboundSendError::Cancelled) => {
+                        break Ok(PromptResponse::new(StopReason::Cancelled));
+                    }
+                    Err(AcpOutboundSendError::Transport(error)) => break Err(error),
+                }
+            }
+            let event = events.recv().await;
+            if event_overflowed.load(Ordering::Acquire) {
+                cancel_after_result = true;
+                let _ = self.agent.cancel_run(run_id.clone()).await;
+                match self
+                    .send_final_agent_message(
+                        cx,
+                        request.session_id.clone(),
+                        "Maple stopped this turn because its bounded ACP event stream overflowed.",
+                        &self.lifetime,
+                    )
+                    .await
+                {
+                    Ok(()) | Err(AcpOutboundSendError::UpdateTooLarge) => {
+                        break Ok(PromptResponse::new(StopReason::EndTurn));
+                    }
+                    Err(AcpOutboundSendError::Cancelled) => {
+                        break Ok(PromptResponse::new(StopReason::Cancelled));
+                    }
+                    Err(AcpOutboundSendError::Transport(error)) => break Err(error),
+                }
+            }
+            match event {
+                Some(AgentRunEvent::TimelineItem(item)) => {
+                    if let Some(update) = timeline_update(&item) {
+                        match self
+                            .send_session_update(
+                                cx,
+                                SessionNotification::new(request.session_id.clone(), update),
+                                &prompt_lifetime,
+                            )
+                            .await
+                        {
+                            Ok(()) => {}
+                            Err(AcpOutboundSendError::UpdateTooLarge) => {
+                                cancel_after_result = true;
+                                let _ = self.agent.cancel_run(run_id.clone()).await;
+                                match self.send_final_agent_message(
+                                    cx,
                                     request.session_id.clone(),
-                                    update,
-                                )) {
-                                    break Err(error);
+                                    "Maple stopped this turn because one ACP update exceeded the 4 MiB transport limit.",
+                                    &self.lifetime,
+                                )
+                                .await
+                                {
+                                    Ok(()) | Err(AcpOutboundSendError::UpdateTooLarge) => {
+                                        break Ok(PromptResponse::new(StopReason::EndTurn));
+                                    }
+                                    Err(AcpOutboundSendError::Cancelled) => {
+                                        break Ok(PromptResponse::new(StopReason::Cancelled));
+                                    }
+                                    Err(AcpOutboundSendError::Transport(error)) => break Err(error),
                                 }
                             }
-                        } else if event.event_type == "error" {
-                            if let Some(message) = event_error_text(&event) {
-                                if let Err(error) = cx.send_notification(SessionNotification::new(
+                            Err(AcpOutboundSendError::Cancelled) => {
+                                cancel_after_result = true;
+                                break Ok(PromptResponse::new(StopReason::Cancelled));
+                            }
+                            Err(AcpOutboundSendError::Transport(error)) => break Err(error),
+                        }
+                    }
+                }
+                Some(AgentRunEvent::Error(item)) => {
+                    if let Some(message) = event_error_text(&item) {
+                        match self
+                            .send_session_update(
+                                cx,
+                                SessionNotification::new(
                                     request.session_id.clone(),
                                     SessionUpdate::AgentMessageChunk(ContentChunk::new(
                                         ContentBlock::Text(TextContent::new(message)),
                                     )),
-                                )) {
-                                    break Err(error);
+                                ),
+                                &prompt_lifetime,
+                            )
+                            .await
+                        {
+                            Ok(()) => {}
+                            Err(AcpOutboundSendError::UpdateTooLarge) => {
+                                cancel_after_result = true;
+                                let _ = self.agent.cancel_run(run_id.clone()).await;
+                                match self.send_final_agent_message(
+                                    cx,
+                                    request.session_id.clone(),
+                                    "Maple stopped this turn because one ACP update exceeded the 4 MiB transport limit.",
+                                    &self.lifetime,
+                                )
+                                .await
+                                {
+                                    Ok(()) | Err(AcpOutboundSendError::UpdateTooLarge) => {
+                                        break Ok(PromptResponse::new(StopReason::EndTurn));
+                                    }
+                                    Err(AcpOutboundSendError::Cancelled) => {
+                                        break Ok(PromptResponse::new(StopReason::Cancelled));
+                                    }
+                                    Err(AcpOutboundSendError::Transport(error)) => break Err(error),
                                 }
                             }
-                        } else if event.event_type == "runFinished" {
-                            let terminal = match event.message.as_deref() {
-                                Some("cancelled") => AgentRunTerminal::Cancelled,
-                                Some("failed") => AgentRunTerminal::Failed,
-                                _ => AgentRunTerminal::Completed,
-                            };
-                            break prompt_result_from_terminal(terminal);
-                        }
-                    }
-                    Ok(_) => {}
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
-                        // Once any frames were lost, the retained per-run signal
-                        // becomes authoritative. It cannot be overwritten by
-                        // unrelated Maple UI traffic.
-                        event_stream_lagged = true;
-                        if let Some(terminal) = observed_terminal {
-                            break prompt_result_from_terminal(terminal);
-                        }
-                    }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
-                        if let Some(terminal) = observed_terminal.or_else(|| *terminal.borrow()) {
-                            break prompt_result_from_terminal(terminal);
-                        }
-                        break Err(agent_client_protocol::Error::internal_error()
-                            .data("Maple Agent event stream closed"));
-                    }
-                },
-                changed = terminal.changed(), if observed_terminal.is_none() => {
-                    match changed {
-                        Ok(()) => {
-                            observed_terminal = *terminal.borrow_and_update();
-                            if event_stream_lagged {
-                                if let Some(terminal) = observed_terminal {
-                                    break prompt_result_from_terminal(terminal);
-                                }
+                            Err(AcpOutboundSendError::Cancelled) => {
+                                cancel_after_result = true;
+                                break Ok(PromptResponse::new(StopReason::Cancelled));
                             }
-                            // In the ordinary path runFinished was broadcast
-                            // before this signal. Keep draining the ordered event
-                            // stream so Buzz receives every available text chunk.
-                        }
-                        Err(_) => {
-                            if let Some(terminal) = *terminal.borrow() {
-                                observed_terminal = Some(terminal);
-                                if event_stream_lagged {
-                                    break prompt_result_from_terminal(terminal);
-                                }
-                            } else {
-                                break Err(agent_client_protocol::Error::internal_error()
-                                    .data("Maple Agent run ended without a terminal result"));
-                            }
+                            Err(AcpOutboundSendError::Transport(error)) => break Err(error),
                         }
                     }
                 }
+                Some(AgentRunEvent::Finished(terminal)) => {
+                    break prompt_result_from_terminal(terminal);
+                }
+                Some(
+                    AgentRunEvent::SessionUpdated(_)
+                    | AgentRunEvent::Started
+                    | AgentRunEvent::SetupWarning(_)
+                    | AgentRunEvent::HistoryReplaced,
+                ) => {}
+                None => {
+                    let current_terminal = *terminal.borrow();
+                    let fallback = match current_terminal {
+                        Some(terminal) => Some(terminal),
+                        None => match terminal.changed().await {
+                            Ok(()) => *terminal.borrow_and_update(),
+                            Err(_) => *terminal.borrow(),
+                        },
+                    };
+                    if let Some(terminal) = fallback {
+                        break prompt_result_from_terminal(terminal);
+                    }
+                    break Err(agent_client_protocol::Error::internal_error()
+                        .data("Maple Agent run ended without a terminal result"));
+                }
             }
         };
-        if result.is_err() {
-            // If the ACP client disappears while Maple is still producing a
-            // turn, stop the underlying run before removing it from this
-            // connection's cleanup map. A completed/failed run simply makes
-            // this best-effort cancellation a no-op.
-            let _ = cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id).await;
+        let mut deferred_prompt_cleanup = false;
+        if cancel_after_result {
+            // Synthetic stream stops settle only after the underlying run has
+            // drained, or retain a same-session fence while it finishes in the
+            // background. A completed run makes this cancellation a no-op.
+            let _ = self.agent.cancel_run(run_id.clone()).await;
+            if tokio::time::timeout(
+                ACP_SYNTHETIC_STOP_DRAIN_TIMEOUT,
+                wait_for_retained_terminal(&mut terminal),
+            )
+            .await
+            .is_err()
+            {
+                // Do not let Buzz start a replacement turn against the same
+                // Goose session while cancellation is still draining. The ACP
+                // response remains bounded, while this retained state and task
+                // own the terminal barrier asynchronously.
+                deferred_prompt_cleanup = true;
+                let context = Arc::clone(self);
+                let draining_session_id = session_id.clone();
+                let mut tasks = self.background_tasks.lock().await;
+                tasks.spawn(async move {
+                    wait_for_retained_terminal(&mut terminal).await;
+                    if matches!(
+                        context
+                            .prompt_states
+                            .lock()
+                            .await
+                            .remove(&draining_session_id),
+                        Some(AcpPromptState::Running { .. })
+                    ) {
+                        context.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+                    }
+                });
+            }
+        } else if result.is_err() {
+            let _ = self.agent.cancel_run(run_id).await;
         }
-        if matches!(
-            self.prompt_states.lock().await.remove(&session_id),
-            Some(AcpPromptState::Running { .. })
-        ) {
+        if !deferred_prompt_cleanup
+            && matches!(
+                self.prompt_states.lock().await.remove(&session_id),
+                Some(AcpPromptState::Running { .. })
+            )
+        {
             self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
         }
         result
@@ -566,19 +877,27 @@ impl AcpConnectionContext {
         notification: CancelNotification,
     ) -> Result<(), agent_client_protocol::Error> {
         let session_id = notification.session_id.0.to_string();
-        let run_id = {
-            let mut states = self.prompt_states.lock().await;
-            match states.get_mut(&session_id) {
-                Some(AcpPromptState::Starting { cancel_requested }) => {
-                    *cancel_requested = true;
-                    None
+        let (cancellation, run_id) = {
+            let states = self.prompt_states.lock().await;
+            match states.get(&session_id) {
+                Some(AcpPromptState::Starting { cancellation }) => {
+                    (Some(cancellation.clone()), None)
                 }
-                Some(AcpPromptState::Running { run_id }) => Some(run_id.clone()),
-                None => None,
+                Some(AcpPromptState::Running {
+                    run_id,
+                    cancellation,
+                }) => (Some(cancellation.clone()), Some(run_id.clone())),
+                None => (None, None),
             }
         };
+        if let Some(cancellation) = cancellation {
+            // This token reaches core setup before a run ID exists and fences
+            // the worker start once core setup completes.
+            cancellation.cancel();
+        }
         if let Some(run_id) = run_id {
-            cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id)
+            self.agent
+                .cancel_run(run_id)
                 .await
                 .map_err(internal_acp_error)?;
         }
@@ -586,12 +905,14 @@ impl AcpConnectionContext {
     }
 
     async fn cleanup(&self) {
+        let deadline = tokio::time::Instant::now() + ACP_CONNECTION_CLEANUP_TIMEOUT;
         {
             // Linearize closure with the last new-session credential commit.
             // A task that reaches finalization after this point observes closed
             // and rolls its newly persisted session back instead of committing.
             let _finalization = self.finalization.lock().await;
             self.closed.store(true, Ordering::SeqCst);
+            self.lifetime.cancel();
             self.bridge_environment.lock().await.clear();
             if self.has_credentials.swap(false, Ordering::SeqCst) {
                 self.stats
@@ -600,24 +921,43 @@ impl AcpConnectionContext {
             }
         }
         let prompt_states = std::mem::take(&mut *self.prompt_states.lock().await);
+        let mut running_ids = Vec::new();
         for state in prompt_states.into_values() {
-            if let AcpPromptState::Running { run_id } = state {
-                let _ =
-                    cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id).await;
-                self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+            match state {
+                AcpPromptState::Starting { cancellation } => cancellation.cancel(),
+                AcpPromptState::Running {
+                    run_id,
+                    cancellation,
+                } => {
+                    cancellation.cancel();
+                    running_ids.push(run_id);
+                    self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+                }
             }
         }
         let sessions = std::mem::take(&mut *self.sessions.lock().await);
-        for environment in sessions.values().flatten() {
-            // Clear the exact Arc installed in Maple's developer client. This
-            // revokes Buzz secrets without waiting behind runtime setup locks.
-            environment.write().await.clear();
+        let session_count = sessions.len();
+        // Revoke every capability synchronously before awaiting registry cleanup.
+        // No queued or detached task can launch another credential-bearing tool
+        // after this barrier returns.
+        for lease in sessions.values() {
+            lease.revoke();
         }
         self.stats
             .active_sessions
-            .fetch_sub(sessions.len(), Ordering::SeqCst);
+            .fetch_sub(session_count, Ordering::SeqCst);
         let mut tasks = self.background_tasks.lock().await;
-        let deadline = tokio::time::Instant::now() + ACP_CONNECTION_CLEANUP_TIMEOUT;
+        for run_id in running_ids {
+            let agent = self.agent.clone();
+            tasks.spawn(async move {
+                let _ = agent.cancel_run(run_id).await;
+            });
+        }
+        for lease in sessions.into_values() {
+            tasks.spawn(async move {
+                lease.release().await;
+            });
+        }
         loop {
             match tokio::time::timeout_at(deadline, tasks.join_next()).await {
                 Ok(Some(_)) => {}
@@ -707,7 +1047,13 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                     let context = Arc::clone(&context);
                     let cx = cx.clone();
                     |request: PromptRequest, responder: Responder<PromptResponse>| async move {
-                        let prompt = context.begin_prompt(&request).await?;
+                        let (prompt, prompt_lifetime) = match context.begin_prompt(&request).await {
+                            Ok(prepared) => prepared,
+                            Err(error) => {
+                                responder.respond_with_error(error)?;
+                                return Ok(());
+                            }
+                        };
                         let prompt_cx = cx.clone();
                         let prompt_context = Arc::clone(&context);
                         let mut tasks = context.background_tasks.lock().await;
@@ -724,7 +1070,9 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                         }
                         tasks.spawn(async move {
                             let _ = responder.respond_with_result(
-                                prompt_context.prompt(&prompt_cx, request, prompt).await,
+                                prompt_context
+                                    .prompt(&prompt_cx, request, prompt, prompt_lifetime)
+                                    .await,
                             );
                         });
                         Ok(())
@@ -773,27 +1121,36 @@ pub async fn agent_acp_load_config(
 #[tauri::command]
 pub async fn agent_acp_save_config(
     app_handle: AppHandle,
+    lifecycle: tauri::State<'_, AgentHostLifecycle>,
     user_id: String,
     config: AgentAcpConfig,
 ) -> Result<AgentAcpConfig, String> {
+    let _guard = lifecycle.lock().await;
+    app_handle
+        .state::<MapleAgentService>()
+        .ensure_accepting_new_work()?;
     let config = normalize_config(config)?;
+    let requested_scope = account_scope(&user_id)?;
     let state = app_handle.state::<AgentAcpState>();
     let running = state.running.lock().await;
     if let Some(running) = running.as_ref() {
-        if running.user_id == user_id {
+        if running.account_scope == requested_scope {
             let current = running.config.read().await.clone();
-            if current.permission_mode != config.permission_mode
-                && running.stats.running.load(Ordering::SeqCst)
+            if running.stats.running.load(Ordering::SeqCst)
+                && (current.permission_mode != config.permission_mode
+                    || current.allowed_project_roots != config.allowed_project_roots
+                    || current.max_connections != config.max_connections)
             {
                 return Err(
-                    "Stop the ACP service before changing the permission policy".to_string()
+                    "Stop the ACP service before changing its permission, project-root, or connection policy"
+                        .to_string(),
                 );
             }
         }
     }
     save_config(&app_handle, &user_id, &config)?;
     if let Some(running) = running.as_ref() {
-        if running.user_id == user_id {
+        if running.account_scope == requested_scope {
             *running.config.write().await = config.clone();
         }
     }
@@ -803,18 +1160,25 @@ pub async fn agent_acp_save_config(
 #[tauri::command]
 pub async fn agent_acp_start(
     app_handle: AppHandle,
+    lifecycle: tauri::State<'_, AgentHostLifecycle>,
     user_id: String,
 ) -> Result<AgentAcpStatus, String> {
-    start_service(&app_handle, &user_id).await?;
+    let _guard = lifecycle.lock().await;
+    app_handle
+        .state::<MapleAgentService>()
+        .ensure_accepting_new_work()?;
+    start_service_locked(&app_handle, &user_id).await?;
     status(&app_handle, &user_id).await
 }
 
 #[tauri::command]
 pub async fn agent_acp_stop(
     app_handle: AppHandle,
+    lifecycle: tauri::State<'_, AgentHostLifecycle>,
     user_id: String,
 ) -> Result<AgentAcpStatus, String> {
-    stop_service(&app_handle, Some(&user_id), true).await?;
+    let _guard = lifecycle.lock().await;
+    stop_service_locked(&app_handle, Some(&user_id), true).await?;
     status(&app_handle, &user_id).await
 }
 
@@ -826,22 +1190,23 @@ pub async fn agent_acp_get_status(
     status(&app_handle, &user_id).await
 }
 
-pub async fn shutdown_agent_acp(app_handle: &AppHandle) -> Result<(), String> {
-    stop_service(app_handle, None, false).await
+pub(crate) async fn shutdown_agent_acp_locked(
+    app_handle: &AppHandle,
+    requested_user: Option<&str>,
+) -> Result<(), String> {
+    stop_service_locked(app_handle, requested_user, false).await
 }
 
 #[cfg(unix)]
-async fn start_service(app_handle: &AppHandle, user_id: &str) -> Result<(), String> {
-    if user_id.trim().is_empty() {
-        return Err("Cannot start ACP without an authenticated Maple user".to_string());
-    }
+async fn start_service_locked(app_handle: &AppHandle, user_id: &str) -> Result<(), String> {
+    let requested_scope = account_scope(user_id)
+        .map_err(|_| "Cannot start ACP without an authenticated Maple user".to_string())?;
     let state = app_handle.state::<AgentAcpState>();
-    let _guard = state.lifecycle.lock().await;
     let stale = {
         let mut slot = state.running.lock().await;
         match slot.as_ref() {
             Some(running) if running.stats.running.load(Ordering::SeqCst) => {
-                if running.user_id == user_id {
+                if running.account_scope == requested_scope {
                     return Ok(());
                 }
                 return Err("ACP is already running for another Maple account".to_string());
@@ -855,7 +1220,15 @@ async fn start_service(app_handle: &AppHandle, user_id: &str) -> Result<(), Stri
         let _ = stale.task.await;
         remove_socket_if_present(&stale.endpoint)?;
     }
-    ensure_agent_runtime_for_user(app_handle, user_id.to_string(), None).await?;
+    let agent = app_handle
+        .state::<MapleAgentService>()
+        .handle_for_user(user_id)
+        .await?;
+    let maple_api_session = app_handle
+        .state::<MapleApiAuthState>()
+        .session_for(user_id)
+        .await?;
+    agent.start(maple_api_session, None).await?;
     let mut config = normalize_config(load_config(app_handle, user_id)?)?;
     config.enabled = true;
 
@@ -869,14 +1242,13 @@ async fn start_service(app_handle: &AppHandle, user_id: &str) -> Result<(), Stri
     let task = tauri::async_runtime::spawn(run_listener(
         listener,
         endpoint.clone(),
-        app_handle.clone(),
-        user_id.to_string(),
+        agent,
         Arc::clone(&config),
         Arc::clone(&stats),
         cancellation.clone(),
     ));
     *state.running.lock().await = Some(RunningAgentAcp {
-        user_id: user_id.to_string(),
+        account_scope: requested_scope,
         endpoint,
         config,
         stats,
@@ -887,21 +1259,21 @@ async fn start_service(app_handle: &AppHandle, user_id: &str) -> Result<(), Stri
 }
 
 #[cfg(not(unix))]
-async fn start_service(_app_handle: &AppHandle, _user_id: &str) -> Result<(), String> {
+async fn start_service_locked(_app_handle: &AppHandle, _user_id: &str) -> Result<(), String> {
     Err("Maple ACP local IPC is not yet supported on this platform".to_string())
 }
 
-async fn stop_service(
+async fn stop_service_locked(
     app_handle: &AppHandle,
     requested_user: Option<&str>,
     persist_disabled: bool,
 ) -> Result<(), String> {
     let state = app_handle.state::<AgentAcpState>();
-    let _guard = state.lifecycle.lock().await;
+    let requested_scope = requested_user.map(account_scope).transpose()?;
     let running = {
         let mut slot = state.running.lock().await;
-        if let (Some(requested), Some(running)) = (requested_user, slot.as_ref()) {
-            if running.user_id != requested {
+        if let (Some(requested), Some(running)) = (requested_scope.as_deref(), slot.as_ref()) {
+            if running.account_scope != requested {
                 return Err("ACP belongs to another Maple account".to_string());
             }
         }
@@ -923,17 +1295,18 @@ async fn stop_service(
     if persist_disabled {
         let mut config = running.config.read().await.clone();
         config.enabled = false;
-        save_config(app_handle, &running.user_id, &config)?;
+        save_config_for_scope(app_handle, &running.account_scope, &config)?;
     }
     Ok(())
 }
 
 async fn status(app_handle: &AppHandle, user_id: &str) -> Result<AgentAcpStatus, String> {
     let state = app_handle.state::<AgentAcpState>();
+    let requested_scope = account_scope(user_id)?;
     let running = state.running.lock().await;
     let harness = harness()?;
     if let Some(running) = running.as_ref() {
-        if running.user_id != user_id {
+        if running.account_scope != requested_scope {
             return Err("ACP belongs to another Maple account".to_string());
         }
         let config = running.config.read().await.clone();
@@ -975,8 +1348,7 @@ async fn status(app_handle: &AppHandle, user_id: &str) -> Result<AgentAcpStatus,
 async fn run_listener(
     listener: UnixListener,
     endpoint: PathBuf,
-    app_handle: AppHandle,
-    user_id: String,
+    agent: AgentRuntimeHandle,
     config: Arc<RwLock<AgentAcpConfig>>,
     stats: Arc<AgentAcpStats>,
     cancellation: CancellationToken,
@@ -997,8 +1369,7 @@ async fn run_listener(
                         drop(stream);
                         continue;
                     };
-                    let app_handle = app_handle.clone();
-                    let user_id = user_id.clone();
+                    let agent = agent.clone();
                     let config = Arc::clone(&config);
                     let stats = Arc::clone(&stats);
                     let connection_cancel = cancellation.clone();
@@ -1006,21 +1377,33 @@ async fn run_listener(
                         let _permit = permit;
                         stats.connected_clients.fetch_add(1, Ordering::SeqCst);
                         let context = AcpConnectionContext::new(
-                            app_handle,
-                            user_id,
+                            agent,
                             config,
                             Arc::clone(&stats),
                         );
                         let (read, write) = stream.into_split();
                         let peer_eof = CancellationToken::new();
                         let read = BoundedLineReader::new(read, peer_eof.clone());
+                        let incoming = FramedRead::new(
+                            read,
+                            LinesCodec::new_with_max_length(MAX_ACP_FRAME_BYTES),
+                        )
+                        .map(|result| {
+                            result.map_err(|error| {
+                                std::io::Error::new(std::io::ErrorKind::InvalidData, error)
+                            })
+                        });
+                        let outgoing = tracked_outgoing_lines(
+                            write,
+                            Arc::clone(&context.outbound),
+                        );
                         let serving = AcpAgent
                             .builder()
                             .name("maple-acp")
                             .with_handler(MapleAcpHandler {
                                 context: Arc::clone(&context),
                             })
-                            .connect_to(ByteStreams::new(write.compat_write(), read.compat()));
+                            .connect_to(Lines::new(outgoing, incoming));
                         tokio::select! {
                             result = serving => {
                                 if let Err(error) = result {
@@ -1140,22 +1523,36 @@ fn harness() -> Result<AgentAcpHarness, String> {
 }
 
 fn config_path(app_handle: &AppHandle, user_id: &str) -> Result<PathBuf, String> {
-    if user_id.trim().is_empty() {
-        return Err("Maple ACP configuration requires an authenticated user".to_string());
-    }
-    let digest = Sha256::digest(user_id.as_bytes());
-    let scope = digest[..16]
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect::<String>();
+    let scope = account_scope(user_id)
+        .map_err(|_| "Maple ACP configuration requires an authenticated user".to_string())?;
+    config_path_for_scope(app_handle, &scope)
+}
+
+fn config_path_for_scope(app_handle: &AppHandle, scope: &str) -> Result<PathBuf, String> {
+    Ok(acp_accounts_root(app_handle)?
+        .join(scope)
+        .join("config.json"))
+}
+
+fn acp_accounts_root(app_handle: &AppHandle) -> Result<PathBuf, String> {
     let root = app_handle
         .path()
         .app_local_data_dir()
         .map_err(|error| format!("Failed to resolve Maple local data: {error}"))?;
-    Ok(root
-        .join("acp")
-        .join("accounts")
-        .join(scope)
+    Ok(root.join("acp").join("accounts"))
+}
+
+fn legacy_config_path(app_handle: &AppHandle, user_id: &str) -> Result<PathBuf, String> {
+    if user_id.trim().is_empty() {
+        return Err("Maple ACP configuration requires an authenticated user".to_string());
+    }
+    let digest = Sha256::digest(user_id.as_bytes());
+    let legacy_scope = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(acp_accounts_root(app_handle)?
+        .join(legacy_scope)
         .join("config.json"))
 }
 
@@ -1165,7 +1562,29 @@ fn load_config(app_handle: &AppHandle, user_id: &str) -> Result<AgentAcpConfig, 
         Ok(bytes) => serde_json::from_slice(&bytes)
             .map_err(|error| format!("Failed to parse Maple ACP configuration: {error}"))
             .and_then(normalize_config),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(AgentAcpConfig::default()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let legacy_path = legacy_config_path(app_handle, user_id)?;
+            match std::fs::read(legacy_path) {
+                Ok(bytes) => {
+                    let config = serde_json::from_slice(&bytes)
+                        .map_err(|error| {
+                            format!("Failed to parse Maple ACP configuration: {error}")
+                        })
+                        .and_then(normalize_config)?;
+                    // Keep the POC file intact so switching back to the original
+                    // branch remains harmless, while future saves use Maple's
+                    // canonical full account scope.
+                    if let Err(error) = save_config(app_handle, user_id, &config) {
+                        log::warn!("Failed to migrate Maple ACP configuration: {error}");
+                    }
+                    Ok(config)
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                    Ok(AgentAcpConfig::default())
+                }
+                Err(error) => Err(format!("Failed to read Maple ACP configuration: {error}")),
+            }
+        }
         Err(error) => Err(format!("Failed to read Maple ACP configuration: {error}")),
     }
 }
@@ -1175,7 +1594,17 @@ fn save_config(
     user_id: &str,
     config: &AgentAcpConfig,
 ) -> Result<(), String> {
-    let path = config_path(app_handle, user_id)?;
+    let scope = account_scope(user_id)
+        .map_err(|_| "Maple ACP configuration requires an authenticated user".to_string())?;
+    save_config_for_scope(app_handle, &scope, config)
+}
+
+fn save_config_for_scope(
+    app_handle: &AppHandle,
+    account_scope: &str,
+    config: &AgentAcpConfig,
+) -> Result<(), String> {
+    let path = config_path_for_scope(app_handle, account_scope)?;
     let parent = path
         .parent()
         .ok_or_else(|| "Invalid Maple ACP configuration path".to_string())?;
@@ -1195,15 +1624,23 @@ fn save_config(
 }
 
 pub(crate) fn clear_agent_acp_config(app_handle: &AppHandle, user_id: &str) -> Result<(), String> {
-    let path = config_path(app_handle, user_id)?;
-    let account_dir = path
-        .parent()
-        .ok_or_else(|| "Invalid Maple ACP configuration path".to_string())?;
-    match std::fs::remove_dir_all(account_dir) {
-        Ok(()) => Ok(()),
-        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
-        Err(error) => Err(format!("Failed to clear Maple ACP configuration: {error}")),
+    let paths = [
+        config_path(app_handle, user_id)?,
+        legacy_config_path(app_handle, user_id)?,
+    ];
+    for path in paths {
+        let account_dir = path
+            .parent()
+            .ok_or_else(|| "Invalid Maple ACP configuration path".to_string())?;
+        match std::fs::remove_dir_all(account_dir) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                return Err(format!("Failed to clear Maple ACP configuration: {error}"));
+            }
+        }
     }
+    Ok(())
 }
 
 fn normalize_config(mut config: AgentAcpConfig) -> Result<AgentAcpConfig, String> {
@@ -1227,17 +1664,17 @@ fn normalize_config(mut config: AgentAcpConfig) -> Result<AgentAcpConfig, String
     Ok(config)
 }
 
-fn ensure_allowed_project_root(cwd: &Path, allowed_roots: &[String]) -> Result<(), String> {
-    if allowed_roots.is_empty() {
-        return Ok(());
-    }
+fn ensure_allowed_project_root(cwd: &Path, allowed_roots: &[String]) -> Result<PathBuf, String> {
     let cwd = cwd
         .canonicalize()
         .map_err(|error| format!("Failed to resolve ACP session cwd: {error}"))?;
+    if allowed_roots.is_empty() {
+        return Ok(cwd);
+    }
     for root in allowed_roots {
         if let Ok(root) = Path::new(root).canonicalize() {
             if cwd.starts_with(root) {
-                return Ok(());
+                return Ok(cwd);
             }
         }
     }
@@ -1311,6 +1748,34 @@ fn filter_bridge_environment(environment: HashMap<String, String>) -> HashMap<St
         .collect()
 }
 
+pub(crate) fn default_tool_context_spec() -> Result<AgentToolContextSpec, String> {
+    AgentToolContextSpec::try_new(
+        BTreeMap::new(),
+        SENSITIVE_BRIDGE_ENV
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        false,
+    )
+}
+
+fn bridge_tool_context_spec(
+    environment: &HashMap<String, String>,
+) -> Result<AgentToolContextSpec, String> {
+    let values = environment
+        .iter()
+        .map(|(key, value)| (key.clone(), value.clone()))
+        .collect::<BTreeMap<_, _>>();
+    let scrub_from_parent = SENSITIVE_BRIDGE_ENV
+        .into_iter()
+        .map(str::to_string)
+        .collect::<BTreeSet<_>>();
+    let ephemeral = SENSITIVE_BRIDGE_ENV
+        .iter()
+        .any(|key| environment.contains_key(*key));
+    AgentToolContextSpec::try_new(values, scrub_from_parent, ephemeral)
+}
+
 fn has_buzz_credentials(environment: &HashMap<String, String>) -> bool {
     environment
         .get("BUZZ_RELAY_URL")
@@ -1336,8 +1801,7 @@ fn prompt_text(blocks: &[ContentBlock]) -> Result<String, agent_client_protocol:
     Ok(text)
 }
 
-fn timeline_update(event: &AgentEventEnvelope) -> Option<SessionUpdate> {
-    let item = event.item.as_ref()?;
+fn timeline_update(item: &AgentTimelineItem) -> Option<SessionUpdate> {
     let text = item.text.as_deref()?.to_string();
     match item.item_type.as_str() {
         "message" if item.role.as_deref() == Some("assistant") => {
@@ -1352,12 +1816,21 @@ fn timeline_update(event: &AgentEventEnvelope) -> Option<SessionUpdate> {
     }
 }
 
-fn event_error_text(event: &AgentEventEnvelope) -> Option<String> {
-    event
-        .message
-        .clone()
-        .or_else(|| event.item.as_ref().and_then(|item| item.text.clone()))
-        .map(|message| bounded_error(&message))
+fn event_error_text(item: &AgentTimelineItem) -> Option<String> {
+    item.text.clone().map(|message| bounded_error(&message))
+}
+
+async fn wait_for_retained_terminal(
+    terminal: &mut tokio::sync::watch::Receiver<Option<AgentRunTerminal>>,
+) {
+    loop {
+        if terminal.borrow().is_some() {
+            return;
+        }
+        if terminal.changed().await.is_err() {
+            return;
+        }
+    }
 }
 
 fn prompt_result_from_terminal(
@@ -1366,9 +1839,12 @@ fn prompt_result_from_terminal(
     match terminal {
         AgentRunTerminal::Completed => Ok(PromptResponse::new(StopReason::EndTurn)),
         AgentRunTerminal::Cancelled => Ok(PromptResponse::new(StopReason::Cancelled)),
-        AgentRunTerminal::Failed => {
-            Err(agent_client_protocol::Error::internal_error().data("Maple Agent prompt failed"))
-        }
+        // A failed terminal is emitted only after a run was admitted. Goose may
+        // already have persisted output or executed tools, and Buzz treats a
+        // JSON-RPC AgentError as pre-mutation/retryable. The preceding error
+        // update carries the failure text; settle the turn successfully here so
+        // non-idempotent work is never replayed automatically.
+        AgentRunTerminal::Failed => Ok(PromptResponse::new(StopReason::EndTurn)),
     }
 }
 
@@ -1504,6 +1980,75 @@ mod tests {
     }
 
     #[test]
+    fn permission_policy_selects_the_authoritative_event_broker() {
+        assert_eq!(
+            AgentAcpPermissionMode::ReadOnly.host_event_policy(),
+            AgentHostEventPolicy::Publish
+        );
+        assert_eq!(
+            AgentAcpPermissionMode::AllowAll.host_event_policy(),
+            AgentHostEventPolicy::Suppress
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn outbound_tracker_releases_credit_only_after_a_socket_write_acknowledgement() {
+        use futures_util::SinkExt as _;
+        use tokio::io::AsyncReadExt as _;
+
+        let tracker = AcpOutboundTracker::with_limits(1, 1024);
+        let cancellation = CancellationToken::new();
+        let first = tracker.reserve(1, &cancellation).await.unwrap();
+        tracker
+            .pending
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .push_back(first);
+
+        let waiting_tracker = Arc::clone(&tracker);
+        let waiting_cancellation = cancellation.clone();
+        let waiting =
+            tokio::spawn(async move { waiting_tracker.reserve(1, &waiting_cancellation).await });
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished());
+
+        let line = r#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#;
+        let (writer, mut reader) = tokio::io::duplex(1024);
+        let mut sink = Box::pin(tracked_outgoing_lines(writer, Arc::clone(&tracker)));
+        sink.send(line.to_string()).await.unwrap();
+        let mut written = vec![0_u8; line.len() + 1];
+        reader.read_exact(&mut written).await.unwrap();
+        assert_eq!(written, format!("{line}\n").into_bytes());
+
+        let second = waiting.await.unwrap().unwrap();
+        drop(second);
+    }
+
+    #[test]
+    fn outbound_credit_acknowledges_only_session_updates() {
+        assert!(is_session_update_line(
+            r#"{"jsonrpc":"2.0","method":"session/update","params":{}}"#
+        ));
+        assert!(!is_session_update_line(
+            r#"{"jsonrpc":"2.0","id":1,"result":{}}"#
+        ));
+    }
+
+    #[test]
+    fn allowed_project_root_returns_the_canonical_admitted_path() {
+        let root = tempfile::tempdir().unwrap();
+        let project = root.path().join("project");
+        std::fs::create_dir(&project).unwrap();
+
+        let admitted =
+            ensure_allowed_project_root(&project, &[root.path().to_string_lossy().into_owned()])
+                .unwrap();
+
+        assert_eq!(admitted, project.canonicalize().unwrap());
+    }
+
+    #[test]
     fn bridge_environment_is_strictly_allowlisted() {
         let filtered = filter_bridge_environment(HashMap::from([
             (
@@ -1542,6 +2087,10 @@ mod tests {
             "cancelled"
         );
 
-        assert!(prompt_result_from_terminal(AgentRunTerminal::Failed).is_err());
+        let failed = prompt_result_from_terminal(AgentRunTerminal::Failed).unwrap();
+        assert_eq!(
+            serde_json::to_value(failed).unwrap()["stopReason"],
+            "end_turn"
+        );
     }
 }

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -1,5 +1,6 @@
 use crate::agent::{
-    AgentCreateSessionRequest, AgentHostEventPolicy, AgentRunEvent, AgentRunTerminal,
+    AgentCreateSessionRequest, AgentHostEventPolicy, AgentPermissionDecision,
+    AgentPermissionRequest, AgentRunEvent, AgentRunPermissionResponder, AgentRunTerminal,
     AgentRuntimeHandle, AgentSendMessageRequest, AgentTimelineItem, AgentToolContextLease,
     AgentToolContextSpec, MapleAgentService, AGENT_TOOL_CONTEXT_INACTIVE_ERROR,
 };
@@ -8,8 +9,9 @@ use crate::maple_api::{account_scope, MapleApiAuthState};
 use agent_client_protocol::schema::v1::{
     AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, Implementation,
     InitializeRequest, InitializeResponse, McpServer, NewSessionRequest, NewSessionResponse,
-    PromptCapabilities, PromptRequest, PromptResponse, SessionId, SessionNotification,
-    SessionUpdate, StopReason, TextContent,
+    PermissionOption, PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
+    RequestPermissionOutcome, RequestPermissionRequest, SessionId, SessionNotification,
+    SessionUpdate, StopReason, TextContent, ToolCall, ToolCallContent, ToolCallStatus, ToolKind,
 };
 use agent_client_protocol::util::MatchDispatchFrom;
 use agent_client_protocol::{
@@ -162,22 +164,10 @@ pub enum AgentAcpPermissionMode {
 
 impl AgentAcpPermissionMode {
     fn maple_mode(&self) -> &'static str {
-        match self {
-            Self::ReadOnly => "smart_approve",
-            Self::AllowAll => "auto",
-        }
-    }
-
-    fn host_event_policy(&self) -> AgentHostEventPolicy {
-        match self {
-            // Maple Desktop remains the one authoritative permission broker for
-            // the guarded policy, so its task and permission events must remain
-            // visible there.
-            Self::ReadOnly => AgentHostEventPolicy::Publish,
-            // Unattended ACP runs do not need to contaminate Desktop's live event
-            // stream; their persisted task remains loadable on refresh.
-            Self::AllowAll => AgentHostEventPolicy::Suppress,
-        }
+        // ACP callers own every unresolved interactive decision. Keep the old
+        // allow_all variant readable for configuration compatibility, but do
+        // not let it bypass the caller through Maple's Auto policy.
+        "smart_approve"
     }
 }
 
@@ -314,6 +304,12 @@ enum AcpOutboundSendError {
     UpdateTooLarge,
     Cancelled,
     Transport(agent_client_protocol::Error),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum AcpPermissionResolution {
+    Continue,
+    Cancelled,
 }
 
 impl AcpOutboundTracker {
@@ -468,7 +464,10 @@ impl AcpConnectionContext {
                     mcp_server_names: None,
                 }),
                 Some(tool_context),
-                config.permission_mode.host_event_policy(),
+                // The ACP caller is the only interactive surface for this task.
+                // Persisted history remains loadable in Maple Desktop, but live
+                // permission cards must never create a second approval broker.
+                AgentHostEventPolicy::Suppress,
             )
             .await
             .map_err(internal_acp_error)?;
@@ -589,6 +588,81 @@ impl AcpConnectionContext {
         .await
     }
 
+    async fn request_permission_from_caller(
+        &self,
+        cx: &ConnectionTo<Client>,
+        session_id: SessionId,
+        request: AgentPermissionRequest,
+        item: &AgentTimelineItem,
+        responder: &AgentRunPermissionResponder,
+        cancellation: &CancellationToken,
+    ) -> Result<AcpPermissionResolution, AcpOutboundSendError> {
+        let tool_call = acp_permission_tool_call(&request, item);
+        let permission_request =
+            RequestPermissionRequest::new(session_id, tool_call.into(), acp_permission_options());
+        let encoded_bytes = serde_json::to_vec(&permission_request)
+            .map_err(|error| {
+                AcpOutboundSendError::Transport(internal_acp_error(format!(
+                    "Failed to encode Maple ACP permission request: {error}"
+                )))
+            })?
+            .len();
+        // Permission requests use the same global event/byte budget as streamed
+        // notifications. Hold the reservation until the caller responds so a
+        // slow client cannot accumulate unbounded JSON-RPC request frames.
+        let reservation = self.outbound.reserve(encoded_bytes, cancellation).await?;
+        if cancellation.is_cancelled() {
+            cancel_maple_permission(responder, &request.request_id).await;
+            return Ok(AcpPermissionResolution::Cancelled);
+        }
+        let sent_request = cx.send_request(permission_request);
+        let mut response_future = Box::pin(sent_request.block_task());
+        let response = tokio::select! {
+            biased;
+            _ = cancellation.cancelled() => None,
+            response = &mut response_future => Some(response),
+        };
+        let Some(response) = response else {
+            // ACP v1 has no stable request-cancellation primitive. Stop Maple
+            // immediately, but keep consuming the already-sent JSON-RPC request
+            // and retain its outbound credits until the client replies or the
+            // connection closes. Otherwise a cancel-and-never-reply client can
+            // accumulate unbounded SDK correlation entries outside our limit.
+            cancel_maple_permission(responder, &request.request_id).await;
+            retain_cancelled_permission_request(response_future, reservation);
+            return Ok(AcpPermissionResolution::Cancelled);
+        };
+        drop(reservation);
+
+        let (decision, resolution) = match response {
+            Ok(response) => match acp_permission_decision(&response.outcome) {
+                Ok(AgentPermissionDecision::Cancel) => (
+                    AgentPermissionDecision::Cancel,
+                    AcpPermissionResolution::Cancelled,
+                ),
+                Ok(decision) => (decision, AcpPermissionResolution::Continue),
+                Err(error) => {
+                    cancel_maple_permission(responder, &request.request_id).await;
+                    return Err(AcpOutboundSendError::Transport(internal_acp_error(error)));
+                }
+            },
+            Err(error) => {
+                cancel_maple_permission(responder, &request.request_id).await;
+                return Err(AcpOutboundSendError::Transport(error));
+            }
+        };
+
+        if let Err(error) = responder.respond(request.request_id, decision).await {
+            if cancellation.is_cancelled() {
+                return Ok(AcpPermissionResolution::Cancelled);
+            }
+            return Err(AcpOutboundSendError::Transport(internal_acp_error(
+                format!("Failed to resolve Maple permission request: {error}"),
+            )));
+        }
+        Ok(resolution)
+    }
+
     async fn prompt(
         self: &Arc<Self>,
         cx: &ConnectionTo<Client>,
@@ -621,7 +695,7 @@ impl AcpConnectionContext {
                 },
                 tool_context_access,
                 prompt_lifetime.clone(),
-                config.permission_mode.host_event_policy(),
+                AgentHostEventPolicy::Suppress,
             )
             .await
         {
@@ -643,6 +717,12 @@ impl AcpConnectionContext {
         let mut events = run.events;
         let mut terminal = run.terminal;
         let event_overflowed = run.event_overflowed;
+        let Some(permission_responder) = run.permission_responder else {
+            let _ = self.agent.cancel_run(run_id).await;
+            self.prompt_states.lock().await.remove(&session_id);
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("Maple did not create an ACP permission responder for this run"));
+        };
         let prompt_registered = {
             let mut states = self.prompt_states.lock().await;
             match states.get_mut(&session_id) {
@@ -751,6 +831,54 @@ impl AcpConnectionContext {
                             }
                             Err(AcpOutboundSendError::Transport(error)) => break Err(error),
                         }
+                    }
+                }
+                Some(AgentRunEvent::PermissionRequested {
+                    request: permission,
+                    item,
+                }) => {
+                    match self
+                        .request_permission_from_caller(
+                            cx,
+                            request.session_id.clone(),
+                            permission,
+                            &item,
+                            &permission_responder,
+                            &prompt_lifetime,
+                        )
+                        .await
+                    {
+                        Ok(AcpPermissionResolution::Continue) => {}
+                        Ok(AcpPermissionResolution::Cancelled) => {
+                            cancel_after_result = true;
+                            break Ok(PromptResponse::new(StopReason::Cancelled));
+                        }
+                        Err(AcpOutboundSendError::UpdateTooLarge) => {
+                            cancel_after_result = true;
+                            let _ = self.agent.cancel_run(run_id.clone()).await;
+                            match self
+                                .send_final_agent_message(
+                                    cx,
+                                    request.session_id.clone(),
+                                    "Maple stopped this turn because one ACP permission request exceeded the 4 MiB transport limit.",
+                                    &self.lifetime,
+                                )
+                                .await
+                            {
+                                Ok(()) | Err(AcpOutboundSendError::UpdateTooLarge) => {
+                                    break Ok(PromptResponse::new(StopReason::EndTurn));
+                                }
+                                Err(AcpOutboundSendError::Cancelled) => {
+                                    break Ok(PromptResponse::new(StopReason::Cancelled));
+                                }
+                                Err(AcpOutboundSendError::Transport(error)) => break Err(error),
+                            }
+                        }
+                        Err(AcpOutboundSendError::Cancelled) => {
+                            cancel_after_result = true;
+                            break Ok(PromptResponse::new(StopReason::Cancelled));
+                        }
+                        Err(AcpOutboundSendError::Transport(error)) => break Err(error),
                     }
                 }
                 Some(AgentRunEvent::Error(item)) => {
@@ -1644,6 +1772,9 @@ pub(crate) fn clear_agent_acp_config(app_handle: &AppHandle, user_id: &str) -> R
 }
 
 fn normalize_config(mut config: AgentAcpConfig) -> Result<AgentAcpConfig, String> {
+    // `allow_all` was the exploratory Desktop-owned bypass. Caller-owned ACP
+    // supersedes it; old files migrate to the guarded policy on their next load.
+    config.permission_mode = AgentAcpPermissionMode::ReadOnly;
     config.max_connections = config.max_connections.clamp(1, MAX_ACP_CONNECTIONS);
     let mut roots = Vec::new();
     for root in config.allowed_project_roots {
@@ -1799,6 +1930,91 @@ fn prompt_text(blocks: &[ContentBlock]) -> Result<String, agent_client_protocol:
             .data("Maple ACP requires at least one text prompt block"));
     }
     Ok(text)
+}
+
+fn acp_permission_tool_call(
+    request: &AgentPermissionRequest,
+    item: &AgentTimelineItem,
+) -> ToolCall {
+    let title = item
+        .title
+        .clone()
+        .unwrap_or_else(|| format!("Approve {}", request.tool_name));
+    let mut tool_call = ToolCall::new(request.request_id.clone(), title)
+        .kind(acp_tool_kind(&request.tool_name))
+        .status(ToolCallStatus::Pending)
+        .raw_input(serde_json::Value::Object(request.arguments.clone()));
+    if let Some(prompt) = request.prompt.as_ref().filter(|prompt| !prompt.is_empty()) {
+        tool_call = tool_call.content(vec![ToolCallContent::from(ContentBlock::Text(
+            TextContent::new(prompt.clone()),
+        ))]);
+    }
+    tool_call
+}
+
+fn acp_tool_kind(tool_name: &str) -> ToolKind {
+    match tool_name.rsplit("__").next().unwrap_or(tool_name) {
+        "shell" | "computer" => ToolKind::Execute,
+        "text_editor" => ToolKind::Edit,
+        "search" | "web_search" => ToolKind::Search,
+        "open_url" => ToolKind::Fetch,
+        _ => ToolKind::Other,
+    }
+}
+
+fn acp_permission_options() -> Vec<PermissionOption> {
+    vec![
+        PermissionOption::new("allow_once", "Allow once", PermissionOptionKind::AllowOnce),
+        PermissionOption::new(
+            "reject_once",
+            "Reject once",
+            PermissionOptionKind::RejectOnce,
+        ),
+    ]
+}
+
+fn acp_permission_decision(
+    outcome: &RequestPermissionOutcome,
+) -> Result<AgentPermissionDecision, String> {
+    match outcome {
+        RequestPermissionOutcome::Cancelled => Ok(AgentPermissionDecision::Cancel),
+        RequestPermissionOutcome::Selected(selected)
+            if selected.option_id.0.as_ref() == "allow_once" =>
+        {
+            Ok(AgentPermissionDecision::AllowOnce)
+        }
+        RequestPermissionOutcome::Selected(selected)
+            if selected.option_id.0.as_ref() == "reject_once" =>
+        {
+            Ok(AgentPermissionDecision::DenyOnce)
+        }
+        RequestPermissionOutcome::Selected(_) => {
+            Err("ACP client selected an unknown Maple permission option".to_string())
+        }
+        _ => Err("ACP client returned an unsupported Maple permission outcome".to_string()),
+    }
+}
+
+async fn cancel_maple_permission(responder: &AgentRunPermissionResponder, request_id: &str) {
+    if let Err(error) = responder
+        .respond(request_id.to_string(), AgentPermissionDecision::Cancel)
+        .await
+    {
+        log::debug!(
+            "Maple ACP permission request {request_id} was already resolved while failing closed: {error}"
+        );
+    }
+}
+
+fn retain_cancelled_permission_request<F, T>(response: F, reservation: AcpOutboundReservation)
+where
+    F: std::future::Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::spawn(async move {
+        let _reservation = reservation;
+        let _ = response.await;
+    });
 }
 
 fn timeline_update(item: &AgentTimelineItem) -> Option<SessionUpdate> {
@@ -1970,9 +2186,10 @@ async fn run_acp_connector_async() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agent_client_protocol::schema::v1::SelectedPermissionOutcome;
 
     #[test]
-    fn default_config_is_disabled_and_read_only() {
+    fn default_config_is_disabled_and_caller_mediated() {
         let config = AgentAcpConfig::default();
         assert!(!config.enabled);
         assert_eq!(config.permission_mode, AgentAcpPermissionMode::ReadOnly);
@@ -1980,15 +2197,89 @@ mod tests {
     }
 
     #[test]
-    fn permission_policy_selects_the_authoritative_event_broker() {
+    fn legacy_allow_all_cannot_bypass_the_acp_caller() {
         assert_eq!(
-            AgentAcpPermissionMode::ReadOnly.host_event_policy(),
-            AgentHostEventPolicy::Publish
+            AgentAcpPermissionMode::ReadOnly.maple_mode(),
+            "smart_approve"
         );
         assert_eq!(
-            AgentAcpPermissionMode::AllowAll.host_event_policy(),
-            AgentHostEventPolicy::Suppress
+            AgentAcpPermissionMode::AllowAll.maple_mode(),
+            "smart_approve"
         );
+        let migrated = normalize_config(AgentAcpConfig {
+            permission_mode: AgentAcpPermissionMode::AllowAll,
+            ..AgentAcpConfig::default()
+        })
+        .unwrap();
+        assert_eq!(migrated.permission_mode, AgentAcpPermissionMode::ReadOnly);
+    }
+
+    #[test]
+    fn permission_request_exposes_only_one_shot_caller_choices() {
+        let request = AgentPermissionRequest {
+            request_id: "request-1".to_string(),
+            tool_name: "developer__shell".to_string(),
+            arguments: serde_json::Map::from_iter([(
+                "command".to_string(),
+                serde_json::json!("git push"),
+            )]),
+            prompt: Some("Push this branch?".to_string()),
+        };
+        let item = AgentTimelineItem {
+            id: "permission-request-1".to_string(),
+            item_type: "permission".to_string(),
+            role: Some("system".to_string()),
+            title: Some("Push branch".to_string()),
+            text: request.prompt.clone(),
+            status: Some("pending".to_string()),
+            input: Some(serde_json::Value::Object(request.arguments.clone())),
+            output: None,
+            created_ms: 1,
+            merge: "replace".to_string(),
+        };
+        let permission = RequestPermissionRequest::new(
+            "session-1",
+            acp_permission_tool_call(&request, &item).into(),
+            acp_permission_options(),
+        );
+        let encoded = serde_json::to_value(permission).unwrap();
+
+        assert_eq!(encoded["toolCall"]["toolCallId"], "request-1");
+        assert_eq!(encoded["toolCall"]["title"], "Push branch");
+        assert_eq!(encoded["toolCall"]["kind"], "execute");
+        assert_eq!(encoded["toolCall"]["status"], "pending");
+        assert_eq!(encoded["toolCall"]["rawInput"]["command"], "git push");
+        assert_eq!(
+            encoded["options"],
+            serde_json::json!([
+                { "optionId": "allow_once", "name": "Allow once", "kind": "allow_once" },
+                { "optionId": "reject_once", "name": "Reject once", "kind": "reject_once" }
+            ])
+        );
+    }
+
+    #[test]
+    fn permission_outcomes_map_fail_closed() {
+        assert_eq!(
+            acp_permission_decision(&RequestPermissionOutcome::Selected(
+                SelectedPermissionOutcome::new("allow_once")
+            )),
+            Ok(AgentPermissionDecision::AllowOnce)
+        );
+        assert_eq!(
+            acp_permission_decision(&RequestPermissionOutcome::Selected(
+                SelectedPermissionOutcome::new("reject_once")
+            )),
+            Ok(AgentPermissionDecision::DenyOnce)
+        );
+        assert_eq!(
+            acp_permission_decision(&RequestPermissionOutcome::Cancelled),
+            Ok(AgentPermissionDecision::Cancel)
+        );
+        assert!(acp_permission_decision(&RequestPermissionOutcome::Selected(
+            SelectedPermissionOutcome::new("allow_always")
+        ))
+        .is_err());
     }
 
     #[cfg(unix)]
@@ -2022,6 +2313,37 @@ mod tests {
         assert_eq!(written, format!("{line}\n").into_bytes());
 
         let second = waiting.await.unwrap().unwrap();
+        drop(second);
+    }
+
+    #[tokio::test]
+    async fn cancelled_permission_retains_credit_until_the_orphan_request_settles() {
+        let tracker = AcpOutboundTracker::with_limits(1, 1024);
+        let cancellation = CancellationToken::new();
+        let first = tracker.reserve(1, &cancellation).await.unwrap();
+        let (settled_tx, settled_rx) = tokio::sync::oneshot::channel::<()>();
+        retain_cancelled_permission_request(
+            async move {
+                let _ = settled_rx.await;
+            },
+            first,
+        );
+
+        assert!(tokio::time::timeout(
+            std::time::Duration::from_millis(10),
+            tracker.reserve(1, &cancellation),
+        )
+        .await
+        .is_err());
+
+        settled_tx.send(()).unwrap();
+        let second = tokio::time::timeout(
+            std::time::Duration::from_secs(1),
+            tracker.reserve(1, &cancellation),
+        )
+        .await
+        .unwrap()
+        .unwrap();
         drop(second);
     }
 

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -1,0 +1,1547 @@
+use crate::agent::{
+    cancel_agent_run_for_user, clear_agent_session_tool_environment, create_agent_session_for_user,
+    delete_agent_session_for_user, ensure_agent_runtime_for_user, send_agent_message_for_user,
+    set_agent_session_tool_environment, subscribe_agent_events, AgentCreateSessionRequest,
+    AgentEventEnvelope, AgentRunTerminal, AgentSendMessageRequest, SharedAgentToolEnvironment,
+};
+use agent_client_protocol::schema::v1::{
+    AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, Implementation,
+    InitializeRequest, InitializeResponse, McpServer, NewSessionRequest, NewSessionResponse,
+    PromptCapabilities, PromptRequest, PromptResponse, SessionNotification, SessionUpdate,
+    StopReason, TextContent,
+};
+use agent_client_protocol::util::MatchDispatchFrom;
+use agent_client_protocol::{
+    Agent as AcpAgent, ByteStreams, Client, ConnectionTo, Dispatch, HandleDispatchFrom, Handled,
+    JsonRpcNotification, Responder,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::Arc;
+use tauri::{AppHandle, Manager};
+use tokio::sync::{Mutex, RwLock, Semaphore};
+use tokio_util::compat::{TokioAsyncReadCompatExt as _, TokioAsyncWriteCompatExt as _};
+use tokio_util::sync::CancellationToken;
+
+#[cfg(target_os = "linux")]
+use std::os::unix::fs::{DirBuilderExt as _, MetadataExt as _};
+#[cfg(unix)]
+use std::os::unix::fs::{FileTypeExt as _, PermissionsExt as _};
+#[cfg(unix)]
+use tokio::net::{UnixListener, UnixStream};
+
+const ACP_PROTOCOL_VERSION: u16 = 1;
+const MAX_ACP_CONNECTIONS: usize = 8;
+const MAX_ACP_ERROR_CHARS: usize = 500;
+const MAX_ACP_FRAME_BYTES: usize = 10 * 1024 * 1024;
+const ACP_CONNECTION_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const BRIDGE_HELLO_METHOD: &str = "_maple/bridge/hello";
+const ALLOWED_BRIDGE_ENV: [&str; 6] = [
+    "BUZZ_RELAY_URL",
+    "BUZZ_PRIVATE_KEY",
+    "BUZZ_AUTH_TAG",
+    "BUZZ_API_TOKEN",
+    "BUZZ_ACP_DISPLAY_NAME",
+    "PATH",
+];
+
+#[cfg(unix)]
+struct BoundedLineReader<R> {
+    inner: R,
+    bytes_since_newline: usize,
+    eof: CancellationToken,
+}
+
+#[cfg(unix)]
+impl<R> BoundedLineReader<R> {
+    fn new(inner: R, eof: CancellationToken) -> Self {
+        Self {
+            inner,
+            bytes_since_newline: 0,
+            eof,
+        }
+    }
+}
+
+#[cfg(unix)]
+impl<R: tokio::io::AsyncRead + Unpin> tokio::io::AsyncRead for BoundedLineReader<R> {
+    fn poll_read(
+        mut self: std::pin::Pin<&mut Self>,
+        cx: &mut std::task::Context<'_>,
+        buf: &mut tokio::io::ReadBuf<'_>,
+    ) -> std::task::Poll<std::io::Result<()>> {
+        let previous_len = buf.filled().len();
+        match std::pin::Pin::new(&mut self.inner).poll_read(cx, buf) {
+            std::task::Poll::Ready(Ok(())) => {
+                if buf.filled().len() == previous_len {
+                    self.eof.cancel();
+                }
+                for byte in &buf.filled()[previous_len..] {
+                    if *byte == b'\n' {
+                        self.bytes_since_newline = 0;
+                    } else {
+                        self.bytes_since_newline = self.bytes_since_newline.saturating_add(1);
+                        if self.bytes_since_newline > MAX_ACP_FRAME_BYTES {
+                            return std::task::Poll::Ready(Err(std::io::Error::new(
+                                std::io::ErrorKind::InvalidData,
+                                "ACP frame exceeds the 10 MiB limit",
+                            )));
+                        }
+                    }
+                }
+                std::task::Poll::Ready(Ok(()))
+            }
+            other => other,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum AgentAcpPermissionMode {
+    ReadOnly,
+    AllowAll,
+}
+
+impl AgentAcpPermissionMode {
+    fn maple_mode(&self) -> &'static str {
+        match self {
+            Self::ReadOnly => "smart_approve",
+            Self::AllowAll => "auto",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentAcpConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_permission_mode")]
+    pub permission_mode: AgentAcpPermissionMode,
+    #[serde(default)]
+    pub allowed_project_roots: Vec<String>,
+    #[serde(default = "default_max_connections")]
+    pub max_connections: usize,
+}
+
+fn default_permission_mode() -> AgentAcpPermissionMode {
+    AgentAcpPermissionMode::ReadOnly
+}
+
+fn default_max_connections() -> usize {
+    1
+}
+
+impl Default for AgentAcpConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            permission_mode: default_permission_mode(),
+            allowed_project_roots: Vec::new(),
+            max_connections: default_max_connections(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentAcpHarness {
+    pub command: String,
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentAcpStatus {
+    pub running: bool,
+    pub enabled: bool,
+    pub connected_clients: usize,
+    pub active_sessions: usize,
+    pub active_runs: usize,
+    pub endpoint: Option<String>,
+    pub endpoint_kind: Option<String>,
+    pub protocol_version: u16,
+    pub error: Option<String>,
+    pub buzz_credentials_available: bool,
+    pub harness: AgentAcpHarness,
+}
+
+#[derive(Default)]
+struct AgentAcpStats {
+    running: AtomicBool,
+    connected_clients: AtomicUsize,
+    active_sessions: AtomicUsize,
+    active_runs: AtomicUsize,
+    credential_connections: AtomicUsize,
+    last_error: Mutex<Option<String>>,
+}
+
+struct RunningAgentAcp {
+    user_id: String,
+    endpoint: PathBuf,
+    config: Arc<RwLock<AgentAcpConfig>>,
+    stats: Arc<AgentAcpStats>,
+    cancellation: CancellationToken,
+    task: tauri::async_runtime::JoinHandle<()>,
+}
+
+pub struct AgentAcpState {
+    lifecycle: Mutex<()>,
+    running: Mutex<Option<RunningAgentAcp>>,
+}
+
+impl AgentAcpState {
+    pub fn new() -> Self {
+        Self {
+            lifecycle: Mutex::new(()),
+            running: Mutex::new(None),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonRpcNotification)]
+#[notification(method = "_maple/bridge/hello")]
+struct BridgeHelloNotification {
+    environment: HashMap<String, String>,
+}
+
+struct AcpConnectionContext {
+    app_handle: AppHandle,
+    user_id: String,
+    config: Arc<RwLock<AgentAcpConfig>>,
+    stats: Arc<AgentAcpStats>,
+    bridge_environment: Mutex<HashMap<String, String>>,
+    sessions: Mutex<HashMap<String, Option<SharedAgentToolEnvironment>>>,
+    prompt_states: Mutex<HashMap<String, AcpPromptState>>,
+    background_tasks: Mutex<tokio::task::JoinSet<()>>,
+    finalization: Mutex<()>,
+    closed: AtomicBool,
+    has_credentials: AtomicBool,
+}
+
+enum AcpPromptState {
+    Starting { cancel_requested: bool },
+    Running { run_id: String },
+}
+
+impl AcpConnectionContext {
+    fn new(
+        app_handle: AppHandle,
+        user_id: String,
+        config: Arc<RwLock<AgentAcpConfig>>,
+        stats: Arc<AgentAcpStats>,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            app_handle,
+            user_id,
+            config,
+            stats,
+            bridge_environment: Mutex::new(HashMap::new()),
+            sessions: Mutex::new(HashMap::new()),
+            prompt_states: Mutex::new(HashMap::new()),
+            background_tasks: Mutex::new(tokio::task::JoinSet::new()),
+            finalization: Mutex::new(()),
+            closed: AtomicBool::new(false),
+            has_credentials: AtomicBool::new(false),
+        })
+    }
+
+    async fn set_bridge_environment(&self, environment: HashMap<String, String>) {
+        let _finalization = self.finalization.lock().await;
+        if self.closed.load(Ordering::SeqCst) {
+            return;
+        }
+        let environment = filter_bridge_environment(environment);
+        let has_credentials = has_buzz_credentials(&environment);
+        *self.bridge_environment.lock().await = environment;
+        if has_credentials && !self.has_credentials.swap(true, Ordering::SeqCst) {
+            self.stats
+                .credential_connections
+                .fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn new_session(
+        &self,
+        request: NewSessionRequest,
+    ) -> Result<NewSessionResponse, agent_client_protocol::Error> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection is closing"));
+        }
+        if !request.cwd.is_absolute() {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("ACP session cwd must be an absolute path"));
+        }
+        let config = self.config.read().await.clone();
+        ensure_allowed_project_root(&request.cwd, &config.allowed_project_roots)
+            .map_err(|error| agent_client_protocol::Error::invalid_params().data(error))?;
+
+        let mut environment = self.bridge_environment.lock().await.clone();
+        merge_mcp_environment(&mut environment, &request.mcp_servers)?;
+        let mode = config.permission_mode.maple_mode().to_string();
+        let detail = create_agent_session_for_user(
+            &self.app_handle,
+            self.user_id.clone(),
+            Some(AgentCreateSessionRequest {
+                project_root: Some(request.cwd.to_string_lossy().into_owned()),
+                title: Some("Buzz ACP".to_string()),
+                model: None,
+                context_limit: None,
+                mode: Some(mode),
+                mcp_server_names: None,
+            }),
+        )
+        .await
+        .map_err(internal_acp_error)?;
+        let session_id = detail.session.id;
+        if self
+            .sessions
+            .lock()
+            .await
+            .insert(session_id.clone(), None)
+            .is_none()
+        {
+            self.stats.active_sessions.fetch_add(1, Ordering::SeqCst);
+        }
+        if self.closed.load(Ordering::SeqCst) {
+            self.discard_uncommitted_session(&session_id).await;
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection closed while creating the session"));
+        }
+        let tool_environment = match set_agent_session_tool_environment(
+            &self.app_handle,
+            &self.user_id,
+            &session_id,
+            environment.clone(),
+        )
+        .await
+        {
+            Ok(tool_environment) => tool_environment,
+            Err(error) => {
+                self.discard_uncommitted_session(&session_id).await;
+                return Err(internal_acp_error(error));
+            }
+        };
+        let finalization = self.finalization.lock().await;
+        if self.closed.load(Ordering::SeqCst) {
+            tool_environment.write().await.clear();
+            drop(finalization);
+            self.discard_uncommitted_session(&session_id).await;
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection closed while configuring the session"));
+        }
+        let environment_slot = self.sessions.lock().await.get_mut(&session_id).map(|slot| {
+            *slot = Some(tool_environment);
+        });
+        if environment_slot.is_none() {
+            drop(finalization);
+            self.discard_uncommitted_session(&session_id).await;
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection lost its new session"));
+        }
+        if has_buzz_credentials(&environment) && !self.has_credentials.swap(true, Ordering::SeqCst)
+        {
+            self.stats
+                .credential_connections
+                .fetch_add(1, Ordering::SeqCst);
+        }
+        drop(finalization);
+        Ok(NewSessionResponse::new(session_id))
+    }
+
+    async fn discard_uncommitted_session(&self, session_id: &str) {
+        let _ =
+            clear_agent_session_tool_environment(&self.app_handle, &self.user_id, session_id).await;
+        let _ = delete_agent_session_for_user(
+            &self.app_handle,
+            self.user_id.clone(),
+            session_id.to_string(),
+        )
+        .await;
+        if self.sessions.lock().await.remove(session_id).is_some() {
+            self.stats.active_sessions.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn begin_prompt(
+        &self,
+        request: &PromptRequest,
+    ) -> Result<String, agent_client_protocol::Error> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection is closing"));
+        }
+        let session_id = request.session_id.0.to_string();
+        if !self.sessions.lock().await.contains_key(&session_id) {
+            return Err(
+                agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                    .data("ACP session is not owned by this connection"),
+            );
+        }
+        let prompt = prompt_text(&request.prompt)?;
+        let mut states = self.prompt_states.lock().await;
+        if states.contains_key(&session_id) {
+            return Err(agent_client_protocol::Error::invalid_request()
+                .data("This ACP session already has an active prompt"));
+        }
+        states.insert(
+            session_id,
+            AcpPromptState::Starting {
+                cancel_requested: false,
+            },
+        );
+        Ok(prompt)
+    }
+
+    async fn prompt(
+        &self,
+        cx: &ConnectionTo<Client>,
+        request: PromptRequest,
+        prompt: String,
+    ) -> Result<PromptResponse, agent_client_protocol::Error> {
+        let session_id = request.session_id.0.to_string();
+        let config = self.config.read().await.clone();
+        let mut events = subscribe_agent_events(&self.app_handle);
+        let run = match send_agent_message_for_user(
+            &self.app_handle,
+            self.user_id.clone(),
+            AgentSendMessageRequest {
+                session_id: session_id.clone(),
+                text: prompt,
+                model: None,
+                context_limit: None,
+                mode: Some(config.permission_mode.maple_mode().to_string()),
+                vision_capable: false,
+            },
+        )
+        .await
+        {
+            Ok(run) => run,
+            Err(error) => {
+                self.prompt_states.lock().await.remove(&session_id);
+                return Err(internal_acp_error(error));
+            }
+        };
+        let run_id = run.run_id;
+        let mut terminal = run.terminal;
+        let cancel_requested = {
+            let mut states = self.prompt_states.lock().await;
+            match states.get_mut(&session_id) {
+                Some(state @ AcpPromptState::Starting { .. }) => {
+                    let requested = match state {
+                        AcpPromptState::Starting { cancel_requested } => *cancel_requested,
+                        AcpPromptState::Running { .. } => unreachable!(),
+                    };
+                    *state = AcpPromptState::Running {
+                        run_id: run_id.clone(),
+                    };
+                    Some(requested)
+                }
+                _ => None,
+            }
+        };
+        let Some(cancel_requested) = cancel_requested else {
+            let _ =
+                cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id.clone())
+                    .await;
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection closed while starting the prompt"));
+        };
+        self.stats.active_runs.fetch_add(1, Ordering::SeqCst);
+        if cancel_requested {
+            // A cancellation failure does not make the active Maple run
+            // disappear. Keep listening so its lifecycle remains tracked.
+            let _ =
+                cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id.clone())
+                    .await;
+        }
+
+        let mut observed_terminal = None;
+        let mut event_stream_lagged = false;
+        let result = loop {
+            tokio::select! {
+                event = events.recv() => match event {
+                    Ok(event)
+                        if event.session_id.as_deref() == Some(session_id.as_str())
+                            && event.run_id.as_deref() == Some(run_id.as_str()) =>
+                    {
+                        if event.event_type == "timelineItem" {
+                            if let Some(update) = timeline_update(&event) {
+                                if let Err(error) = cx.send_notification(SessionNotification::new(
+                                    request.session_id.clone(),
+                                    update,
+                                )) {
+                                    break Err(error);
+                                }
+                            }
+                        } else if event.event_type == "error" {
+                            if let Some(message) = event_error_text(&event) {
+                                if let Err(error) = cx.send_notification(SessionNotification::new(
+                                    request.session_id.clone(),
+                                    SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                                        ContentBlock::Text(TextContent::new(message)),
+                                    )),
+                                )) {
+                                    break Err(error);
+                                }
+                            }
+                        } else if event.event_type == "runFinished" {
+                            let terminal = match event.message.as_deref() {
+                                Some("cancelled") => AgentRunTerminal::Cancelled,
+                                Some("failed") => AgentRunTerminal::Failed,
+                                _ => AgentRunTerminal::Completed,
+                            };
+                            break prompt_result_from_terminal(terminal);
+                        }
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                        // Once any frames were lost, the retained per-run signal
+                        // becomes authoritative. It cannot be overwritten by
+                        // unrelated Maple UI traffic.
+                        event_stream_lagged = true;
+                        if let Some(terminal) = observed_terminal {
+                            break prompt_result_from_terminal(terminal);
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        if let Some(terminal) = observed_terminal.or_else(|| *terminal.borrow()) {
+                            break prompt_result_from_terminal(terminal);
+                        }
+                        break Err(agent_client_protocol::Error::internal_error()
+                            .data("Maple Agent event stream closed"));
+                    }
+                },
+                changed = terminal.changed(), if observed_terminal.is_none() => {
+                    match changed {
+                        Ok(()) => {
+                            observed_terminal = *terminal.borrow_and_update();
+                            if event_stream_lagged {
+                                if let Some(terminal) = observed_terminal {
+                                    break prompt_result_from_terminal(terminal);
+                                }
+                            }
+                            // In the ordinary path runFinished was broadcast
+                            // before this signal. Keep draining the ordered event
+                            // stream so Buzz receives every available text chunk.
+                        }
+                        Err(_) => {
+                            if let Some(terminal) = *terminal.borrow() {
+                                observed_terminal = Some(terminal);
+                                if event_stream_lagged {
+                                    break prompt_result_from_terminal(terminal);
+                                }
+                            } else {
+                                break Err(agent_client_protocol::Error::internal_error()
+                                    .data("Maple Agent run ended without a terminal result"));
+                            }
+                        }
+                    }
+                }
+            }
+        };
+        if result.is_err() {
+            // If the ACP client disappears while Maple is still producing a
+            // turn, stop the underlying run before removing it from this
+            // connection's cleanup map. A completed/failed run simply makes
+            // this best-effort cancellation a no-op.
+            let _ = cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id).await;
+        }
+        if matches!(
+            self.prompt_states.lock().await.remove(&session_id),
+            Some(AcpPromptState::Running { .. })
+        ) {
+            self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+        }
+        result
+    }
+
+    async fn cancel(
+        &self,
+        notification: CancelNotification,
+    ) -> Result<(), agent_client_protocol::Error> {
+        let session_id = notification.session_id.0.to_string();
+        let run_id = {
+            let mut states = self.prompt_states.lock().await;
+            match states.get_mut(&session_id) {
+                Some(AcpPromptState::Starting { cancel_requested }) => {
+                    *cancel_requested = true;
+                    None
+                }
+                Some(AcpPromptState::Running { run_id }) => Some(run_id.clone()),
+                None => None,
+            }
+        };
+        if let Some(run_id) = run_id {
+            cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id)
+                .await
+                .map_err(internal_acp_error)?;
+        }
+        Ok(())
+    }
+
+    async fn cleanup(&self) {
+        {
+            // Linearize closure with the last new-session credential commit.
+            // A task that reaches finalization after this point observes closed
+            // and rolls its newly persisted session back instead of committing.
+            let _finalization = self.finalization.lock().await;
+            self.closed.store(true, Ordering::SeqCst);
+            self.bridge_environment.lock().await.clear();
+            if self.has_credentials.swap(false, Ordering::SeqCst) {
+                self.stats
+                    .credential_connections
+                    .fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+        let prompt_states = std::mem::take(&mut *self.prompt_states.lock().await);
+        for state in prompt_states.into_values() {
+            if let AcpPromptState::Running { run_id } = state {
+                let _ =
+                    cancel_agent_run_for_user(&self.app_handle, self.user_id.clone(), run_id).await;
+                self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+            }
+        }
+        let sessions = std::mem::take(&mut *self.sessions.lock().await);
+        for environment in sessions.values().flatten() {
+            // Clear the exact Arc installed in Maple's developer client. This
+            // revokes Buzz secrets without waiting behind runtime setup locks.
+            environment.write().await.clear();
+        }
+        self.stats
+            .active_sessions
+            .fetch_sub(sessions.len(), Ordering::SeqCst);
+        let mut tasks = self.background_tasks.lock().await;
+        let deadline = tokio::time::Instant::now() + ACP_CONNECTION_CLEANUP_TIMEOUT;
+        loop {
+            match tokio::time::timeout_at(deadline, tasks.join_next()).await {
+                Ok(Some(_)) => {}
+                Ok(None) => break,
+                Err(_) => {
+                    // Session creation and the pre-run prompt path both cross
+                    // persistent core state before returning an ID. Aborting
+                    // them here could orphan that state. Detaching preserves
+                    // their existing closed checks and rollback/cancel paths
+                    // while keeping connection shutdown bounded.
+                    tasks.detach_all();
+                    break;
+                }
+            }
+        }
+        drop(tasks);
+    }
+}
+
+#[derive(Clone)]
+struct MapleAcpHandler {
+    context: Arc<AcpConnectionContext>,
+}
+
+impl HandleDispatchFrom<Client> for MapleAcpHandler {
+    fn describe_chain(&self) -> impl std::fmt::Debug {
+        "maple-acp"
+    }
+
+    fn handle_dispatch_from(
+        &mut self,
+        message: Dispatch,
+        cx: ConnectionTo<Client>,
+    ) -> impl std::future::Future<Output = Result<Handled<Dispatch>, agent_client_protocol::Error>> + Send
+    {
+        let context = Arc::clone(&self.context);
+        Box::pin(async move {
+            MatchDispatchFrom::new(message, &cx)
+                .if_notification({
+                    let context = Arc::clone(&context);
+                    |notification: BridgeHelloNotification| async move {
+                        context.set_bridge_environment(notification.environment).await;
+                        Ok(())
+                    }
+                })
+                .await
+                .if_request(
+                    |_request: InitializeRequest, responder: Responder<InitializeResponse>| async {
+                        let capabilities = AgentCapabilities::new().prompt_capabilities(
+                            PromptCapabilities::new()
+                                .image(false)
+                                .audio(false)
+                                .embedded_context(false),
+                        );
+                        responder.respond(
+                            InitializeResponse::new(
+                                agent_client_protocol::schema::ProtocolVersion::V1,
+                            )
+                            .agent_info(Implementation::new("maple", env!("CARGO_PKG_VERSION")))
+                            .agent_capabilities(capabilities),
+                        )
+                    },
+                )
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    |request: NewSessionRequest, responder: Responder<NewSessionResponse>| async move {
+                        let task_context = Arc::clone(&context);
+                        let mut tasks = context.background_tasks.lock().await;
+                        while tasks.try_join_next().is_some() {}
+                        if context.closed.load(Ordering::SeqCst) {
+                            responder.respond_with_error(
+                                agent_client_protocol::Error::internal_error()
+                                    .data("The Maple ACP connection is closing"),
+                            )?;
+                            return Ok(());
+                        }
+                        tasks.spawn(async move {
+                            let _ = responder
+                                .respond_with_result(task_context.new_session(request).await);
+                        });
+                        Ok(())
+                    }
+                })
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    let cx = cx.clone();
+                    |request: PromptRequest, responder: Responder<PromptResponse>| async move {
+                        let prompt = context.begin_prompt(&request).await?;
+                        let prompt_cx = cx.clone();
+                        let prompt_context = Arc::clone(&context);
+                        let mut tasks = context.background_tasks.lock().await;
+                        while tasks.try_join_next().is_some() {}
+                        if context.closed.load(Ordering::SeqCst) {
+                            context.prompt_states.lock().await.remove(
+                                &request.session_id.0.to_string(),
+                            );
+                            responder.respond_with_error(
+                                agent_client_protocol::Error::internal_error()
+                                    .data("The Maple ACP connection is closing"),
+                            )?;
+                            return Ok(());
+                        }
+                        tasks.spawn(async move {
+                            let _ = responder.respond_with_result(
+                                prompt_context.prompt(&prompt_cx, request, prompt).await,
+                            );
+                        });
+                        Ok(())
+                    }
+                })
+                .await
+                .if_notification({
+                    let context = Arc::clone(&context);
+                    |notification: CancelNotification| async move {
+                        context.cancel(notification).await
+                    }
+                })
+                .await
+                .otherwise({
+                    let cx = cx.clone();
+                    |message: Dispatch| async move {
+                        match message {
+                            Dispatch::Request(_, responder) => {
+                                responder.respond_with_error(
+                                    agent_client_protocol::Error::method_not_found(),
+                                )?;
+                            }
+                            Dispatch::Response(result, router) => {
+                                router.respond_with_result(result)?;
+                            }
+                            Dispatch::Notification(_) => {}
+                        }
+                        let _ = cx;
+                        Ok(())
+                    }
+                })
+                .await
+                .map(|()| Handled::Yes)
+        })
+    }
+}
+
+#[tauri::command]
+pub async fn agent_acp_load_config(
+    app_handle: AppHandle,
+    user_id: String,
+) -> Result<AgentAcpConfig, String> {
+    load_config(&app_handle, &user_id)
+}
+
+#[tauri::command]
+pub async fn agent_acp_save_config(
+    app_handle: AppHandle,
+    user_id: String,
+    config: AgentAcpConfig,
+) -> Result<AgentAcpConfig, String> {
+    let config = normalize_config(config)?;
+    let state = app_handle.state::<AgentAcpState>();
+    let running = state.running.lock().await;
+    if let Some(running) = running.as_ref() {
+        if running.user_id == user_id {
+            let current = running.config.read().await.clone();
+            if current.permission_mode != config.permission_mode
+                && running.stats.running.load(Ordering::SeqCst)
+            {
+                return Err(
+                    "Stop the ACP service before changing the permission policy".to_string()
+                );
+            }
+        }
+    }
+    save_config(&app_handle, &user_id, &config)?;
+    if let Some(running) = running.as_ref() {
+        if running.user_id == user_id {
+            *running.config.write().await = config.clone();
+        }
+    }
+    Ok(config)
+}
+
+#[tauri::command]
+pub async fn agent_acp_start(
+    app_handle: AppHandle,
+    user_id: String,
+) -> Result<AgentAcpStatus, String> {
+    start_service(&app_handle, &user_id).await?;
+    status(&app_handle, &user_id).await
+}
+
+#[tauri::command]
+pub async fn agent_acp_stop(
+    app_handle: AppHandle,
+    user_id: String,
+) -> Result<AgentAcpStatus, String> {
+    stop_service(&app_handle, Some(&user_id), true).await?;
+    status(&app_handle, &user_id).await
+}
+
+#[tauri::command]
+pub async fn agent_acp_get_status(
+    app_handle: AppHandle,
+    user_id: String,
+) -> Result<AgentAcpStatus, String> {
+    status(&app_handle, &user_id).await
+}
+
+pub async fn shutdown_agent_acp(app_handle: &AppHandle) -> Result<(), String> {
+    stop_service(app_handle, None, false).await
+}
+
+#[cfg(unix)]
+async fn start_service(app_handle: &AppHandle, user_id: &str) -> Result<(), String> {
+    if user_id.trim().is_empty() {
+        return Err("Cannot start ACP without an authenticated Maple user".to_string());
+    }
+    let state = app_handle.state::<AgentAcpState>();
+    let _guard = state.lifecycle.lock().await;
+    let stale = {
+        let mut slot = state.running.lock().await;
+        match slot.as_ref() {
+            Some(running) if running.stats.running.load(Ordering::SeqCst) => {
+                if running.user_id == user_id {
+                    return Ok(());
+                }
+                return Err("ACP is already running for another Maple account".to_string());
+            }
+            Some(_) => slot.take(),
+            None => None,
+        }
+    };
+    if let Some(stale) = stale {
+        stale.cancellation.cancel();
+        let _ = stale.task.await;
+        remove_socket_if_present(&stale.endpoint)?;
+    }
+    ensure_agent_runtime_for_user(app_handle, user_id.to_string(), None).await?;
+    let mut config = normalize_config(load_config(app_handle, user_id)?)?;
+    config.enabled = true;
+
+    let (listener, endpoint) = bind_listener()?;
+
+    save_config(app_handle, user_id, &config)?;
+    let config = Arc::new(RwLock::new(config));
+    let stats = Arc::new(AgentAcpStats::default());
+    stats.running.store(true, Ordering::SeqCst);
+    let cancellation = CancellationToken::new();
+    let task = tauri::async_runtime::spawn(run_listener(
+        listener,
+        endpoint.clone(),
+        app_handle.clone(),
+        user_id.to_string(),
+        Arc::clone(&config),
+        Arc::clone(&stats),
+        cancellation.clone(),
+    ));
+    *state.running.lock().await = Some(RunningAgentAcp {
+        user_id: user_id.to_string(),
+        endpoint,
+        config,
+        stats,
+        cancellation,
+        task,
+    });
+    Ok(())
+}
+
+#[cfg(not(unix))]
+async fn start_service(_app_handle: &AppHandle, _user_id: &str) -> Result<(), String> {
+    Err("Maple ACP local IPC is not yet supported on this platform".to_string())
+}
+
+async fn stop_service(
+    app_handle: &AppHandle,
+    requested_user: Option<&str>,
+    persist_disabled: bool,
+) -> Result<(), String> {
+    let state = app_handle.state::<AgentAcpState>();
+    let _guard = state.lifecycle.lock().await;
+    let running = {
+        let mut slot = state.running.lock().await;
+        if let (Some(requested), Some(running)) = (requested_user, slot.as_ref()) {
+            if running.user_id != requested {
+                return Err("ACP belongs to another Maple account".to_string());
+            }
+        }
+        slot.take()
+    };
+    let Some(running) = running else {
+        if persist_disabled {
+            if let Some(user_id) = requested_user {
+                let mut config = load_config(app_handle, user_id)?;
+                config.enabled = false;
+                save_config(app_handle, user_id, &config)?;
+            }
+        }
+        return Ok(());
+    };
+    running.cancellation.cancel();
+    let _ = running.task.await;
+    remove_socket_if_present(&running.endpoint)?;
+    if persist_disabled {
+        let mut config = running.config.read().await.clone();
+        config.enabled = false;
+        save_config(app_handle, &running.user_id, &config)?;
+    }
+    Ok(())
+}
+
+async fn status(app_handle: &AppHandle, user_id: &str) -> Result<AgentAcpStatus, String> {
+    let state = app_handle.state::<AgentAcpState>();
+    let running = state.running.lock().await;
+    let harness = harness()?;
+    if let Some(running) = running.as_ref() {
+        if running.user_id != user_id {
+            return Err("ACP belongs to another Maple account".to_string());
+        }
+        let config = running.config.read().await.clone();
+        return Ok(AgentAcpStatus {
+            running: running.stats.running.load(Ordering::SeqCst),
+            enabled: config.enabled,
+            connected_clients: running.stats.connected_clients.load(Ordering::SeqCst),
+            active_sessions: running.stats.active_sessions.load(Ordering::SeqCst),
+            active_runs: running.stats.active_runs.load(Ordering::SeqCst),
+            endpoint: Some(running.endpoint.to_string_lossy().into_owned()),
+            endpoint_kind: Some("unix_socket".to_string()),
+            protocol_version: ACP_PROTOCOL_VERSION,
+            error: running.stats.last_error.lock().await.clone(),
+            buzz_credentials_available: running.stats.credential_connections.load(Ordering::SeqCst)
+                > 0,
+            harness,
+        });
+    }
+    drop(running);
+    let config = load_config(app_handle, user_id)?;
+    Ok(AgentAcpStatus {
+        running: false,
+        enabled: config.enabled,
+        connected_clients: 0,
+        active_sessions: 0,
+        active_runs: 0,
+        endpoint: endpoint_path()
+            .ok()
+            .map(|path| path.to_string_lossy().into_owned()),
+        endpoint_kind: cfg!(unix).then(|| "unix_socket".to_string()),
+        protocol_version: ACP_PROTOCOL_VERSION,
+        error: None,
+        buzz_credentials_available: false,
+        harness,
+    })
+}
+
+#[cfg(unix)]
+async fn run_listener(
+    listener: UnixListener,
+    endpoint: PathBuf,
+    app_handle: AppHandle,
+    user_id: String,
+    config: Arc<RwLock<AgentAcpConfig>>,
+    stats: Arc<AgentAcpStats>,
+    cancellation: CancellationToken,
+) {
+    let limit = Arc::new(Semaphore::new(config.read().await.max_connections));
+    let mut connections = tokio::task::JoinSet::new();
+    loop {
+        tokio::select! {
+            _ = cancellation.cancelled() => break,
+            completed = connections.join_next(), if !connections.is_empty() => {
+                if let Some(Err(error)) = completed {
+                    *stats.last_error.lock().await = Some(bounded_error(&error.to_string()));
+                }
+            }
+            accepted = listener.accept() => match accepted {
+                Ok((stream, _)) => {
+                    let Ok(permit) = Arc::clone(&limit).try_acquire_owned() else {
+                        drop(stream);
+                        continue;
+                    };
+                    let app_handle = app_handle.clone();
+                    let user_id = user_id.clone();
+                    let config = Arc::clone(&config);
+                    let stats = Arc::clone(&stats);
+                    let connection_cancel = cancellation.clone();
+                    connections.spawn(async move {
+                        let _permit = permit;
+                        stats.connected_clients.fetch_add(1, Ordering::SeqCst);
+                        let context = AcpConnectionContext::new(
+                            app_handle,
+                            user_id,
+                            config,
+                            Arc::clone(&stats),
+                        );
+                        let (read, write) = stream.into_split();
+                        let peer_eof = CancellationToken::new();
+                        let read = BoundedLineReader::new(read, peer_eof.clone());
+                        let serving = AcpAgent
+                            .builder()
+                            .name("maple-acp")
+                            .with_handler(MapleAcpHandler {
+                                context: Arc::clone(&context),
+                            })
+                            .connect_to(ByteStreams::new(write.compat_write(), read.compat()));
+                        tokio::select! {
+                            result = serving => {
+                                if let Err(error) = result {
+                                    *stats.last_error.lock().await = Some(bounded_error(&error.to_string()));
+                                }
+                            }
+                            _ = connection_cancel.cancelled() => {}
+                            _ = peer_eof.cancelled() => {}
+                        }
+                        context.cleanup().await;
+                        stats.connected_clients.fetch_sub(1, Ordering::SeqCst);
+                    });
+                }
+                Err(error) => {
+                    *stats.last_error.lock().await = Some(bounded_error(&error.to_string()));
+                    break;
+                }
+            }
+        }
+    }
+    cancellation.cancel();
+    while connections.join_next().await.is_some() {}
+    stats.running.store(false, Ordering::SeqCst);
+    let _ = remove_socket_if_present(&endpoint);
+}
+
+#[cfg(unix)]
+fn bind_listener() -> Result<(UnixListener, PathBuf), String> {
+    let endpoint = endpoint_path()?;
+    if let Ok(metadata) = std::fs::symlink_metadata(&endpoint) {
+        if metadata.file_type().is_symlink() || !metadata.file_type().is_socket() {
+            return Err(format!(
+                "Refusing to replace unexpected ACP endpoint {}",
+                endpoint.display()
+            ));
+        }
+        if std::os::unix::net::UnixStream::connect(&endpoint).is_ok() {
+            return Err("Another Maple ACP service is already listening".to_string());
+        }
+        std::fs::remove_file(&endpoint)
+            .map_err(|error| format!("Failed to remove stale ACP endpoint: {error}"))?;
+    }
+    let listener = UnixListener::bind(&endpoint)
+        .map_err(|error| format!("Failed to bind Maple ACP endpoint: {error}"))?;
+    std::fs::set_permissions(&endpoint, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| format!("Failed to secure Maple ACP endpoint: {error}"))?;
+    Ok((listener, endpoint))
+}
+
+fn endpoint_path() -> Result<PathBuf, String> {
+    let executable = stable_executable_path()?;
+    let digest = Sha256::digest(executable.to_string_lossy().as_bytes());
+    let suffix = digest[..8]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    Ok(endpoint_root()?.join(format!("maple-acp-{suffix}.sock")))
+}
+
+#[cfg(target_os = "linux")]
+fn endpoint_root() -> Result<PathBuf, String> {
+    let current_uid = std::fs::metadata("/proc/self")
+        .map_err(|error| format!("Failed to resolve the current Linux user: {error}"))?
+        .uid();
+    let root = std::env::var_os("XDG_RUNTIME_DIR")
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::temp_dir().join(format!("maple-acp-{current_uid}")));
+    match std::fs::symlink_metadata(&root) {
+        Ok(_) => {}
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            let mut builder = std::fs::DirBuilder::new();
+            builder.mode(0o700);
+            builder.create(&root).map_err(|error| {
+                format!("Failed to create the Maple ACP runtime directory: {error}")
+            })?;
+        }
+        Err(error) => {
+            return Err(format!(
+                "Failed to inspect the Maple ACP runtime directory: {error}"
+            ));
+        }
+    }
+    let metadata = std::fs::symlink_metadata(&root)
+        .map_err(|error| format!("Failed to inspect the Maple ACP runtime directory: {error}"))?;
+    if metadata.file_type().is_symlink()
+        || !metadata.file_type().is_dir()
+        || metadata.uid() != current_uid
+    {
+        return Err("Maple ACP runtime directory is not owned by the current user".to_string());
+    }
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("Failed to secure the Maple ACP runtime directory: {error}"))?;
+    Ok(root)
+}
+
+#[cfg(not(target_os = "linux"))]
+fn endpoint_root() -> Result<PathBuf, String> {
+    Ok(std::env::temp_dir())
+}
+
+fn stable_executable_path() -> Result<PathBuf, String> {
+    #[cfg(target_os = "linux")]
+    if let Some(appimage) = std::env::var_os("APPIMAGE") {
+        return Ok(PathBuf::from(appimage));
+    }
+    let executable = std::env::current_exe()
+        .map_err(|error| format!("Failed to find the Maple executable: {error}"))?;
+    Ok(executable.canonicalize().unwrap_or(executable))
+}
+
+fn harness() -> Result<AgentAcpHarness, String> {
+    Ok(AgentAcpHarness {
+        command: stable_executable_path()?.to_string_lossy().into_owned(),
+        args: vec!["acp".to_string()],
+    })
+}
+
+fn config_path(app_handle: &AppHandle, user_id: &str) -> Result<PathBuf, String> {
+    if user_id.trim().is_empty() {
+        return Err("Maple ACP configuration requires an authenticated user".to_string());
+    }
+    let digest = Sha256::digest(user_id.as_bytes());
+    let scope = digest[..16]
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let root = app_handle
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("Failed to resolve Maple local data: {error}"))?;
+    Ok(root
+        .join("acp")
+        .join("accounts")
+        .join(scope)
+        .join("config.json"))
+}
+
+fn load_config(app_handle: &AppHandle, user_id: &str) -> Result<AgentAcpConfig, String> {
+    let path = config_path(app_handle, user_id)?;
+    match std::fs::read(&path) {
+        Ok(bytes) => serde_json::from_slice(&bytes)
+            .map_err(|error| format!("Failed to parse Maple ACP configuration: {error}"))
+            .and_then(normalize_config),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(AgentAcpConfig::default()),
+        Err(error) => Err(format!("Failed to read Maple ACP configuration: {error}")),
+    }
+}
+
+fn save_config(
+    app_handle: &AppHandle,
+    user_id: &str,
+    config: &AgentAcpConfig,
+) -> Result<(), String> {
+    let path = config_path(app_handle, user_id)?;
+    let parent = path
+        .parent()
+        .ok_or_else(|| "Invalid Maple ACP configuration path".to_string())?;
+    std::fs::create_dir_all(parent)
+        .map_err(|error| format!("Failed to create Maple ACP configuration directory: {error}"))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(parent, std::fs::Permissions::from_mode(0o700))
+        .map_err(|error| format!("Failed to secure Maple ACP configuration directory: {error}"))?;
+    let bytes = serde_json::to_vec_pretty(config)
+        .map_err(|error| format!("Failed to encode Maple ACP configuration: {error}"))?;
+    std::fs::write(&path, bytes)
+        .map_err(|error| format!("Failed to save Maple ACP configuration: {error}"))?;
+    #[cfg(unix)]
+    std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))
+        .map_err(|error| format!("Failed to secure Maple ACP configuration: {error}"))?;
+    Ok(())
+}
+
+pub(crate) fn clear_agent_acp_config(app_handle: &AppHandle, user_id: &str) -> Result<(), String> {
+    let path = config_path(app_handle, user_id)?;
+    let account_dir = path
+        .parent()
+        .ok_or_else(|| "Invalid Maple ACP configuration path".to_string())?;
+    match std::fs::remove_dir_all(account_dir) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("Failed to clear Maple ACP configuration: {error}")),
+    }
+}
+
+fn normalize_config(mut config: AgentAcpConfig) -> Result<AgentAcpConfig, String> {
+    config.max_connections = config.max_connections.clamp(1, MAX_ACP_CONNECTIONS);
+    let mut roots = Vec::new();
+    for root in config.allowed_project_roots {
+        let root = root.trim();
+        if root.is_empty() {
+            continue;
+        }
+        let path = PathBuf::from(root);
+        if !path.is_absolute() {
+            return Err("ACP allowed project roots must be absolute paths".to_string());
+        }
+        let root = path.to_string_lossy().into_owned();
+        if !roots.contains(&root) {
+            roots.push(root);
+        }
+    }
+    config.allowed_project_roots = roots;
+    Ok(config)
+}
+
+fn ensure_allowed_project_root(cwd: &Path, allowed_roots: &[String]) -> Result<(), String> {
+    if allowed_roots.is_empty() {
+        return Ok(());
+    }
+    let cwd = cwd
+        .canonicalize()
+        .map_err(|error| format!("Failed to resolve ACP session cwd: {error}"))?;
+    for root in allowed_roots {
+        if let Ok(root) = Path::new(root).canonicalize() {
+            if cwd.starts_with(root) {
+                return Ok(());
+            }
+        }
+    }
+    Err("ACP session cwd is outside the configured project roots".to_string())
+}
+
+fn merge_mcp_environment(
+    environment: &mut HashMap<String, String>,
+    servers: &[McpServer],
+) -> Result<(), agent_client_protocol::Error> {
+    for server in servers {
+        let McpServer::Stdio(server) = server else {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Maple ACP currently supports only stdio MCP session definitions"));
+        };
+        let command = Path::new(&server.command);
+        let is_buzz_dev_mcp = server.name == "buzz-dev-mcp"
+            && command
+                .file_name()
+                .and_then(|name| name.to_str())
+                .is_some_and(|name| name == "buzz-dev-mcp" || name == "buzz-dev-mcp.exe")
+            && server.args.is_empty();
+        if !is_buzz_dev_mcp || !command.is_absolute() {
+            return Err(agent_client_protocol::Error::invalid_params().data(
+                "Maple ACP currently adapts only Buzz's absolute buzz-dev-mcp stdio definition",
+            ));
+        }
+        let metadata = std::fs::metadata(command).map_err(|_| {
+            agent_client_protocol::Error::invalid_params()
+                .data("Buzz buzz-dev-mcp command does not exist")
+        })?;
+        if !metadata.is_file() {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Buzz buzz-dev-mcp command is not a file"));
+        }
+        #[cfg(unix)]
+        if metadata.permissions().mode() & 0o111 == 0 {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Buzz buzz-dev-mcp command is not executable"));
+        }
+        // Maple already exposes a tightly controlled shell tool. For Buzz's
+        // dev MCP, adapt the exact child environment into that per-session
+        // shell rather than launching a second general-purpose shell server.
+        for variable in &server.env {
+            if !ALLOWED_BRIDGE_ENV.contains(&variable.name.as_str()) {
+                continue;
+            }
+            if let Some(existing) = environment.get(&variable.name) {
+                if existing != &variable.value {
+                    return Err(agent_client_protocol::Error::invalid_params().data(format!(
+                        "Conflicting ACP environment value for {}",
+                        variable.name
+                    )));
+                }
+            } else {
+                environment.insert(variable.name.clone(), variable.value.clone());
+            }
+        }
+    }
+    Ok(())
+}
+
+fn filter_bridge_environment(environment: HashMap<String, String>) -> HashMap<String, String> {
+    environment
+        .into_iter()
+        .filter(|(key, value)| {
+            ALLOWED_BRIDGE_ENV.contains(&key.as_str())
+                && !value.contains('\0')
+                && value.len() <= 16 * 1024
+        })
+        .collect()
+}
+
+fn has_buzz_credentials(environment: &HashMap<String, String>) -> bool {
+    environment
+        .get("BUZZ_RELAY_URL")
+        .is_some_and(|value| !value.is_empty())
+        && environment
+            .get("BUZZ_PRIVATE_KEY")
+            .is_some_and(|value| !value.is_empty())
+}
+
+fn prompt_text(blocks: &[ContentBlock]) -> Result<String, agent_client_protocol::Error> {
+    let text = blocks
+        .iter()
+        .filter_map(|block| match block {
+            ContentBlock::Text(text) => Some(text.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+    if text.trim().is_empty() {
+        return Err(agent_client_protocol::Error::invalid_params()
+            .data("Maple ACP requires at least one text prompt block"));
+    }
+    Ok(text)
+}
+
+fn timeline_update(event: &AgentEventEnvelope) -> Option<SessionUpdate> {
+    let item = event.item.as_ref()?;
+    let text = item.text.as_deref()?.to_string();
+    match item.item_type.as_str() {
+        "message" if item.role.as_deref() == Some("assistant") => {
+            Some(SessionUpdate::AgentMessageChunk(ContentChunk::new(
+                ContentBlock::Text(TextContent::new(text)),
+            )))
+        }
+        "thinking" => Some(SessionUpdate::AgentThoughtChunk(ContentChunk::new(
+            ContentBlock::Text(TextContent::new(text)),
+        ))),
+        _ => None,
+    }
+}
+
+fn event_error_text(event: &AgentEventEnvelope) -> Option<String> {
+    event
+        .message
+        .clone()
+        .or_else(|| event.item.as_ref().and_then(|item| item.text.clone()))
+        .map(|message| bounded_error(&message))
+}
+
+fn prompt_result_from_terminal(
+    terminal: AgentRunTerminal,
+) -> Result<PromptResponse, agent_client_protocol::Error> {
+    match terminal {
+        AgentRunTerminal::Completed => Ok(PromptResponse::new(StopReason::EndTurn)),
+        AgentRunTerminal::Cancelled => Ok(PromptResponse::new(StopReason::Cancelled)),
+        AgentRunTerminal::Failed => {
+            Err(agent_client_protocol::Error::internal_error().data("Maple Agent prompt failed"))
+        }
+    }
+}
+
+fn internal_acp_error(error: String) -> agent_client_protocol::Error {
+    agent_client_protocol::Error::internal_error().data(bounded_error(&error))
+}
+
+fn bounded_error(error: &str) -> String {
+    error.chars().take(MAX_ACP_ERROR_CHARS).collect()
+}
+
+fn remove_socket_if_present(path: &Path) -> Result<(), String> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(error) => Err(format!("Failed to remove Maple ACP endpoint: {error}")),
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn verify_connector_endpoint(path: &Path) -> Result<(), String> {
+    let current_uid = std::fs::metadata("/proc/self")
+        .map_err(|error| format!("Failed to resolve the current Linux user: {error}"))?
+        .uid();
+    let metadata = std::fs::symlink_metadata(path)
+        .map_err(|error| format!("Maple Desktop ACP service is unavailable: {error}"))?;
+    if metadata.file_type().is_symlink()
+        || !metadata.file_type().is_socket()
+        || metadata.uid() != current_uid
+        || metadata.permissions().mode() & 0o077 != 0
+    {
+        return Err("Refusing an insecure Maple ACP endpoint".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "linux"))]
+fn verify_connector_endpoint(_path: &Path) -> Result<(), String> {
+    Ok(())
+}
+
+pub fn run_acp_connector() -> Result<(), String> {
+    #[cfg(unix)]
+    {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| format!("Failed to start Maple ACP connector: {error}"))?;
+        runtime.block_on(run_acp_connector_async())
+    }
+    #[cfg(not(unix))]
+    Err("Maple ACP local IPC is not yet supported on this platform".to_string())
+}
+
+#[cfg(unix)]
+async fn run_acp_connector_async() -> Result<(), String> {
+    use tokio::io::{copy, AsyncWriteExt as _};
+
+    let endpoint = endpoint_path()?;
+    verify_connector_endpoint(&endpoint)?;
+    let stream = UnixStream::connect(&endpoint).await.map_err(|error| {
+        format!(
+            "Maple Desktop ACP service is unavailable at {}: {error}",
+            endpoint.display()
+        )
+    })?;
+    let (mut socket_read, mut socket_write) = stream.into_split();
+    let environment = ALLOWED_BRIDGE_ENV
+        .iter()
+        .filter_map(|key| {
+            std::env::var(key)
+                .ok()
+                .map(|value| ((*key).to_string(), value))
+        })
+        .collect::<HashMap<_, _>>();
+    let hello = serde_json::json!({
+        "jsonrpc": "2.0",
+        "method": BRIDGE_HELLO_METHOD,
+        "params": { "environment": environment }
+    });
+    let mut hello = serde_json::to_vec(&hello)
+        .map_err(|error| format!("Failed to encode Maple ACP bridge hello: {error}"))?;
+    hello.push(b'\n');
+    socket_write
+        .write_all(&hello)
+        .await
+        .map_err(|error| format!("Failed to initialize Maple ACP bridge: {error}"))?;
+    socket_write
+        .flush()
+        .await
+        .map_err(|error| format!("Failed to flush Maple ACP bridge: {error}"))?;
+
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = tokio::io::stdout();
+    let outbound = async {
+        copy(&mut stdin, &mut socket_write).await?;
+        socket_write.shutdown().await
+    };
+    let inbound = async {
+        copy(&mut socket_read, &mut stdout).await?;
+        stdout.flush().await
+    };
+    tokio::pin!(outbound);
+    tokio::pin!(inbound);
+    tokio::select! {
+        result = &mut inbound => {
+            // The desktop service closing the socket must terminate the
+            // Buzz-owned connector even while its stdin remains open.
+            result.map_err(|error| format!("Maple ACP bridge failed: {error}"))?;
+        }
+        result = &mut outbound => {
+            // When Buzz closes stdin, preserve the half-close behavior and
+            // keep relaying any final ACP response until Maple closes output.
+            result.map_err(|error| format!("Maple ACP bridge failed: {error}"))?;
+            inbound
+                .await
+                .map_err(|error| format!("Maple ACP bridge failed: {error}"))?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_disabled_and_read_only() {
+        let config = AgentAcpConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.permission_mode, AgentAcpPermissionMode::ReadOnly);
+        assert_eq!(config.max_connections, 1);
+    }
+
+    #[test]
+    fn bridge_environment_is_strictly_allowlisted() {
+        let filtered = filter_bridge_environment(HashMap::from([
+            (
+                "BUZZ_RELAY_URL".to_string(),
+                "ws://localhost:3000".to_string(),
+            ),
+            ("UNRELATED_SECRET".to_string(), "nope".to_string()),
+        ]));
+        assert_eq!(filtered.len(), 1);
+        assert!(filtered.contains_key("BUZZ_RELAY_URL"));
+    }
+
+    #[test]
+    fn prompt_blocks_preserve_buzz_order() {
+        let blocks = vec![
+            ContentBlock::Text(TextContent::new("[Base]\nbase")),
+            ContentBlock::Text(TextContent::new("[System]\nsystem")),
+        ];
+        assert_eq!(
+            prompt_text(&blocks).unwrap(),
+            "[Base]\nbase\n\n[System]\nsystem"
+        );
+    }
+
+    #[test]
+    fn retained_terminal_results_preserve_all_stop_states() {
+        let completed = prompt_result_from_terminal(AgentRunTerminal::Completed).unwrap();
+        assert_eq!(
+            serde_json::to_value(completed).unwrap()["stopReason"],
+            "end_turn"
+        );
+
+        let cancelled = prompt_result_from_terminal(AgentRunTerminal::Cancelled).unwrap();
+        assert_eq!(
+            serde_json::to_value(cancelled).unwrap()["stopReason"],
+            "cancelled"
+        );
+
+        assert!(prompt_result_from_terminal(AgentRunTerminal::Failed).is_err());
+    }
+}

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -1,8 +1,9 @@
 use crate::agent::{
     AgentCreateSessionRequest, AgentHostEventPolicy, AgentPermissionDecision,
-    AgentPermissionRequest, AgentRunEvent, AgentRunPermissionResponder, AgentRunTerminal,
-    AgentRuntimeHandle, AgentSendMessageRequest, AgentTimelineItem, AgentToolContextLease,
-    AgentToolContextSpec, MapleAgentService, AGENT_TOOL_CONTEXT_INACTIVE_ERROR,
+    AgentPermissionRequest, AgentRunCancellation, AgentRunEvent, AgentRunPermissionResponder,
+    AgentRunTerminal, AgentRuntimeHandle, AgentSendMessageRequest, AgentTimelineItem,
+    AgentToolContextLease, AgentToolContextSpec, MapleAgentService,
+    AGENT_TOOL_CONTEXT_INACTIVE_ERROR,
 };
 use crate::agent_host::AgentHostLifecycle;
 use crate::maple_api::{account_scope, MapleApiAuthState};
@@ -283,8 +284,8 @@ enum AcpPromptState {
         cancellation: CancellationToken,
     },
     Running {
-        run_id: String,
         cancellation: CancellationToken,
+        run_cancellation: Box<AgentRunCancellation>,
     },
 }
 
@@ -713,12 +714,18 @@ impl AcpConnectionContext {
                 return Err(internal_acp_error(error));
             }
         };
-        let run_id = run.run_id;
         let mut events = run.events;
         let mut terminal = run.terminal;
         let event_overflowed = run.event_overflowed;
+        let Some(run_cancellation) = run.cancellation else {
+            prompt_lifetime.cancel();
+            self.prompt_states.lock().await.remove(&session_id);
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("Maple did not create an ACP cancellation capability for this run"));
+        };
         let Some(permission_responder) = run.permission_responder else {
-            let _ = self.agent.cancel_run(run_id).await;
+            prompt_lifetime.cancel();
+            let _ = run_cancellation.cancel().await;
             self.prompt_states.lock().await.remove(&session_id);
             return Err(agent_client_protocol::Error::internal_error()
                 .data("Maple did not create an ACP permission responder for this run"));
@@ -728,8 +735,8 @@ impl AcpConnectionContext {
             match states.get_mut(&session_id) {
                 Some(state @ AcpPromptState::Starting { .. }) => {
                     *state = AcpPromptState::Running {
-                        run_id: run_id.clone(),
                         cancellation: prompt_lifetime.clone(),
+                        run_cancellation: Box::new(run_cancellation.clone()),
                     };
                     true
                 }
@@ -737,7 +744,7 @@ impl AcpConnectionContext {
             }
         };
         if !prompt_registered {
-            let _ = self.agent.cancel_run(run_id.clone()).await;
+            let _ = run_cancellation.cancel().await;
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection closed while starting the prompt"));
         }
@@ -745,14 +752,14 @@ impl AcpConnectionContext {
         if prompt_lifetime.is_cancelled() {
             // A cancellation failure does not make the active Maple run
             // disappear. Keep listening so its lifecycle remains tracked.
-            let _ = self.agent.cancel_run(run_id.clone()).await;
+            let _ = run_cancellation.cancel().await;
         }
 
         let mut cancel_after_result = false;
         let result = loop {
             if event_overflowed.load(Ordering::Acquire) {
                 cancel_after_result = true;
-                let _ = self.agent.cancel_run(run_id.clone()).await;
+                let _ = run_cancellation.cancel().await;
                 match self
                     .send_final_agent_message(
                         cx,
@@ -774,7 +781,7 @@ impl AcpConnectionContext {
             let event = events.recv().await;
             if event_overflowed.load(Ordering::Acquire) {
                 cancel_after_result = true;
-                let _ = self.agent.cancel_run(run_id.clone()).await;
+                let _ = run_cancellation.cancel().await;
                 match self
                     .send_final_agent_message(
                         cx,
@@ -807,7 +814,7 @@ impl AcpConnectionContext {
                             Ok(()) => {}
                             Err(AcpOutboundSendError::UpdateTooLarge) => {
                                 cancel_after_result = true;
-                                let _ = self.agent.cancel_run(run_id.clone()).await;
+                                let _ = run_cancellation.cancel().await;
                                 match self.send_final_agent_message(
                                     cx,
                                     request.session_id.clone(),
@@ -855,7 +862,7 @@ impl AcpConnectionContext {
                         }
                         Err(AcpOutboundSendError::UpdateTooLarge) => {
                             cancel_after_result = true;
-                            let _ = self.agent.cancel_run(run_id.clone()).await;
+                            let _ = run_cancellation.cancel().await;
                             match self
                                 .send_final_agent_message(
                                     cx,
@@ -899,7 +906,7 @@ impl AcpConnectionContext {
                             Ok(()) => {}
                             Err(AcpOutboundSendError::UpdateTooLarge) => {
                                 cancel_after_result = true;
-                                let _ = self.agent.cancel_run(run_id.clone()).await;
+                                let _ = run_cancellation.cancel().await;
                                 match self.send_final_agent_message(
                                     cx,
                                     request.session_id.clone(),
@@ -956,7 +963,7 @@ impl AcpConnectionContext {
             // Synthetic stream stops settle only after the underlying run has
             // drained, or retain a same-session fence while it finishes in the
             // background. A completed run makes this cancellation a no-op.
-            let _ = self.agent.cancel_run(run_id.clone()).await;
+            let _ = run_cancellation.cancel().await;
             if tokio::time::timeout(
                 ACP_SYNTHETIC_STOP_DRAIN_TIMEOUT,
                 wait_for_retained_terminal(&mut terminal),
@@ -987,7 +994,7 @@ impl AcpConnectionContext {
                 });
             }
         } else if result.is_err() {
-            let _ = self.agent.cancel_run(run_id).await;
+            let _ = run_cancellation.cancel().await;
         }
         if !deferred_prompt_cleanup
             && matches!(
@@ -1005,16 +1012,16 @@ impl AcpConnectionContext {
         notification: CancelNotification,
     ) -> Result<(), agent_client_protocol::Error> {
         let session_id = notification.session_id.0.to_string();
-        let (cancellation, run_id) = {
+        let (cancellation, run_cancellation) = {
             let states = self.prompt_states.lock().await;
             match states.get(&session_id) {
                 Some(AcpPromptState::Starting { cancellation }) => {
                     (Some(cancellation.clone()), None)
                 }
                 Some(AcpPromptState::Running {
-                    run_id,
                     cancellation,
-                }) => (Some(cancellation.clone()), Some(run_id.clone())),
+                    run_cancellation,
+                }) => (Some(cancellation.clone()), Some(run_cancellation.clone())),
                 None => (None, None),
             }
         };
@@ -1023,9 +1030,9 @@ impl AcpConnectionContext {
             // the worker start once core setup completes.
             cancellation.cancel();
         }
-        if let Some(run_id) = run_id {
-            self.agent
-                .cancel_run(run_id)
+        if let Some(run_cancellation) = run_cancellation {
+            run_cancellation
+                .cancel()
                 .await
                 .map_err(internal_acp_error)?;
         }
@@ -1049,16 +1056,16 @@ impl AcpConnectionContext {
             }
         }
         let prompt_states = std::mem::take(&mut *self.prompt_states.lock().await);
-        let mut running_ids = Vec::new();
+        let mut running_cancellations = Vec::new();
         for state in prompt_states.into_values() {
             match state {
                 AcpPromptState::Starting { cancellation } => cancellation.cancel(),
                 AcpPromptState::Running {
-                    run_id,
                     cancellation,
+                    run_cancellation,
                 } => {
                     cancellation.cancel();
-                    running_ids.push(run_id);
+                    running_cancellations.push(run_cancellation);
                     self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
                 }
             }
@@ -1075,10 +1082,9 @@ impl AcpConnectionContext {
             .active_sessions
             .fetch_sub(session_count, Ordering::SeqCst);
         let mut tasks = self.background_tasks.lock().await;
-        for run_id in running_ids {
-            let agent = self.agent.clone();
+        for run_cancellation in running_cancellations {
             tasks.spawn(async move {
-                let _ = agent.cancel_run(run_id).await;
+                let _ = run_cancellation.cancel().await;
             });
         }
         for lease in sessions.into_values() {

--- a/frontend/src-tauri/src/agent_host.rs
+++ b/frontend/src-tauri/src/agent_host.rs
@@ -3,6 +3,7 @@ use crate::agent::{
     MapleAgentHostResources, MapleAgentService,
 };
 use crate::maple_api::MapleApiSession;
+use serde::Serialize;
 use std::sync::Arc;
 use tauri::{AppHandle, Manager};
 use tokio::sync::{Mutex, MutexGuard};
@@ -15,6 +16,18 @@ use tokio::sync::{Mutex, MutexGuard};
 /// between the two phases and retain a stale runtime handle.
 pub(crate) struct AgentHostLifecycle {
     gate: Mutex<()>,
+}
+
+/// Result of a runtime mutation that also had to clean up the ACP edge.
+///
+/// Runtime success is authoritative even when ACP cleanup reports an error.
+/// Keeping both facts lets Desktop resynchronize its runtime state while
+/// security-sensitive callers can still fail closed on the ACP warning.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentRuntimeLifecycleOutcome {
+    pub status: AgentRuntimeStatus,
+    pub acp_shutdown_error: Option<String>,
 }
 
 impl AgentHostLifecycle {
@@ -44,11 +57,13 @@ impl AgentHostLifecycle {
         app_handle: &AppHandle,
         user_id: &str,
         handle: &AgentRuntimeHandle,
-    ) -> Result<AgentRuntimeStatus, String> {
+    ) -> Result<AgentRuntimeLifecycleOutcome, String> {
         let _guard = self.lock().await;
         handle.verify_generation().await?;
-        crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await?;
-        handle.stop().await
+        let acp_result =
+            crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await;
+        let runtime_result = handle.stop().await;
+        combine_runtime_lifecycle_results(acp_result, runtime_result, "stop")
     }
 
     pub(crate) async fn restart_runtime(
@@ -58,11 +73,13 @@ impl AgentHostLifecycle {
         handle: &AgentRuntimeHandle,
         api_session: Arc<MapleApiSession>,
         request: Option<AgentStartRequest>,
-    ) -> Result<AgentRuntimeStatus, String> {
+    ) -> Result<AgentRuntimeLifecycleOutcome, String> {
         let _guard = self.lock().await;
         handle.verify_generation().await?;
-        crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await?;
-        handle.restart(api_session, request).await
+        let acp_result =
+            crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await;
+        let runtime_result = handle.restart(api_session, request).await;
+        combine_runtime_lifecycle_results(acp_result, runtime_result, "restart")
     }
 
     pub(crate) async fn clear_user_data(
@@ -100,14 +117,7 @@ impl AgentHostLifecycle {
         service.begin_draining();
         let acp_result = crate::agent_acp::shutdown_agent_acp_locked(app_handle, None).await;
         let runtime_result = service.shutdown_all().await;
-        let result = match (acp_result, runtime_result) {
-            (Ok(()), Ok(())) => Ok(()),
-            (Err(acp), Ok(())) => Err(acp),
-            (Ok(()), Err(runtime)) => Err(runtime),
-            (Err(acp), Err(runtime)) => Err(format!(
-                "Failed to stop ACP ({acp}); failed to stop Agent Mode ({runtime})"
-            )),
-        };
+        let result = combine_surface_results(acp_result, runtime_result, "stop");
         if reopen_on_error && result.is_err() {
             service.reopen_after_failed_shutdown();
         }
@@ -120,6 +130,38 @@ impl AgentHostLifecycle {
 
     pub(crate) async fn shutdown_for_update(&self, app_handle: &AppHandle) -> Result<(), String> {
         self.shutdown_services(app_handle, true).await
+    }
+}
+
+fn combine_surface_results<T>(
+    acp_result: Result<(), String>,
+    runtime_result: Result<T, String>,
+    runtime_action: &str,
+) -> Result<T, String> {
+    match (acp_result, runtime_result) {
+        (Ok(()), Ok(runtime)) => Ok(runtime),
+        (Err(acp), Ok(_)) => Err(acp),
+        (Ok(()), Err(runtime)) => Err(runtime),
+        (Err(acp), Err(runtime)) => Err(format!(
+            "Failed to stop ACP ({acp}); failed to {runtime_action} Agent Mode ({runtime})"
+        )),
+    }
+}
+
+fn combine_runtime_lifecycle_results(
+    acp_result: Result<(), String>,
+    runtime_result: Result<AgentRuntimeStatus, String>,
+    runtime_action: &str,
+) -> Result<AgentRuntimeLifecycleOutcome, String> {
+    match (acp_result, runtime_result) {
+        (acp_result, Ok(status)) => Ok(AgentRuntimeLifecycleOutcome {
+            status,
+            acp_shutdown_error: acp_result.err(),
+        }),
+        (Ok(()), Err(runtime)) => Err(runtime),
+        (Err(acp), Err(runtime)) => Err(format!(
+            "Failed to stop ACP ({acp}); failed to {runtime_action} Agent Mode ({runtime})"
+        )),
     }
 }
 
@@ -144,4 +186,103 @@ pub(crate) fn build_service(app_handle: &AppHandle) -> Result<MapleAgentService,
         event_sink,
         default_tool_context,
     )))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        combine_runtime_lifecycle_results, combine_surface_results, AgentRuntimeLifecycleOutcome,
+    };
+    use crate::agent::AgentRuntimeStatus;
+    use std::collections::HashMap;
+
+    fn runtime_status(running: bool) -> AgentRuntimeStatus {
+        AgentRuntimeStatus {
+            running,
+            project_root: None,
+            model: None,
+            mode: None,
+            active_runs: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn surface_results_return_the_runtime_value_when_both_succeed() {
+        assert_eq!(
+            combine_surface_results(Ok(()), Ok("runtime status"), "restart"),
+            Ok("runtime status")
+        );
+    }
+
+    #[test]
+    fn surface_results_preserve_a_single_error() {
+        assert_eq!(
+            combine_surface_results::<()>(Err("acp error".into()), Ok(()), "stop"),
+            Err("acp error".into())
+        );
+        assert_eq!(
+            combine_surface_results::<()>(Ok(()), Err("runtime error".into()), "stop"),
+            Err("runtime error".into())
+        );
+    }
+
+    #[test]
+    fn surface_results_report_both_errors_and_the_runtime_action() {
+        assert_eq!(
+            combine_surface_results::<()>(
+                Err("acp error".into()),
+                Err("runtime error".into()),
+                "restart",
+            ),
+            Err(
+                "Failed to stop ACP (acp error); failed to restart Agent Mode (runtime error)"
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn runtime_lifecycle_reports_acp_partial_failure_with_runtime_status() {
+        let status = runtime_status(true);
+        let outcome = combine_runtime_lifecycle_results(
+            Err("acp error".into()),
+            Ok(status.clone()),
+            "restart",
+        )
+        .expect("runtime success should remain observable");
+
+        assert_eq!(outcome.status.running, status.running);
+        assert_eq!(outcome.acp_shutdown_error.as_deref(), Some("acp error"));
+    }
+
+    #[test]
+    fn runtime_lifecycle_reports_runtime_failures_strictly() {
+        assert_eq!(
+            combine_runtime_lifecycle_results(Ok(()), Err("runtime error".into()), "stop"),
+            Err("runtime error".into())
+        );
+        assert_eq!(
+            combine_runtime_lifecycle_results(
+                Err("acp error".into()),
+                Err("runtime error".into()),
+                "restart",
+            ),
+            Err(
+                "Failed to stop ACP (acp error); failed to restart Agent Mode (runtime error)"
+                    .into()
+            )
+        );
+    }
+
+    #[test]
+    fn runtime_lifecycle_success_has_no_cleanup_warning() {
+        let AgentRuntimeLifecycleOutcome {
+            status,
+            acp_shutdown_error,
+        } = combine_runtime_lifecycle_results(Ok(()), Ok(runtime_status(false)), "stop")
+            .expect("both surfaces should succeed");
+
+        assert!(!status.running);
+        assert!(acp_shutdown_error.is_none());
+    }
 }

--- a/frontend/src-tauri/src/agent_host.rs
+++ b/frontend/src-tauri/src/agent_host.rs
@@ -1,0 +1,147 @@
+use crate::agent::{
+    AgentPathLayout, AgentRuntimeHandle, AgentRuntimeStatus, AgentStartRequest,
+    MapleAgentHostResources, MapleAgentService,
+};
+use crate::maple_api::MapleApiSession;
+use std::sync::Arc;
+use tauri::{AppHandle, Manager};
+use tokio::sync::{Mutex, MutexGuard};
+
+/// Serializes operations that span both Agent surfaces.
+///
+/// Maple's core runtime has its own internal lifecycle lock, while ACP also
+/// owns listener and connection state. Composite host operations such as
+/// stop, restart, clear, and app exit must cover both or an ACP start can slip
+/// between the two phases and retain a stale runtime handle.
+pub(crate) struct AgentHostLifecycle {
+    gate: Mutex<()>,
+}
+
+impl AgentHostLifecycle {
+    pub(crate) fn new() -> Self {
+        Self {
+            gate: Mutex::new(()),
+        }
+    }
+
+    pub(crate) async fn lock(&self) -> MutexGuard<'_, ()> {
+        self.gate.lock().await
+    }
+
+    pub(crate) async fn start_runtime(
+        &self,
+        handle: &AgentRuntimeHandle,
+        api_session: Arc<MapleApiSession>,
+        request: Option<AgentStartRequest>,
+    ) -> Result<AgentRuntimeStatus, String> {
+        let _guard = self.lock().await;
+        handle.verify_generation().await?;
+        handle.start(api_session, request).await
+    }
+
+    pub(crate) async fn stop_runtime(
+        &self,
+        app_handle: &AppHandle,
+        user_id: &str,
+        handle: &AgentRuntimeHandle,
+    ) -> Result<AgentRuntimeStatus, String> {
+        let _guard = self.lock().await;
+        handle.verify_generation().await?;
+        crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await?;
+        handle.stop().await
+    }
+
+    pub(crate) async fn restart_runtime(
+        &self,
+        app_handle: &AppHandle,
+        user_id: &str,
+        handle: &AgentRuntimeHandle,
+        api_session: Arc<MapleApiSession>,
+        request: Option<AgentStartRequest>,
+    ) -> Result<AgentRuntimeStatus, String> {
+        let _guard = self.lock().await;
+        handle.verify_generation().await?;
+        crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await?;
+        handle.restart(api_session, request).await
+    }
+
+    pub(crate) async fn clear_user_data(
+        &self,
+        app_handle: &AppHandle,
+        user_id: &str,
+        handle: &AgentRuntimeHandle,
+    ) -> Result<(), String> {
+        let _guard = self.lock().await;
+        handle.verify_generation().await?;
+        crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await?;
+        handle.clear_data().await?;
+        crate::agent_acp::clear_agent_acp_config(app_handle, user_id)
+    }
+
+    pub(crate) async fn clear_user_history(
+        &self,
+        app_handle: &AppHandle,
+        user_id: &str,
+        handle: &AgentRuntimeHandle,
+    ) -> Result<(), String> {
+        let _guard = self.lock().await;
+        handle.verify_generation().await?;
+        crate::agent_acp::shutdown_agent_acp_locked(app_handle, Some(user_id)).await?;
+        handle.clear_history().await
+    }
+
+    async fn shutdown_services(
+        &self,
+        app_handle: &AppHandle,
+        reopen_on_error: bool,
+    ) -> Result<(), String> {
+        let _guard = self.lock().await;
+        let service = app_handle.state::<MapleAgentService>();
+        service.begin_draining();
+        let acp_result = crate::agent_acp::shutdown_agent_acp_locked(app_handle, None).await;
+        let runtime_result = service.shutdown_all().await;
+        let result = match (acp_result, runtime_result) {
+            (Ok(()), Ok(())) => Ok(()),
+            (Err(acp), Ok(())) => Err(acp),
+            (Ok(()), Err(runtime)) => Err(runtime),
+            (Err(acp), Err(runtime)) => Err(format!(
+                "Failed to stop ACP ({acp}); failed to stop Agent Mode ({runtime})"
+            )),
+        };
+        if reopen_on_error && result.is_err() {
+            service.reopen_after_failed_shutdown();
+        }
+        result
+    }
+
+    pub(crate) async fn shutdown_for_exit(&self, app_handle: &AppHandle) -> Result<(), String> {
+        self.shutdown_services(app_handle, false).await
+    }
+
+    pub(crate) async fn shutdown_for_update(&self, app_handle: &AppHandle) -> Result<(), String> {
+        self.shutdown_services(app_handle, true).await
+    }
+}
+
+/// Compose Maple's transport-neutral runtime with its two edge adapters.
+///
+/// Tauri owns Desktop event projection; ACP owns its transient environment
+/// policy. Neither adapter reaches through the other to operate the runtime.
+pub(crate) fn build_service(app_handle: &AppHandle) -> Result<MapleAgentService, String> {
+    let app_config_root = app_handle
+        .path()
+        .app_config_dir()
+        .map_err(|error| format!("Failed to resolve Maple config directory: {error}"))?;
+    let app_local_data_root = app_handle
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("Failed to resolve Maple local data directory: {error}"))?;
+    let paths = AgentPathLayout::from_app_roots(app_config_root, app_local_data_root);
+    let event_sink = crate::agent_tauri::event_sink(app_handle);
+    let default_tool_context = crate::agent_acp::default_tool_context_spec()?;
+    Ok(MapleAgentService::new(MapleAgentHostResources::new(
+        paths,
+        event_sink,
+        default_tool_context,
+    )))
+}

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -7,7 +7,7 @@ use crate::agent::{
     AgentSetSessionMcpServerRequest, AgentStartRequest, AgentTimelineItem, MapleAgentService,
     RecentProjectRoot,
 };
-use crate::agent_host::AgentHostLifecycle;
+use crate::agent_host::{AgentHostLifecycle, AgentRuntimeLifecycleOutcome};
 use crate::maple_api::MapleApiAuthState;
 use serde::Serialize;
 use std::sync::Arc;
@@ -187,7 +187,7 @@ pub async fn agent_stop_runtime(
     state: State<'_, MapleAgentService>,
     host_lifecycle: State<'_, AgentHostLifecycle>,
     user_id: String,
-) -> Result<AgentRuntimeStatus, String> {
+) -> Result<AgentRuntimeLifecycleOutcome, String> {
     let handle = handle_for_user(&state, &user_id).await?;
     host_lifecycle
         .stop_runtime(&app_handle, &user_id, &handle)
@@ -202,7 +202,7 @@ pub async fn agent_restart_runtime(
     host_lifecycle: State<'_, AgentHostLifecycle>,
     user_id: String,
     request: Option<AgentStartRequest>,
-) -> Result<AgentRuntimeStatus, String> {
+) -> Result<AgentRuntimeLifecycleOutcome, String> {
     let handle = handle_for_user(&state, &user_id).await?;
     let api_session = api_auth_state.session_for(&user_id).await?;
     host_lifecycle
@@ -481,7 +481,7 @@ pub async fn agent_cancel_run(
     let _ = app_handle;
     handle_for_user(&state, &user_id)
         .await?
-        .cancel_run(run_id)
+        .cancel_desktop_run(run_id)
         .await
 }
 

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -90,6 +90,13 @@ pub(crate) fn project_agent_event(event: &AgentServiceEvent) -> AgentEventEnvelo
                     envelope.event_type = "timelineItem".to_string();
                     envelope.item = Some(item.clone());
                 }
+                AgentRunEvent::PermissionRequested { item, .. } => {
+                    // Keep the Desktop wire contract unchanged while the shared
+                    // service exposes a typed permission request to non-Tauri
+                    // callers through the run-local event stream.
+                    envelope.event_type = "timelineItem".to_string();
+                    envelope.item = Some(item.clone());
+                }
                 AgentRunEvent::SetupWarning(message) => {
                     envelope.event_type = "error".to_string();
                     // Preserve the existing Desktop contract. Setup warnings
@@ -667,5 +674,42 @@ mod tests {
         assert_eq!(warning.session_id, None);
         assert_eq!(warning.run_id.as_deref(), Some("run-1"));
         assert_eq!(warning.message.as_deref(), Some("setup warning"));
+    }
+
+    #[test]
+    fn typed_permission_requests_keep_the_existing_desktop_timeline_shape() {
+        let item = AgentTimelineItem {
+            id: "permission-request-1".to_string(),
+            item_type: "permission".to_string(),
+            role: Some("system".to_string()),
+            title: Some("Run shell command".to_string()),
+            text: Some("Run this command?".to_string()),
+            status: Some("pending".to_string()),
+            input: Some(json!({ "command": "git status --short" })),
+            output: None,
+            created_ms: 4,
+            merge: "replace".to_string(),
+        };
+        let projected = project_agent_event(&AgentServiceEvent::Run {
+            session_id: "session-1".to_string(),
+            run_id: "run-1".to_string(),
+            event: AgentRunEvent::PermissionRequested {
+                request: crate::agent::AgentPermissionRequest {
+                    request_id: "request-1".to_string(),
+                    tool_name: "shell".to_string(),
+                    arguments: serde_json::Map::from_iter([(
+                        "command".to_string(),
+                        json!("git status --short"),
+                    )]),
+                    prompt: Some("Run this command?".to_string()),
+                },
+                item: item.clone(),
+            },
+        });
+
+        assert_eq!(projected.event_type, "timelineItem");
+        assert_eq!(projected.session_id.as_deref(), Some("session-1"));
+        assert_eq!(projected.run_id.as_deref(), Some("run-1"));
+        assert_eq!(projected.item, Some(item));
     }
 }

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -1,0 +1,36 @@
+use crate::agent::{
+    AgentEventEnvelope, AgentEventSink, AgentPathLayout, MapleAgentHostResources,
+    MapleAgentService, AGENT_EVENT_NAME,
+};
+use std::sync::Arc;
+use tauri::{AppHandle, Emitter, Manager};
+
+struct TauriAgentEventSink {
+    app_handle: AppHandle,
+}
+
+impl AgentEventSink for TauriAgentEventSink {
+    fn emit(&self, event: &AgentEventEnvelope) {
+        if let Err(error) = self.app_handle.emit(AGENT_EVENT_NAME, event) {
+            log::warn!("Failed to emit Agent Mode event: {error}");
+        }
+    }
+}
+
+pub(crate) fn build_service(app_handle: &AppHandle) -> Result<MapleAgentService, String> {
+    let app_config_root = app_handle
+        .path()
+        .app_config_dir()
+        .map_err(|error| format!("Failed to resolve Maple config directory: {error}"))?;
+    let app_local_data_root = app_handle
+        .path()
+        .app_local_data_dir()
+        .map_err(|error| format!("Failed to resolve Maple local data directory: {error}"))?;
+    let paths = AgentPathLayout::from_app_roots(app_config_root, app_local_data_root);
+    let event_sink = Arc::new(TauriAgentEventSink {
+        app_handle: app_handle.clone(),
+    });
+    Ok(MapleAgentService::new(MapleAgentHostResources::new(
+        paths, event_sink,
+    )))
+}

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -1,36 +1,671 @@
 use crate::agent::{
-    AgentEventEnvelope, AgentEventSink, AgentPathLayout, MapleAgentHostResources,
-    MapleAgentService, AGENT_EVENT_NAME,
+    AgentConfig, AgentCreateSessionRequest, AgentEventSink, AgentMcpServer,
+    AgentPermissionModeRequest, AgentPermissionResponse, AgentProjectRootRegistration,
+    AgentProjectSkillsTrustStatus, AgentRunEvent, AgentRunResponse, AgentRunTerminal,
+    AgentRuntimeHandle, AgentRuntimeStatus, AgentSendMessageRequest, AgentServiceEvent,
+    AgentSessionDetail, AgentSessionMcpServer, AgentSessionSummary,
+    AgentSetSessionMcpServerRequest, AgentStartRequest, AgentTimelineItem, MapleAgentService,
+    RecentProjectRoot,
 };
+use crate::agent_host::AgentHostLifecycle;
+use crate::maple_api::MapleApiAuthState;
+use serde::Serialize;
 use std::sync::Arc;
-use tauri::{AppHandle, Emitter, Manager};
+use tauri::{AppHandle, Emitter, State};
+
+const AGENT_EVENT_NAME: &str = "agent-event";
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct AgentEventEnvelope {
+    pub(crate) event_type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) session_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) run_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) item: Option<AgentTimelineItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) status: Option<AgentRuntimeStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) session: Option<AgentSessionSummary>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) message: Option<String>,
+}
+
+pub(crate) fn project_agent_event(event: &AgentServiceEvent) -> AgentEventEnvelope {
+    let mut envelope = AgentEventEnvelope {
+        event_type: String::new(),
+        session_id: None,
+        run_id: None,
+        item: None,
+        status: None,
+        session: None,
+        message: None,
+    };
+    match event {
+        AgentServiceEvent::RuntimeStatus(status) => {
+            envelope.event_type = "runtimeStatus".to_string();
+            envelope.status = Some(status.clone());
+        }
+        AgentServiceEvent::SessionCreated(session) => {
+            envelope.event_type = "sessionCreated".to_string();
+            envelope.session_id = Some(session.id.clone());
+            envelope.session = Some(session.clone());
+        }
+        AgentServiceEvent::SessionUpdated {
+            session_id,
+            run_id,
+            session,
+        } => {
+            envelope.event_type = "sessionUpdated".to_string();
+            envelope.session_id = Some(session_id.clone());
+            envelope.run_id.clone_from(run_id);
+            envelope.session = Some(session.clone());
+        }
+        AgentServiceEvent::TimelineItem {
+            session_id,
+            run_id,
+            item,
+        } => {
+            envelope.event_type = "timelineItem".to_string();
+            envelope.session_id = Some(session_id.clone());
+            envelope.run_id.clone_from(run_id);
+            envelope.item = Some(item.clone());
+        }
+        AgentServiceEvent::Run {
+            session_id,
+            run_id,
+            event,
+        } => {
+            envelope.session_id = Some(session_id.clone());
+            envelope.run_id = Some(run_id.clone());
+            match event {
+                AgentRunEvent::SessionUpdated(session) => {
+                    envelope.event_type = "sessionUpdated".to_string();
+                    envelope.session = Some(session.clone());
+                }
+                AgentRunEvent::Started => envelope.event_type = "runStarted".to_string(),
+                AgentRunEvent::TimelineItem(item) => {
+                    envelope.event_type = "timelineItem".to_string();
+                    envelope.item = Some(item.clone());
+                }
+                AgentRunEvent::SetupWarning(message) => {
+                    envelope.event_type = "error".to_string();
+                    // Preserve the existing Desktop contract. Setup warnings
+                    // historically carried a run ID but no task ID.
+                    envelope.session_id = None;
+                    envelope.message = Some(message.clone());
+                }
+                AgentRunEvent::HistoryReplaced => {
+                    envelope.event_type = "historyReplaced".to_string();
+                }
+                AgentRunEvent::Error(item) => {
+                    envelope.event_type = "error".to_string();
+                    envelope.item = Some(item.clone());
+                }
+                AgentRunEvent::Finished(terminal) => {
+                    envelope.event_type = "runFinished".to_string();
+                    envelope.message = Some(
+                        match terminal {
+                            AgentRunTerminal::Completed => "completed",
+                            AgentRunTerminal::Cancelled => "cancelled",
+                            AgentRunTerminal::Failed => "failed",
+                        }
+                        .to_string(),
+                    );
+                }
+            }
+        }
+    }
+    envelope
+}
 
 struct TauriAgentEventSink {
     app_handle: AppHandle,
 }
 
 impl AgentEventSink for TauriAgentEventSink {
-    fn emit(&self, event: &AgentEventEnvelope) {
-        if let Err(error) = self.app_handle.emit(AGENT_EVENT_NAME, event) {
+    fn emit(&self, event: &AgentServiceEvent) {
+        if let Err(error) = self
+            .app_handle
+            .emit(AGENT_EVENT_NAME, project_agent_event(event))
+        {
             log::warn!("Failed to emit Agent Mode event: {error}");
         }
     }
 }
 
-pub(crate) fn build_service(app_handle: &AppHandle) -> Result<MapleAgentService, String> {
-    let app_config_root = app_handle
-        .path()
-        .app_config_dir()
-        .map_err(|error| format!("Failed to resolve Maple config directory: {error}"))?;
-    let app_local_data_root = app_handle
-        .path()
-        .app_local_data_dir()
-        .map_err(|error| format!("Failed to resolve Maple local data directory: {error}"))?;
-    let paths = AgentPathLayout::from_app_roots(app_config_root, app_local_data_root);
-    let event_sink = Arc::new(TauriAgentEventSink {
+pub(crate) fn event_sink(app_handle: &AppHandle) -> Arc<dyn AgentEventSink> {
+    Arc::new(TauriAgentEventSink {
         app_handle: app_handle.clone(),
-    });
-    Ok(MapleAgentService::new(MapleAgentHostResources::new(
-        paths, event_sink,
-    )))
+    })
+}
+
+async fn handle_for_user(
+    state: &State<'_, MapleAgentService>,
+    user_id: &str,
+) -> Result<AgentRuntimeHandle, String> {
+    state.handle_for_user(user_id).await
+}
+
+#[tauri::command]
+pub async fn agent_get_runtime_status(
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+) -> Result<AgentRuntimeStatus, String> {
+    handle_for_user(&state, &user_id).await?.status().await
+}
+
+#[tauri::command]
+pub async fn agent_start_runtime(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    api_auth_state: State<'_, MapleApiAuthState>,
+    host_lifecycle: State<'_, AgentHostLifecycle>,
+    user_id: String,
+    request: Option<AgentStartRequest>,
+) -> Result<AgentRuntimeStatus, String> {
+    let _ = app_handle;
+    let handle = handle_for_user(&state, &user_id).await?;
+    let api_session = api_auth_state.session_for(&user_id).await?;
+    host_lifecycle
+        .start_runtime(&handle, api_session, request)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_stop_runtime(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    host_lifecycle: State<'_, AgentHostLifecycle>,
+    user_id: String,
+) -> Result<AgentRuntimeStatus, String> {
+    let handle = handle_for_user(&state, &user_id).await?;
+    host_lifecycle
+        .stop_runtime(&app_handle, &user_id, &handle)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_restart_runtime(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    api_auth_state: State<'_, MapleApiAuthState>,
+    host_lifecycle: State<'_, AgentHostLifecycle>,
+    user_id: String,
+    request: Option<AgentStartRequest>,
+) -> Result<AgentRuntimeStatus, String> {
+    let handle = handle_for_user(&state, &user_id).await?;
+    let api_session = api_auth_state.session_for(&user_id).await?;
+    host_lifecycle
+        .restart_runtime(&app_handle, &user_id, &handle, api_session, request)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_clear_user_data(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    host_lifecycle: State<'_, AgentHostLifecycle>,
+    user_id: String,
+) -> Result<(), String> {
+    let handle = handle_for_user(&state, &user_id).await?;
+    host_lifecycle
+        .clear_user_data(&app_handle, &user_id, &handle)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_clear_user_history(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    host_lifecycle: State<'_, AgentHostLifecycle>,
+    user_id: String,
+) -> Result<(), String> {
+    let handle = handle_for_user(&state, &user_id).await?;
+    host_lifecycle
+        .clear_user_history(&app_handle, &user_id, &handle)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_load_config(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+) -> Result<AgentConfig, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id).await?.load_config().await
+}
+
+#[tauri::command]
+pub async fn agent_save_config(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    config: AgentConfig,
+) -> Result<(), String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .save_config(config)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_list_mcp_servers(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+) -> Result<Vec<AgentMcpServer>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .list_mcp_servers()
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_save_mcp_servers(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    servers: Vec<AgentMcpServer>,
+) -> Result<Vec<AgentMcpServer>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .save_mcp_servers(servers)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_list_recent_project_roots(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+) -> Result<Vec<RecentProjectRoot>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .list_recent_project_roots()
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_save_recent_project_root(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    path: String,
+) -> Result<AgentProjectRootRegistration, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .save_recent_project_root(path)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_remove_project_root(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    path: String,
+    fallback_path: Option<String>,
+) -> Result<AgentConfig, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .remove_project_root(path, fallback_path)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_get_project_skills_trust(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    path: String,
+) -> Result<AgentProjectSkillsTrustStatus, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .get_project_skills_trust(path)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_set_project_skills_trust(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    path: String,
+    trusted: bool,
+) -> Result<AgentProjectSkillsTrustStatus, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .set_project_skills_trust(path, trusted)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_save_project_root_order(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    paths: Vec<String>,
+) -> Result<Vec<RecentProjectRoot>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .save_project_root_order(paths)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_create_session(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    request: Option<AgentCreateSessionRequest>,
+) -> Result<AgentSessionDetail, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .create_session(request)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_list_sessions(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    project_root: Option<String>,
+) -> Result<Vec<AgentSessionSummary>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .list_sessions(project_root)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_load_session(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    session_id: String,
+) -> Result<AgentSessionDetail, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .load_session(session_id)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_list_session_mcp_servers(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    session_id: String,
+) -> Result<Vec<AgentSessionMcpServer>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .list_session_mcp_servers(session_id)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_set_session_mcp_server_enabled(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    request: AgentSetSessionMcpServerRequest,
+) -> Result<Vec<AgentSessionMcpServer>, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .set_session_mcp_server_enabled(request)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_delete_session(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    session_id: String,
+) -> Result<(), String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .delete_session(session_id)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_send_message(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    request: AgentSendMessageRequest,
+) -> Result<AgentRunResponse, String> {
+    let _ = app_handle;
+    let run = handle_for_user(&state, &user_id)
+        .await?
+        .send_message(request)
+        .await?;
+    Ok(AgentRunResponse { run_id: run.run_id })
+}
+
+#[tauri::command]
+pub async fn agent_cancel_run(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    run_id: String,
+) -> Result<(), String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .cancel_run(run_id)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_set_permission_mode(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    request: AgentPermissionModeRequest,
+) -> Result<(), String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .set_permission_mode(request)
+        .await
+}
+
+#[tauri::command]
+pub async fn agent_permission_respond(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    response: AgentPermissionResponse,
+) -> Result<(), String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .permission_respond(response)
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::collections::HashMap;
+
+    #[test]
+    fn service_events_project_to_the_stable_desktop_wire_contract() {
+        let status = AgentRuntimeStatus {
+            running: true,
+            project_root: Some("/tmp/project".to_string()),
+            model: Some("maple-model".to_string()),
+            mode: Some("smart_approve".to_string()),
+            active_runs: HashMap::from([("session-1".to_string(), "run-1".to_string())]),
+        };
+        let session = AgentSessionSummary {
+            id: "session-1".to_string(),
+            title: "Task".to_string(),
+            project_root: "/tmp/project".to_string(),
+            created_ms: 1,
+            updated_ms: 2,
+            message_count: 3,
+            model: Some("maple-model".to_string()),
+            mode: "smart_approve".to_string(),
+        };
+        let item = AgentTimelineItem {
+            id: "message-1".to_string(),
+            item_type: "message".to_string(),
+            role: Some("assistant".to_string()),
+            title: None,
+            text: Some("hello".to_string()),
+            status: None,
+            input: None,
+            output: None,
+            created_ms: 4,
+            merge: "append".to_string(),
+        };
+        let events = [
+            AgentServiceEvent::RuntimeStatus(status),
+            AgentServiceEvent::SessionCreated(session.clone()),
+            AgentServiceEvent::SessionUpdated {
+                session_id: "session-1".to_string(),
+                run_id: Some("run-1".to_string()),
+                session,
+            },
+            AgentServiceEvent::Run {
+                session_id: "session-1".to_string(),
+                run_id: "run-1".to_string(),
+                event: AgentRunEvent::Started,
+            },
+            AgentServiceEvent::Run {
+                session_id: "session-1".to_string(),
+                run_id: "run-1".to_string(),
+                event: AgentRunEvent::TimelineItem(item.clone()),
+            },
+            AgentServiceEvent::Run {
+                session_id: "session-1".to_string(),
+                run_id: "run-1".to_string(),
+                event: AgentRunEvent::Error(item),
+            },
+            AgentServiceEvent::Run {
+                session_id: "session-1".to_string(),
+                run_id: "run-1".to_string(),
+                event: AgentRunEvent::HistoryReplaced,
+            },
+            AgentServiceEvent::Run {
+                session_id: "session-1".to_string(),
+                run_id: "run-1".to_string(),
+                event: AgentRunEvent::Finished(AgentRunTerminal::Completed),
+            },
+        ];
+        let projected = events.iter().map(project_agent_event).collect::<Vec<_>>();
+
+        assert_eq!(
+            serde_json::to_value(projected).unwrap(),
+            json!([
+                {
+                    "eventType": "runtimeStatus",
+                    "status": {
+                        "running": true,
+                        "projectRoot": "/tmp/project",
+                        "model": "maple-model",
+                        "mode": "smart_approve",
+                        "activeRuns": { "session-1": "run-1" }
+                    }
+                },
+                {
+                    "eventType": "sessionCreated",
+                    "sessionId": "session-1",
+                    "session": {
+                        "id": "session-1",
+                        "title": "Task",
+                        "projectRoot": "/tmp/project",
+                        "createdMs": 1,
+                        "updatedMs": 2,
+                        "messageCount": 3,
+                        "model": "maple-model",
+                        "mode": "smart_approve"
+                    }
+                },
+                {
+                    "eventType": "sessionUpdated",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "session": {
+                        "id": "session-1",
+                        "title": "Task",
+                        "projectRoot": "/tmp/project",
+                        "createdMs": 1,
+                        "updatedMs": 2,
+                        "messageCount": 3,
+                        "model": "maple-model",
+                        "mode": "smart_approve"
+                    }
+                },
+                { "eventType": "runStarted", "sessionId": "session-1", "runId": "run-1" },
+                {
+                    "eventType": "timelineItem",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "item": {
+                        "id": "message-1",
+                        "itemType": "message",
+                        "role": "assistant",
+                        "text": "hello",
+                        "createdMs": 4,
+                        "merge": "append"
+                    }
+                },
+                {
+                    "eventType": "error",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "item": {
+                        "id": "message-1",
+                        "itemType": "message",
+                        "role": "assistant",
+                        "text": "hello",
+                        "createdMs": 4,
+                        "merge": "append"
+                    }
+                },
+                { "eventType": "historyReplaced", "sessionId": "session-1", "runId": "run-1" },
+                {
+                    "eventType": "runFinished",
+                    "sessionId": "session-1",
+                    "runId": "run-1",
+                    "message": "completed"
+                }
+            ])
+        );
+
+        let warning = project_agent_event(&AgentServiceEvent::Run {
+            session_id: "session-1".to_string(),
+            run_id: "run-1".to_string(),
+            event: AgentRunEvent::SetupWarning("setup warning".to_string()),
+        });
+        assert_eq!(warning.event_type, "error");
+        assert_eq!(warning.session_id, None);
+        assert_eq!(warning.run_id.as_deref(), Some("run-1"));
+        assert_eq!(warning.message.as_deref(), Some("setup warning"));
+    }
 }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -3,12 +3,14 @@ use tauri_plugin_deep_link::DeepLinkExt;
 
 #[cfg(desktop)]
 mod agent;
-#[cfg(any(desktop, target_os = "ios"))]
-mod legacy_tts_cleanup;
 #[cfg(desktop)]
 mod agent_acp;
 #[cfg(desktop)]
+mod agent_host;
+#[cfg(desktop)]
 mod agent_tauri;
+#[cfg(any(desktop, target_os = "ios"))]
+mod legacy_tts_cleanup;
 #[cfg(desktop)]
 mod maple_api;
 mod onnxruntime;
@@ -20,8 +22,8 @@ mod proxy;
 #[tauri::command]
 async fn restart_for_update(app_handle: tauri::AppHandle) -> Result<(), String> {
     log::info!("User requested restart for update");
-    agent_acp::shutdown_agent_acp(&app_handle).await?;
-    agent::shutdown_agent_runtime(&app_handle).await?;
+    let lifecycle = app_handle.state::<agent_host::AgentHostLifecycle>();
+    lifecycle.shutdown_for_update(&app_handle).await?;
     app_handle.restart();
 }
 
@@ -56,11 +58,9 @@ fn handle_desktop_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEven
 
     let app_handle = app_handle.clone();
     tauri::async_runtime::spawn(async move {
-        if let Err(error) = agent_acp::shutdown_agent_acp(&app_handle).await {
-            log::error!("Failed to stop ACP during app exit: {error}");
-        }
-        if let Err(error) = agent::shutdown_agent_runtime(&app_handle).await {
-            log::error!("Failed to stop Agent Mode during app exit: {error}");
+        let lifecycle = app_handle.state::<agent_host::AgentHostLifecycle>();
+        if let Err(error) = lifecycle.shutdown_for_exit(&app_handle).await {
+            log::error!("Failed to stop Agent services during app exit: {error}");
         }
         AGENT_EXIT_CLEANUP_COMPLETE.store(true, Ordering::SeqCst);
         app_handle.exit(code.unwrap_or_default());
@@ -93,35 +93,36 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(agent_acp::AgentAcpState::new())
+        .manage(agent_host::AgentHostLifecycle::new())
         .manage(maple_api::MapleApiAuthState::new())
         .manage(proxy::ProxyState::new())
         .invoke_handler(tauri::generate_handler![
-            agent::agent_get_runtime_status,
-            agent::agent_start_runtime,
-            agent::agent_stop_runtime,
-            agent::agent_restart_runtime,
-            agent::agent_load_config,
-            agent::agent_save_config,
-            agent::agent_list_mcp_servers,
-            agent::agent_save_mcp_servers,
-            agent::agent_list_recent_project_roots,
-            agent::agent_save_recent_project_root,
-            agent::agent_remove_project_root,
-            agent::agent_get_project_skills_trust,
-            agent::agent_set_project_skills_trust,
-            agent::agent_save_project_root_order,
-            agent::agent_create_session,
-            agent::agent_list_sessions,
-            agent::agent_load_session,
-            agent::agent_list_session_mcp_servers,
-            agent::agent_set_session_mcp_server_enabled,
-            agent::agent_delete_session,
-            agent::agent_send_message,
-            agent::agent_cancel_run,
-            agent::agent_set_permission_mode,
-            agent::agent_permission_respond,
-            agent::agent_clear_user_history,
-            agent::agent_clear_user_data,
+            agent_tauri::agent_get_runtime_status,
+            agent_tauri::agent_start_runtime,
+            agent_tauri::agent_stop_runtime,
+            agent_tauri::agent_restart_runtime,
+            agent_tauri::agent_load_config,
+            agent_tauri::agent_save_config,
+            agent_tauri::agent_list_mcp_servers,
+            agent_tauri::agent_save_mcp_servers,
+            agent_tauri::agent_list_recent_project_roots,
+            agent_tauri::agent_save_recent_project_root,
+            agent_tauri::agent_remove_project_root,
+            agent_tauri::agent_get_project_skills_trust,
+            agent_tauri::agent_set_project_skills_trust,
+            agent_tauri::agent_save_project_root_order,
+            agent_tauri::agent_create_session,
+            agent_tauri::agent_list_sessions,
+            agent_tauri::agent_load_session,
+            agent_tauri::agent_list_session_mcp_servers,
+            agent_tauri::agent_set_session_mcp_server_enabled,
+            agent_tauri::agent_delete_session,
+            agent_tauri::agent_send_message,
+            agent_tauri::agent_cancel_run,
+            agent_tauri::agent_set_permission_mode,
+            agent_tauri::agent_permission_respond,
+            agent_tauri::agent_clear_user_history,
+            agent_tauri::agent_clear_user_data,
             agent_acp::agent_acp_load_config,
             agent_acp::agent_acp_save_config,
             agent_acp::agent_acp_start,
@@ -144,7 +145,7 @@ pub fn run() {
         .setup(|app| {
             legacy_tts_cleanup::schedule(app.handle());
 
-            let service = agent_tauri::build_service(app.handle())?;
+            let service = agent_host::build_service(app.handle())?;
             if !app.manage(service) {
                 return Err("Maple Agent service was already initialized".into());
             }

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tauri_plugin_deep_link::DeepLinkExt;
 
 #[cfg(desktop)]
@@ -7,6 +7,8 @@ mod agent;
 mod legacy_tts_cleanup;
 #[cfg(desktop)]
 mod agent_acp;
+#[cfg(desktop)]
+mod agent_tauri;
 #[cfg(desktop)]
 mod maple_api;
 mod onnxruntime;
@@ -90,7 +92,6 @@ pub fn run() {
         .plugin(tauri_plugin_os::init())
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
-        .manage(agent::AgentRuntimeState::new())
         .manage(agent_acp::AgentAcpState::new())
         .manage(maple_api::MapleApiAuthState::new())
         .manage(proxy::ProxyState::new())
@@ -142,6 +143,11 @@ pub fn run() {
         ])
         .setup(|app| {
             legacy_tts_cleanup::schedule(app.handle());
+
+            let service = agent_tauri::build_service(app.handle())?;
+            if !app.manage(service) {
+                return Err("Maple Agent service was already initialized".into());
+            }
 
             // Initialize proxy auto-start
             {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -6,6 +6,8 @@ mod agent;
 #[cfg(any(desktop, target_os = "ios"))]
 mod legacy_tts_cleanup;
 #[cfg(desktop)]
+mod agent_acp;
+#[cfg(desktop)]
 mod maple_api;
 mod onnxruntime;
 mod pdf_extractor;
@@ -16,6 +18,7 @@ mod proxy;
 #[tauri::command]
 async fn restart_for_update(app_handle: tauri::AppHandle) -> Result<(), String> {
     log::info!("User requested restart for update");
+    agent_acp::shutdown_agent_acp(&app_handle).await?;
     agent::shutdown_agent_runtime(&app_handle).await?;
     app_handle.restart();
 }
@@ -51,6 +54,9 @@ fn handle_desktop_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEven
 
     let app_handle = app_handle.clone();
     tauri::async_runtime::spawn(async move {
+        if let Err(error) = agent_acp::shutdown_agent_acp(&app_handle).await {
+            log::error!("Failed to stop ACP during app exit: {error}");
+        }
         if let Err(error) = agent::shutdown_agent_runtime(&app_handle).await {
             log::error!("Failed to stop Agent Mode during app exit: {error}");
         }
@@ -85,6 +91,7 @@ pub fn run() {
         .plugin(tauri_plugin_fs::init())
         .plugin(tauri_plugin_dialog::init())
         .manage(agent::AgentRuntimeState::new())
+        .manage(agent_acp::AgentAcpState::new())
         .manage(maple_api::MapleApiAuthState::new())
         .manage(proxy::ProxyState::new())
         .invoke_handler(tauri::generate_handler![
@@ -114,6 +121,11 @@ pub fn run() {
             agent::agent_permission_respond,
             agent::agent_clear_user_history,
             agent::agent_clear_user_data,
+            agent_acp::agent_acp_load_config,
+            agent_acp::agent_acp_save_config,
+            agent_acp::agent_acp_start,
+            agent_acp::agent_acp_stop,
+            agent_acp::agent_acp_get_status,
             maple_api::maple_api_set_auth,
             maple_api::maple_api_get_auth,
             maple_api::maple_api_clear_auth,
@@ -368,6 +380,11 @@ pub fn run() {
     #[cfg(not(desktop))]
     app.run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(desktop)]
+pub fn run_acp_connector() -> Result<(), String> {
+    agent_acp::run_acp_connector()
 }
 
 // Create a global variable to track if an update is already prepared and notified

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -2,5 +2,13 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    let mut args = std::env::args().skip(1);
+    if args.next().as_deref() == Some("acp") {
+        if let Err(error) = app_lib::run_acp_connector() {
+            eprintln!("{error}");
+            std::process::exit(1);
+        }
+        return;
+    }
     app_lib::run();
 }

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -1532,8 +1532,11 @@ export function AgentMode({ userId }: { userId: string }) {
           const requestedMode = selectedModeRef.current;
           const request = { projectRoot, model: model || DEFAULT_MODEL, mode: requestedMode };
           const runStateGeneration = runStateGenerationRef.current;
-          const status = restart
+          const restartOutcome = restart
             ? await agentRuntimeService.restartRuntime(userId, request)
+            : null;
+          const status = restartOutcome
+            ? restartOutcome.status
             : await agentRuntimeService.startRuntime(userId, request);
           if (
             startRequestGenerationRef.current !== requestGeneration ||
@@ -1546,6 +1549,11 @@ export function AgentMode({ userId }: { userId: string }) {
           setModel(status.model || model || DEFAULT_MODEL);
           applyAuthoritativeMode(normalizeAgentPermissionMode(status.mode || requestedMode));
           await refreshSessions();
+          if (restartOutcome?.acpShutdownError) {
+            setError(
+              `Agent Mode restarted, but ACP cleanup failed: ${restartOutcome.acpShutdownError}`
+            );
+          }
           return status;
         });
       } catch (startError) {

--- a/frontend/src/components/settings/AgentConnectionsSettings.tsx
+++ b/frontend/src/components/settings/AgentConnectionsSettings.tsx
@@ -484,8 +484,8 @@ export function AgentConnectionsSettings() {
       </SettingsSection>
 
       <SettingsSection
-        title="Agent policy"
-        description="Choose the tool policy Maple applies to new ACP sessions."
+        title="ACP approvals"
+        description="The connected ACP client handles unresolved tool approvals."
       >
         <div className="space-y-4">
           <div className="grid gap-2">
@@ -506,8 +506,7 @@ export function AgentConnectionsSettings() {
                 <SelectValue />
               </SelectTrigger>
               <SelectContent>
-                <SelectItem value="read_only">Require local approvals</SelectItem>
-                <SelectItem value="allow_all">Allow all (unattended Buzz)</SelectItem>
+                <SelectItem value="read_only">ACP client decides</SelectItem>
               </SelectContent>
             </Select>
             <p className="text-xs leading-relaxed text-muted-foreground">
@@ -515,11 +514,9 @@ export function AgentConnectionsSettings() {
                 ? isConfigLoading
                   ? "Loading your saved agent policy."
                   : "Your saved policy is unavailable. Refresh before changing or starting ACP."
-                : permissionMode === "read_only"
-                  ? running
-                    ? "Stop the ACP service before changing its policy. Write-capable tools require approval in Maple Desktop."
-                    : "Write-capable tools require approval in Maple Desktop. This mode is not suitable for unattended Buzz operation."
-                  : "Required for unattended Buzz operation. Connected clients may run commands and modify files without local approval prompts."}
+                : running
+                  ? "Stop the ACP service before changing its policy. Maple sends guarded requests to the connected client, which may prompt, deny, or approve automatically."
+                  : "Maple sends guarded requests to the connected client. Buzz currently selects Allow once automatically, so trusted prompts can run unattended."}
             </p>
           </div>
 
@@ -531,17 +528,6 @@ export function AgentConnectionsSettings() {
               operating-system sandbox.
             </AlertDescription>
           </Alert>
-
-          {permissionMode === "allow_all" && displayedConfig !== null && (
-            <Alert className="border-maple-warning/40 bg-maple-warning/10">
-              <AlertCircle className="h-4 w-4 text-maple-warning" />
-              <AlertDescription>
-                Allow all is intended only for clients and projects you trust. Buzz can ask Maple to
-                run local commands and make external changes without local approval while this
-                service is active.
-              </AlertDescription>
-            </Alert>
-          )}
 
           <div className="flex justify-end">
             <Button

--- a/frontend/src/components/settings/AgentConnectionsSettings.tsx
+++ b/frontend/src/components/settings/AgentConnectionsSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { useOpenSecret } from "@opensecret/react";
 import {
   AlertCircle,
@@ -62,12 +62,15 @@ export function AgentConnectionsSettings() {
   const [message, setMessage] = useState<string | null>(null);
   const [copied, setCopied] = useState<CopyTarget | null>(null);
   const userIdRef = useRef(userId);
-  userIdRef.current = userId;
   const operationRef = useRef(operation);
-  operationRef.current = operation;
   const statusRequestGenerationRef = useRef(0);
   const isBusy = operation !== null;
   useSettingsNavigationLock(isBusy);
+
+  useLayoutEffect(() => {
+    userIdRef.current = userId;
+    operationRef.current = operation;
+  }, [operation, userId]);
 
   const refreshSettings = useCallback(async () => {
     if (!userId) return;

--- a/frontend/src/components/settings/AgentConnectionsSettings.tsx
+++ b/frontend/src/components/settings/AgentConnectionsSettings.tsx
@@ -1,0 +1,770 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useOpenSecret } from "@opensecret/react";
+import {
+  AlertCircle,
+  Check,
+  Copy,
+  Loader2,
+  Play,
+  RefreshCw,
+  Server,
+  ShieldCheck,
+  Square,
+  Terminal
+} from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+import { useSettingsNavigationLock } from "@/contexts/SettingsNavigationLockContext";
+import { awaitAgentAuthUser } from "@/services/agentRuntimeService";
+import {
+  BUZZ_DEFAULT_AGENT_PARALLELISM,
+  BUZZ_MAPLE_AGENT_PARALLELISM,
+  BUZZ_MAPLE_HARNESS_ID,
+  BUZZ_MAPLE_HARNESS_NAME,
+  isMapleAcpConfigReady,
+  isMapleAcpPolicyDirty,
+  mapleAcpService,
+  serializeBuzzCustomHarness,
+  type MapleAcpConfig,
+  type MapleAcpPermissionMode,
+  type MapleAcpStatus
+} from "@/services/mapleAcpService";
+import { SettingsPage, SettingsSection } from "./SettingsPage";
+
+const STATUS_POLL_INTERVAL_MS = 2_500;
+
+type CopyTarget = "name" | "id" | "command" | "argument" | "harness";
+
+export function AgentConnectionsSettings() {
+  const os = useOpenSecret();
+  const userId = os.auth.user?.user.id ?? null;
+  const [config, setConfig] = useState<MapleAcpConfig | null>(null);
+  const [savedConfig, setSavedConfig] = useState<MapleAcpConfig | null>(null);
+  const [configUserId, setConfigUserId] = useState<string | null>(null);
+  const [status, setStatus] = useState<MapleAcpStatus | null>(null);
+  const [isConfigLoading, setIsConfigLoading] = useState(true);
+  const [isStatusLoading, setIsStatusLoading] = useState(true);
+  const [operation, setOperation] = useState<"start" | "stop" | "save" | "refresh" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [configLoadError, setConfigLoadError] = useState<string | null>(null);
+  const [statusLoadError, setStatusLoadError] = useState<string | null>(null);
+  const [message, setMessage] = useState<string | null>(null);
+  const [copied, setCopied] = useState<CopyTarget | null>(null);
+  const userIdRef = useRef(userId);
+  userIdRef.current = userId;
+  const operationRef = useRef(operation);
+  operationRef.current = operation;
+  const statusRequestGenerationRef = useRef(0);
+  const isBusy = operation !== null;
+  useSettingsNavigationLock(isBusy);
+
+  const refreshSettings = useCallback(async () => {
+    if (!userId) return;
+
+    statusRequestGenerationRef.current += 1;
+    const shouldRetryConfig = savedConfig === null || configUserId !== userId;
+    setOperation("refresh");
+    setError(null);
+    setMessage(null);
+    setIsStatusLoading(true);
+    setStatusLoadError(null);
+    if (shouldRetryConfig) {
+      setIsConfigLoading(true);
+      setConfigLoadError(null);
+    }
+
+    const authReady = awaitAgentAuthUser(userId);
+    const configRequest = shouldRetryConfig
+      ? authReady
+          .then(() => mapleAcpService.loadConfig(userId))
+          .then((nextConfig) => {
+            if (userIdRef.current !== userId) return false;
+            setConfig(nextConfig);
+            setSavedConfig(nextConfig);
+            setConfigUserId(userId);
+            setConfigLoadError(null);
+            return true;
+          })
+          .catch((loadError) => {
+            if (userIdRef.current !== userId) return false;
+            setConfigLoadError(errorMessage(loadError, "Maple could not load the agent policy."));
+            return false;
+          })
+          .finally(() => {
+            if (userIdRef.current === userId) setIsConfigLoading(false);
+          })
+      : Promise.resolve(true);
+    const statusRequest = authReady
+      .then(() => mapleAcpService.getStatus(userId))
+      .then((nextStatus) => {
+        if (userIdRef.current !== userId) return false;
+        setStatus(nextStatus);
+        setStatusLoadError(null);
+        return true;
+      })
+      .catch((loadError) => {
+        if (userIdRef.current !== userId) return false;
+        setStatusLoadError(errorMessage(loadError, "Maple could not load the ACP service status."));
+        return false;
+      })
+      .finally(() => {
+        if (userIdRef.current === userId) setIsStatusLoading(false);
+      });
+
+    const [configLoaded, statusLoaded] = await Promise.all([configRequest, statusRequest]);
+    if (userIdRef.current !== userId) return;
+    setOperation(null);
+
+    if (configLoaded && statusLoaded) {
+      setMessage(shouldRetryConfig ? "Agent policy and status refreshed." : "Status refreshed.");
+    } else if (configLoaded && shouldRetryConfig) {
+      setMessage("Agent policy loaded. Service status is still unavailable.");
+    }
+  }, [configUserId, savedConfig, userId]);
+
+  useEffect(() => {
+    statusRequestGenerationRef.current += 1;
+    if (!userId) {
+      setConfig(null);
+      setSavedConfig(null);
+      setConfigUserId(null);
+      setStatus(null);
+      setIsConfigLoading(false);
+      setIsStatusLoading(false);
+      setConfigLoadError(null);
+      setStatusLoadError(null);
+      setError(null);
+      setMessage(null);
+      setOperation(null);
+      return;
+    }
+
+    let disposed = false;
+    let timer: number | undefined;
+
+    setConfig(null);
+    setSavedConfig(null);
+    setConfigUserId(null);
+    setStatus(null);
+    setIsConfigLoading(true);
+    setIsStatusLoading(true);
+    setConfigLoadError(null);
+    setStatusLoadError(null);
+    setError(null);
+    setMessage(null);
+    setOperation(null);
+
+    const authReady = awaitAgentAuthUser(userId);
+    const configLoad = authReady
+      .then(() => mapleAcpService.loadConfig(userId))
+      .then((nextConfig) => {
+        if (disposed) return;
+        setConfig(nextConfig);
+        setSavedConfig(nextConfig);
+        setConfigUserId(userId);
+        setConfigLoadError(null);
+      })
+      .catch((loadError) => {
+        if (!disposed) {
+          setConfigLoadError(errorMessage(loadError, "Maple could not load the agent policy."));
+        }
+      })
+      .finally(() => {
+        if (!disposed) setIsConfigLoading(false);
+      });
+
+    const statusLoad = authReady
+      .then(() => mapleAcpService.getStatus(userId))
+      .then((nextStatus) => {
+        if (disposed) return;
+        setStatus(nextStatus);
+        setStatusLoadError(null);
+      })
+      .catch((loadError) => {
+        if (!disposed) {
+          setStatusLoadError(
+            errorMessage(loadError, "Maple could not load the ACP service status.")
+          );
+        }
+      })
+      .finally(() => {
+        if (!disposed) setIsStatusLoading(false);
+      });
+
+    const poll = async () => {
+      if (disposed) return;
+      if (operationRef.current === null) {
+        const requestGeneration = statusRequestGenerationRef.current;
+        try {
+          const nextStatus = await mapleAcpService.getStatus(userId);
+          if (
+            !disposed &&
+            requestGeneration === statusRequestGenerationRef.current &&
+            operationRef.current === null
+          ) {
+            setStatus(nextStatus);
+            setStatusLoadError(null);
+          }
+        } catch {
+          // Keep the last known status. Explicit refreshes surface diagnostics.
+        }
+      }
+      if (!disposed) timer = window.setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+    };
+
+    void Promise.allSettled([configLoad, statusLoad]).then(() => {
+      if (!disposed) timer = window.setTimeout(poll, STATUS_POLL_INTERVAL_MS);
+    });
+    return () => {
+      disposed = true;
+      if (timer !== undefined) window.clearTimeout(timer);
+    };
+  }, [userId]);
+
+  const savePolicy = async (): Promise<MapleAcpConfig | null> => {
+    if (!userId || !config || !savedConfig || configUserId !== userId) return null;
+    const operationUserId = userId;
+    setOperation("save");
+    setError(null);
+    setMessage(null);
+    try {
+      const nextConfig = await mapleAcpService.saveConfig(userId, {
+        ...config,
+        enabled: status?.enabled ?? config.enabled
+      });
+      if (userIdRef.current !== operationUserId) return null;
+      setConfig(nextConfig);
+      setSavedConfig(nextConfig);
+      setMessage("Agent policy saved.");
+      return nextConfig;
+    } catch (saveError) {
+      if (userIdRef.current === operationUserId) setError(errorMessage(saveError));
+      return null;
+    } finally {
+      if (userIdRef.current === operationUserId) setOperation(null);
+    }
+  };
+
+  const startService = async () => {
+    if (!userId || !config || !savedConfig || configUserId !== userId) return;
+    statusRequestGenerationRef.current += 1;
+    const operationUserId = userId;
+    setOperation("start");
+    setError(null);
+    setMessage(null);
+    try {
+      const nextConfig = await mapleAcpService.saveConfig(userId, {
+        ...config,
+        enabled: status?.enabled ?? config.enabled
+      });
+      if (userIdRef.current !== operationUserId) return;
+      const nextStatus = await mapleAcpService.start(userId);
+      if (userIdRef.current !== operationUserId) return;
+      const startedConfig = { ...nextConfig, enabled: nextStatus.enabled || nextStatus.running };
+      setConfig(startedConfig);
+      setSavedConfig(startedConfig);
+      setStatus(nextStatus);
+      setMessage("Maple is ready for local ACP clients.");
+    } catch (startError) {
+      if (userIdRef.current === operationUserId) setError(errorMessage(startError));
+    } finally {
+      if (userIdRef.current === operationUserId) setOperation(null);
+    }
+  };
+
+  const stopService = async () => {
+    if (!userId) return;
+    statusRequestGenerationRef.current += 1;
+    const operationUserId = userId;
+    setOperation("stop");
+    setError(null);
+    setMessage(null);
+    try {
+      const nextStatus = await mapleAcpService.stop(userId);
+      if (userIdRef.current !== operationUserId) return;
+      setStatus(nextStatus);
+      setConfig((current) => (current ? { ...current, enabled: false } : current));
+      setSavedConfig((current) => (current ? { ...current, enabled: false } : current));
+      setMessage("Local ACP connections are disabled.");
+    } catch (stopError) {
+      if (userIdRef.current === operationUserId) setError(errorMessage(stopError));
+    } finally {
+      if (userIdRef.current === operationUserId) setOperation(null);
+    }
+  };
+
+  const harnessJson = useMemo(
+    () => (status?.harness ? serializeBuzzCustomHarness(status.harness) : ""),
+    [status?.harness]
+  );
+  const displayedConfig = configUserId === userId ? config : null;
+  const displayedSavedConfig = configUserId === userId ? savedConfig : null;
+  const running = status?.running === true;
+  const configReady = isMapleAcpConfigReady(displayedConfig, displayedSavedConfig);
+  const permissionMode = displayedConfig?.permissionMode ?? "read_only";
+  const policyDirty = isMapleAcpPolicyDirty(displayedConfig, displayedSavedConfig);
+  const mutationsDisabled = isBusy || !userId || !configReady;
+  const policyMutationsDisabled = mutationsDisabled || running;
+
+  const copyText = async (target: CopyTarget, value: string) => {
+    if (!value) return;
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopied(target);
+      window.setTimeout(() => setCopied((current) => (current === target ? null : current)), 2_000);
+    } catch (copyError) {
+      setError(errorMessage(copyError, "Maple could not copy to the clipboard."));
+    }
+  };
+
+  const statusLabel =
+    status === null
+      ? "Unavailable"
+      : running
+        ? status.connectedClients > 0
+          ? "Connected"
+          : "Ready"
+        : "Stopped";
+
+  return (
+    <SettingsPage
+      title="Agent connections"
+      description="Let trusted local ACP clients such as Buzz use Maple Agent through this desktop app."
+      actions={<Badge variant="outline">Preview</Badge>}
+    >
+      <span className="sr-only" aria-live="polite">
+        {copied ? `${copied === "harness" ? "Harness JSON" : copied} copied to clipboard.` : ""}
+      </span>
+      <SettingsSection
+        title="Local ACP service"
+        description="Maple Desktop owns your authenticated Agent runtime. Keep Maple open and signed in while connected clients are working."
+      >
+        <div className="space-y-4">
+          {error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )}
+          {configLoadError && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {configLoadError} Policy controls remain locked so Maple cannot replace your saved
+                policy with defaults. Use refresh to try again.
+              </AlertDescription>
+            </Alert>
+          )}
+          {statusLoadError && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>
+                {statusLoadError} The last known status is preserved. Use refresh to try again.
+              </AlertDescription>
+            </Alert>
+          )}
+          {message && !error && (
+            <Alert role="status" aria-live="polite">
+              <Check className="h-4 w-4 text-maple-success" />
+              <AlertDescription>{message}</AlertDescription>
+            </Alert>
+          )}
+          {status?.error && !error && (
+            <Alert variant="destructive">
+              <AlertCircle className="h-4 w-4" />
+              <AlertDescription>{status.error}</AlertDescription>
+            </Alert>
+          )}
+
+          <div
+            className="flex flex-col gap-4 rounded-xl border border-border/70 bg-background/40 p-4 sm:flex-row sm:items-center sm:justify-between"
+            aria-busy={isConfigLoading || isStatusLoading || isBusy}
+          >
+            <div className="flex min-w-0 items-start gap-3">
+              <div className="rounded-lg bg-[hsl(var(--maple-primary-container))] p-2 text-[hsl(var(--maple-primary-strong))]">
+                <Server className="h-5 w-5" />
+              </div>
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2">
+                  <p className="font-medium">
+                    {isStatusLoading
+                      ? "Checking local ACP service"
+                      : status
+                        ? `ACP service ${statusLabel.toLowerCase()}`
+                        : "ACP service status unavailable"}
+                  </p>
+                  <Badge variant={running ? "secondary" : "outline"}>
+                    {isStatusLoading ? "Checking" : statusLabel}
+                  </Badge>
+                </div>
+                <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
+                  {isStatusLoading
+                    ? "Reading the local service status."
+                    : status === null
+                      ? "Refresh to retry. Maple will not assume the service is stopped."
+                      : running
+                        ? status?.connectedClients
+                          ? `${status.connectedClients} local client${status.connectedClients === 1 ? " is" : "s are"} connected.`
+                          : "Waiting for a trusted local ACP client to connect."
+                        : "Disabled by default. Start it when you are ready to connect Buzz."}
+                </p>
+              </div>
+            </div>
+            <div className="flex shrink-0 gap-2">
+              <Button
+                type="button"
+                size="icon"
+                variant="outline"
+                onClick={() => void refreshSettings()}
+                disabled={isConfigLoading || isStatusLoading || isBusy || !userId}
+                aria-label="Refresh ACP settings and service status"
+              >
+                {operation === "refresh" ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+              </Button>
+              {running ? (
+                <Button
+                  type="button"
+                  variant="destructive"
+                  onClick={() => void stopService()}
+                  disabled={isBusy || !userId}
+                >
+                  {operation === "stop" ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Square className="mr-2 h-4 w-4" />
+                  )}
+                  {operation === "stop" ? "Stopping..." : "Stop service"}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={() => void startService()}
+                  disabled={mutationsDisabled}
+                >
+                  {operation === "start" ? (
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  ) : (
+                    <Play className="mr-2 h-4 w-4" />
+                  )}
+                  {operation === "start" ? "Starting..." : "Start service"}
+                </Button>
+              )}
+            </div>
+          </div>
+
+          <div className="grid grid-cols-3 gap-2 text-center">
+            <StatusMetric label="Clients" value={status?.connectedClients ?? 0} />
+            <StatusMetric label="Sessions" value={status?.activeSessions ?? 0} />
+            <StatusMetric label="Active runs" value={status?.activeRuns ?? 0} />
+          </div>
+
+          <Alert role="note">
+            <ShieldCheck className="h-4 w-4" />
+            <AlertDescription>
+              The bridge does not put your Maple access tokens, API keys, or Buzz private key in its
+              command or harness configuration. Stopping it disconnects every local client.
+            </AlertDescription>
+          </Alert>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Agent policy"
+        description="Choose the tool policy Maple applies to new ACP sessions."
+      >
+        <div className="space-y-4">
+          <div className="grid gap-2">
+            <Label htmlFor="agent-acp-permission-mode">Permission mode</Label>
+            <Select
+              value={permissionMode}
+              onValueChange={(value) => {
+                if (!displayedConfig) return;
+                setConfig((current) => ({
+                  ...(current ?? displayedConfig),
+                  permissionMode: value as MapleAcpPermissionMode
+                }));
+                setMessage(null);
+              }}
+              disabled={policyMutationsDisabled}
+            >
+              <SelectTrigger id="agent-acp-permission-mode">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="read_only">Require local approvals</SelectItem>
+                <SelectItem value="allow_all">Allow all (unattended Buzz)</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              {displayedConfig === null
+                ? isConfigLoading
+                  ? "Loading your saved agent policy."
+                  : "Your saved policy is unavailable. Refresh before changing or starting ACP."
+                : permissionMode === "read_only"
+                  ? running
+                    ? "Stop the ACP service before changing its policy. Write-capable tools require approval in Maple Desktop."
+                    : "Write-capable tools require approval in Maple Desktop. This mode is not suitable for unattended Buzz operation."
+                  : "Required for unattended Buzz operation. Connected clients may run commands and modify files without local approval prompts."}
+            </p>
+          </div>
+
+          <Alert role="note" className="border-maple-warning/40 bg-maple-warning/10">
+            <AlertCircle className="h-4 w-4 text-maple-warning" />
+            <AlertDescription>
+              This preview does not yet expose project-root allowlisting. A connected client can
+              select any absolute working directory Maple can access. Neither policy is an
+              operating-system sandbox.
+            </AlertDescription>
+          </Alert>
+
+          {permissionMode === "allow_all" && displayedConfig !== null && (
+            <Alert className="border-maple-warning/40 bg-maple-warning/10">
+              <AlertCircle className="h-4 w-4 text-maple-warning" />
+              <AlertDescription>
+                Allow all is intended only for clients and projects you trust. Buzz can ask Maple to
+                run local commands and make external changes without local approval while this
+                service is active.
+              </AlertDescription>
+            </Alert>
+          )}
+
+          <div className="flex justify-end">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => void savePolicy()}
+              disabled={policyMutationsDisabled || !policyDirty}
+            >
+              {operation === "save" && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              {operation === "save" ? "Saving..." : "Save policy"}
+            </Button>
+          </div>
+        </div>
+      </SettingsSection>
+
+      <SettingsSection
+        title="Connect Buzz"
+        description="Enter these values as separate fields in Buzz Desktop's custom harness form."
+      >
+        <div className="space-y-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <CopyableHarnessField
+              id="agent-acp-buzz-name"
+              label="Name"
+              value={BUZZ_MAPLE_HARNESS_NAME}
+              target="name"
+              copied={copied}
+              onCopy={copyText}
+            />
+            <CopyableHarnessField
+              id="agent-acp-buzz-id"
+              label="ID"
+              value={BUZZ_MAPLE_HARNESS_ID}
+              target="id"
+              copied={copied}
+              onCopy={copyText}
+            />
+            <CopyableHarnessField
+              id="agent-acp-buzz-command"
+              label="Command"
+              value={status?.harness?.command ?? ""}
+              placeholder="Exact Maple executable unavailable"
+              target="command"
+              copied={copied}
+              onCopy={copyText}
+            />
+            <CopyableHarnessField
+              id="agent-acp-buzz-argument"
+              label="Argument"
+              value={status?.harness?.args[0] ?? ""}
+              placeholder="Bridge argument unavailable"
+              target="argument"
+              copied={copied}
+              onCopy={copyText}
+            />
+          </div>
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Command is the executable path only. Add <code className="font-mono">acp</code> as a
+            separate argument row in Buzz; do not append it to Command.
+          </p>
+
+          <Alert role="note">
+            <Server className="h-4 w-4" />
+            <AlertDescription>
+              In Buzz managed-agent settings, set parallelism to {BUZZ_MAPLE_AGENT_PARALLELISM}.
+              Buzz defaults to {BUZZ_DEFAULT_AGENT_PARALLELISM}, while Maple accepts one local ACP
+              connection by default.
+            </AlertDescription>
+          </Alert>
+
+          <div className="grid gap-2">
+            <div className="flex items-center justify-between gap-3">
+              <Label htmlFor="agent-acp-buzz-json">Advanced/manual configuration JSON</Label>
+              <Button
+                type="button"
+                size="sm"
+                variant="outline"
+                onClick={() => void copyText("harness", harnessJson)}
+                disabled={!harnessJson}
+              >
+                {copied === "harness" ? (
+                  <Check className="mr-2 h-4 w-4 text-maple-success" />
+                ) : (
+                  <Copy className="mr-2 h-4 w-4" />
+                )}
+                {copied === "harness" ? "Copied" : "Copy JSON"}
+              </Button>
+            </div>
+            <Textarea
+              id="agent-acp-buzz-json"
+              value={harnessJson}
+              readOnly
+              placeholder="Harness configuration unavailable"
+              className="min-h-40 resize-y font-mono text-xs"
+            />
+            <p className="text-xs leading-relaxed text-muted-foreground">
+              This JSON is for advanced or manual configuration. Buzz Desktop's custom harness form
+              uses the separate fields above. Keep this Maple Desktop instance running after setup.
+            </p>
+          </div>
+
+          <details className="group rounded-lg border border-border/70">
+            <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
+              Connection diagnostics
+            </summary>
+            <dl className="grid gap-3 border-t border-border/70 p-4 text-xs sm:grid-cols-2">
+              <Diagnostic label="Transport" value={formatEndpointKind(status?.endpointKind)} />
+              <Diagnostic label="Endpoint" value={status?.endpoint || "Not listening"} mono />
+              <Diagnostic
+                label="Protocol"
+                value={status?.protocolVersion ? `ACP ${status.protocolVersion}` : "ACP"}
+              />
+              <Diagnostic
+                label="Buzz relay credentials"
+                value={status?.buzzCredentialsAvailable ? "Available" : "Waiting for Buzz"}
+              />
+            </dl>
+          </details>
+
+          {!status?.buzzCredentialsAvailable && status?.connectedClients ? (
+            <Alert className="border-maple-warning/40 bg-maple-warning/10">
+              <Terminal className="h-4 w-4 text-maple-warning" />
+              <AlertDescription>
+                A client is connected without Buzz relay credentials. Maple can stream ACP output,
+                but it may not be able to post a durable reply to the Buzz channel.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+        </div>
+      </SettingsSection>
+    </SettingsPage>
+  );
+}
+
+function CopyableHarnessField({
+  id,
+  label,
+  value,
+  placeholder,
+  target,
+  copied,
+  onCopy
+}: {
+  id: string;
+  label: string;
+  value: string;
+  placeholder?: string;
+  target: CopyTarget;
+  copied: CopyTarget | null;
+  onCopy: (target: CopyTarget, value: string) => Promise<void>;
+}) {
+  const wasCopied = copied === target;
+
+  return (
+    <div className="grid gap-2">
+      <Label htmlFor={id}>{label}</Label>
+      <div className="flex gap-2">
+        <Input
+          id={id}
+          value={value}
+          readOnly
+          placeholder={placeholder}
+          className="font-mono text-xs"
+        />
+        <Button
+          type="button"
+          size="icon"
+          variant="outline"
+          onClick={() => void onCopy(target, value)}
+          disabled={!value}
+          aria-label={wasCopied ? `${label} copied` : `Copy ${label}`}
+        >
+          {wasCopied ? (
+            <Check className="h-4 w-4 text-maple-success" />
+          ) : (
+            <Copy className="h-4 w-4" />
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+function StatusMetric({ label, value }: { label: string; value: number }) {
+  return (
+    <div className="rounded-lg border border-border/70 bg-muted/30 px-2 py-3">
+      <p className="text-lg font-semibold tabular-nums">{value}</p>
+      <p className="text-[11px] text-muted-foreground">{label}</p>
+    </div>
+  );
+}
+
+function Diagnostic({
+  label,
+  value,
+  mono = false
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="font-medium text-muted-foreground">{label}</dt>
+      <dd className={mono ? "mt-1 break-all font-mono" : "mt-1 break-words"}>{value}</dd>
+    </div>
+  );
+}
+
+function formatEndpointKind(value?: string | null): string {
+  if (!value) return "Local IPC";
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}
+
+function errorMessage(
+  error: unknown,
+  fallback = "Maple could not update the ACP service."
+): string {
+  if (error instanceof Error && error.message.trim()) return error.message;
+  if (typeof error === "string" && error.trim()) return error;
+  return fallback;
+}

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -4,6 +4,7 @@ import { useOpenSecret } from "@opensecret/react";
 import {
   ArrowLeft,
   BookOpen,
+  Cable,
   CreditCard,
   Database,
   KeyRound,
@@ -36,7 +37,7 @@ import {
 import { resetWorkspaceModePreference } from "@/services/workspaceModePreference";
 import { useLocalState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
-import { isIOS } from "@/utils/platform";
+import { isIOS, isLinux, isMacOS, isTauriDesktop } from "@/utils/platform";
 import { getTeamSeatMismatch } from "@/utils/teamSeats";
 import { cn } from "@/utils/utils";
 import packageJson from "../../../package.json";
@@ -50,6 +51,7 @@ type SettingsNavItem = {
     | "/settings/billing"
     | "/settings/team"
     | "/settings/api"
+    | "/settings/agent-connections"
     | "/settings/history"
     | "/settings/about";
   icon: ComponentType<{ className?: string }>;
@@ -233,6 +235,7 @@ function SettingsLayoutContent() {
   });
 
   const isIOSPlatform = isIOS();
+  const supportsAgentConnections = isTauriDesktop() && (isMacOS() || isLinux());
   const { data: products, isError: productsError } = useQuery({
     queryKey: ["products-version-check", isIOSPlatform],
     queryFn: () => getBillingService().getProducts(`v${packageJson.version}`),
@@ -278,9 +281,20 @@ function SettingsLayoutContent() {
     },
     {
       label: "Developer",
-      items: showApiManagement
-        ? [{ label: "API & credits", to: "/settings/api", icon: KeyRound }]
-        : []
+      items: [
+        ...(showApiManagement
+          ? [{ label: "API & credits", to: "/settings/api" as const, icon: KeyRound }]
+          : []),
+        ...(supportsAgentConnections
+          ? [
+              {
+                label: "Agent connections",
+                to: "/settings/agent-connections" as const,
+                icon: Cable
+              }
+            ]
+          : [])
+      ]
     },
     {
       label: "Data",

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -34,10 +34,11 @@ import {
   restoreMapleApiAuthForUser,
   stopAgentRuntimeForUser
 } from "@/services/agentRuntimeService";
+import { isAgentConnectionsAvailable } from "@/services/agentConnectionsAvailability";
 import { resetWorkspaceModePreference } from "@/services/workspaceModePreference";
 import { useLocalState } from "@/state/useLocalState";
 import type { TeamStatus } from "@/types/team";
-import { isIOS, isLinux, isMacOS, isTauriDesktop } from "@/utils/platform";
+import { isIOS } from "@/utils/platform";
 import { getTeamSeatMismatch } from "@/utils/teamSeats";
 import { cn } from "@/utils/utils";
 import packageJson from "../../../package.json";
@@ -235,7 +236,7 @@ function SettingsLayoutContent() {
   });
 
   const isIOSPlatform = isIOS();
-  const supportsAgentConnections = isTauriDesktop() && (isMacOS() || isLinux());
+  const supportsAgentConnections = isAgentConnectionsAvailable();
   const { data: products, isError: productsError } = useQuery({
     queryKey: ["products-version-check", isIOSPlatform],
     queryFn: () => getBillingService().getProducts(`v${packageJson.version}`),

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -35,6 +35,7 @@ import { Route as SettingsHistoryRouteImport } from './routes/settings.history'
 import { Route as SettingsDeleteAccountRouteImport } from './routes/settings.delete-account'
 import { Route as SettingsBillingRouteImport } from './routes/settings.billing'
 import { Route as SettingsApiRouteImport } from './routes/settings.api'
+import { Route as SettingsAgentConnectionsRouteImport } from './routes/settings.agent-connections'
 import { Route as SettingsAccountRouteImport } from './routes/settings.account'
 import { Route as SettingsAboutRouteImport } from './routes/settings.about'
 import { Route as PasswordResetConfirmRouteImport } from './routes/password-reset.confirm'
@@ -178,6 +179,12 @@ const SettingsApiRoute = SettingsApiRouteImport.update({
   path: '/api',
   getParentRoute: () => SettingsRoute,
 } as any)
+const SettingsAgentConnectionsRoute =
+  SettingsAgentConnectionsRouteImport.update({
+    id: '/agent-connections',
+    path: '/agent-connections',
+    getParentRoute: () => SettingsRoute,
+  } as any)
 const SettingsAccountRoute = SettingsAccountRouteImport.update({
   id: '/account',
   path: '/account',
@@ -260,6 +267,7 @@ export interface FileRoutesByFullPath {
   '/password-reset/confirm': typeof PasswordResetConfirmRoute
   '/settings/about': typeof SettingsAboutRoute
   '/settings/account': typeof SettingsAccountRoute
+  '/settings/agent-connections': typeof SettingsAgentConnectionsRoute
   '/settings/api': typeof SettingsApiRouteWithChildren
   '/settings/billing': typeof SettingsBillingRoute
   '/settings/delete-account': typeof SettingsDeleteAccountRoute
@@ -299,6 +307,7 @@ export interface FileRoutesByTo {
   '/password-reset/confirm': typeof PasswordResetConfirmRoute
   '/settings/about': typeof SettingsAboutRoute
   '/settings/account': typeof SettingsAccountRoute
+  '/settings/agent-connections': typeof SettingsAgentConnectionsRoute
   '/settings/billing': typeof SettingsBillingRoute
   '/settings/delete-account': typeof SettingsDeleteAccountRoute
   '/settings/history': typeof SettingsHistoryRoute
@@ -337,6 +346,7 @@ export interface FileRoutesById {
   '/password-reset/confirm': typeof PasswordResetConfirmRoute
   '/settings/about': typeof SettingsAboutRoute
   '/settings/account': typeof SettingsAccountRoute
+  '/settings/agent-connections': typeof SettingsAgentConnectionsRoute
   '/settings/api': typeof SettingsApiRouteWithChildren
   '/settings/billing': typeof SettingsBillingRoute
   '/settings/delete-account': typeof SettingsDeleteAccountRoute
@@ -379,6 +389,7 @@ export interface FileRouteTypes {
     | '/password-reset/confirm'
     | '/settings/about'
     | '/settings/account'
+    | '/settings/agent-connections'
     | '/settings/api'
     | '/settings/billing'
     | '/settings/delete-account'
@@ -418,6 +429,7 @@ export interface FileRouteTypes {
     | '/password-reset/confirm'
     | '/settings/about'
     | '/settings/account'
+    | '/settings/agent-connections'
     | '/settings/billing'
     | '/settings/delete-account'
     | '/settings/history'
@@ -455,6 +467,7 @@ export interface FileRouteTypes {
     | '/password-reset/confirm'
     | '/settings/about'
     | '/settings/account'
+    | '/settings/agent-connections'
     | '/settings/api'
     | '/settings/billing'
     | '/settings/delete-account'
@@ -682,6 +695,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof SettingsApiRouteImport
       parentRoute: typeof SettingsRoute
     }
+    '/settings/agent-connections': {
+      id: '/settings/agent-connections'
+      path: '/agent-connections'
+      fullPath: '/settings/agent-connections'
+      preLoaderRoute: typeof SettingsAgentConnectionsRouteImport
+      parentRoute: typeof SettingsRoute
+    }
     '/settings/account': {
       id: '/settings/account'
       path: '/account'
@@ -828,6 +848,7 @@ const SettingsTeamRouteWithChildren = SettingsTeamRoute._addFileChildren(
 interface SettingsRouteChildren {
   SettingsAboutRoute: typeof SettingsAboutRoute
   SettingsAccountRoute: typeof SettingsAccountRoute
+  SettingsAgentConnectionsRoute: typeof SettingsAgentConnectionsRoute
   SettingsApiRoute: typeof SettingsApiRouteWithChildren
   SettingsBillingRoute: typeof SettingsBillingRoute
   SettingsDeleteAccountRoute: typeof SettingsDeleteAccountRoute
@@ -841,6 +862,7 @@ interface SettingsRouteChildren {
 const SettingsRouteChildren: SettingsRouteChildren = {
   SettingsAboutRoute: SettingsAboutRoute,
   SettingsAccountRoute: SettingsAccountRoute,
+  SettingsAgentConnectionsRoute: SettingsAgentConnectionsRoute,
   SettingsApiRoute: SettingsApiRouteWithChildren,
   SettingsBillingRoute: SettingsBillingRoute,
   SettingsDeleteAccountRoute: SettingsDeleteAccountRoute,

--- a/frontend/src/routes/settings.agent-connections.tsx
+++ b/frontend/src/routes/settings.agent-connections.tsx
@@ -1,13 +1,13 @@
 import { createFileRoute, Navigate } from "@tanstack/react-router";
 import { AgentConnectionsSettings } from "@/components/settings/AgentConnectionsSettings";
-import { isLinux, isMacOS, isTauriDesktop } from "@/utils/platform";
+import { isAgentConnectionsAvailable } from "@/services/agentConnectionsAvailability";
 
 export const Route = createFileRoute("/settings/agent-connections")({
   component: AgentConnectionsRoute
 });
 
 function AgentConnectionsRoute() {
-  if (!isTauriDesktop() || (!isMacOS() && !isLinux())) {
+  if (!isAgentConnectionsAvailable()) {
     return <Navigate to="/settings/account" replace />;
   }
 

--- a/frontend/src/routes/settings.agent-connections.tsx
+++ b/frontend/src/routes/settings.agent-connections.tsx
@@ -1,0 +1,15 @@
+import { createFileRoute, Navigate } from "@tanstack/react-router";
+import { AgentConnectionsSettings } from "@/components/settings/AgentConnectionsSettings";
+import { isLinux, isMacOS, isTauriDesktop } from "@/utils/platform";
+
+export const Route = createFileRoute("/settings/agent-connections")({
+  component: AgentConnectionsRoute
+});
+
+function AgentConnectionsRoute() {
+  if (!isTauriDesktop() || (!isMacOS() && !isLinux())) {
+    return <Navigate to="/settings/account" replace />;
+  }
+
+  return <AgentConnectionsSettings />;
+}

--- a/frontend/src/services/agentConnectionsAvailability.test.ts
+++ b/frontend/src/services/agentConnectionsAvailability.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isAgentConnectionsAvailable,
+  type AgentConnectionsAvailabilityChecks
+} from "./agentConnectionsAvailability";
+import { FEATURE_FLAGS } from "./flags";
+
+function availabilityChecks({
+  forcedOn = true,
+  tauriDesktop = true,
+  macOS = false,
+  linux = false
+}: {
+  forcedOn?: boolean;
+  tauriDesktop?: boolean;
+  macOS?: boolean;
+  linux?: boolean;
+} = {}): AgentConnectionsAvailabilityChecks {
+  return {
+    isForcedOn: () => forcedOn,
+    isTauriDesktop: () => tauriDesktop,
+    isMacOS: () => macOS,
+    isLinux: () => linux
+  };
+}
+
+describe("isAgentConnectionsAvailable", () => {
+  test("requires the local agent_connections force flag", () => {
+    let requestedFlag = "";
+    const checks = availabilityChecks({ macOS: true });
+    checks.isForcedOn = (key) => {
+      requestedFlag = key;
+      return false;
+    };
+
+    expect(isAgentConnectionsAvailable(checks)).toBe(false);
+    expect(requestedFlag).toBe(FEATURE_FLAGS.AGENT_CONNECTIONS);
+  });
+
+  test.each([
+    ["macOS Tauri Desktop", true, true, false, true],
+    ["Linux Tauri Desktop", true, false, true, true],
+    ["Windows Tauri Desktop", true, false, false, false],
+    ["macOS outside Tauri Desktop", false, true, false, false],
+    ["Linux outside Tauri Desktop", false, false, true, false]
+  ])("returns the supported state for %s", (_name, tauriDesktop, macOS, linux, expected) => {
+    expect(isAgentConnectionsAvailable(availabilityChecks({ tauriDesktop, macOS, linux }))).toBe(
+      expected
+    );
+  });
+
+  test("fails closed if an availability check throws", () => {
+    const checks = availabilityChecks({ macOS: true });
+    checks.isTauriDesktop = () => {
+      throw new Error("platform unavailable");
+    };
+
+    expect(isAgentConnectionsAvailable(checks)).toBe(false);
+  });
+});

--- a/frontend/src/services/agentConnectionsAvailability.ts
+++ b/frontend/src/services/agentConnectionsAvailability.ts
@@ -1,0 +1,34 @@
+import { FEATURE_FLAGS, isForcedOn } from "@/services/flags";
+import { isLinux, isMacOS, isTauriDesktop } from "@/utils/platform";
+
+export interface AgentConnectionsAvailabilityChecks {
+  isForcedOn: (key: string) => boolean;
+  isTauriDesktop: () => boolean;
+  isMacOS: () => boolean;
+  isLinux: () => boolean;
+}
+
+const defaultChecks: AgentConnectionsAvailabilityChecks = {
+  isForcedOn,
+  isTauriDesktop,
+  isMacOS,
+  isLinux
+};
+
+/**
+ * Agent connections is a local desktop preview, not a remotely enabled feature.
+ * Keep this synchronous so navigation and direct-route admission share one gate.
+ */
+export function isAgentConnectionsAvailable(
+  checks: AgentConnectionsAvailabilityChecks = defaultChecks
+): boolean {
+  try {
+    return (
+      checks.isForcedOn(FEATURE_FLAGS.AGENT_CONNECTIONS) &&
+      checks.isTauriDesktop() &&
+      (checks.isMacOS() || checks.isLinux())
+    );
+  } catch {
+    return false;
+  }
+}

--- a/frontend/src/services/agentRuntimeService.test.ts
+++ b/frontend/src/services/agentRuntimeService.test.ts
@@ -1,10 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import {
+  AgentRuntimeStopCoordinator,
   AgentRuntimeService,
   type AgentRuntimeBridge,
+  type AgentRuntimeStopBridge,
   type AgentCreateSessionRequest,
   type AgentSendMessageRequest
 } from "./agentRuntimeService";
+import type { AgentOperationBlock } from "./agentOperationFence";
 
 class RecordingBridge implements AgentRuntimeBridge {
   readonly events: string[] = [];
@@ -66,5 +69,47 @@ describe("AgentRuntimeService", () => {
 
     expect(bridge.events).toEqual(["fence:user-a", "sync:user-a", "invoke:agent_create_session"]);
     expect(bridge.lastArgs).toEqual({ userId: "user-a", request });
+  });
+});
+
+class RecordingStopBridge implements AgentRuntimeStopBridge {
+  readonly events: string[] = [];
+  readonly block: AgentOperationBlock = {
+    release: () => this.events.push("release"),
+    retainUntilNextSession: () => this.events.push("retain")
+  };
+  acpError: Error | null = null;
+
+  async blockAndDrain(userId: string): Promise<AgentOperationBlock> {
+    this.events.push(`block:${userId}`);
+    return this.block;
+  }
+
+  async stopAcp(userId: string): Promise<void> {
+    this.events.push(`stop-acp:${userId}`);
+    if (this.acpError) throw this.acpError;
+  }
+
+  async stopRuntime(userId: string): Promise<void> {
+    this.events.push(`stop-runtime:${userId}`);
+  }
+}
+
+describe("AgentRuntimeStopCoordinator", () => {
+  test("drains work and stops ACP before the Agent runtime", async () => {
+    const bridge = new RecordingStopBridge();
+    const coordinator = new AgentRuntimeStopCoordinator(bridge);
+
+    expect(await coordinator.stop("user-a")).toBe(bridge.block);
+    expect(bridge.events).toEqual(["block:user-a", "stop-acp:user-a", "stop-runtime:user-a"]);
+  });
+
+  test("an ACP stop failure prevents runtime shutdown and releases the cleanup lease", async () => {
+    const bridge = new RecordingStopBridge();
+    bridge.acpError = new Error("ACP still alive");
+    const coordinator = new AgentRuntimeStopCoordinator(bridge);
+
+    await expect(coordinator.stop("user-a")).rejects.toThrow("ACP still alive");
+    expect(bridge.events).toEqual(["block:user-a", "stop-acp:user-a", "release"]);
   });
 });

--- a/frontend/src/services/agentRuntimeService.test.ts
+++ b/frontend/src/services/agentRuntimeService.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test";
 import {
   AgentRuntimeStopCoordinator,
+  AgentRuntimePartialStopError,
   AgentRuntimeService,
   type AgentRuntimeBridge,
   type AgentRuntimeStopBridge,
+  type AgentRuntimeLifecycleOutcome,
   type AgentCreateSessionRequest,
   type AgentSendMessageRequest
 } from "./agentRuntimeService";
@@ -78,38 +80,61 @@ class RecordingStopBridge implements AgentRuntimeStopBridge {
     release: () => this.events.push("release"),
     retainUntilNextSession: () => this.events.push("retain")
   };
-  acpError: Error | null = null;
+  stopError: Error | null = null;
+  outcome: AgentRuntimeLifecycleOutcome = {
+    status: { running: false, activeRuns: {} },
+    acpShutdownError: null
+  };
 
   async blockAndDrain(userId: string): Promise<AgentOperationBlock> {
     this.events.push(`block:${userId}`);
     return this.block;
   }
 
-  async stopAcp(userId: string): Promise<void> {
-    this.events.push(`stop-acp:${userId}`);
-    if (this.acpError) throw this.acpError;
-  }
-
-  async stopRuntime(userId: string): Promise<void> {
-    this.events.push(`stop-runtime:${userId}`);
+  async stopHost(userId: string): Promise<AgentRuntimeLifecycleOutcome> {
+    this.events.push(`stop-host:${userId}`);
+    if (this.stopError) throw this.stopError;
+    return this.outcome;
   }
 }
 
 describe("AgentRuntimeStopCoordinator", () => {
-  test("drains work and stops ACP before the Agent runtime", async () => {
+  test("drains work and delegates one composite stop to the native host", async () => {
     const bridge = new RecordingStopBridge();
     const coordinator = new AgentRuntimeStopCoordinator(bridge);
 
     expect(await coordinator.stop("user-a")).toBe(bridge.block);
-    expect(bridge.events).toEqual(["block:user-a", "stop-acp:user-a", "stop-runtime:user-a"]);
+    expect(bridge.events).toEqual(["block:user-a", "stop-host:user-a"]);
   });
 
-  test("an ACP stop failure prevents runtime shutdown and releases the cleanup lease", async () => {
+  test("a native host failure releases the cleanup lease", async () => {
     const bridge = new RecordingStopBridge();
-    bridge.acpError = new Error("ACP still alive");
+    bridge.stopError = new Error("runtime still alive");
     const coordinator = new AgentRuntimeStopCoordinator(bridge);
 
-    await expect(coordinator.stop("user-a")).rejects.toThrow("ACP still alive");
-    expect(bridge.events).toEqual(["block:user-a", "stop-acp:user-a", "release"]);
+    await expect(coordinator.stop("user-a")).rejects.toThrow("runtime still alive");
+    expect(bridge.events).toEqual(["block:user-a", "stop-host:user-a", "release"]);
+  });
+
+  test("partial ACP cleanup releases the lease and preserves the stopped runtime status", async () => {
+    const bridge = new RecordingStopBridge();
+    bridge.outcome = {
+      status: { running: false, activeRuns: {} },
+      acpShutdownError: "ACP still alive"
+    };
+    const coordinator = new AgentRuntimeStopCoordinator(bridge);
+
+    try {
+      await coordinator.stop("user-a");
+      throw new Error("expected partial stop failure");
+    } catch (error) {
+      expect(error).toBeInstanceOf(AgentRuntimePartialStopError);
+      expect((error as AgentRuntimePartialStopError).outcome.status.running).toBe(false);
+      expect(error).toHaveProperty(
+        "message",
+        "Agent runtime stopped, but ACP cleanup failed: ACP still alive"
+      );
+    }
+    expect(bridge.events).toEqual(["block:user-a", "stop-host:user-a", "release"]);
   });
 });

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -74,6 +74,11 @@ export interface AgentRuntimeStatus {
   activeRuns?: Record<string, string>;
 }
 
+export interface AgentRuntimeLifecycleOutcome {
+  status: AgentRuntimeStatus;
+  acpShutdownError: string | null;
+}
+
 export interface RecentProjectRoot {
   path: string;
   name: string;
@@ -161,14 +166,13 @@ export interface AgentRuntimeBridge {
 
 export interface AgentRuntimeStopBridge {
   blockAndDrain(userId: string): Promise<AgentOperationBlock>;
-  stopAcp(userId: string): Promise<void>;
-  stopRuntime(userId: string): Promise<void>;
+  stopHost(userId: string): Promise<AgentRuntimeLifecycleOutcome>;
 }
 
 /**
- * Owns the security-sensitive shutdown order shared by logout and account
- * transitions. ACP must be gone before the runtime can stop and credentials
- * can be cleared, because connected ACP clients can still submit Agent work.
+ * Owns the security-sensitive host shutdown shared by logout and account
+ * transitions. Native code attempts ACP cleanup first and always attempts the
+ * core runtime stop; credential cleanup proceeds only when both succeeded.
  */
 export class AgentRuntimeStopCoordinator {
   constructor(private readonly bridge: AgentRuntimeStopBridge) {}
@@ -176,13 +180,24 @@ export class AgentRuntimeStopCoordinator {
   async stop(userId: string): Promise<AgentOperationBlock> {
     const block = await this.bridge.blockAndDrain(userId);
     try {
-      await this.bridge.stopAcp(userId);
-      await this.bridge.stopRuntime(userId);
+      const outcome = await this.bridge.stopHost(userId);
+      if (outcome.acpShutdownError) {
+        throw new AgentRuntimePartialStopError(outcome);
+      }
       return block;
     } catch (error) {
       block.release();
       throw error;
     }
+  }
+}
+
+export class AgentRuntimePartialStopError extends Error {
+  constructor(readonly outcome: AgentRuntimeLifecycleOutcome) {
+    super(
+      `Agent runtime stopped, but ACP cleanup failed: ${outcome.acpShutdownError || "unknown ACP error"}`
+    );
+    this.name = "AgentRuntimePartialStopError";
   }
 }
 
@@ -194,13 +209,11 @@ const defaultAgentRuntimeBridge: AgentRuntimeBridge = {
 
 const agentRuntimeStopCoordinator = new AgentRuntimeStopCoordinator({
   blockAndDrain: async (userId) => await agentOperationFence.blockAndDrain(userId),
-  // The cleanup lease is already held, so this deliberately invokes the
-  // local command directly instead of re-entering MapleAcpService's fence.
-  stopAcp: async (userId) => {
-    await invokeAgent("agent_acp_stop", { userId });
-  },
-  stopRuntime: async (userId) => {
-    await invokeAgent<AgentRuntimeStatus>("agent_stop_runtime", { userId });
+  // The cleanup lease is already held. Native code owns the single composite
+  // ACP-plus-runtime lifecycle gate; the manual ACP Stop command is reserved
+  // for the settings page because it also changes saved configuration.
+  stopHost: async (userId) => {
+    return await invokeAgent<AgentRuntimeLifecycleOutcome>("agent_stop_runtime", { userId });
   }
 });
 
@@ -218,8 +231,11 @@ export class AgentRuntimeService {
     });
   }
 
-  async restartRuntime(userId: string, request?: AgentStartRequest): Promise<AgentRuntimeStatus> {
-    return await this.invokeForUser<AgentRuntimeStatus>(userId, "agent_restart_runtime", {
+  async restartRuntime(
+    userId: string,
+    request?: AgentStartRequest
+  ): Promise<AgentRuntimeLifecycleOutcome> {
+    return await this.invokeForUser<AgentRuntimeLifecycleOutcome>(userId, "agent_restart_runtime", {
       userId,
       request: request ?? null
     });

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -159,11 +159,50 @@ export interface AgentRuntimeBridge {
   invoke<T>(command: string, args?: Record<string, unknown>): Promise<T>;
 }
 
+export interface AgentRuntimeStopBridge {
+  blockAndDrain(userId: string): Promise<AgentOperationBlock>;
+  stopAcp(userId: string): Promise<void>;
+  stopRuntime(userId: string): Promise<void>;
+}
+
+/**
+ * Owns the security-sensitive shutdown order shared by logout and account
+ * transitions. ACP must be gone before the runtime can stop and credentials
+ * can be cleared, because connected ACP clients can still submit Agent work.
+ */
+export class AgentRuntimeStopCoordinator {
+  constructor(private readonly bridge: AgentRuntimeStopBridge) {}
+
+  async stop(userId: string): Promise<AgentOperationBlock> {
+    const block = await this.bridge.blockAndDrain(userId);
+    try {
+      await this.bridge.stopAcp(userId);
+      await this.bridge.stopRuntime(userId);
+      return block;
+    } catch (error) {
+      block.release();
+      throw error;
+    }
+  }
+}
+
 const defaultAgentRuntimeBridge: AgentRuntimeBridge = {
   syncAuth: async (userId) => await mapleApiAuthService.sync(userId),
   runForUser: async (userId, operation) => await agentOperationFence.run(userId, operation),
   invoke: invokeAgent
 };
+
+const agentRuntimeStopCoordinator = new AgentRuntimeStopCoordinator({
+  blockAndDrain: async (userId) => await agentOperationFence.blockAndDrain(userId),
+  // The cleanup lease is already held, so this deliberately invokes the
+  // local command directly instead of re-entering MapleAcpService's fence.
+  stopAcp: async (userId) => {
+    await invokeAgent("agent_acp_stop", { userId });
+  },
+  stopRuntime: async (userId) => {
+    await invokeAgent<AgentRuntimeStatus>("agent_stop_runtime", { userId });
+  }
+});
 
 export class AgentRuntimeService {
   constructor(private readonly bridge: AgentRuntimeBridge = defaultAgentRuntimeBridge) {}
@@ -432,20 +471,13 @@ export async function stopAgentRuntimeForUser(
 ): Promise<AgentOperationBlock> {
   if (!isTauriDesktop()) return noOpOperationBlock();
   if (!userId) throw new Error("Cannot stop Agent Mode without an authenticated user");
-  const block = await agentOperationFence.blockAndDrain(userId);
-  try {
-    await invokeAgent<AgentRuntimeStatus>("agent_stop_runtime", { userId });
-    return block;
-  } catch (error) {
-    block.release();
-    throw error;
-  }
+  return await agentRuntimeStopCoordinator.stop(userId);
 }
 
 export async function clearAgentDataForUser(userId?: string | null): Promise<AgentOperationBlock> {
   if (!isTauriDesktop()) return noOpOperationBlock();
   if (!userId) throw new Error("Cannot clear Agent Mode data without an authenticated user");
-  const block = await agentOperationFence.blockAndDrain(userId);
+  const block = await agentRuntimeStopCoordinator.stop(userId);
   try {
     await invokeAgent("agent_clear_user_data", { userId });
     return block;
@@ -460,7 +492,7 @@ export async function clearAgentHistoryForUser(
 ): Promise<AgentOperationBlock> {
   if (!isTauriDesktop()) return noOpOperationBlock();
   if (!userId) throw new Error("Cannot clear Agent Mode history without an authenticated user");
-  const block = await agentOperationFence.blockAndDrain(userId);
+  const block = await agentRuntimeStopCoordinator.stop(userId);
   try {
     await invokeAgent("agent_clear_user_history", { userId });
     return block;

--- a/frontend/src/services/flags.ts
+++ b/frontend/src/services/flags.ts
@@ -4,7 +4,8 @@ const DEV_FLAGS_BASE_URL = "https://flags-dev.opensecret.cloud";
 const PROD_FLAGS_BASE_URL = "https://flags.opensecret.cloud";
 
 export const FEATURE_FLAGS = {
-  AGENT_MODE: "agent_mode"
+  AGENT_MODE: "agent_mode",
+  AGENT_CONNECTIONS: "agent_connections"
 } as const;
 
 export type FlagValues = Readonly<Record<string, boolean>>;

--- a/frontend/src/services/mapleAcpService.test.ts
+++ b/frontend/src/services/mapleAcpService.test.ts
@@ -136,6 +136,22 @@ describe("Maple ACP response normalization", () => {
     });
   });
 
+  test("migrates the former Maple-owned allow-all bypass to caller-owned approvals", () => {
+    expect(
+      normalizeMapleAcpConfig({
+        enabled: true,
+        permissionMode: "allow_all",
+        allowedProjectRoots: [],
+        maxConnections: 1
+      })
+    ).toEqual({
+      enabled: true,
+      permissionMode: "read_only",
+      allowedProjectRoots: [],
+      maxConnections: 1
+    });
+  });
+
   test("accepts the native status and tolerates optional future fields", () => {
     expect(
       normalizeMapleAcpStatus({

--- a/frontend/src/services/mapleAcpService.test.ts
+++ b/frontend/src/services/mapleAcpService.test.ts
@@ -1,0 +1,219 @@
+import { describe, expect, test } from "bun:test";
+import {
+  BUZZ_DEFAULT_AGENT_PARALLELISM,
+  BUZZ_MAPLE_AGENT_PARALLELISM,
+  BUZZ_MAPLE_HARNESS_ID,
+  BUZZ_MAPLE_HARNESS_NAME,
+  DEFAULT_MAPLE_ACP_CONFIG,
+  MapleAcpService,
+  buildBuzzCustomHarness,
+  isMapleAcpConfigReady,
+  isMapleAcpPolicyDirty,
+  normalizeMapleAcpConfig,
+  normalizeMapleAcpStatus,
+  serializeBuzzCustomHarness,
+  type MapleAcpBridge,
+  type MapleAcpHarness
+} from "./mapleAcpService";
+
+class RecordingBridge implements MapleAcpBridge {
+  readonly events: string[] = [];
+  lastArgs: Record<string, unknown> | undefined;
+  result: unknown = undefined;
+  desktop = true;
+
+  isDesktop(): boolean {
+    return this.desktop;
+  }
+
+  async syncAuth(userId: string): Promise<void> {
+    this.events.push(`sync:${userId}`);
+  }
+
+  async runForUser<T>(userId: string, operation: () => Promise<T>): Promise<T> {
+    this.events.push(`fence:${userId}`);
+    return await operation();
+  }
+
+  async invoke<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+    this.events.push(`invoke:${command}`);
+    this.lastArgs = args;
+    return this.result as T;
+  }
+}
+
+const harness: MapleAcpHarness = {
+  command: "/Applications/Maple Desktop.app/Contents/MacOS/maple",
+  args: ["acp"]
+};
+
+describe("MapleAcpService", () => {
+  test("start synchronizes native authentication inside the account fence", async () => {
+    const bridge = new RecordingBridge();
+    bridge.result = { running: true, harness };
+    const service = new MapleAcpService(bridge);
+
+    await service.start("user-a");
+
+    expect(bridge.events).toEqual(["fence:user-a", "sync:user-a", "invoke:agent_acp_start"]);
+    expect(bridge.lastArgs).toEqual({ userId: "user-a" });
+  });
+
+  test("stop and polling remain account-fenced without refreshing credentials", async () => {
+    const bridge = new RecordingBridge();
+    bridge.result = { running: false };
+    const service = new MapleAcpService(bridge);
+
+    await service.getStatus("user-a");
+    await service.stop("user-a");
+
+    expect(bridge.events).toEqual([
+      "fence:user-a",
+      "invoke:agent_acp_get_status",
+      "fence:user-a",
+      "invoke:agent_acp_stop"
+    ]);
+  });
+
+  test("save sends a normalized, account-scoped config", async () => {
+    const bridge = new RecordingBridge();
+    bridge.result = {
+      enabled: false,
+      permissionMode: "read_only",
+      allowedProjectRoots: [],
+      maxConnections: 1
+    };
+    const service = new MapleAcpService(bridge);
+
+    await service.saveConfig("user-a", {
+      enabled: false,
+      permissionMode: "read_only",
+      allowedProjectRoots: [" /tmp/project ", "/tmp/project"],
+      maxConnections: 1
+    });
+
+    expect(bridge.lastArgs).toEqual({
+      userId: "user-a",
+      config: {
+        enabled: false,
+        permissionMode: "read_only",
+        allowedProjectRoots: ["/tmp/project"],
+        maxConnections: 1
+      }
+    });
+  });
+
+  test("rejects every operation outside Maple Desktop", async () => {
+    const bridge = new RecordingBridge();
+    bridge.desktop = false;
+    const service = new MapleAcpService(bridge);
+
+    await expect(service.loadConfig("user-a")).rejects.toThrow("available in Maple Desktop");
+    await expect(service.saveConfig("user-a", DEFAULT_MAPLE_ACP_CONFIG)).rejects.toThrow(
+      "available in Maple Desktop"
+    );
+    await expect(service.start("user-a")).rejects.toThrow("available in Maple Desktop");
+    await expect(service.stop("user-a")).rejects.toThrow("available in Maple Desktop");
+    await expect(service.getStatus("user-a")).rejects.toThrow("available in Maple Desktop");
+    expect(bridge.events).toEqual([]);
+  });
+});
+
+describe("Maple ACP response normalization", () => {
+  test("fails closed on malformed config values", () => {
+    expect(
+      normalizeMapleAcpConfig({
+        enabled: "yes",
+        permissionMode: "unattended",
+        allowedProjectRoots: ["/tmp/a", 42, " /tmp/a ", "/tmp/b"],
+        maxConnections: -3
+      })
+    ).toEqual({
+      enabled: false,
+      permissionMode: "read_only",
+      allowedProjectRoots: ["/tmp/a", "/tmp/b"],
+      maxConnections: 1
+    });
+  });
+
+  test("accepts the native status and tolerates optional future fields", () => {
+    expect(
+      normalizeMapleAcpStatus({
+        running: true,
+        enabled: true,
+        connectedClients: 2,
+        activeSessions: 3,
+        activeRuns: 1,
+        endpointKind: "unix_socket",
+        endpoint: { path: "/tmp/maple.sock" },
+        protocolVersion: 1,
+        lastError: "",
+        buzzCredentialsAvailable: true,
+        harness,
+        ignoredFutureField: "okay"
+      })
+    ).toEqual({
+      running: true,
+      enabled: true,
+      connectedClients: 2,
+      activeSessions: 3,
+      activeRuns: 1,
+      endpoint: "/tmp/maple.sock",
+      endpointKind: "unix_socket",
+      protocolVersion: 1,
+      error: null,
+      buzzCredentialsAvailable: true,
+      harness
+    });
+  });
+});
+
+describe("Buzz custom harness output", () => {
+  test("matches the separate values expected by the Buzz custom harness form", () => {
+    expect(buildBuzzCustomHarness(harness)).toEqual({
+      id: BUZZ_MAPLE_HARNESS_ID,
+      label: BUZZ_MAPLE_HARNESS_NAME,
+      command: harness.command,
+      args: ["acp"],
+      env: {}
+    });
+
+    const serialized = serializeBuzzCustomHarness(harness);
+    expect(JSON.parse(serialized)).toEqual(buildBuzzCustomHarness(harness));
+    expect(serialized).toContain(harness.command);
+    expect(serialized).not.toContain("BUZZ_PRIVATE_KEY");
+    expect(serialized).not.toContain("accessToken");
+    expect(serialized).not.toContain("endpoint");
+  });
+
+  test("documents Buzz parallelism that matches Maple's default connection limit", () => {
+    expect(BUZZ_MAPLE_AGENT_PARALLELISM).toBe(1);
+    expect(BUZZ_DEFAULT_AGENT_PARALLELISM).toBe(10);
+    expect(DEFAULT_MAPLE_ACP_CONFIG.maxConnections).toBe(Number(BUZZ_MAPLE_AGENT_PARALLELISM));
+  });
+});
+
+describe("Agent connections policy state", () => {
+  const savedConfig = {
+    enabled: true,
+    permissionMode: "allow_all" as const,
+    allowedProjectRoots: [],
+    maxConnections: 1
+  };
+
+  test("keeps mutations locked until the saved config has loaded", () => {
+    expect(isMapleAcpConfigReady(null, null)).toBe(false);
+    expect(isMapleAcpConfigReady(savedConfig, null)).toBe(false);
+    expect(isMapleAcpConfigReady(null, savedConfig)).toBe(false);
+    expect(isMapleAcpConfigReady(savedConfig, savedConfig)).toBe(true);
+  });
+
+  test("never treats a missing config as a dirty default policy", () => {
+    const editedConfig = { ...savedConfig, permissionMode: "read_only" as const };
+
+    expect(isMapleAcpPolicyDirty(null, savedConfig)).toBe(false);
+    expect(isMapleAcpPolicyDirty(editedConfig, null)).toBe(false);
+    expect(isMapleAcpPolicyDirty(savedConfig, savedConfig)).toBe(false);
+    expect(isMapleAcpPolicyDirty(editedConfig, savedConfig)).toBe(true);
+  });
+});

--- a/frontend/src/services/mapleAcpService.ts
+++ b/frontend/src/services/mapleAcpService.ts
@@ -219,7 +219,11 @@ function asRecord(value: unknown): Record<string, unknown> | null {
 }
 
 function normalizePermissionMode(value: unknown): MapleAcpPermissionMode {
-  return value === "allow_all" ? "allow_all" : "read_only";
+  // `allow_all` was an exploratory Maple-owned bypass. Preserve the wire type
+  // while older native builds exist, but migrate every UI policy to caller-owned
+  // ACP approval routing.
+  void value;
+  return "read_only";
 }
 
 function safeCount(value: unknown, fallback = 0): number {

--- a/frontend/src/services/mapleAcpService.ts
+++ b/frontend/src/services/mapleAcpService.ts
@@ -1,0 +1,249 @@
+import { agentOperationFence } from "@/services/agentOperationFence";
+import { mapleApiAuthService } from "@/services/mapleApiAuthService";
+import { isTauriDesktop } from "@/utils/platform";
+
+export type MapleAcpPermissionMode = "read_only" | "allow_all";
+
+export interface MapleAcpConfig {
+  enabled: boolean;
+  permissionMode: MapleAcpPermissionMode;
+  allowedProjectRoots: string[];
+  maxConnections: number;
+}
+
+export interface MapleAcpHarness {
+  command: string;
+  args: string[];
+}
+
+export interface MapleAcpStatus {
+  running: boolean;
+  enabled: boolean;
+  connectedClients: number;
+  activeSessions: number;
+  activeRuns: number;
+  endpoint: string | null;
+  endpointKind: string | null;
+  protocolVersion: string | number | null;
+  error: string | null;
+  buzzCredentialsAvailable: boolean;
+  harness: MapleAcpHarness | null;
+}
+
+export interface BuzzCustomHarnessDefinition {
+  id: "maple";
+  label: "Maple";
+  command: string;
+  args: string[];
+  env: Record<string, never>;
+}
+
+export const BUZZ_MAPLE_HARNESS_ID = "maple" as const;
+export const BUZZ_MAPLE_HARNESS_NAME = "Maple" as const;
+export const BUZZ_MAPLE_AGENT_PARALLELISM = 1 as const;
+export const BUZZ_DEFAULT_AGENT_PARALLELISM = 10 as const;
+
+export interface MapleAcpBridge {
+  isDesktop(): boolean;
+  syncAuth(userId: string): Promise<void>;
+  runForUser<T>(userId: string, operation: () => Promise<T>): Promise<T>;
+  invoke<T>(command: string, args?: Record<string, unknown>): Promise<T>;
+}
+
+export const DEFAULT_MAPLE_ACP_CONFIG: MapleAcpConfig = Object.freeze({
+  enabled: false,
+  permissionMode: "read_only",
+  allowedProjectRoots: [],
+  maxConnections: 1
+});
+
+const defaultBridge: MapleAcpBridge = {
+  isDesktop: isTauriDesktop,
+  syncAuth: async (userId) => await mapleApiAuthService.sync(userId),
+  runForUser: async (userId, operation) => await agentOperationFence.run(userId, operation),
+  invoke: invokeMapleAcp
+};
+
+export class MapleAcpService {
+  constructor(private readonly bridge: MapleAcpBridge = defaultBridge) {}
+
+  async loadConfig(userId: string): Promise<MapleAcpConfig> {
+    const raw = await this.invokeAuthenticated<unknown>(userId, "agent_acp_load_config");
+    return normalizeMapleAcpConfig(raw);
+  }
+
+  async saveConfig(userId: string, config: MapleAcpConfig): Promise<MapleAcpConfig> {
+    const normalized = normalizeMapleAcpConfig(config);
+    const raw = await this.invokeAuthenticated<unknown>(userId, "agent_acp_save_config", {
+      config: normalized
+    });
+    return normalizeMapleAcpConfig(raw);
+  }
+
+  async start(userId: string): Promise<MapleAcpStatus> {
+    const raw = await this.invokeAuthenticated<unknown>(userId, "agent_acp_start");
+    return normalizeMapleAcpStatus(raw);
+  }
+
+  async stop(userId: string): Promise<MapleAcpStatus> {
+    // Stopping is a local control-plane operation. It must remain available
+    // when credentials are expired or are being cleared during logout.
+    const raw = await this.invokeLocal<unknown>(userId, "agent_acp_stop");
+    return normalizeMapleAcpStatus(raw);
+  }
+
+  async getStatus(userId: string): Promise<MapleAcpStatus> {
+    // Polling status should neither refresh credentials nor turn a local
+    // diagnostics page into recurring authenticated network work.
+    const raw = await this.invokeLocal<unknown>(userId, "agent_acp_get_status");
+    return normalizeMapleAcpStatus(raw);
+  }
+
+  private async invokeAuthenticated<T>(
+    userId: string,
+    command: string,
+    args?: Record<string, unknown>
+  ): Promise<T> {
+    this.requireDesktop();
+    return await this.bridge.runForUser(userId, async () => {
+      await this.bridge.syncAuth(userId);
+      return await this.bridge.invoke<T>(command, { userId, ...args });
+    });
+  }
+
+  private async invokeLocal<T>(
+    userId: string,
+    command: string,
+    args?: Record<string, unknown>
+  ): Promise<T> {
+    this.requireDesktop();
+    return await this.bridge.runForUser(userId, async () => {
+      return await this.bridge.invoke<T>(command, { userId, ...args });
+    });
+  }
+
+  private requireDesktop(): void {
+    if (!this.bridge.isDesktop()) {
+      throw new Error("Local ACP connections are available in Maple Desktop.");
+    }
+  }
+}
+
+export function normalizeMapleAcpConfig(value: unknown): MapleAcpConfig {
+  const record = asRecord(value);
+  const roots = Array.isArray(record?.allowedProjectRoots)
+    ? record.allowedProjectRoots.filter(
+        (root): root is string => typeof root === "string" && root.trim().length > 0
+      )
+    : DEFAULT_MAPLE_ACP_CONFIG.allowedProjectRoots;
+  const maxConnections = safeCount(record?.maxConnections, DEFAULT_MAPLE_ACP_CONFIG.maxConnections);
+
+  return {
+    enabled:
+      typeof record?.enabled === "boolean" ? record.enabled : DEFAULT_MAPLE_ACP_CONFIG.enabled,
+    permissionMode: normalizePermissionMode(record?.permissionMode),
+    allowedProjectRoots: [...new Set(roots.map((root) => root.trim()))],
+    maxConnections: Math.max(1, maxConnections)
+  };
+}
+
+export function normalizeMapleAcpStatus(value: unknown): MapleAcpStatus {
+  const record = asRecord(value);
+  const harnessRecord = asRecord(record?.harness);
+  const command = firstString(harnessRecord?.command, record?.executable, record?.executablePath);
+  const rawArgs = Array.isArray(harnessRecord?.args)
+    ? harnessRecord.args
+    : Array.isArray(record?.args)
+      ? record.args
+      : [];
+  const args = rawArgs.filter((argument): argument is string => typeof argument === "string");
+  const error = firstString(record?.error, record?.lastError);
+
+  return {
+    running: record?.running === true,
+    enabled: record?.enabled === true,
+    connectedClients: safeCount(record?.connectedClients),
+    activeSessions: safeCount(record?.activeSessions),
+    activeRuns: safeCount(record?.activeRuns),
+    endpoint: normalizeEndpoint(record?.endpoint),
+    endpointKind: firstString(record?.endpointKind),
+    protocolVersion: normalizeProtocolVersion(record?.protocolVersion),
+    error: error || null,
+    buzzCredentialsAvailable: record?.buzzCredentialsAvailable === true,
+    harness: command ? { command, args } : null
+  };
+}
+
+export function buildBuzzCustomHarness(harness: MapleAcpHarness): BuzzCustomHarnessDefinition {
+  return {
+    id: BUZZ_MAPLE_HARNESS_ID,
+    label: BUZZ_MAPLE_HARNESS_NAME,
+    command: harness.command,
+    args: [...harness.args],
+    env: {}
+  };
+}
+
+export function serializeBuzzCustomHarness(harness: MapleAcpHarness): string {
+  return JSON.stringify(buildBuzzCustomHarness(harness), null, 2);
+}
+
+export function isMapleAcpConfigReady(
+  config: MapleAcpConfig | null,
+  savedConfig: MapleAcpConfig | null
+): boolean {
+  return config !== null && savedConfig !== null;
+}
+
+export function isMapleAcpPolicyDirty(
+  config: MapleAcpConfig | null,
+  savedConfig: MapleAcpConfig | null
+): boolean {
+  return (
+    config !== null && savedConfig !== null && config.permissionMode !== savedConfig.permissionMode
+  );
+}
+
+async function invokeMapleAcp<T>(command: string, args?: Record<string, unknown>): Promise<T> {
+  if (!isTauriDesktop()) {
+    throw new Error("Local ACP connections are available in Maple Desktop.");
+  }
+  const { invoke } = await import("@tauri-apps/api/core");
+  return await invoke<T>(command, args);
+}
+
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function normalizePermissionMode(value: unknown): MapleAcpPermissionMode {
+  return value === "allow_all" ? "allow_all" : "read_only";
+}
+
+function safeCount(value: unknown, fallback = 0): number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0 ? value : fallback;
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function normalizeEndpoint(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  const record = asRecord(value);
+  if (!record) return null;
+  return firstString(record.display, record.path, record.address);
+}
+
+function normalizeProtocolVersion(value: unknown): string | number | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  return null;
+}
+
+export const mapleAcpService = new MapleAcpService();

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -3,6 +3,7 @@
 interface ImportMetaEnv {
   readonly VITE_OPEN_SECRET_API_URL: string;
   readonly VITE_OS_FLAGS_BASE_URL?: string;
+  readonly VITE_FORCE_FEATURE_FLAGS?: string;
   readonly VITE_CLIENT_ID?: string;
   readonly VITE_MAPLE_BILLING_API_URL?: string;
   readonly VITE_DEV_MODEL_OVERRIDE?: string;


### PR DESCRIPTION
## Status

This is a draft architecture and implementation review.

This branch supersedes the implementation and architecture proposed in #714, while leaving that PR open as the original exploration record. It preserves the successful proof that Buzz can control the real Maple Agent without forking Buzz or Goose, but restructures the work around a maintainable Maple-owned runtime service.

The intended merge boundary is:

- the shared Maple Agent runtime refactor should be production-quality and useful to primary Desktop Agent Mode;
- normal Maple Agent behavior should remain unchanged;
- ACP remains an experimental, desktop-only, default-off edge adapter; and
- no remote ACP, HTTP control plane, mobile control, or complete Goose ACP parity is proposed here.

## Summary

This PR:

- makes the existing embedded-Goose runtime explicitly accessible through a transport-neutral `MapleAgentService`;
- keeps Tauri as a thin projection for Maple Desktop;
- keeps ACP as a separate thin projection for external harnesses;
- ensures both surfaces use the same account-scoped Maple provider, tasks, tools, policy, history, and lifecycle;
- routes unresolved ACP permissions to the ACP caller that started the run;
- isolates live Desktop and ACP status, cancellation, timelines, and permissions;
- adds a composite host lifecycle for stop, restart, clear, update, logout, and exit;
- supports a packaged `maple acp` stdio connector backed by an owner-only local Unix socket;
- keeps Buzz credentials in bounded, revocable, connection/session-scoped tool context rather than process-global state or persisted harness configuration;
- hides the Agent connections UI behind a local-only feature gate; and
- does not fork Buzz or Goose.

The important result is not merely that Maple speaks ACP. It is that there remains exactly one Maple-controlled Goose runtime.

## Architecture

```mermaid
flowchart LR
    UI["Maple Agent UI"] --> FE["AgentRuntimeService"]
    FE --> Tauri["Thin Tauri commands and event projection"]

    Client["Buzz or another ACP client"] --> Connector["maple acp stdio connector"]
    Connector --> Socket["Owner-only local Unix socket"]
    Socket --> ACP["ACP transport and protocol adapter"]

    Tauri --> Core["MapleAgentService typed runtime facade"]
    ACP --> Core

    Host["AgentHostLifecycle"] -. "serializes stop, restart, clear, update, and exit" .-> ACP
    Host -. "composite lifecycle" .-> Core

    Core --> Goose["Existing embedded Goose runtime"]
    Goose --> Provider["MapleProvider and authenticated MapleApiSession"]
    Goose --> Tools["Maple developer, web, and Skills clients"]
```

There is one account-scoped runtime. Desktop and ACP independently project onto it; neither adapter calls through the other.

The core service owns Maple semantics:

- account-bound, generation-checked runtime handles;
- task creation, loading, deletion, and history;
- model locking and restoration;
- run admission, cancellation, and retained terminal state;
- isolated bounded event streams;
- typed permission requests and exact-run responders;
- transient tool-context leases and revocation;
- runtime/session lifecycle fencing; and
- Maple's existing provider, developer tools, web tools, and trusted Skills behavior.

The adapters own surface-specific concerns:

| Layer | Responsibilities |
| --- | --- |
| Tauri adapter | Existing Desktop command arguments, `agent-event` envelopes, and UI projection |
| ACP adapter | ACP dispatch, notifications, permissions, stop reasons, connection/session leases, bounded wire flow, and Buzz compatibility |
| Host lifecycle | Atomic operations that must span both the runtime and ACP listener |
| `maple acp` connector | Bridge harness-owned stdio and environment into the already-running Desktop process |

The core imports no Tauri or ACP protocol types. “Thin adapter” refers to this ownership boundary, not necessarily line count: a safe ACP edge still needs substantial transport, correlation, backpressure, cleanup, and IPC logic.

## Why this refactor is useful beyond ACP

This is directionally the architecture Maple Agent should have even if ACP remains hidden.

Primary Agent Mode stays direct:

```text
Maple UI -> Tauri adapter -> MapleAgentService -> embedded Goose -> MapleProvider
```

External harnesses remain optional:

```text
External harness -> ACP adapter -> MapleAgentService -> embedded Goose -> MapleProvider
```

The service is a Maple-owned superset. Desktop and ACP do not need identical command sets, event types, or capabilities. Each adapter exposes the subset appropriate for its caller without forcing Maple's domain model to conform to ACP.

This PR intentionally does not extract the core into a standalone crate or decompose every large Agent module. It remains composed inside the Tauri binary. A future headless host could justify further extraction, but this pass lets primary Maple Agent features continue driving the internal design.

## Desktop compatibility

The Desktop boundary remains intentionally stable:

- existing Tauri command names and arguments remain;
- existing `agent-event` envelopes remain;
- normal Agent Mode interaction and rendering remain; and
- no frontend Agent Mode architecture was replaced with ACP.

Stop and restart now return a small lifecycle outcome:

```ts
{
  status: AgentRuntimeStatus;
  acpShutdownError: string | null;
}
```

This is intentional. If the core runtime successfully changes state but ACP cleanup fails, Desktop must apply the authoritative runtime status instead of remaining visually stale. The frontend unwraps this result, refreshes sessions, and then shows the cleanup warning.

## Surface ownership and isolation

A late review pass found several places where a shared runtime could accidentally expose one surface's live state to another. This branch now makes ownership explicit:

- Desktop runtime status excludes ACP-owned runs.
- Desktop cancellation can act only on Desktop-owned runs.
- ACP retains an opaque cancellation capability bound to the exact account, task, run, and calling surface.
- Wrong-session or cross-surface cancellation is rejected before any permission, timeline, or tool-context side effect.
- Live timeline state is tagged with its owning surface.
- ACP events cannot overlay, mutate, or remove Desktop live state.
- Persisted history remains visible later, but live control remains isolated.
- Persisted tool and elicitation requests settle from canonical responses even if no stop notice was recorded.
- When Desktop reconstructs a task, only a genuinely Desktop-owned pending request remains actionable.
- An ACP-owned request is shown as `controlled_externally`; an orphaned pending request becomes `cancelled`.

The intended distinction is:

> Desktop may inspect an ACP-created task later, but cannot approve, cancel, or otherwise control a live leased ACP run.

Focused regression tests cover status filtering, cancellation scope, timeline isolation, terminal cleanup, and persisted permission reconciliation.

## Caller-owned ACP approvals

The surface that starts a run owns its unresolved interactive permission decisions:

```mermaid
sequenceDiagram
    participant Client as ACP caller
    participant Adapter as Maple ACP adapter
    participant Core as MapleAgentService
    participant Goose as Embedded Goose

    Client->>Adapter: session/prompt
    Adapter->>Core: send message with connection-scoped context
    Core->>Goose: run with Maple provider, tools, and policy
    Goose-->>Core: action requires permission
    Core->>Core: apply Maple automatic classifier

    alt Covered by Maple policy
        Core->>Goose: automatic decision
    else Unresolved ACP-owned request
        Core-->>Adapter: typed run-scoped permission request
        Adapter->>Client: request_permission
        Note over Adapter,Client: allow_once or reject_once
        Client-->>Adapter: caller decision
        Adapter->>Core: opaque exact-run response
        Core->>Goose: permission confirmation
    end

    Goose-->>Core: ordered events and terminal state
    Core-->>Adapter: bounded run stream
    Adapter-->>Client: session/update and prompt result
```

This branch deliberately does not add a “wait for approval inside Maple Desktop” broker for ACP runs.

Behavior is fail-closed:

- cancellation, disconnect, transport failure, unknown options, duplicate responses, and reused request IDs do not grant access;
- an outstanding ACP v1 permission request cannot be cancelled on the wire, so Maple cancels Goose immediately but retains the response future and its outbound-budget reservation until reply or disconnect;
- the caller sees only `allow_once` and `reject_once`; and
- Maple Desktop receives no actionable approval card for the ACP-owned run.

The old exploratory `allow_all` setting is migrated to the caller-mediated `read_only`/`smart_approve` policy. `read_only` is a retained serialized name, not a literal filesystem sandbox.

Buzz's current behavior is to select `allow_once` automatically. That is Buzz's product decision, not a second Maple approval mode.

Maple does not yet have a separate non-overridable “dangerous deny” classifier. If one is introduced later, it should run as Maple policy before any ACP permission request, not become a competing interactive broker.

## Composite host lifecycle

ACP and the core runtime have separate internal state, but process-level lifecycle operations must cover both:

```mermaid
sequenceDiagram
    participant UI as Desktop frontend
    participant Fence as Account operation fence
    participant Host as Native host lifecycle
    participant ACP as ACP listener
    participant Core as Maple Agent runtime

    UI->>Fence: blockAndDrain(user)
    UI->>Host: stop or restart
    Host->>ACP: attempt shutdown
    ACP-->>Host: success or cleanup warning
    Host->>Core: always stop or restart
    Core-->>Host: authoritative runtime status
    Host-->>UI: status plus optional acpShutdownError
    UI->>UI: apply status and refresh sessions

    alt ACP cleanup warning
        UI->>UI: surface warning
        Note over UI: security-sensitive credential cleanup remains blocked
    end
```

The host lifecycle now:

- serializes ACP and runtime stop/restart so a new connection cannot race between phases;
- always attempts the core operation even if ACP cleanup fails;
- returns successful runtime state together with a nonfatal ACP cleanup warning;
- preserves strict failure behavior when the runtime itself fails;
- keeps logout and credential cleanup fail-closed;
- requires ACP cleanup before local Agent data/history deletion; and
- treats update restart and application exit as strict shutdowns across both surfaces.

The frontend performs one native composite stop. The manual `agent_acp_stop` command remains reserved for the settings page because that action also updates saved configuration.

## Why Goose ACP is not instantiated directly

The Goose team's suggested shape—add an ACP crate, instantiate a server, and plug in the existing GDK loop—is directionally exactly what Maple wants.

At Maple's pinned Goose revision, `c3111c71cd682ed1d115741677f0ca9946c51499`, the public Rust API is not yet that shape.

### About the `goose-acp` crate

At this revision:

- there is no reusable ACP runtime package named `goose-acp`;
- `goose-acp-macros` exists, but it is a proc-macro crate for custom JSON-RPC dispatch and schema generation;
- the ACP server implementation lives in the main `goose::acp` module; and
- the reusable `serve<R, W>` transport is concrete over `Arc<GooseAcpAgent>`, not a host-supplied backend or loop trait.

`GooseAcpAgent::new(GooseAcpAgentOptions)` accepts a provider factory, builtins, paths, platform/source roots, naming policy, and scheduler. It does not accept an existing:

- prompt loop;
- `AgentManager`;
- `SessionManager`;
- `PermissionManager`;
- task/session service;
- permission broker;
- tool surface; or
- event stream.

Its constructor creates fresh session and permission managers, a fresh provider inventory, an `AgentConfig` using `Config::global()`, and a fresh `AgentManager`.

Consequently:

- starting `goose acp` would expose independently configured Goose;
- turning on `goose serve` after Maple initializes would still create a second runtime;
- constructing `GooseAcpAgent` with a Maple provider factory would solve provider creation only;
- sharing Maple's data directory would not share active-run claims, account generations, cancellation, permissions, tool-context leases, or event ownership; and
- two independently cached runtimes could load and mutate the same persisted task without one lifecycle owner.

Maple's semantic boundary is not a bare Goose `Agent`. It includes:

- the authenticated, account-scoped `MapleApiSession` and `MapleProvider`;
- task persistence and model restoration/locking;
- Maple developer and web tools;
- trust-filtered project Skills;
- transient external tool-context leases;
- lifecycle and account generations;
- Maple's automatic permission classifiers;
- surface-scoped approval routing; and
- Desktop timeline behavior.

Goose ACP also owns permission requests and confirmations directly, advertises persistent choices such as allow/reject always, can substitute ACP-client filesystem/terminal behavior, and accepts generic client MCP definitions. Bypassing Maple's wrapper would therefore change both its security policy and its product behavior.

Goose's mature history replay, response builders, tool converters, usage mapping, permission mapping, and handlers are useful, but at this revision they are private or `pub(crate)` and tied to concrete `GooseAcpAgent` state.

### Upstream seams that would help

The ideal upstream improvement is to separate ACP protocol projection from runtime ownership. Useful options include:

1. Construct ACP around existing manager handles.
2. Provide a host-supplied backend or prompt-loop trait.
3. Use an injectable provider resolver consistently across create, load, restore, and reconfigure.
4. Add host admission, activation, prompt preparation, and cleanup hooks.
5. Accept an invocation-scoped permission responder.
6. Preserve host-installed developer/tool clients.
7. Support transient per-session context with explicit cleanup.
8. Extract Goose's `AgentEvent -> session/update` projector.
9. Remove global configuration and path assumptions from the embedded path.

A `GooseAcpAgent::from_components` constructor plus pluggable prompt runner, permission broker, tool setup, and projector would also address most of the gap.

Even with those seams, Maple would retain the small local connector: Buzz owns the spawned stdio process and its environment, while Maple authentication lives in the already-running Desktop process.

Until then, the narrow adapter over `agent-client-protocol` 1.0.1 is the smallest no-fork path that exposes Maple rather than a parallel Goose runtime.

## Current ACP surface

The detailed capability-by-capability analysis is in `docs/agent-mode-acp.md`. The condensed state is:

| Capability | Status | Remaining work or limiting layer |
| --- | --- | --- |
| `initialize` | Yes | Implemented with intentionally narrow advertised capabilities |
| `session/new` | Yes | Creates a real Maple task from an absolute `cwd` |
| Text `session/prompt` | Yes | One active prompt per session |
| Text/thought updates | Partial | Low–Medium projection work for richer updates |
| `session/cancel` | Yes | Exact run-scoped cancellation |
| Permission requests | Yes | Caller-owned, one-shot allow/reject |
| Basic tool lifecycle | Partial | Low–Medium projection and correlation work |
| `session/list` | No | Low code plus task-enumeration policy |
| `session/close` | No | Low–Medium race-safe ownership cleanup |
| Additional workspace roots | No | Medium Maple workspace/trust-model work |
| `session/resume` | No | Medium leasing and transient-context restoration |
| `session/fork` | No | Medium wrapper/policy/rollback work; unstable protocol commitment |
| Session mode | No | Medium mapping plus unattended-approval policy |
| Usage/context updates | No | Medium protocol-neutral usage and billing semantics |
| Prompt images | No | Medium structured prompt and model-capability work |
| `session/load` | No | Medium–High faithful ordered history projection |
| Model/config selection | No | Medium–High Maple catalog and model-lock semantics |
| Rich tools/resources/locations | No | Medium–High event-model/projector work |
| Terminal and diff parity | No | Medium–High architectural choice: Maple executes local tools rather than delegating them through ACP client RPCs |
| Embedded binary/resource links | No | Medium–High ingestion, provenance, root, and security policy |
| Arbitrary ACP-provided MCP | No | High code-execution, secret, lifecycle, and packaging boundary |
| Prompt audio | No | High; pinned Goose has no native audio message variant |
| Goose/Buzz steering extension | No | Medium code, high coupling; intentionally omitted because Buzz has cancel-and-merge fallback |

`No` means “not implemented by this preview,” not “fundamentally impossible.”

Two ACP v1 baseline gaps are important:

- generic `ResourceLink` prompt blocks are not accepted; and
- arbitrary stdio MCP definitions are not supported.

The preview should therefore be described as parity for the tested Buzz task path, not complete ACP v1 conformance or Goose ACP parity.

None of the missing rows blocks the previously tested Buzz flow. Buzz does not require list/load/resume/fork/close for that path, tolerates Maple's default model/config, and falls back from its unstable native steering extension.

## Buzz compatibility and credentials

The wire surface is standard ACP v1, but the first consumer requires explicit compatibility behavior:

- a private bridge hello for connector-owned environment transfer;
- a five-variable `BUZZ_*` allowlist plus `PATH`;
- recognition of one narrowly shaped absolute `buzz-dev-mcp` definition;
- adaptation into Maple's existing developer shell rather than launching arbitrary client MCP;
- a `Buzz ACP` task title; and
- custom-harness configuration and parallelism guidance.

If this integration is maintained, those constants and transformations should move behind a dedicated Buzz compatibility module.

External tool context is installed as an exclusive, revocable per-session lease. It is checked by account, session, and installation identity and never mutates Maple's process-global environment. Revocation is linearized with process launch so no already-copied context can start another command after the revoke barrier returns.

This improves containment, but it is not a sandbox:

- the socket trusts processes running as the same OS user;
- allowed project roots gate session admission, not every later tool path;
- trusted agent commands can inspect or transmit Buzz credentials;
- Unix process-group cleanup cannot prevent deliberate detachment; and
- a hard Maple crash can bypass in-process cleanup.

Flatpak credential-bearing execution fails closed. Windows local IPC is unsupported.

## Feature gate and configuration

The Agent connections surface is:

- hidden and default-off;
- enabled only by the local `VITE_FORCE_FEATURE_FLAGS=agent_connections` override;
- unavailable to remote feature flags;
- limited to macOS/Linux Tauri Desktop; and
- unavailable on web, mobile, and Windows.

Activation is manual after every Maple launch. A saved `enabled` value does not auto-start the listener.

The page supports:

- manual start/stop;
- connection, session, and active-run status;
- packaged executable path and `acp` argument;
- Buzz harness JSON;
- protocol, endpoint, and credential diagnostics; and
- allowed-root and parallelism guidance.

Policy changes require Stop → Save → Start to avoid an admission race. Maple currently defaults to one ACP connection, matching the validated Buzz setup.

## Historical Buzz end-to-end evidence

The original macOS exploration used:

- Goose `c3111c71cd682ed1d115741677f0ca9946c51499`;
- Buzz `3a4bf513df0e0c258587bfcbed9463d63723b56b`;
- a packaged arm64 macOS development app;
- ACP v1;
- Buzz owner-only channel admission;
- Buzz parallelism `1`; and
- Maple's former unattended `allow_all` policy.

Two Buzz GUI tasks completed:

1. A deterministic mention produced exactly `MAPLE-GUI-OK`.
2. Maple read the checkout's real `README.md` using its local tools and posted a substantive explanation of the project.

This proves that the connector, local IPC, Maple runtime, local tools, ACP stream, and signed Buzz publication path can work together.

It does **not** prove the final caller-mediated permission path end to end. The old `allow_all` path has been removed and migrated. Current caller ownership is covered by implementation and focused tests, but this PR should not claim a fresh caller-owned Buzz GUI result unless one is explicitly rerun.

The README task took roughly two to three minutes. That has not been profiled and should not be attributed to ACP.

## Validation

Automated and local validation on the rebased branch:

- `cargo check --tests` passed.
- Focused Rust cancellation, permission, timeline, surface-ownership, host-lifecycle, and ACP tests passed.
- Full Rust `cargo test --all-targets` passed in the final pre-commit run: 264 passed, 0 failed, 1 model-backed OCR test ignored.
- One pre-existing timing-sensitive developer-tools shell test flaked on an earlier first attempt, then passed in isolation and on both subsequent full runs.
- Frontend tests: 504 passed, 0 failed, 1,731 assertions.
- Production frontend build passed.
- ESLint reported 0 errors and the same 13 pre-existing warnings.
- `cargo fmt --check`, strict `cargo clippy -- -D warnings`, Prettier, and `git diff --check` passed. Patched `tao` emits its existing dependency warnings.
- Managed local OpenSecret/Billing smoke passed after reboot (`OpenSecret` on `127.0.0.1:31061`, Billing on `127.0.0.1:36201`).
- A workspace-specific debug `Maple.app` was built, ad-hoc signed, verified under the exact workspace bundle ID, and confirmed to contain the local OpenSecret endpoint. The expected updater-signing step reported the intentionally absent private key only after producing the `.app`, `.dmg`, and updater archive.
- The exact packaged app loaded the existing Agent Mode UI and completed a real local GUI turn with the expected `MAPLE-REVIEW-SMOKE-OK` response.
- A fresh review of the final diff found no confirmed medium- or high-priority issue.

Current test coverage includes:

- Desktop status excluding caller-owned runs;
- cross-surface and wrong-session cancellation rejection;
- live timeline isolation and owner-only cleanup;
- exact-surface permission updates;
- persisted tool/elicitation settlement;
- Desktop permission reconciliation;
- caller permission option/outcome mapping;
- outbound permission backpressure;
- lifecycle result composition; and
- frontend composite-stop behavior.

Still absent:

- a checked-in complete ACP wire fixture;
- socket lifecycle/reconnect coverage;
- a Buzz GUI automation fixture;
- a fresh caller-mediated Buzz E2E;
- component-level restart-warning coverage; and
- a real host integration test that injects simultaneous ACP and runtime shutdown failures.

## Tradeoffs

### Benefits

- One real Maple runtime rather than a parallel Goose process.
- No Buzz fork.
- No Goose fork.
- Primary Desktop Agent Mode stays direct.
- Maple provider, account, task, tool, and policy semantics remain authoritative.
- Protocol types do not leak into Maple's domain model.
- Surface ownership and lifecycle are explicit and tested.
- The service is useful for future non-UI hosts without prematurely designing remote control.

### Costs

- Maple owns a partial ACP adapter that overlaps upstream Goose behavior.
- Safe ACP transport and lifecycle code is not small.
- Buzz-specific compatibility remains mixed into the adapter.
- The shared Agent core remains large.
- Coarse lifecycle locks trade some control-plane concurrency for predictable race behavior.
- The protocol surface is intentionally incomplete.
- Local same-user IPC is a trust boundary, not application authentication.
- There is no checked-in full wire or Buzz fixture yet.

## Maintenance recommendation

Keep Maple Agent's primary path direct and continue building Maple features against `MapleAgentService`.

Keep ACP default-off at the edge. Add protocol capabilities only for demonstrated consumers rather than chasing speculative Goose parity.

Maintaining this bounded adapter is reasonable if external harness interoperability remains strategically useful. Maple should not:

- restructure primary Agent Mode around ACP;
- design remote/mobile control in this PR;
- fork Goose solely for this preview; or
- copy Goose's complete private ACP projection surface.

The best long-term reduction in Maple-owned ACP code is an upstream Goose embedding seam for runtime injection, permission routing, transient context, and event projection.

If the adapter remains:

1. move Buzz compatibility into its own module;
2. add a protocol/socket fixture before broadening support;
3. keep the Desktop and calling-surface ownership tests as invariants;
4. generalize the current Desktop/CallingSurface identity only when a real third surface requires it; and
5. let primary Maple Agent requirements—not ACP completeness—drive further core refactoring.

## Suggested review order

1. `frontend/src-tauri/src/agent.rs` — Maple service, runtime handles, routing, cancellation, permissions, timelines.
2. `frontend/src-tauri/src/agent_tauri.rs` — thin Desktop projection and preserved event contract.
3. `frontend/src-tauri/src/agent_host.rs` — composite lifecycle behavior.
4. `frontend/src-tauri/src/agent/tool_context.rs` and developer-tool changes — bounded transient context and process cleanup.
5. `frontend/src-tauri/src/agent_acp.rs` — protocol, IPC, backpressure, caller permissions, and Buzz adaptation.
6. Frontend runtime/settings services — feature gate, manual lifecycle, and structured cleanup warnings.
7. `docs/agent-mode-acp.md` — detailed support matrix, trust model, and maintenance guidance.

## Questions for reviewers

1. Is `MapleAgentService` the right durable boundary for Maple-controlled Goose?
2. Is caller-owned permission handling the correct ACP v1 policy?
3. Are the Desktop/CallingSurface ownership rules sufficiently explicit?
4. Is the composite lifecycle result the right way to represent partial ACP cleanup?
5. Should the default-off ACP adapter remain in-tree while upstream Goose seams are pursued?
6. Which missing ACP capability is justified by a real consumer next?
7. Is the same-user local socket trust model acceptable for an experimental preview?
8. Which Goose injection/projector seam would provide the most upstream leverage first?
