### PR TITLE
feat(agent): improve Agent Mode sidebar behavior

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -10,6 +10,7 @@
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",
+        "@radix-ui/react-hover-card": "1.1.15",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
@@ -288,6 +289,8 @@
     "@radix-ui/react-focus-guards": ["@radix-ui/react-focus-guards@1.1.3", "", { "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw=="],
 
     "@radix-ui/react-focus-scope": ["@radix-ui/react-focus-scope@1.1.7", "", { "dependencies": { "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-callback-ref": "1.1.1" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw=="],
+
+    "@radix-ui/react-hover-card": ["@radix-ui/react-hover-card@1.1.15", "", { "dependencies": { "@radix-ui/primitive": "1.1.3", "@radix-ui/react-compose-refs": "1.1.2", "@radix-ui/react-context": "1.1.2", "@radix-ui/react-dismissable-layer": "1.1.11", "@radix-ui/react-popper": "1.2.8", "@radix-ui/react-portal": "1.1.9", "@radix-ui/react-presence": "1.1.5", "@radix-ui/react-primitive": "2.1.3", "@radix-ui/react-use-controllable-state": "1.2.2" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-qgTkjNT1CfKMoP0rcasmlH2r1DAiYicWsDsufxl940sT2wHNEWWv6FMWIQXWhVdmC1d/HYfbhQx60KYyAtKxjg=="],
 
     "@radix-ui/react-id": ["@radix-ui/react-id@1.1.1", "", { "dependencies": { "@radix-ui/react-use-layout-effect": "1.1.1" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,6 +36,7 @@
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-hover-card": "1.1.15",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -2,9 +2,7 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "windows": [
-    "main"
-  ],
+  "windows": ["main"],
   "platforms": ["macOS", "windows", "linux"],
   "permissions": [
     "core:default",
@@ -60,6 +58,7 @@
         }
       ]
     },
+    "opener:allow-reveal-item-in-dir",
     "sign-in-with-apple:default"
   ]
 }

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -24,7 +24,9 @@ import {
   Expand,
   FilePenLine,
   FileSearch,
+  Folder,
   FolderOpen,
+  FolderPlus,
   Globe2,
   Loader2,
   Lock,
@@ -77,9 +79,11 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { MapleWordmark } from "@/components/MapleWordmark";
 import { DeleteChatDialog } from "@/components/DeleteChatDialog";
+import { RenameAgentProjectDialog } from "@/components/RenameAgentProjectDialog";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { AgentMcpMenu, AgentMcpServersDialog } from "@/components/agent/AgentMcpControls";
 import { handleAgentModeThoughtRunFinished } from "@/components/agent/agentModeThoughtRun";
@@ -153,11 +157,27 @@ import {
   cn,
   POWERFUL_MODEL_ALIAS,
   QUICK_MODEL_ALIAS,
+  useIsCoarsePointer,
   useIsLandscapeMobile,
   useIsMobile
 } from "@/utils/utils";
 import { isTauriDesktop } from "@/utils/platform";
 import { useLazyRef } from "@/utils/useLazyRef";
+import { revealAgentProjectFolder } from "@/services/agentProjectFolder";
+import {
+  aggregateAgentSidebarStatus,
+  agentTaskAccessibleLabel
+} from "@/services/agentSidebarPresentation";
+import {
+  loadAgentSidebarPreferences,
+  projectRootsWithDisplayNames,
+  renameAgentProjectDisplayName,
+  saveAgentSidebarPreferences,
+  toggleAgentProjectCollapsed,
+  type AgentProjectRootView,
+  type AgentSidebarPreferences
+} from "@/services/agentSidebarPreferences";
+import { useNotification } from "@/contexts/NotificationContext";
 import { useBillingState, useModelState } from "@/state/useLocalState";
 import {
   usePersistentHomeNavigation,
@@ -183,12 +203,9 @@ const AGENT_SESSION_DELETED_EVENT = "maple:agent-session-deleted";
 const AGENT_MODEL_PREFERENCE_KEY = "selectedAgentModel";
 // Mode switches remount AgentMode, so project-root mutations must be ordered outside it.
 const projectRootPersistenceQueues = new Map<string, Promise<void>>();
-const AGENT_SIDEBAR_ELLIPSIS_FADE =
-  "pointer-events-none w-4 shrink-0 self-stretch bg-gradient-to-r from-transparent to-[hsl(var(--muted))] dark:to-[hsl(var(--sidebar))]";
-const AGENT_SIDEBAR_ELLIPSIS_TRIGGER_ROW_BASE =
-  "absolute inset-y-0 right-0 z-30 flex min-h-0 items-stretch";
-const AGENT_SIDEBAR_ELLIPSIS_BUTTON =
-  "relative z-10 shrink-0 rounded-full border-0 bg-muted p-1.5 text-foreground/40 transition-colors dark:bg-[hsl(var(--sidebar))] hover:text-foreground group-hover:text-foreground focus-visible:text-foreground focus-visible:outline-none";
+const AGENT_SIDEBAR_ACTION_ROW_BASE = "absolute inset-y-0 right-0 z-30 flex min-h-0 items-stretch";
+const AGENT_SIDEBAR_ACTION_BUTTON =
+  "relative z-10 flex shrink-0 items-center justify-center rounded-full border-0 bg-transparent text-muted-foreground transition-colors hover:bg-foreground/5 hover:text-foreground focus-visible:bg-foreground/5 focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/70";
 
 class PendingAgentSendCancelledError extends Error {
   constructor() {
@@ -223,9 +240,36 @@ function newTaskAgentModel(preference: AgentModelPreference): string {
   return preference.preferred || preference.configuredDefault;
 }
 
-function agentSidebarEllipsisTriggerRowClass(isCompactLayout: boolean): string {
-  if (isCompactLayout) return AGENT_SIDEBAR_ELLIPSIS_TRIGGER_ROW_BASE;
-  return `${AGENT_SIDEBAR_ELLIPSIS_TRIGGER_ROW_BASE} transition-opacity duration-150 opacity-0 pointer-events-none group-hover:pointer-events-auto group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:opacity-100 has-[[data-state=open]]:pointer-events-auto has-[[data-state=open]]:opacity-100`;
+function projectActionRowClass(
+  isTouchLayout: boolean,
+  menuOpen: boolean,
+  hasKeyboardFocus: boolean
+): string {
+  return cn(
+    AGENT_SIDEBAR_ACTION_ROW_BASE,
+    "transition-opacity duration-150 motion-reduce:transition-none",
+    isTouchLayout || menuOpen || hasKeyboardFocus
+      ? "pointer-events-auto opacity-100"
+      : "pointer-events-none opacity-0 group-hover/project:pointer-events-auto group-hover/project:opacity-100"
+  );
+}
+
+function taskActionRowClass(
+  isTouchLayout: boolean,
+  menuOpen: boolean,
+  hasKeyboardFocus: boolean
+): string {
+  return cn(
+    AGENT_SIDEBAR_ACTION_ROW_BASE,
+    "transition-opacity duration-150 motion-reduce:transition-none",
+    isTouchLayout || menuOpen || hasKeyboardFocus
+      ? "pointer-events-auto opacity-100"
+      : "pointer-events-none opacity-0 group-hover/task:pointer-events-auto group-hover/task:opacity-100"
+  );
+}
+
+function isKeyboardFocusTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && target.matches(":focus-visible");
 }
 
 type AgentPermissionMode = "smart_approve" | "auto";
@@ -323,10 +367,17 @@ export function AgentMode({ userId }: { userId: string }) {
   const { availableModels, setAvailableModels, modelAliases, setModelAliases, setHasWhisperModel } =
     useModelState();
   const { agentSessionSelection } = usePersistentHomeNavigation();
+  const { showNotification } = useNotification();
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
+  const isCoarsePointer = useIsCoarsePointer();
   const isCompactLayout = isMobile || isLandscapeMobile;
+  const isTouchLayout = isCompactLayout || isCoarsePointer;
   const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
+  const [sidebarPreferences, setSidebarPreferences] = useState<AgentSidebarPreferences>(() =>
+    loadAgentSidebarPreferences(userId)
+  );
+  const sidebarPreferencesRef = useRef(sidebarPreferences);
   const [runtimeStatus, setRuntimeStatus] = useState<AgentRuntimeStatus | null>(null);
   const [projectOrderState, dispatchProjectOrder] = useReducer(
     projectOrderReducer<RecentProjectRoot>,
@@ -337,7 +388,8 @@ export function AgentMode({ userId }: { userId: string }) {
   const [sessions, setSessions] = useState<AgentSessionSummary[]>([]);
   const [isSessionHistoryReady, setIsSessionHistoryReady] = useState(false);
   const [sessionToDelete, setSessionToDelete] = useState<AgentSessionSummary | null>(null);
-  const [projectToRemove, setProjectToRemove] = useState<RecentProjectRoot | null>(null);
+  const [projectToRename, setProjectToRename] = useState<AgentProjectRootView | null>(null);
+  const [projectToRemove, setProjectToRemove] = useState<AgentProjectRootView | null>(null);
   const [projectRemovalError, setProjectRemovalError] = useState<string | null>(null);
   const [isProjectRemovalPending, setIsProjectRemovalPending] = useState(false);
   const [activeSessionId, setActiveSessionId] = useState<string | null>(null);
@@ -469,6 +521,16 @@ export function AgentMode({ userId }: { userId: string }) {
       }
     },
     [agentModelPreferenceRef]
+  );
+
+  const commitSidebarPreferences = useCallback(
+    (update: (current: AgentSidebarPreferences) => AgentSidebarPreferences) => {
+      const next = update(sidebarPreferencesRef.current);
+      sidebarPreferencesRef.current = next;
+      setSidebarPreferences(next);
+      saveAgentSidebarPreferences(userId, next);
+    },
+    [userId]
   );
 
   if (!thoughtLabelProvisionalSchedulerRef.current) {
@@ -724,6 +786,10 @@ export function AgentMode({ userId }: { userId: string }) {
     () => mergeAgentProjectRoots(recentRoots, projectRoot, sessions, removedProjectRoots),
     [projectRoot, recentRoots, removedProjectRoots, sessions]
   );
+  const displayProjectRoots = useMemo(
+    () => projectRootsWithDisplayNames(visibleProjectRoots, sidebarPreferences),
+    [sidebarPreferences, visibleProjectRoots]
+  );
   const visibleSessions = useMemo(
     () => visibleAgentSessions(sessions, removedProjectRoots),
     [removedProjectRoots, sessions]
@@ -735,9 +801,10 @@ export function AgentMode({ userId }: { userId: string }) {
   const activeRootLabel = useMemo(() => {
     if (!projectRoot) return "Select folder";
     return (
-      visibleProjectRoots.find((root) => root.path === projectRoot)?.name || basename(projectRoot)
+      displayProjectRoots.find((root) => root.path === projectRoot)?.displayName ||
+      basename(projectRoot)
     );
-  }, [projectRoot, visibleProjectRoots]);
+  }, [displayProjectRoots, projectRoot]);
   const activeSessionTitle = useMemo(() => {
     const activeSession = sessions.find((session) => session.id === activeSessionId);
     return activeSession ? sessionTitle(activeSession) : "New task";
@@ -811,16 +878,43 @@ export function AgentMode({ userId }: { userId: string }) {
   const isComposerMcpLoading = activeSessionId
     ? isSessionMcpServersLoading || sessionMcpServersSessionId !== activeSessionId
     : isMcpServersLoading;
-  const runningSessionIds = useMemo(() => {
+  const agentRunningSessionIds = useMemo(() => {
     const ids = new Set(Object.keys(activeRunsBySession));
     for (const sessionId of pendingSendSessionIds) {
       if (sessionId !== NEW_SESSION_PENDING_KEY) ids.add(sessionId);
     }
+    return ids;
+  }, [activeRunsBySession, pendingSendSessionIds]);
+  const runningSessionIds = useMemo(() => {
+    const ids = new Set(agentRunningSessionIds);
     if (pendingSessionSelectionId && pendingSessionSelectionId !== NEW_SESSION_PENDING_KEY) {
       ids.add(pendingSessionSelectionId);
     }
     return ids;
-  }, [activeRunsBySession, pendingSendSessionIds, pendingSessionSelectionId]);
+  }, [agentRunningSessionIds, pendingSessionSelectionId]);
+  const agentSidebarStatus = useMemo(() => {
+    const sessionById = new Map(sessions.map((session) => [session.id, session]));
+    const isVisibleSessionId = (sessionId: string) => {
+      const session = sessionById.get(sessionId);
+      return !session || !removedProjectRoots.has(session.projectRoot);
+    };
+    const visibleRunningSessionIds = new Set(
+      [...agentRunningSessionIds].filter(isVisibleSessionId)
+    );
+    if (pendingSendSessionIds.has(NEW_SESSION_PENDING_KEY)) {
+      visibleRunningSessionIds.add(NEW_SESSION_PENDING_KEY);
+    }
+    const visibleUnreadSessionIds = new Set(
+      [...completedUnreadSessionIds].filter(isVisibleSessionId)
+    );
+    return aggregateAgentSidebarStatus(visibleRunningSessionIds, visibleUnreadSessionIds);
+  }, [
+    completedUnreadSessionIds,
+    agentRunningSessionIds,
+    pendingSendSessionIds,
+    removedProjectRoots,
+    sessions
+  ]);
 
   const toggleSidebar = useCallback(() => setIsSidebarOpen((prev) => !prev), [setIsSidebarOpen]);
 
@@ -1603,7 +1697,7 @@ export function AgentMode({ userId }: { userId: string }) {
   );
 
   const startRuntime = useCallback(
-    async (restart = false) => {
+    async (restart = false, requestedProjectRoot = projectRoot) => {
       const requestGeneration = startRequestGenerationRef.current + 1;
       startRequestGenerationRef.current = requestGeneration;
       const interactionGeneration = interactionGenerationRef.current;
@@ -1611,12 +1705,13 @@ export function AgentMode({ userId }: { userId: string }) {
       setIsStarting(true);
       try {
         return await trackAgentWorkflow(async () => {
-          if (!projectRoot) {
+          if (!requestedProjectRoot.trim()) {
             throw new Error("Select a project folder first");
           }
+          const targetProjectRoot = requestedProjectRoot;
           const requestedMode = selectedModeRef.current;
           const request = {
-            projectRoot,
+            projectRoot: targetProjectRoot,
             model: agentModelPreferenceRef.current.configuredDefault,
             mode: requestedMode
           };
@@ -1634,7 +1729,7 @@ export function AgentMode({ userId }: { userId: string }) {
             return status;
           }
           applyRuntimeStatus(status, runStateGeneration);
-          setProjectRoot(status.projectRoot || projectRoot);
+          setProjectRoot(status.projectRoot || targetProjectRoot);
           applyAuthoritativeMode(normalizeAgentPermissionMode(status.mode || requestedMode));
           await refreshSessions();
           if (restartOutcome?.acpShutdownError) {
@@ -1746,85 +1841,90 @@ export function AgentMode({ userId }: { userId: string }) {
     ]
   );
 
-  const createSession = useCallback(async () => {
-    if (isAgentModelCatalogLoading) return;
-    if (!projectRoot.trim()) {
-      setError("Select a project folder before creating a task");
-      return;
-    }
-    if (pendingSessionSelectionIdRef.current === NEW_SESSION_PENDING_KEY) return;
-    const requestModel = newTaskAgentModel(agentModelPreferenceRef.current);
-    const selectionGeneration = beginSessionSelection(NEW_SESSION_PENDING_KEY);
-    const interactionGeneration = interactionGenerationRef.current;
-    setError(null);
-    try {
-      const detail = await trackAgentWorkflow(async () => {
-        if (!runtimeStatus?.running) {
-          await startRuntime(false);
-        }
-        return await agentRuntimeService.createSession(userId, {
-          projectRoot,
-          title: "New task",
-          model: requestModel,
-          contextLimit: contextLimitForModel(requestModel),
-          mode: selectedModeRef.current,
-          mcpServerNames: selectedNewChatMcpServerNames
+  const createSession = useCallback(
+    async (requestedProjectRoot = projectRoot) => {
+      if (isAgentModelCatalogLoading) return;
+      if (!requestedProjectRoot.trim()) {
+        setError("Select a project folder before creating a task");
+        return;
+      }
+      const targetProjectRoot = requestedProjectRoot;
+      if (pendingSessionSelectionIdRef.current === NEW_SESSION_PENDING_KEY) return;
+      const requestModel = newTaskAgentModel(agentModelPreferenceRef.current);
+      const selectionGeneration = beginSessionSelection(NEW_SESSION_PENDING_KEY);
+      const interactionGeneration = interactionGenerationRef.current;
+      setError(null);
+      try {
+        const detail = await trackAgentWorkflow(async () => {
+          if (!runtimeStatus?.running) {
+            await startRuntime(false, targetProjectRoot);
+          }
+          return await agentRuntimeService.createSession(userId, {
+            projectRoot: targetProjectRoot,
+            title: "New task",
+            model: requestModel,
+            contextLimit: contextLimitForModel(requestModel),
+            mode: selectedModeRef.current,
+            mcpServerNames: selectedNewChatMcpServerNames
+          });
         });
-      });
-      deletedSessionIdsRef.current.delete(detail.session.id);
-      setSessions((current) => [
-        detail.session,
-        ...current.filter((session) => session.id !== detail.session.id)
-      ]);
-      replaceSessionTimeline(detail.session.id, detail.timeline);
-
-      if (
-        isAgentModeMountedRef.current &&
-        sessionSelectionGenerationRef.current === selectionGeneration &&
-        interactionGenerationRef.current === interactionGeneration
-      ) {
-        shouldAutoScrollRef.current = true;
-        activeSessionIdRef.current = detail.session.id;
-        setActiveSessionId(detail.session.id);
-        agentSessionSelection.remember(userId, detail.session.id);
-        isAgentModelLockedRef.current = false;
-        currentAgentModelRef.current = requestModel;
-        setModel(requestModel);
-        applyAuthoritativeMode(normalizeAgentPermissionMode(detail.session.mode));
+        deletedSessionIdsRef.current.delete(detail.session.id);
+        setSessions((current) => [
+          detail.session,
+          ...current.filter((session) => session.id !== detail.session.id)
+        ]);
         replaceSessionTimeline(detail.session.id, detail.timeline);
-        const mcpError = mcpConnectionErrorMessage(detail.mcpErrors);
-        if (mcpError) setError(mcpError);
+
+        if (
+          isAgentModeMountedRef.current &&
+          sessionSelectionGenerationRef.current === selectionGeneration &&
+          interactionGenerationRef.current === interactionGeneration
+        ) {
+          shouldAutoScrollRef.current = true;
+          activeSessionIdRef.current = detail.session.id;
+          setActiveSessionId(detail.session.id);
+          agentSessionSelection.remember(userId, detail.session.id);
+          setProjectRoot(detail.session.projectRoot);
+          isAgentModelLockedRef.current = false;
+          currentAgentModelRef.current = requestModel;
+          setModel(requestModel);
+          applyAuthoritativeMode(normalizeAgentPermissionMode(detail.session.mode));
+          replaceSessionTimeline(detail.session.id, detail.timeline);
+          const mcpError = mcpConnectionErrorMessage(detail.mcpErrors);
+          if (mcpError) setError(mcpError);
+        }
+      } catch (createError) {
+        if (
+          isAgentModeMountedRef.current &&
+          sessionSelectionGenerationRef.current === selectionGeneration &&
+          interactionGenerationRef.current === interactionGeneration
+        ) {
+          setError(errorMessage(createError));
+        }
+      } finally {
+        if (isAgentModeMountedRef.current) {
+          finishSessionSelection(selectionGeneration);
+        }
       }
-    } catch (createError) {
-      if (
-        isAgentModeMountedRef.current &&
-        sessionSelectionGenerationRef.current === selectionGeneration &&
-        interactionGenerationRef.current === interactionGeneration
-      ) {
-        setError(errorMessage(createError));
-      }
-    } finally {
-      if (isAgentModeMountedRef.current) {
-        finishSessionSelection(selectionGeneration);
-      }
-    }
-  }, [
-    agentModelPreferenceRef,
-    applyAuthoritativeMode,
-    agentSessionSelection,
-    beginSessionSelection,
-    contextLimitForModel,
-    deletedSessionIdsRef,
-    finishSessionSelection,
-    isAgentModelCatalogLoading,
-    projectRoot,
-    replaceSessionTimeline,
-    runtimeStatus?.running,
-    selectedNewChatMcpServerNames,
-    startRuntime,
-    trackAgentWorkflow,
-    userId
-  ]);
+    },
+    [
+      agentModelPreferenceRef,
+      applyAuthoritativeMode,
+      agentSessionSelection,
+      beginSessionSelection,
+      contextLimitForModel,
+      deletedSessionIdsRef,
+      finishSessionSelection,
+      isAgentModelCatalogLoading,
+      projectRoot,
+      replaceSessionTimeline,
+      runtimeStatus?.running,
+      selectedNewChatMcpServerNames,
+      startRuntime,
+      trackAgentWorkflow,
+      userId
+    ]
+  );
 
   const loadSession = useCallback(
     async (sessionId: string) => {
@@ -2492,12 +2592,52 @@ export function AgentMode({ userId }: { userId: string }) {
   }, [handleAgentEvent, userId]);
 
   const handleCreateSession = useCallback(() => {
-    void createSession();
-  }, [createSession]);
-  const handlePromptProjectRemoval = useCallback((root: RecentProjectRoot) => {
+    void createSession(projectRoot);
+  }, [createSession, projectRoot]);
+  const handleCreateSessionForProject = useCallback(
+    (targetProjectRoot: string) => {
+      if (targetProjectRoot !== projectRoot) {
+        selectProjectRoot(targetProjectRoot);
+      }
+      void createSession(targetProjectRoot);
+    },
+    [createSession, projectRoot, selectProjectRoot]
+  );
+  const handlePromptProjectRemoval = useCallback((root: AgentProjectRootView) => {
     setProjectRemovalError(null);
     setProjectToRemove(root);
   }, []);
+  const handlePromptProjectRename = useCallback((root: AgentProjectRootView) => {
+    setProjectToRename(root);
+  }, []);
+  const handleRenameProject = useCallback(
+    (root: AgentProjectRootView, displayName: string) => {
+      commitSidebarPreferences((current) =>
+        renameAgentProjectDisplayName(current, root, displayName)
+      );
+    },
+    [commitSidebarPreferences]
+  );
+  const handleToggleProjectDisclosure = useCallback(
+    (path: string) => {
+      commitSidebarPreferences((current) => toggleAgentProjectCollapsed(current, path));
+    },
+    [commitSidebarPreferences]
+  );
+  const handleRevealProjectRoot = useCallback(
+    (path: string) => {
+      void revealAgentProjectFolder(path).catch((revealError) => {
+        console.error("Unable to reveal Agent project folder", revealError);
+        showNotification({
+          type: "error",
+          title: "Couldn’t reveal project folder",
+          message: "The folder may have been moved or is no longer available.",
+          duration: 7000
+        });
+      });
+    },
+    [showNotification]
+  );
   const handleSelectSession = useCallback(
     (sessionId: string) => {
       void loadSession(sessionId);
@@ -2543,18 +2683,21 @@ export function AgentMode({ userId }: { userId: string }) {
                 ? pendingSessionSelectionId
                 : activeSessionId
             }
-            isCompactLayout={isCompactLayout}
+            collapsedProjectRoots={sidebarPreferences.collapsedProjectRoots}
+            isTouchLayout={isTouchLayout}
             projectRoot={projectRoot}
-            recentRoots={visibleProjectRoots}
+            recentRoots={displayProjectRoots}
             completedUnreadSessionIds={completedUnreadSessionIds}
             disabled={areAgentSettingsLocked}
             runningSessionIds={runningSessionIds}
             sessions={visibleSessions}
             onChooseProjectRoot={chooseProjectRoot}
-            onCreateSession={handleCreateSession}
+            onCreateSession={handleCreateSessionForProject}
+            onProjectDisclosureToggle={handleToggleProjectDisclosure}
             onProjectOrderChange={saveProjectRootOrder}
+            onProjectRename={handlePromptProjectRename}
             onProjectRemove={handlePromptProjectRemoval}
-            onProjectRootChange={selectProjectRoot}
+            onRevealProjectRoot={handleRevealProjectRoot}
             onSessionDelete={setSessionToDelete}
             onSessionSelect={handleSelectSession}
           />
@@ -2567,6 +2710,18 @@ export function AgentMode({ userId }: { userId: string }) {
         }
         onToggle={toggleSidebar}
       />
+
+      {projectToRename ? (
+        <RenameAgentProjectDialog
+          key={projectToRename.path}
+          open
+          currentDisplayName={projectToRename.displayName}
+          onOpenChange={(open) => {
+            if (!open) setProjectToRename(null);
+          }}
+          onRename={(displayName) => handleRenameProject(projectToRename, displayName)}
+        />
+      ) : null}
 
       {sessionToDelete ? (
         <DeleteChatDialog
@@ -2592,7 +2747,7 @@ export function AgentMode({ userId }: { userId: string }) {
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Remove {projectToRemove?.name || "project"}?</AlertDialogTitle>
+            <AlertDialogTitle>Remove {projectToRemove?.displayName || "project"}?</AlertDialogTitle>
             <AlertDialogDescription>
               Removing this project from Maple won&apos;t delete its files or existing tasks. Add
               the same folder again to restore its tasks on this account and device.
@@ -2683,7 +2838,7 @@ export function AgentMode({ userId }: { userId: string }) {
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
         {!isSidebarOpen && (
           <div className="fixed left-4 top-[9.5px] z-20 flex items-center gap-1.5">
-            <SidebarToggle onToggle={toggleSidebar} />
+            <SidebarToggle onToggle={toggleSidebar} agentStatus={agentSidebarStatus} />
             <MapleWordmark
               className="h-4 w-auto animate-in fade-in-0 slide-in-from-left-1 duration-300"
               aria-hidden
@@ -2740,7 +2895,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   mode={mode}
                   model={model}
                   projectRoot={projectRoot}
-                  recentRoots={visibleProjectRoots}
+                  recentRoots={displayProjectRoots}
                   isExpanded={isAgentFullscreen}
                   onCancelPrompt={cancelPrompt}
                   onChooseProjectRoot={chooseProjectRoot}
@@ -2784,7 +2939,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   mode={mode}
                   model={model}
                   projectRoot={projectRoot}
-                  recentRoots={visibleProjectRoots}
+                  recentRoots={displayProjectRoots}
                   onCancelPrompt={cancelPrompt}
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={setInput}
@@ -2842,18 +2997,21 @@ function EmptyAgentState(props: AgentComposerProps) {
 
 interface AgentSidebarContentProps {
   activeSessionId: string | null;
-  isCompactLayout: boolean;
+  collapsedProjectRoots: ReadonlySet<string>;
+  isTouchLayout: boolean;
   projectRoot: string;
-  recentRoots: RecentProjectRoot[];
+  recentRoots: AgentProjectRootView[];
   completedUnreadSessionIds: Set<string>;
   disabled: boolean;
   runningSessionIds: Set<string>;
   sessions: AgentSessionSummary[];
   onChooseProjectRoot: () => void;
-  onCreateSession: () => void;
-  onProjectOrderChange: (roots: RecentProjectRoot[]) => void;
-  onProjectRemove: (root: RecentProjectRoot) => void;
-  onProjectRootChange: (value: string) => void;
+  onCreateSession: (projectRoot: string) => void;
+  onProjectDisclosureToggle: (path: string) => void;
+  onProjectOrderChange: (roots: AgentProjectRootView[]) => void;
+  onProjectRename: (root: AgentProjectRootView) => void;
+  onProjectRemove: (root: AgentProjectRootView) => void;
+  onRevealProjectRoot: (projectRoot: string) => void;
   onSessionDelete: (session: AgentSessionSummary) => void;
   onSessionSelect: (sessionId: string) => void;
 }
@@ -2868,6 +3026,7 @@ interface PendingProjectPointer {
   grabOffsetY: number;
   ghostWidth: number;
   headerElement: HTMLElement;
+  isCollapsed: boolean;
 }
 
 interface ProjectDragState extends PendingProjectPointer {
@@ -2877,9 +3036,206 @@ interface ProjectDragState extends PendingProjectPointer {
   markerTop: number | null;
 }
 
+interface AgentSidebarTaskRowProps {
+  actionsLocked: boolean;
+  isActive: boolean;
+  isRunning: boolean;
+  isTouchLayout: boolean;
+  isUnreadCompleted: boolean;
+  onDelete: (session: AgentSessionSummary) => void;
+  onSelect: (sessionId: string) => void;
+  rowRef: (node: HTMLDivElement | null) => void;
+  session: AgentSessionSummary;
+}
+
+function AgentSidebarTaskRow({
+  actionsLocked,
+  isActive,
+  isRunning,
+  isTouchLayout,
+  isUnreadCompleted,
+  onDelete,
+  onSelect,
+  rowRef,
+  session
+}: AgentSidebarTaskRowProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [hasKeyboardFocusWithin, setHasKeyboardFocusWithin] = useState(false);
+  const [isTitleOverflowing, setIsTitleOverflowing] = useState(false);
+  const titleRef = useRef<HTMLSpanElement>(null);
+  const title = sessionTitle(session);
+  const hasVisualStatus = isRunning || isUnreadCompleted;
+
+  const measureTitleOverflow = useCallback(
+    (actionsVisible: boolean) => {
+      const titleElement = titleRef.current;
+      if (!titleElement) return;
+      const actionOverlayWidth = !isTouchLayout && actionsVisible ? (hasVisualStatus ? 16 : 48) : 0;
+      setIsTitleOverflowing(
+        titleElement.scrollWidth > Math.max(0, titleElement.clientWidth - actionOverlayWidth) + 1
+      );
+    },
+    [hasVisualStatus, isTouchLayout]
+  );
+
+  useLayoutEffect(() => {
+    measureTitleOverflow(menuOpen);
+    const titleElement = titleRef.current;
+    if (!titleElement || typeof ResizeObserver === "undefined") return;
+    const observer = new ResizeObserver(() => measureTitleOverflow(menuOpen));
+    observer.observe(titleElement);
+    return () => observer.disconnect();
+  }, [measureTitleOverflow, menuOpen, title]);
+
+  const activeSurface =
+    menuOpen || hasKeyboardFocusWithin
+      ? isActive
+        ? "bg-[hsl(var(--sidebar-row-selected-hover))] ring-1 ring-ring/70"
+        : "bg-[hsl(var(--sidebar-row-hover))] ring-1 ring-ring/70"
+      : null;
+
+  return (
+    <div
+      ref={rowRef}
+      className={cn(
+        "group/task relative isolate flex w-full min-w-0 select-none items-stretch rounded-xl transition-colors motion-reduce:transition-none",
+        isTouchLayout ? "min-h-10" : "min-h-[30px]",
+        isActive
+          ? "bg-[hsl(var(--sidebar-row-selected))] hover:bg-[hsl(var(--sidebar-row-selected-hover))]"
+          : "hover:bg-[hsl(var(--sidebar-row-hover))]",
+        activeSurface
+      )}
+      onContextMenu={(event) => event.preventDefault()}
+      onFocusCapture={(event) => setHasKeyboardFocusWithin(isKeyboardFocusTarget(event.target))}
+      onBlurCapture={(event) => {
+        const nextTarget = event.relatedTarget;
+        setHasKeyboardFocusWithin(
+          event.currentTarget.contains(nextTarget as Node) && isKeyboardFocusTarget(nextTarget)
+        );
+      }}
+      onPointerEnter={() => measureTitleOverflow(true)}
+      onPointerLeave={() => measureTitleOverflow(menuOpen || hasKeyboardFocusWithin)}
+    >
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              "relative z-0 flex min-w-0 flex-1 cursor-pointer items-center pl-8 text-left text-sm text-foreground/95 transition-colors focus-visible:outline-none aria-disabled:cursor-default",
+              isTouchLayout ? "min-h-10" : "min-h-[30px]",
+              isActive && "font-medium text-foreground",
+              isTouchLayout
+                ? hasVisualStatus
+                  ? "pr-[4.75rem]"
+                  : "pr-10"
+                : hasVisualStatus
+                  ? "pr-8"
+                  : "pr-0"
+            )}
+            onClick={() => {
+              if (!actionsLocked) onSelect(session.id);
+            }}
+            onFocus={() => measureTitleOverflow(true)}
+            onBlur={() => measureTitleOverflow(menuOpen)}
+            aria-disabled={actionsLocked || undefined}
+            aria-current={isActive ? "page" : undefined}
+            aria-label={agentTaskAccessibleLabel(title, {
+              running: isRunning,
+              unread: isUnreadCompleted
+            })}
+          >
+            <span ref={titleRef} className="min-w-0 flex-1 truncate">
+              {title}
+            </span>
+          </button>
+        </TooltipTrigger>
+        {isTitleOverflowing ? (
+          <TooltipContent side="right" className="max-w-xs break-words">
+            {title}
+          </TooltipContent>
+        ) : null}
+      </Tooltip>
+
+      {hasVisualStatus ? (
+        <span
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none absolute top-1/2 z-40 flex -translate-y-1/2 items-center justify-center transition-opacity duration-150 motion-reduce:transition-none",
+            isTouchLayout ? "right-10" : "right-2",
+            !isTouchLayout && "group-hover/task:opacity-0",
+            !isTouchLayout && (menuOpen || hasKeyboardFocusWithin) && "opacity-0"
+          )}
+        >
+          {isRunning ? (
+            <Loader2 className="h-3.5 w-3.5 text-[hsl(var(--maple-primary))] motion-safe:animate-spin" />
+          ) : (
+            <span className="h-2 w-2 rounded-full bg-maple-success" />
+          )}
+        </span>
+      ) : null}
+
+      <div className={taskActionRowClass(isTouchLayout, menuOpen, hasKeyboardFocusWithin)}>
+        <div
+          aria-hidden="true"
+          className={cn(
+            "pointer-events-none w-5 shrink-0 self-stretch bg-gradient-to-r from-transparent transition-colors",
+            isActive
+              ? "to-[hsl(var(--sidebar-row-selected))] group-hover/task:to-[hsl(var(--sidebar-row-selected-hover))]"
+              : "to-[hsl(var(--sidebar))] group-hover/task:to-[hsl(var(--sidebar-row-hover))]",
+            (menuOpen || hasKeyboardFocusWithin) &&
+              (isActive
+                ? "to-[hsl(var(--sidebar-row-selected-hover))]"
+                : "to-[hsl(var(--sidebar-row-hover))]")
+          )}
+        />
+        <div
+          className={cn(
+            "flex items-center rounded-r-xl pr-0.5",
+            isActive
+              ? "bg-[hsl(var(--sidebar-row-selected))] group-hover/task:bg-[hsl(var(--sidebar-row-selected-hover))]"
+              : "bg-[hsl(var(--sidebar))] group-hover/task:bg-[hsl(var(--sidebar-row-hover))]",
+            (menuOpen || hasKeyboardFocusWithin) &&
+              (isActive
+                ? "bg-[hsl(var(--sidebar-row-selected-hover))]"
+                : "bg-[hsl(var(--sidebar-row-hover))]")
+          )}
+        >
+          <DropdownMenu open={menuOpen} onOpenChange={setMenuOpen}>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className={cn(AGENT_SIDEBAR_ACTION_BUTTON, isTouchLayout ? "h-9 w-9" : "h-7 w-7")}
+                onClick={(event) => {
+                  event.preventDefault();
+                  event.stopPropagation();
+                }}
+                aria-label={`Open task menu for ${title}`}
+              >
+                <MoreHorizontal className="h-4 w-4" strokeWidth={SIDEBAR_ICON_STROKE} />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" collisionPadding={8} className="max-w-48">
+              <DropdownMenuItem
+                disabled={actionsLocked || isRunning}
+                onClick={() => onDelete(session)}
+              >
+                <Trash className="mr-2 h-4 w-4 shrink-0" strokeWidth={SIDEBAR_ICON_STROKE} />
+                <span className="min-w-0 whitespace-normal leading-snug">
+                  {isRunning ? "Stop Agent Before Deleting Task" : "Delete Task"}
+                </span>
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 function AgentSidebarContent({
   activeSessionId,
-  isCompactLayout,
+  collapsedProjectRoots,
+  isTouchLayout,
   projectRoot,
   recentRoots,
   completedUnreadSessionIds,
@@ -2888,9 +3244,11 @@ function AgentSidebarContent({
   sessions,
   onChooseProjectRoot,
   onCreateSession,
+  onProjectDisclosureToggle,
   onProjectOrderChange,
+  onProjectRename,
   onProjectRemove,
-  onProjectRootChange,
+  onRevealProjectRoot,
   onSessionDelete,
   onSessionSelect
 }: AgentSidebarContentProps) {
@@ -2906,7 +3264,8 @@ function AgentSidebarContent({
   const suppressProjectClickUntilRef = useRef(0);
   const [projectDrag, setProjectDrag] = useState<ProjectDragState | null>(null);
   const isProjectDragging = projectDrag !== null;
-  const [collapsedProjectRoots, setCollapsedProjectRoots] = useState<Set<string>>(() => new Set());
+  const [openProjectMenuPath, setOpenProjectMenuPath] = useState<string | null>(null);
+  const [keyboardFocusProjectPath, setKeyboardFocusProjectPath] = useState<string | null>(null);
   const projectRows = recentRoots;
   const sessionsByRoot = useMemo(() => groupAgentSessionsByRoot(sessions), [sessions]);
   const setAnimatedRowRef = useCallback(
@@ -3111,7 +3470,7 @@ function AgentSidebarContent({
   );
 
   const beginProjectPointer = useCallback(
-    (event: React.PointerEvent<HTMLDivElement>, root: RecentProjectRoot) => {
+    (event: React.PointerEvent<HTMLDivElement>, root: AgentProjectRootView) => {
       if (
         disabled ||
         !event.isPrimary ||
@@ -3125,16 +3484,17 @@ function AgentSidebarContent({
       pendingProjectPointerRef.current = {
         pointerId: event.pointerId,
         path: root.path,
-        name: root.name,
+        name: root.displayName,
         startX: event.clientX,
         startY: event.clientY,
         grabOffsetX: event.clientX - rect.left,
         grabOffsetY: event.clientY - rect.top,
         ghostWidth: rect.width,
-        headerElement: event.currentTarget
+        headerElement: event.currentTarget,
+        isCollapsed: collapsedProjectRoots.has(root.path)
       };
     },
-    [disabled]
+    [collapsedProjectRoots, disabled]
   );
 
   const suppressActivatedProjectClick = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
@@ -3276,18 +3636,6 @@ function AgentSidebarContent({
     };
   }, [stopProjectAutoScroll]);
 
-  const toggleProjectCollapsed = useCallback((path: string) => {
-    setCollapsedProjectRoots((current) => {
-      const next = new Set(current);
-      if (next.has(path)) {
-        next.delete(path);
-      } else {
-        next.add(path);
-      }
-      return next;
-    });
-  }, []);
-
   return (
     <>
       <div className="mb-2 flex items-center justify-between gap-3">
@@ -3301,9 +3649,9 @@ function AgentSidebarContent({
           className="h-7 w-7 text-muted-foreground hover:text-foreground"
           onClick={onChooseProjectRoot}
           disabled={disabled}
-          aria-label="Choose project folder"
+          aria-label="Add project folder"
         >
-          <FolderOpen className="h-4 w-4" />
+          <FolderPlus className="h-4 w-4" />
         </Button>
       </div>
 
@@ -3332,209 +3680,242 @@ function AgentSidebarContent({
             const showProjectRunningIndicator = isCollapsed && hasRunningSession;
             const showProjectUnreadIndicator =
               isCollapsed && !hasRunningSession && hasUnreadCompletedSession;
+            const hasProjectStatus = showProjectRunningIndicator || showProjectUnreadIndicator;
+            const projectMenuOpen = openProjectMenuPath === root.path;
+            const hasProjectKeyboardFocus = keyboardFocusProjectPath === root.path;
 
             return (
               <div
                 key={root.path}
                 ref={(node) => setProjectGroupRef(root.path, node)}
                 className={cn(
-                  "space-y-2",
-                  rootIndex < projectRows.length - 1 && "mb-2",
+                  "space-y-px",
+                  rootIndex < projectRows.length - 1 && "mb-3",
                   isProjectDragging && "opacity-25"
                 )}
               >
                 <div
                   ref={(node) => setProjectHeaderRef(root.path, node)}
                   className={cn(
-                    "flex select-none items-center gap-1 rounded-2xl text-foreground",
+                    "group/project relative flex select-none items-center rounded-xl text-foreground transition-colors motion-reduce:transition-none hover:bg-[hsl(var(--sidebar-row-hover))]",
+                    isTouchLayout ? "min-h-10" : "min-h-[30px]",
+                    (projectMenuOpen || hasProjectKeyboardFocus) &&
+                      "bg-[hsl(var(--sidebar-row-hover))] ring-1 ring-ring/70",
                     !disabled && projectRows.length > 1 && "touch-none",
                     !disabled &&
                       (projectDrag?.path === root.path ? "cursor-grabbing" : "cursor-grab")
                   )}
                   onPointerDown={(event) => beginProjectPointer(event, root)}
                   onClickCapture={suppressActivatedProjectClick}
+                  onFocusCapture={(event) =>
+                    setKeyboardFocusProjectPath(
+                      isKeyboardFocusTarget(event.target) ? root.path : null
+                    )
+                  }
+                  onBlurCapture={(event) => {
+                    const nextTarget = event.relatedTarget;
+                    const staysKeyboardFocused =
+                      event.currentTarget.contains(nextTarget as Node) &&
+                      isKeyboardFocusTarget(nextTarget);
+                    setKeyboardFocusProjectPath((current) =>
+                      staysKeyboardFocused ? root.path : current === root.path ? null : current
+                    );
+                  }}
                 >
                   <button
                     type="button"
                     className={cn(
-                      "flex min-w-0 flex-1 items-center gap-2 rounded-2xl py-1.5 pr-1 text-left text-sm transition-colors",
-                      isActive
-                        ? "font-bold text-foreground"
-                        : "text-foreground/95 hover:text-foreground"
+                      "flex min-w-0 flex-1 items-center gap-2 rounded-xl px-2 text-left text-sm text-foreground/95 transition-colors focus-visible:outline-none",
+                      isTouchLayout ? "min-h-10" : "min-h-[30px]",
+                      isActive && "font-semibold text-foreground",
+                      isTouchLayout
+                        ? hasProjectStatus
+                          ? "pr-24"
+                          : "pr-[4.75rem]"
+                        : hasProjectStatus
+                          ? "pr-8"
+                          : "pr-2"
                     )}
-                    onClick={() => onProjectRootChange(root.path)}
-                    disabled={disabled}
+                    onClick={() => onProjectDisclosureToggle(root.path)}
+                    aria-expanded={!isCollapsed}
+                    aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${root.displayName}${
+                      hasRunningSession
+                        ? ", contains a running task"
+                        : hasUnreadCompletedSession
+                          ? ", contains a completed unread task"
+                          : ""
+                    }`}
                     title={root.path}
                   >
-                    <FolderOpen className="h-4 w-4 shrink-0" />
-                    <span className="min-w-0 flex-1 truncate">{root.name}</span>
-                    {showProjectRunningIndicator ? (
-                      <Loader2 className="h-3.5 w-3.5 shrink-0 animate-spin text-[hsl(var(--maple-primary))]" />
-                    ) : showProjectUnreadIndicator ? (
-                      <span className="h-2 w-2 shrink-0 rounded-full bg-maple-success" />
-                    ) : null}
+                    {isCollapsed ? (
+                      <Folder className="h-4 w-4 shrink-0" />
+                    ) : (
+                      <FolderOpen className="h-4 w-4 shrink-0" />
+                    )}
+                    <span className="min-w-0 flex-1 truncate">{root.displayName}</span>
                   </button>
-                  {projectSessions.length > 0 ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                      onClick={() => toggleProjectCollapsed(root.path)}
-                      aria-label={isCollapsed ? "Expand project tasks" : "Collapse project tasks"}
-                    >
-                      {isCollapsed ? (
-                        <ChevronRight className="h-4 w-4" />
-                      ) : (
-                        <ChevronDown className="h-4 w-4" />
+
+                  {hasProjectStatus ? (
+                    <span
+                      aria-hidden="true"
+                      className={cn(
+                        "pointer-events-none absolute top-1/2 z-40 flex -translate-y-1/2 items-center justify-center transition-opacity duration-150 motion-reduce:transition-none",
+                        isTouchLayout ? "right-[4.75rem]" : "right-2",
+                        !isTouchLayout && "group-hover/project:opacity-0",
+                        !isTouchLayout &&
+                          (projectMenuOpen || hasProjectKeyboardFocus) &&
+                          "opacity-0"
                       )}
-                    </Button>
-                  ) : null}
-                  {isActive ? (
-                    <Button
-                      type="button"
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 shrink-0 text-muted-foreground hover:text-foreground"
-                      onClick={onCreateSession}
-                      disabled={disabled || !projectRoot}
-                      aria-label="New Task"
                     >
-                      <MessageSquarePlus className="h-4 w-4" />
-                    </Button>
+                      {showProjectRunningIndicator ? (
+                        <Loader2 className="h-3.5 w-3.5 text-[hsl(var(--maple-primary))] motion-safe:animate-spin" />
+                      ) : (
+                        <span className="h-2 w-2 rounded-full bg-maple-success" />
+                      )}
+                    </span>
                   ) : null}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
+
+                  <div
+                    className={projectActionRowClass(
+                      isTouchLayout,
+                      projectMenuOpen,
+                      hasProjectKeyboardFocus
+                    )}
+                  >
+                    <div
+                      aria-hidden="true"
+                      className={cn(
+                        "pointer-events-none w-5 shrink-0 self-stretch bg-gradient-to-r from-transparent to-[hsl(var(--sidebar))] transition-colors group-hover/project:to-[hsl(var(--sidebar-row-hover))]",
+                        (projectMenuOpen || hasProjectKeyboardFocus) &&
+                          "to-[hsl(var(--sidebar-row-hover))]"
+                      )}
+                    />
+                    <div
+                      className={cn(
+                        "flex items-center rounded-r-xl bg-[hsl(var(--sidebar))] pr-0.5 transition-colors group-hover/project:bg-[hsl(var(--sidebar-row-hover))]",
+                        (projectMenuOpen || hasProjectKeyboardFocus) &&
+                          "bg-[hsl(var(--sidebar-row-hover))]"
+                      )}
+                    >
+                      <DropdownMenu
+                        modal={false}
+                        open={projectMenuOpen}
+                        onOpenChange={(open) => setOpenProjectMenuPath(open ? root.path : null)}
+                      >
+                        <DropdownMenuTrigger asChild>
+                          <button
+                            type="button"
+                            className={cn(
+                              AGENT_SIDEBAR_ACTION_BUTTON,
+                              isTouchLayout ? "h-9 w-9" : "h-7 w-7"
+                            )}
+                            disabled={disabled}
+                            onPointerDown={(event) => event.stopPropagation()}
+                            onClick={(event) => {
+                              event.preventDefault();
+                              event.stopPropagation();
+                            }}
+                            aria-label={`Open project menu for ${root.displayName}`}
+                          >
+                            <MoreHorizontal className="h-4 w-4" strokeWidth={SIDEBAR_ICON_STROKE} />
+                          </button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent
+                          align="end"
+                          collisionPadding={8}
+                          className={cn(
+                            "max-w-[calc(100vw-1rem)]",
+                            hasRunningSession ? "w-48" : "w-max"
+                          )}
+                        >
+                          <DropdownMenuItem
+                            disabled={disabled}
+                            onClick={() => onProjectRename(root)}
+                          >
+                            <FilePenLine
+                              className="mr-2 h-4 w-4 shrink-0"
+                              strokeWidth={SIDEBAR_ICON_STROKE}
+                            />
+                            Rename Project
+                          </DropdownMenuItem>
+                          <DropdownMenuItem onClick={() => onRevealProjectRoot(root.path)}>
+                            <FolderOpen
+                              className="mr-2 h-4 w-4 shrink-0"
+                              strokeWidth={SIDEBAR_ICON_STROKE}
+                            />
+                            <span className="whitespace-nowrap">Open Project Folder</span>
+                          </DropdownMenuItem>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            disabled={disabled || hasRunningSession}
+                            onClick={() => onProjectRemove(root)}
+                          >
+                            <X
+                              className="mr-2 h-4 w-4 shrink-0"
+                              strokeWidth={SIDEBAR_ICON_STROKE}
+                            />
+                            <span className="min-w-0 whitespace-normal leading-snug">
+                              {hasRunningSession
+                                ? "Stop Agent Before Removing Project"
+                                : "Remove Project"}
+                            </span>
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                       <button
                         type="button"
-                        className={AGENT_SIDEBAR_ELLIPSIS_BUTTON}
-                        disabled={disabled}
+                        className={cn(
+                          AGENT_SIDEBAR_ACTION_BUTTON,
+                          isTouchLayout ? "h-9 w-9" : "h-7 w-7"
+                        )}
                         onPointerDown={(event) => event.stopPropagation()}
                         onClick={(event) => {
                           event.preventDefault();
                           event.stopPropagation();
+                          onCreateSession(root.path);
                         }}
-                        aria-label={`Open project menu for ${root.name}`}
+                        disabled={disabled || !root.path}
+                        aria-label={`New task in ${root.displayName}`}
                       >
-                        <MoreHorizontal className="h-4 w-4" strokeWidth={SIDEBAR_ICON_STROKE} />
+                        <MessageSquarePlus className="h-4 w-4" />
                       </button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
-                      <DropdownMenuItem
-                        disabled={disabled || hasRunningSession}
-                        onClick={() => onProjectRemove(root)}
-                      >
-                        <X className="mr-2 h-4 w-4" strokeWidth={SIDEBAR_ICON_STROKE} />
-                        {hasRunningSession
-                          ? "Stop Agent Before Removing Project"
-                          : "Remove Project"}
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
+                    </div>
+                  </div>
                 </div>
 
-                {!isCollapsed ? (
-                  <div className="mt-2 w-full space-y-2 pl-6">
-                    {projectSessions.length === 0 ? (
-                      isActive ? (
-                        <p className="py-1 text-xs text-muted-foreground/75">No tasks yet</p>
-                      ) : null
-                    ) : (
-                      projectSessions.map((session) => {
-                        const isActiveSession = session.id === activeSessionId;
-                        const isRunning = runningSessionIds.has(session.id);
-                        const isUnreadCompleted = completedUnreadSessionIds.has(session.id);
-                        const title = sessionTitle(session);
-                        const accessibleStatus = isRunning
-                          ? "running"
-                          : isUnreadCompleted
-                            ? "completed, unread"
-                            : null;
-
-                        return (
-                          <div
-                            key={session.id}
-                            ref={(node) => setAnimatedRowRef(`session:${session.id}`, node)}
-                            className="group relative isolate flex w-full min-w-0 select-none items-stretch gap-0.5 rounded-2xl"
-                            onContextMenu={(event) => event.preventDefault()}
-                          >
-                            <button
-                              type="button"
-                              className={cn(
-                                "relative z-0 min-w-0 flex-1 cursor-pointer py-1 pr-2 text-left text-sm transition-colors",
-                                isActiveSession
-                                  ? "font-bold text-foreground"
-                                  : "text-foreground/95 group-hover:text-foreground"
-                              )}
-                              onClick={() => onSessionSelect(session.id)}
-                              disabled={disabled}
-                              aria-current={isActiveSession ? "page" : undefined}
-                              aria-label={
-                                accessibleStatus ? `${title}, ${accessibleStatus}` : title
-                              }
-                            >
-                              <div className="pr-8">
-                                <div className="relative z-0 flex min-w-0 items-center gap-1.5">
-                                  {isRunning ? (
-                                    <Loader2
-                                      className="h-3 w-3 shrink-0 animate-spin text-[hsl(var(--maple-primary))]"
-                                      aria-hidden="true"
-                                    />
-                                  ) : isUnreadCompleted ? (
-                                    <span
-                                      className="h-2 w-2 shrink-0 rounded-full bg-maple-success"
-                                      aria-hidden="true"
-                                    />
-                                  ) : null}
-                                  <span className="min-w-0 flex-1 truncate">{title}</span>
-                                </div>
-                              </div>
-                            </button>
-
-                            <div className={agentSidebarEllipsisTriggerRowClass(isCompactLayout)}>
-                              <div className={AGENT_SIDEBAR_ELLIPSIS_FADE} aria-hidden="true" />
-                              <div className="flex items-center">
-                                <DropdownMenu>
-                                  <DropdownMenuTrigger asChild>
-                                    <button
-                                      type="button"
-                                      className={AGENT_SIDEBAR_ELLIPSIS_BUTTON}
-                                      disabled={disabled}
-                                      onClick={(event) => {
-                                        event.preventDefault();
-                                        event.stopPropagation();
-                                      }}
-                                      aria-label={`Open task menu for ${title}`}
-                                    >
-                                      <MoreHorizontal
-                                        className="h-4 w-4"
-                                        strokeWidth={SIDEBAR_ICON_STROKE}
-                                      />
-                                    </button>
-                                  </DropdownMenuTrigger>
-                                  <DropdownMenuContent align="end">
-                                    <DropdownMenuItem
-                                      disabled={disabled || isRunning}
-                                      onClick={() => onSessionDelete(session)}
-                                    >
-                                      <Trash
-                                        className="mr-2 h-4 w-4"
-                                        strokeWidth={SIDEBAR_ICON_STROKE}
-                                      />
-                                      {isRunning
-                                        ? "Stop Agent Before Deleting Task"
-                                        : "Delete Task"}
-                                    </DropdownMenuItem>
-                                  </DropdownMenuContent>
-                                </DropdownMenu>
-                              </div>
-                            </div>
-                          </div>
-                        );
-                      })
+                {!isCollapsed && projectSessions.length === 0 && isActive ? (
+                  <p
+                    className={cn(
+                      "flex items-center pl-8 text-xs text-muted-foreground/75",
+                      isTouchLayout ? "min-h-10" : "min-h-[30px]"
                     )}
-                  </div>
+                  >
+                    No tasks yet
+                  </p>
                 ) : null}
+
+                {!isCollapsed
+                  ? projectSessions.map((session) => {
+                      const isActiveSession = session.id === activeSessionId;
+                      const isRunning = runningSessionIds.has(session.id);
+                      const isUnreadCompleted = completedUnreadSessionIds.has(session.id);
+
+                      return (
+                        <AgentSidebarTaskRow
+                          key={session.id}
+                          actionsLocked={disabled}
+                          isActive={isActiveSession}
+                          isRunning={isRunning}
+                          isTouchLayout={isTouchLayout}
+                          isUnreadCompleted={isUnreadCompleted}
+                          onDelete={onSessionDelete}
+                          onSelect={onSessionSelect}
+                          rowRef={(node) => setAnimatedRowRef(`session:${session.id}`, node)}
+                          session={session}
+                        />
+                      );
+                    })
+                  : null}
               </div>
             );
           })}
@@ -3561,7 +3942,11 @@ function AgentSidebarContent({
             maxWidth: "calc(100vw - 24px)"
           }}
         >
-          <FolderOpen className="h-4 w-4 shrink-0" />
+          {projectDrag.isCollapsed ? (
+            <Folder className="h-4 w-4 shrink-0" />
+          ) : (
+            <FolderOpen className="h-4 w-4 shrink-0" />
+          )}
           <span className="min-w-0 flex-1 truncate">{projectDrag.name}</span>
         </div>
       ) : null}
@@ -3592,7 +3977,7 @@ interface AgentComposerProps {
   mode: AgentPermissionMode;
   model: string;
   projectRoot: string;
-  recentRoots: RecentProjectRoot[];
+  recentRoots: AgentProjectRootView[];
   isExpanded?: boolean;
   onCancelPrompt: () => void;
   onChooseProjectRoot: () => void;
@@ -3729,7 +4114,7 @@ function AgentComposer({
               {rootOptions.length > 0 ? <SelectSeparator /> : null}
               {rootOptions.map((root) => (
                 <SelectItem key={root.path} value={root.path}>
-                  {root.name}
+                  {root.displayName}
                 </SelectItem>
               ))}
             </SelectContent>

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -30,6 +30,7 @@ import {
   Globe2,
   Loader2,
   Lock,
+  MessageSquare,
   MessageSquarePlus,
   MoreHorizontal,
   ShieldCheck,
@@ -79,13 +80,14 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger
 } from "@/components/ui/dropdown-menu";
-import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
+import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
 import { MapleWordmark } from "@/components/MapleWordmark";
 import { DeleteChatDialog } from "@/components/DeleteChatDialog";
 import { RenameAgentProjectDialog } from "@/components/RenameAgentProjectDialog";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { AgentMcpMenu, AgentMcpServersDialog } from "@/components/agent/AgentMcpControls";
+import { AgentSidebarInfoCard } from "@/components/agent/AgentSidebarInfoCard";
 import { handleAgentModeThoughtRunFinished } from "@/components/agent/agentModeThoughtRun";
 import {
   agentRuntimeService,
@@ -166,6 +168,8 @@ import { useLazyRef } from "@/utils/useLazyRef";
 import { revealAgentProjectFolder } from "@/services/agentProjectFolder";
 import {
   aggregateAgentSidebarStatus,
+  agentProjectProgressLabel,
+  agentProjectTaskSummaryLabel,
   agentTaskAccessibleLabel
 } from "@/services/agentSidebarPresentation";
 import {
@@ -1965,6 +1969,7 @@ export function AgentMode({ userId }: { userId: string }) {
         // this point the previous chat remains active and its composer is gated.
         shouldAutoScrollRef.current = true;
         activeSessionIdRef.current = detail.session.id;
+        clearCompletedUnreadSession(detail.session.id);
         setActiveSessionId(detail.session.id);
         agentSessionSelection.remember(userId, detail.session.id);
         setProjectRoot(detail.session.projectRoot);
@@ -2689,6 +2694,7 @@ export function AgentMode({ userId }: { userId: string }) {
             recentRoots={displayProjectRoots}
             completedUnreadSessionIds={completedUnreadSessionIds}
             disabled={areAgentSettingsLocked}
+            inProgressSessionIds={agentRunningSessionIds}
             runningSessionIds={runningSessionIds}
             sessions={visibleSessions}
             onChooseProjectRoot={chooseProjectRoot}
@@ -3003,6 +3009,7 @@ interface AgentSidebarContentProps {
   recentRoots: AgentProjectRootView[];
   completedUnreadSessionIds: Set<string>;
   disabled: boolean;
+  inProgressSessionIds: Set<string>;
   runningSessionIds: Set<string>;
   sessions: AgentSessionSummary[];
   onChooseProjectRoot: () => void;
@@ -3039,11 +3046,14 @@ interface ProjectDragState extends PendingProjectPointer {
 interface AgentSidebarTaskRowProps {
   actionsLocked: boolean;
   isActive: boolean;
+  isInProgress: boolean;
   isRunning: boolean;
   isTouchLayout: boolean;
   isUnreadCompleted: boolean;
   onDelete: (session: AgentSessionSummary) => void;
+  onRevealProjectRoot: (projectRoot: string) => void;
   onSelect: (sessionId: string) => void;
+  projectDisplayName: string;
   rowRef: (node: HTMLDivElement | null) => void;
   session: AgentSessionSummary;
 }
@@ -3051,48 +3061,62 @@ interface AgentSidebarTaskRowProps {
 function AgentSidebarTaskRow({
   actionsLocked,
   isActive,
+  isInProgress,
   isRunning,
   isTouchLayout,
   isUnreadCompleted,
   onDelete,
+  onRevealProjectRoot,
   onSelect,
+  projectDisplayName,
   rowRef,
   session
 }: AgentSidebarTaskRowProps) {
   const [menuOpen, setMenuOpen] = useState(false);
   const [hasKeyboardFocusWithin, setHasKeyboardFocusWithin] = useState(false);
-  const [isTitleOverflowing, setIsTitleOverflowing] = useState(false);
-  const titleRef = useRef<HTMLSpanElement>(null);
+  const [infoCardOpen, setInfoCardOpen] = useState(false);
   const title = sessionTitle(session);
   const hasVisualStatus = isRunning || isUnreadCompleted;
+  const visibleInfoCardOpen = !isTouchLayout && infoCardOpen;
 
-  const measureTitleOverflow = useCallback(
-    (actionsVisible: boolean) => {
-      const titleElement = titleRef.current;
-      if (!titleElement) return;
-      const actionOverlayWidth = !isTouchLayout && actionsVisible ? (hasVisualStatus ? 16 : 48) : 0;
-      setIsTitleOverflowing(
-        titleElement.scrollWidth > Math.max(0, titleElement.clientWidth - actionOverlayWidth) + 1
-      );
-    },
-    [hasVisualStatus, isTouchLayout]
-  );
-
-  useLayoutEffect(() => {
-    measureTitleOverflow(menuOpen);
-    const titleElement = titleRef.current;
-    if (!titleElement || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => measureTitleOverflow(menuOpen));
-    observer.observe(titleElement);
-    return () => observer.disconnect();
-  }, [measureTitleOverflow, menuOpen, title]);
+  useEffect(() => {
+    if (isTouchLayout) setInfoCardOpen(false);
+  }, [isTouchLayout]);
 
   const activeSurface =
-    menuOpen || hasKeyboardFocusWithin
+    menuOpen || hasKeyboardFocusWithin || visibleInfoCardOpen
       ? isActive
         ? "bg-[hsl(var(--sidebar-row-selected-hover))] ring-1 ring-ring/70"
         : "bg-[hsl(var(--sidebar-row-hover))] ring-1 ring-ring/70"
       : null;
+  const taskSelectionButton = (
+    <button
+      type="button"
+      className={cn(
+        "relative z-0 flex min-w-0 flex-1 cursor-pointer items-center pl-8 text-left text-sm text-foreground/95 transition-colors focus-visible:outline-none aria-disabled:cursor-default",
+        isTouchLayout ? "min-h-10" : "min-h-[30px]",
+        isActive && "font-medium text-foreground",
+        isTouchLayout
+          ? hasVisualStatus
+            ? "pr-[4.75rem]"
+            : "pr-10"
+          : hasVisualStatus
+            ? "pr-8"
+            : "pr-0"
+      )}
+      onClick={() => {
+        if (!actionsLocked) onSelect(session.id);
+      }}
+      aria-disabled={actionsLocked || undefined}
+      aria-current={isActive ? "page" : undefined}
+      aria-label={agentTaskAccessibleLabel(title, {
+        running: isRunning,
+        unread: isUnreadCompleted
+      })}
+    >
+      <span className="min-w-0 flex-1 truncate">{title}</span>
+    </button>
+  );
 
   return (
     <div
@@ -3113,48 +3137,34 @@ function AgentSidebarTaskRow({
           event.currentTarget.contains(nextTarget as Node) && isKeyboardFocusTarget(nextTarget)
         );
       }}
-      onPointerEnter={() => measureTitleOverflow(true)}
-      onPointerLeave={() => measureTitleOverflow(menuOpen || hasKeyboardFocusWithin)}
     >
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <button
-            type="button"
-            className={cn(
-              "relative z-0 flex min-w-0 flex-1 cursor-pointer items-center pl-8 text-left text-sm text-foreground/95 transition-colors focus-visible:outline-none aria-disabled:cursor-default",
-              isTouchLayout ? "min-h-10" : "min-h-[30px]",
-              isActive && "font-medium text-foreground",
-              isTouchLayout
-                ? hasVisualStatus
-                  ? "pr-[4.75rem]"
-                  : "pr-10"
-                : hasVisualStatus
-                  ? "pr-8"
-                  : "pr-0"
-            )}
-            onClick={() => {
-              if (!actionsLocked) onSelect(session.id);
-            }}
-            onFocus={() => measureTitleOverflow(true)}
-            onBlur={() => measureTitleOverflow(menuOpen)}
-            aria-disabled={actionsLocked || undefined}
-            aria-current={isActive ? "page" : undefined}
-            aria-label={agentTaskAccessibleLabel(title, {
-              running: isRunning,
-              unread: isUnreadCompleted
-            })}
-          >
-            <span ref={titleRef} className="min-w-0 flex-1 truncate">
-              {title}
-            </span>
-          </button>
-        </TooltipTrigger>
-        {isTitleOverflowing ? (
-          <TooltipContent side="right" className="max-w-xs break-words">
-            {title}
-          </TooltipContent>
+      <HoverCard
+        open={visibleInfoCardOpen}
+        openDelay={450}
+        closeDelay={180}
+        onOpenChange={setInfoCardOpen}
+      >
+        {isTouchLayout ? (
+          taskSelectionButton
+        ) : (
+          <HoverCardTrigger asChild>{taskSelectionButton}</HoverCardTrigger>
+        )}
+        {!isTouchLayout ? (
+          <HoverCardContent side="right">
+            <AgentSidebarInfoCard
+              folderPath={session.projectRoot}
+              icon={MessageSquare}
+              isInProgress={isInProgress}
+              metadata={projectDisplayName}
+              metadataIcon={Folder}
+              onDismiss={() => setInfoCardOpen(false)}
+              onOpenProjectFolder={() => onRevealProjectRoot(session.projectRoot)}
+              progressLabel={isInProgress ? "In progress" : "Not in progress"}
+              title={title}
+            />
+          </HoverCardContent>
         ) : null}
-      </Tooltip>
+      </HoverCard>
 
       {hasVisualStatus ? (
         <span
@@ -3163,7 +3173,9 @@ function AgentSidebarTaskRow({
             "pointer-events-none absolute top-1/2 z-40 flex -translate-y-1/2 items-center justify-center transition-opacity duration-150 motion-reduce:transition-none",
             isTouchLayout ? "right-10" : "right-2",
             !isTouchLayout && "group-hover/task:opacity-0",
-            !isTouchLayout && (menuOpen || hasKeyboardFocusWithin) && "opacity-0"
+            !isTouchLayout &&
+              (menuOpen || hasKeyboardFocusWithin || visibleInfoCardOpen) &&
+              "opacity-0"
           )}
         >
           {isRunning ? (
@@ -3174,7 +3186,13 @@ function AgentSidebarTaskRow({
         </span>
       ) : null}
 
-      <div className={taskActionRowClass(isTouchLayout, menuOpen, hasKeyboardFocusWithin)}>
+      <div
+        className={taskActionRowClass(
+          isTouchLayout,
+          menuOpen,
+          hasKeyboardFocusWithin || visibleInfoCardOpen
+        )}
+      >
         <div
           aria-hidden="true"
           className={cn(
@@ -3182,7 +3200,7 @@ function AgentSidebarTaskRow({
             isActive
               ? "to-[hsl(var(--sidebar-row-selected))] group-hover/task:to-[hsl(var(--sidebar-row-selected-hover))]"
               : "to-[hsl(var(--sidebar))] group-hover/task:to-[hsl(var(--sidebar-row-hover))]",
-            (menuOpen || hasKeyboardFocusWithin) &&
+            (menuOpen || hasKeyboardFocusWithin || visibleInfoCardOpen) &&
               (isActive
                 ? "to-[hsl(var(--sidebar-row-selected-hover))]"
                 : "to-[hsl(var(--sidebar-row-hover))]")
@@ -3194,7 +3212,7 @@ function AgentSidebarTaskRow({
             isActive
               ? "bg-[hsl(var(--sidebar-row-selected))] group-hover/task:bg-[hsl(var(--sidebar-row-selected-hover))]"
               : "bg-[hsl(var(--sidebar))] group-hover/task:bg-[hsl(var(--sidebar-row-hover))]",
-            (menuOpen || hasKeyboardFocusWithin) &&
+            (menuOpen || hasKeyboardFocusWithin || visibleInfoCardOpen) &&
               (isActive
                 ? "bg-[hsl(var(--sidebar-row-selected-hover))]"
                 : "bg-[hsl(var(--sidebar-row-hover))]")
@@ -3240,6 +3258,7 @@ function AgentSidebarContent({
   recentRoots,
   completedUnreadSessionIds,
   disabled,
+  inProgressSessionIds,
   runningSessionIds,
   sessions,
   onChooseProjectRoot,
@@ -3264,10 +3283,16 @@ function AgentSidebarContent({
   const suppressProjectClickUntilRef = useRef(0);
   const [projectDrag, setProjectDrag] = useState<ProjectDragState | null>(null);
   const isProjectDragging = projectDrag !== null;
+  const [openProjectInfoCardPath, setOpenProjectInfoCardPath] = useState<string | null>(null);
   const [openProjectMenuPath, setOpenProjectMenuPath] = useState<string | null>(null);
   const [keyboardFocusProjectPath, setKeyboardFocusProjectPath] = useState<string | null>(null);
   const projectRows = recentRoots;
   const sessionsByRoot = useMemo(() => groupAgentSessionsByRoot(sessions), [sessions]);
+
+  useEffect(() => {
+    if (isTouchLayout) setOpenProjectInfoCardPath(null);
+  }, [isTouchLayout]);
+
   const setAnimatedRowRef = useCallback(
     (key: string, node: HTMLElement | null) => {
       if (node) {
@@ -3480,6 +3505,7 @@ function AgentSidebarContent({
       ) {
         return;
       }
+      setOpenProjectInfoCardPath(null);
       const rect = event.currentTarget.getBoundingClientRect();
       pendingProjectPointerRef.current = {
         pointerId: event.pointerId,
@@ -3674,15 +3700,53 @@ function AgentSidebarContent({
             const hasRunningSession = projectSessions.some((session) =>
               runningSessionIds.has(session.id)
             );
-            const hasUnreadCompletedSession = projectSessions.some((session) =>
-              completedUnreadSessionIds.has(session.id)
+            const inProgressSessionCount = projectSessions.reduce(
+              (count, session) => count + (inProgressSessionIds.has(session.id) ? 1 : 0),
+              0
             );
+            const unreadSessionCount = projectSessions.reduce(
+              (count, session) => count + (completedUnreadSessionIds.has(session.id) ? 1 : 0),
+              0
+            );
+            const hasUnreadCompletedSession = unreadSessionCount > 0;
             const showProjectRunningIndicator = isCollapsed && hasRunningSession;
             const showProjectUnreadIndicator =
               isCollapsed && !hasRunningSession && hasUnreadCompletedSession;
             const hasProjectStatus = showProjectRunningIndicator || showProjectUnreadIndicator;
+            const projectInfoCardOpen = openProjectInfoCardPath === root.path;
             const projectMenuOpen = openProjectMenuPath === root.path;
             const hasProjectKeyboardFocus = keyboardFocusProjectPath === root.path;
+            const projectDisclosureButton = (
+              <button
+                type="button"
+                className={cn(
+                  "flex min-w-0 flex-1 items-center gap-2 rounded-xl px-2 text-left text-sm text-foreground/95 transition-colors focus-visible:outline-none",
+                  isTouchLayout ? "min-h-10" : "min-h-[30px]",
+                  isActive && "font-semibold text-foreground",
+                  isTouchLayout
+                    ? hasProjectStatus
+                      ? "pr-24"
+                      : "pr-[4.75rem]"
+                    : hasProjectStatus
+                      ? "pr-8"
+                      : "pr-2"
+                )}
+                onClick={() => onProjectDisclosureToggle(root.path)}
+                aria-expanded={!isCollapsed}
+                aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${root.displayName}${
+                  inProgressSessionCount > 0
+                    ? `, ${agentProjectProgressLabel(inProgressSessionCount)}`
+                    : ""
+                }${unreadSessionCount > 0 ? `, ${unreadSessionCount} unread` : ""}`}
+              >
+                {isCollapsed ? (
+                  <Folder className="h-4 w-4 shrink-0" />
+                ) : (
+                  <FolderOpen className="h-4 w-4 shrink-0" />
+                )}
+                <span className="min-w-0 flex-1 truncate">{root.displayName}</span>
+              </button>
+            );
 
             return (
               <div
@@ -3699,7 +3763,7 @@ function AgentSidebarContent({
                   className={cn(
                     "group/project relative flex select-none items-center rounded-xl text-foreground transition-colors motion-reduce:transition-none hover:bg-[hsl(var(--sidebar-row-hover))]",
                     isTouchLayout ? "min-h-10" : "min-h-[30px]",
-                    (projectMenuOpen || hasProjectKeyboardFocus) &&
+                    (projectInfoCardOpen || projectMenuOpen || hasProjectKeyboardFocus) &&
                       "bg-[hsl(var(--sidebar-row-hover))] ring-1 ring-ring/70",
                     !disabled && projectRows.length > 1 && "touch-none",
                     !disabled &&
@@ -3722,38 +3786,40 @@ function AgentSidebarContent({
                     );
                   }}
                 >
-                  <button
-                    type="button"
-                    className={cn(
-                      "flex min-w-0 flex-1 items-center gap-2 rounded-xl px-2 text-left text-sm text-foreground/95 transition-colors focus-visible:outline-none",
-                      isTouchLayout ? "min-h-10" : "min-h-[30px]",
-                      isActive && "font-semibold text-foreground",
-                      isTouchLayout
-                        ? hasProjectStatus
-                          ? "pr-24"
-                          : "pr-[4.75rem]"
-                        : hasProjectStatus
-                          ? "pr-8"
-                          : "pr-2"
-                    )}
-                    onClick={() => onProjectDisclosureToggle(root.path)}
-                    aria-expanded={!isCollapsed}
-                    aria-label={`${isCollapsed ? "Expand" : "Collapse"} ${root.displayName}${
-                      hasRunningSession
-                        ? ", contains a running task"
-                        : hasUnreadCompletedSession
-                          ? ", contains a completed unread task"
-                          : ""
-                    }`}
-                    title={root.path}
+                  <HoverCard
+                    open={projectInfoCardOpen && !isProjectDragging && !isTouchLayout}
+                    openDelay={450}
+                    closeDelay={180}
+                    onOpenChange={(open) =>
+                      setOpenProjectInfoCardPath((current) =>
+                        open ? root.path : current === root.path ? null : current
+                      )
+                    }
                   >
-                    {isCollapsed ? (
-                      <Folder className="h-4 w-4 shrink-0" />
+                    {isTouchLayout ? (
+                      projectDisclosureButton
                     ) : (
-                      <FolderOpen className="h-4 w-4 shrink-0" />
+                      <HoverCardTrigger asChild>{projectDisclosureButton}</HoverCardTrigger>
                     )}
-                    <span className="min-w-0 flex-1 truncate">{root.displayName}</span>
-                  </button>
+                    {!isTouchLayout ? (
+                      <HoverCardContent side="right">
+                        <AgentSidebarInfoCard
+                          folderPath={root.path}
+                          icon={isCollapsed ? Folder : FolderOpen}
+                          isInProgress={inProgressSessionCount > 0}
+                          metadata={agentProjectTaskSummaryLabel(
+                            projectSessions.length,
+                            unreadSessionCount
+                          )}
+                          metadataIcon={MessageSquare}
+                          onDismiss={() => setOpenProjectInfoCardPath(null)}
+                          onOpenProjectFolder={() => onRevealProjectRoot(root.path)}
+                          progressLabel={agentProjectProgressLabel(inProgressSessionCount)}
+                          title={root.displayName}
+                        />
+                      </HoverCardContent>
+                    ) : null}
+                  </HoverCard>
 
                   {hasProjectStatus ? (
                     <span
@@ -3763,7 +3829,7 @@ function AgentSidebarContent({
                         isTouchLayout ? "right-[4.75rem]" : "right-2",
                         !isTouchLayout && "group-hover/project:opacity-0",
                         !isTouchLayout &&
-                          (projectMenuOpen || hasProjectKeyboardFocus) &&
+                          (projectInfoCardOpen || projectMenuOpen || hasProjectKeyboardFocus) &&
                           "opacity-0"
                       )}
                     >
@@ -3779,21 +3845,21 @@ function AgentSidebarContent({
                     className={projectActionRowClass(
                       isTouchLayout,
                       projectMenuOpen,
-                      hasProjectKeyboardFocus
+                      hasProjectKeyboardFocus || projectInfoCardOpen
                     )}
                   >
                     <div
                       aria-hidden="true"
                       className={cn(
                         "pointer-events-none w-5 shrink-0 self-stretch bg-gradient-to-r from-transparent to-[hsl(var(--sidebar))] transition-colors group-hover/project:to-[hsl(var(--sidebar-row-hover))]",
-                        (projectMenuOpen || hasProjectKeyboardFocus) &&
+                        (projectInfoCardOpen || projectMenuOpen || hasProjectKeyboardFocus) &&
                           "to-[hsl(var(--sidebar-row-hover))]"
                       )}
                     />
                     <div
                       className={cn(
                         "flex items-center rounded-r-xl bg-[hsl(var(--sidebar))] pr-0.5 transition-colors group-hover/project:bg-[hsl(var(--sidebar-row-hover))]",
-                        (projectMenuOpen || hasProjectKeyboardFocus) &&
+                        (projectInfoCardOpen || projectMenuOpen || hasProjectKeyboardFocus) &&
                           "bg-[hsl(var(--sidebar-row-hover))]"
                       )}
                     >
@@ -3897,6 +3963,7 @@ function AgentSidebarContent({
                 {!isCollapsed
                   ? projectSessions.map((session) => {
                       const isActiveSession = session.id === activeSessionId;
+                      const isInProgress = inProgressSessionIds.has(session.id);
                       const isRunning = runningSessionIds.has(session.id);
                       const isUnreadCompleted = completedUnreadSessionIds.has(session.id);
 
@@ -3905,11 +3972,14 @@ function AgentSidebarContent({
                           key={session.id}
                           actionsLocked={disabled}
                           isActive={isActiveSession}
+                          isInProgress={isInProgress}
                           isRunning={isRunning}
                           isTouchLayout={isTouchLayout}
                           isUnreadCompleted={isUnreadCompleted}
                           onDelete={onSessionDelete}
+                          onRevealProjectRoot={onRevealProjectRoot}
                           onSelect={onSessionSelect}
+                          projectDisplayName={root.displayName}
                           rowRef={(node) => setAnimatedRowRef(`session:${session.id}`, node)}
                           session={session}
                         />

--- a/frontend/src/components/RenameAgentProjectDialog.tsx
+++ b/frontend/src/components/RenameAgentProjectDialog.tsx
@@ -1,0 +1,87 @@
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface RenameAgentProjectDialogProps {
+  currentDisplayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRename: (displayName: string) => void;
+}
+
+export function RenameAgentProjectDialog({
+  currentDisplayName,
+  open,
+  onOpenChange,
+  onRename
+}: RenameAgentProjectDialogProps) {
+  const [displayName, setDisplayName] = useState(currentDisplayName);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedDisplayName = displayName.trim();
+    if (!trimmedDisplayName) {
+      setError("Project name cannot be empty.");
+      return;
+    }
+
+    onRename(trimmedDisplayName);
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>Rename Project</DialogTitle>
+          <DialogDescription>
+            Change this project&apos;s display name in Maple. The folder on your computer will not
+            be renamed or moved.
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="grid gap-4 py-4">
+          <div className="grid gap-2">
+            <Label htmlFor="agent-project-display-name">Project Name</Label>
+            <Input
+              id="agent-project-display-name"
+              value={displayName}
+              onChange={(event) => {
+                setDisplayName(event.target.value);
+                if (error) setError(null);
+              }}
+              aria-invalid={error ? true : undefined}
+              aria-describedby={error ? "agent-project-display-name-error" : undefined}
+              autoFocus
+            />
+            {error ? (
+              <p
+                id="agent-project-display-name-error"
+                className="text-sm text-destructive"
+                role="alert"
+              >
+                {error}
+              </p>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit">Rename Project</Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/Sidebar.test.tsx
+++ b/frontend/src/components/Sidebar.test.tsx
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SidebarToggle } from "./Sidebar";
+
+function renderToggle(agentStatus?: { runningCount: number; unreadCount: number }): string {
+  return renderToStaticMarkup(<SidebarToggle onToggle={() => {}} agentStatus={agentStatus} />);
+}
+
+describe("SidebarToggle", () => {
+  test("keeps the default Chat presentation unchanged", () => {
+    const markup = renderToggle();
+
+    expect(markup).toContain('aria-label="Open sidebar"');
+    expect(markup).toContain("lucide-menu");
+    expect(markup).not.toContain("data-agent-sidebar-status");
+  });
+
+  test("renders a motion-safe running indicator and reports every aggregate count", () => {
+    const markup = renderToggle({ runningCount: 1, unreadCount: 2 });
+
+    expect(markup).toContain(
+      'aria-label="Open Agent sidebar, 1 task running, 2 completed tasks unread"'
+    );
+    expect(markup).toContain('data-agent-sidebar-status="running"');
+    expect(markup).toContain("motion-safe:animate-spin");
+    expect(markup).toContain('aria-hidden="true"');
+    expect(markup).not.toContain('data-agent-sidebar-status="unread"');
+  });
+
+  test("renders the unread indicator only when no task is running", () => {
+    const markup = renderToggle({ runningCount: 0, unreadCount: 2 });
+
+    expect(markup).toContain('aria-label="Open Agent sidebar, 2 completed tasks unread"');
+    expect(markup).toContain('data-agent-sidebar-status="unread"');
+    expect(markup).not.toContain('data-agent-sidebar-status="running"');
+  });
+
+  test("keeps an idle Agent toggle free of a visual status marker", () => {
+    const markup = renderToggle({ runningCount: 0, unreadCount: 0 });
+
+    expect(markup).toContain('aria-label="Open Agent sidebar"');
+    expect(markup).not.toContain("data-agent-sidebar-status");
+  });
+});

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import {
   Search,
   SquarePenIcon,
   ArrowLeftFromLine,
+  Loader2,
   Menu,
   XCircle,
   Trash2,
@@ -50,6 +51,11 @@ import {
   createChatHistoryEntryForDraft,
   type NewChatNavigationDetail
 } from "@/services/chatRuntimeNavigation";
+import {
+  agentSidebarToggleLabel,
+  agentSidebarVisualStatus,
+  type AgentSidebarAggregateStatus
+} from "@/services/agentSidebarPresentation";
 
 export function Sidebar({
   chatId,
@@ -497,15 +503,41 @@ export function Sidebar({
   );
 }
 
-export function SidebarToggle({ onToggle }: { onToggle: () => void }) {
+export function SidebarToggle({
+  onToggle,
+  agentStatus
+}: {
+  onToggle: () => void;
+  agentStatus?: AgentSidebarAggregateStatus;
+}) {
+  const visualStatus = agentSidebarVisualStatus(agentStatus);
+
   return (
     <button
       type="button"
-      className="h-9 w-9 flex items-center justify-center text-foreground hover:text-foreground/70 transition-colors"
+      className={cn(
+        "h-9 w-9 flex items-center justify-center text-foreground hover:text-foreground/70 transition-colors",
+        agentStatus && "relative"
+      )}
       onClick={onToggle}
-      aria-label="Open sidebar"
+      aria-label={agentSidebarToggleLabel(agentStatus)}
+      aria-live={agentStatus ? "polite" : undefined}
+      aria-atomic={agentStatus ? "true" : undefined}
     >
       <Menu className="h-4 w-4" />
+      {visualStatus === "running" ? (
+        <Loader2
+          aria-hidden="true"
+          data-agent-sidebar-status="running"
+          className="absolute right-1 top-1 h-2.5 w-2.5 text-[hsl(var(--maple-primary))] motion-safe:animate-spin"
+        />
+      ) : visualStatus === "unread" ? (
+        <span
+          aria-hidden="true"
+          data-agent-sidebar-status="unread"
+          className="absolute right-1 top-1 h-2 w-2 rounded-full bg-maple-success"
+        />
+      ) : null}
     </button>
   );
 }

--- a/frontend/src/components/agent/AgentSidebarInfoCard.test.tsx
+++ b/frontend/src/components/agent/AgentSidebarInfoCard.test.tsx
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { Folder, MessageSquare } from "lucide-react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import { AgentSidebarInfoCard } from "./AgentSidebarInfoCard";
+
+const LONG_PROJECT_PATH = "/Users/admin/workspaces/agent-mode-sidebar/maple/frontend";
+
+describe("AgentSidebarInfoCard", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+      renderer = null;
+    }
+  });
+
+  test("presents the title, metadata, progress, and a middle-truncated folder path", () => {
+    const markup = renderToStaticMarkup(
+      <AgentSidebarInfoCard
+        folderPath={LONG_PROJECT_PATH}
+        icon={Folder}
+        isInProgress
+        metadata="3 tasks · 2 unread"
+        metadataIcon={MessageSquare}
+        onDismiss={() => {}}
+        onOpenProjectFolder={() => {}}
+        progressLabel="2 tasks in progress"
+        title="Maple sidebar"
+      />
+    );
+
+    expect(markup).toContain(">Maple sidebar</p>");
+    expect(markup).toContain(">3 tasks · 2 unread</span>");
+    expect(markup).toContain(">2 tasks in progress</span>");
+    expect(markup).toContain("motion-safe:animate-ping");
+    expect(markup).toContain(`aria-label="Open project folder: ${LONG_PROJECT_PATH}"`);
+    expect(markup).toContain(`<span class="sr-only">${LONG_PROJECT_PATH}</span>`);
+    expect(markup).toContain('<span aria-hidden="true">/Users/admin/…/maple/frontend</span>');
+  });
+
+  test("isolates the folder interaction, dismisses the card, and opens the folder once", () => {
+    const callOrder: string[] = [];
+    const onDismiss = mock(() => callOrder.push("dismiss"));
+    const onOpenProjectFolder = mock(() => callOrder.push("open"));
+
+    act(() => {
+      renderer = create(
+        <AgentSidebarInfoCard
+          folderPath="/Users/admin/workspaces/maple"
+          icon={Folder}
+          isInProgress={false}
+          metadata="1 task"
+          metadataIcon={MessageSquare}
+          onDismiss={onDismiss}
+          onOpenProjectFolder={onOpenProjectFolder}
+          progressLabel="No tasks in progress"
+          title="Maple"
+        />
+      );
+    });
+
+    if (!renderer) throw new Error("AgentSidebarInfoCard did not mount");
+    const folderButton = renderer.root.findByType("button");
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(onOpenProjectFolder).not.toHaveBeenCalled();
+
+    const preventDefault = mock(() => {});
+    const stopClickPropagation = mock(() => {});
+
+    act(() => {
+      folderButton.props.onClick({
+        preventDefault,
+        stopPropagation: stopClickPropagation
+      });
+    });
+
+    expect(preventDefault).toHaveBeenCalledTimes(1);
+    expect(stopClickPropagation).toHaveBeenCalledTimes(1);
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(onOpenProjectFolder).toHaveBeenCalledTimes(1);
+    expect(callOrder).toEqual(["dismiss", "open"]);
+  });
+});

--- a/frontend/src/components/agent/AgentSidebarInfoCard.tsx
+++ b/frontend/src/components/agent/AgentSidebarInfoCard.tsx
@@ -1,0 +1,83 @@
+import { FolderOpen, type LucideIcon } from "lucide-react";
+
+import { truncatePathMiddle } from "@/utils/path";
+import { cn } from "@/utils/utils";
+
+interface AgentSidebarInfoCardProps {
+  folderPath: string;
+  icon: LucideIcon;
+  isInProgress: boolean;
+  metadata: string;
+  metadataIcon: LucideIcon;
+  onDismiss: () => void;
+  onOpenProjectFolder: () => void;
+  progressLabel: string;
+  title: string;
+}
+
+export function AgentSidebarInfoCard({
+  folderPath,
+  icon: Icon,
+  isInProgress,
+  metadata,
+  metadataIcon: MetadataIcon,
+  onDismiss,
+  onOpenProjectFolder,
+  progressLabel,
+  title
+}: AgentSidebarInfoCardProps) {
+  return (
+    <div>
+      <div className="flex min-w-0 items-start gap-2.5">
+        <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted/60 text-[hsl(var(--maple-primary))]">
+          <Icon aria-hidden="true" className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <p className="break-words text-[13px] font-semibold leading-5">{title}</p>
+          <div className="mt-0.5 flex min-w-0 items-start gap-1.5 text-xs leading-4 text-muted-foreground">
+            <MetadataIcon aria-hidden="true" className="mt-px h-3.5 w-3.5 shrink-0" />
+            <span className="min-w-0 break-words">{metadata}</span>
+          </div>
+        </div>
+      </div>
+
+      <div aria-hidden="true" className="my-2.5 h-px bg-border/70" />
+
+      <div className="flex items-center gap-2 px-1 text-xs font-medium text-foreground/90">
+        <span aria-hidden="true" className="relative flex h-2 w-2 shrink-0">
+          {isInProgress ? (
+            <span className="absolute inline-flex h-full w-full rounded-full bg-[hsl(var(--maple-primary))] opacity-40 motion-safe:animate-ping" />
+          ) : null}
+          <span
+            className={cn(
+              "relative inline-flex h-2 w-2 rounded-full",
+              isInProgress ? "bg-[hsl(var(--maple-primary))]" : "bg-muted-foreground/45"
+            )}
+          />
+        </span>
+        <span>{progressLabel}</span>
+      </div>
+
+      <button
+        type="button"
+        className="group/folder -mx-1 mt-1 flex w-[calc(100%+0.5rem)] items-start gap-2 rounded-lg px-2 py-1.5 text-left text-xs text-muted-foreground transition-colors hover:bg-muted/70 hover:text-foreground focus-visible:bg-muted/70 focus-visible:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring/70"
+        onClick={(event) => {
+          event.preventDefault();
+          event.stopPropagation();
+          onDismiss();
+          onOpenProjectFolder();
+        }}
+        aria-label={`Open project folder: ${folderPath}`}
+      >
+        <FolderOpen
+          aria-hidden="true"
+          className="mt-px h-3.5 w-3.5 shrink-0 transition-colors group-hover/folder:text-foreground"
+        />
+        <span className="min-w-0 whitespace-nowrap font-mono leading-4">
+          <span className="sr-only">{folderPath}</span>
+          <span aria-hidden="true">{truncatePathMiddle(folderPath, 40)}</span>
+        </span>
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/hover-card.tsx
+++ b/frontend/src/components/ui/hover-card.tsx
@@ -1,0 +1,34 @@
+import * as React from "react";
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card";
+
+import { cn } from "@/utils/utils";
+
+const HoverCard = HoverCardPrimitive.Root;
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger;
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "start", sideOffset = 8, onPointerDown, ...props }, ref) => (
+  <HoverCardPrimitive.Portal>
+    <HoverCardPrimitive.Content
+      ref={ref}
+      align={align}
+      sideOffset={sideOffset}
+      collisionPadding={8}
+      onPointerDown={(event) => {
+        event.stopPropagation();
+        onPointerDown?.(event);
+      }}
+      className={cn(
+        "z-[1000] w-[21rem] max-w-[calc(100vw-1rem)] rounded-xl border border-border/80 bg-popover p-3 text-popover-foreground shadow-xl outline-none animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 motion-reduce:animate-none",
+        className
+      )}
+      {...props}
+    />
+  </HoverCardPrimitive.Portal>
+));
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName;
+
+export { HoverCard, HoverCardTrigger, HoverCardContent };

--- a/frontend/src/components/ui/tooltip.tsx
+++ b/frontend/src/components/ui/tooltip.tsx
@@ -13,15 +13,17 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
-  <TooltipPrimitive.Content
-    ref={ref}
-    sideOffset={sideOffset}
-    className={cn(
-      "z-[1000] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-      className
-    )}
-    {...props}
-  />
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-[1000] overflow-hidden rounded-md border bg-popover px-3 py-1.5 text-sm text-popover-foreground shadow-md animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        className
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
 ));
 TooltipContent.displayName = TooltipPrimitive.Content.displayName;
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -100,9 +100,13 @@
     --neutral-950: 0 0% 4%;
 
     /* Sidebar account + plan credits (stroke / ring track / fills) — semantic, not the same as neutral-700 */
+    --sidebar: var(--neutral-100);
     --sidebar-chrome: 0 0% 100%;
     --sidebar-chrome-hover: 0 0% 96%;
     --on-sidebar-chrome: 0 0% 15%;
+    --sidebar-row-hover: var(--neutral-50);
+    --sidebar-row-selected: var(--neutral-200);
+    --sidebar-row-selected-hover: var(--neutral-300);
 
     /* Sidebar scrollbar vs bg-muted (96% L): thumb ≥2:1 (65% ≈ 2.1:1) */
     --sidebar-scrollbar-thumb: 0 0% 65%;
@@ -212,6 +216,9 @@
     --sidebar-chrome: var(--neutral-700);
     --sidebar-chrome-hover: var(--neutral-600);
     --on-sidebar-chrome: 0 0% 98%;
+    --sidebar-row-hover: var(--neutral-700);
+    --sidebar-row-selected: var(--neutral-600);
+    --sidebar-row-selected-hover: var(--neutral-500);
 
     /* vs neutral-800 (~15% L): ~2:1 — neutral-600/500 */
     --sidebar-scrollbar-thumb: var(--neutral-600);

--- a/frontend/src/services/agentProjectFolder.test.ts
+++ b/frontend/src/services/agentProjectFolder.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+
+import { revealAgentProjectFolder } from "./agentProjectFolder";
+
+describe("revealAgentProjectFolder", () => {
+  test("reveals the exact canonical project path once", async () => {
+    const projectPath = "/Users/example/My Project";
+    const revealedPaths: string[] = [];
+
+    await revealAgentProjectFolder(projectPath, async (path) => {
+      revealedPaths.push(path);
+    });
+
+    expect(revealedPaths).toEqual([projectPath]);
+  });
+
+  test.each(["", "   \n\t"])("rejects a blank project path", async (projectPath) => {
+    let revealCallCount = 0;
+
+    await expect(
+      revealAgentProjectFolder(projectPath, async () => {
+        revealCallCount += 1;
+      })
+    ).rejects.toThrow("Project folder path is required.");
+
+    expect(revealCallCount).toBe(0);
+  });
+
+  test("propagates reveal failures", async () => {
+    const revealError = new Error("folder is unavailable");
+    let revealCallCount = 0;
+    let caughtError: unknown;
+
+    try {
+      await revealAgentProjectFolder("/missing/project", async () => {
+        revealCallCount += 1;
+        throw revealError;
+      });
+    } catch (error) {
+      caughtError = error;
+    }
+
+    expect(revealCallCount).toBe(1);
+    expect(caughtError).toBe(revealError);
+  });
+});

--- a/frontend/src/services/agentProjectFolder.ts
+++ b/frontend/src/services/agentProjectFolder.ts
@@ -1,0 +1,17 @@
+export type AgentProjectFolderRevealer = (projectPath: string) => Promise<void>;
+
+async function revealProjectFolderWithTauri(projectPath: string): Promise<void> {
+  const { revealItemInDir } = await import("@tauri-apps/plugin-opener");
+  await revealItemInDir(projectPath);
+}
+
+export async function revealAgentProjectFolder(
+  projectPath: string,
+  reveal: AgentProjectFolderRevealer = revealProjectFolderWithTauri
+): Promise<void> {
+  if (typeof projectPath !== "string" || projectPath.trim().length === 0) {
+    throw new Error("Project folder path is required.");
+  }
+
+  await reveal(projectPath);
+}

--- a/frontend/src/services/agentProjectOrdering.test.ts
+++ b/frontend/src/services/agentProjectOrdering.test.ts
@@ -152,9 +152,9 @@ describe("groupAgentSessionsByRoot", () => {
 describe("project drag helpers", () => {
   const roots = [root("/a"), root("/b"), root("/c")];
 
-  test("uses a six pixel movement threshold", () => {
-    expect(hasExceededProjectDragThreshold(0, 0, 3, 4)).toBe(false);
-    expect(hasExceededProjectDragThreshold(0, 0, 6, 0)).toBe(true);
+  test("uses a ten pixel movement threshold", () => {
+    expect(hasExceededProjectDragThreshold(0, 0, 6, 0)).toBe(false);
+    expect(hasExceededProjectDragThreshold(0, 0, 6, 8)).toBe(true);
   });
 
   test("calculates insertion positions before, between, and after non-dragged rows", () => {

--- a/frontend/src/services/agentProjectOrdering.ts
+++ b/frontend/src/services/agentProjectOrdering.ts
@@ -1,6 +1,6 @@
 import type { AgentSessionSummary, RecentProjectRoot } from "@/services/agentRuntimeService";
 
-export const PROJECT_DRAG_THRESHOLD_PX = 6;
+export const PROJECT_DRAG_THRESHOLD_PX = 10;
 
 export interface ProjectHeaderCenter {
   path: string;

--- a/frontend/src/services/agentSidebarPreferences.test.ts
+++ b/frontend/src/services/agentSidebarPreferences.test.ts
@@ -1,0 +1,268 @@
+import { describe, expect, test } from "bun:test";
+
+import type { RecentProjectRoot } from "./agentRuntimeService";
+import {
+  AGENT_SIDEBAR_PREFERENCES_STORAGE_PREFIX,
+  agentSidebarPreferencesStorageKey,
+  createEmptyAgentSidebarPreferences,
+  loadAgentSidebarPreferences,
+  projectRootsWithDisplayNames,
+  renameAgentProjectDisplayName,
+  saveAgentSidebarPreferences,
+  toggleAgentProjectCollapsed,
+  type AgentSidebarPreferencesStorage
+} from "./agentSidebarPreferences";
+
+class MemoryStorage implements AgentSidebarPreferencesStorage {
+  readonly values = new Map<string, string>();
+  writes = 0;
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.writes += 1;
+    this.values.set(key, value);
+  }
+
+  seed(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+function root(path: string, name = path.split(/[\\/]/).filter(Boolean).at(-1) || path) {
+  return { path, name, lastUsedMs: 1 } satisfies RecentProjectRoot;
+}
+
+describe("Agent sidebar preference persistence", () => {
+  test("uses a versioned account-scoped key and keeps accounts isolated", () => {
+    const storage = new MemoryStorage();
+    const first = toggleAgentProjectCollapsed(createEmptyAgentSidebarPreferences(), "/first");
+    const second = renameAgentProjectDisplayName(
+      createEmptyAgentSidebarPreferences(),
+      root("/second"),
+      "Second account"
+    );
+
+    expect(agentSidebarPreferencesStorageKey("account/a")).toBe(
+      `${AGENT_SIDEBAR_PREFERENCES_STORAGE_PREFIX}account%2Fa`
+    );
+    expect(saveAgentSidebarPreferences("account/a", first, storage)).toBe(true);
+    expect(saveAgentSidebarPreferences("account/b", second, storage)).toBe(true);
+    expect(storage.values.size).toBe(2);
+
+    expect([...loadAgentSidebarPreferences("account/a", storage).collapsedProjectRoots]).toEqual([
+      "/first"
+    ]);
+    expect([
+      ...loadAgentSidebarPreferences("account/a", storage).projectDisplayNameOverrides
+    ]).toEqual([]);
+    expect([...loadAgentSidebarPreferences("account/b", storage).collapsedProjectRoots]).toEqual(
+      []
+    );
+    expect([
+      ...loadAgentSidebarPreferences("account/b", storage).projectDisplayNameOverrides
+    ]).toEqual([["/second", "Second account"]]);
+  });
+
+  test("defaults safely for missing, malformed, wrong-version, and unavailable storage", () => {
+    const storage = new MemoryStorage();
+    const key = agentSidebarPreferencesStorageKey("account");
+
+    expect(loadAgentSidebarPreferences("account", storage)).toEqual({
+      collapsedProjectRoots: new Set(),
+      projectDisplayNameOverrides: new Map()
+    });
+
+    storage.seed(key, "not json");
+    expect(loadAgentSidebarPreferences("account", storage)).toEqual({
+      collapsedProjectRoots: new Set(),
+      projectDisplayNameOverrides: new Map()
+    });
+
+    storage.seed(
+      key,
+      JSON.stringify({
+        version: 2,
+        collapsedProjectRoots: ["/wrong-version"],
+        projectDisplayNameOverrides: [{ path: "/wrong-version", displayName: "Wrong" }]
+      })
+    );
+    expect(loadAgentSidebarPreferences("account", storage)).toEqual({
+      collapsedProjectRoots: new Set(),
+      projectDisplayNameOverrides: new Map()
+    });
+
+    const unavailable: AgentSidebarPreferencesStorage = {
+      getItem: () => {
+        throw new Error("storage unavailable");
+      },
+      setItem: () => {
+        throw new Error("storage unavailable");
+      }
+    };
+    expect(loadAgentSidebarPreferences("account", null)).toEqual({
+      collapsedProjectRoots: new Set(),
+      projectDisplayNameOverrides: new Map()
+    });
+    expect(loadAgentSidebarPreferences("account", unavailable)).toEqual({
+      collapsedProjectRoots: new Set(),
+      projectDisplayNameOverrides: new Map()
+    });
+    expect(saveAgentSidebarPreferences("account", createEmptyAgentSidebarPreferences(), null)).toBe(
+      false
+    );
+    expect(
+      saveAgentSidebarPreferences("account", createEmptyAgentSidebarPreferences(), unavailable)
+    ).toBe(false);
+  });
+
+  test("restores valid entries while filtering malformed values and deduplicating by canonical path", () => {
+    const storage = new MemoryStorage();
+    storage.seed(
+      agentSidebarPreferencesStorageKey("account"),
+      JSON.stringify({
+        version: 1,
+        collapsedProjectRoots: ["/alpha", "", 42, "/alpha", "/path with space "],
+        projectDisplayNameOverrides: [
+          { path: "/alpha", displayName: " First name " },
+          null,
+          { path: "", displayName: "Missing path" },
+          { path: "/blank", displayName: "   " },
+          { path: "/number", displayName: 42 },
+          { path: "/alpha", displayName: " Last name wins " },
+          { path: "/path with space ", displayName: " Spaced path " }
+        ]
+      })
+    );
+
+    const restored = loadAgentSidebarPreferences("account", storage);
+    expect(restored.collapsedProjectRoots).toEqual(new Set(["/alpha", "/path with space "]));
+    expect(restored.projectDisplayNameOverrides).toEqual(
+      new Map([
+        ["/alpha", "Last name wins"],
+        ["/path with space ", "Spaced path"]
+      ])
+    );
+    expect(restored.collapsedProjectRoots).toBeInstanceOf(Set);
+    expect(restored.projectDisplayNameOverrides).toBeInstanceOf(Map);
+  });
+
+  test("round-trips the exact v1 array schema with an explicit save", () => {
+    const storage = new MemoryStorage();
+    let preferences = toggleAgentProjectCollapsed(createEmptyAgentSidebarPreferences(), "/alpha");
+    preferences = renameAgentProjectDisplayName(
+      preferences,
+      root("/alpha", "alpha"),
+      " Alpha display "
+    );
+
+    expect(saveAgentSidebarPreferences("account", preferences, storage)).toBe(true);
+    expect(
+      JSON.parse(storage.getItem(agentSidebarPreferencesStorageKey("account")) || "null")
+    ).toEqual({
+      version: 1,
+      collapsedProjectRoots: ["/alpha"],
+      projectDisplayNameOverrides: [{ path: "/alpha", displayName: "Alpha display" }]
+    });
+
+    const restored = loadAgentSidebarPreferences("account", storage);
+    expect(restored.collapsedProjectRoots).toEqual(new Set(["/alpha"]));
+    expect(restored.projectDisplayNameOverrides).toEqual(new Map([["/alpha", "Alpha display"]]));
+  });
+});
+
+describe("Agent project display preferences", () => {
+  test("keeps stale preferences inert, defaults new roots to expanded, and never writes during load or projection", () => {
+    const storage = new MemoryStorage();
+    storage.seed(
+      agentSidebarPreferencesStorageKey("account"),
+      JSON.stringify({
+        version: 1,
+        collapsedProjectRoots: ["/stale"],
+        projectDisplayNameOverrides: [{ path: "/stale", displayName: "Old project" }]
+      })
+    );
+
+    const preferences = loadAgentSidebarPreferences("account", storage);
+    expect(projectRootsWithDisplayNames([], preferences)).toEqual([]);
+    const projected = projectRootsWithDisplayNames([root("/new", "new")], preferences);
+
+    expect(projected[0].displayName).toBe("new");
+    expect(preferences.collapsedProjectRoots.has("/new")).toBe(false);
+    expect(preferences.collapsedProjectRoots.has("/stale")).toBe(true);
+    expect(preferences.projectDisplayNameOverrides.get("/stale")).toBe("Old project");
+    expect(storage.writes).toBe(0);
+  });
+
+  test("trims renames, rejects blank names, and deletes an override equal to the native fallback", () => {
+    const project = root("/work/native", "native");
+    const empty = createEmptyAgentSidebarPreferences();
+    const renamed = renameAgentProjectDisplayName(empty, project, "  Custom name  ");
+
+    expect(renamed.projectDisplayNameOverrides.get(project.path)).toBe("Custom name");
+    expect(() => renameAgentProjectDisplayName(renamed, project, "   ")).toThrow(
+      "Project name cannot be empty."
+    );
+    expect(renamed.projectDisplayNameOverrides.get(project.path)).toBe("Custom name");
+
+    const reverted = renameAgentProjectDisplayName(renamed, project, " native ");
+    expect(reverted.projectDisplayNameOverrides.has(project.path)).toBe(false);
+    expect(projectRootsWithDisplayNames([project], reverted)[0].displayName).toBe("native");
+  });
+
+  test("allows duplicate display names because canonical paths remain the identity", () => {
+    const first = root("/projects/first", "first");
+    const second = root("/projects/second", "second");
+    let preferences = renameAgentProjectDisplayName(
+      createEmptyAgentSidebarPreferences(),
+      first,
+      "Shared"
+    );
+    preferences = renameAgentProjectDisplayName(preferences, second, " Shared ");
+
+    expect(
+      projectRootsWithDisplayNames([first, second], preferences).map((item) => item.displayName)
+    ).toEqual(["Shared", "Shared"]);
+    expect([...preferences.projectDisplayNameOverrides]).toEqual([
+      [first.path, "Shared"],
+      [second.path, "Shared"]
+    ]);
+  });
+
+  test("preserves project order, canonical identity, native fields, and basename fallback", () => {
+    const roots = [
+      root("/projects/beta", "beta"),
+      root("C:\\work\\alpha", "   "),
+      root("/projects/gamma", "gamma")
+    ];
+    roots[0].lastUsedMs = 20;
+    roots[1].lastUsedMs = 10;
+    roots[2].lastUsedMs = 5;
+    const preferences = renameAgentProjectDisplayName(
+      createEmptyAgentSidebarPreferences(),
+      roots[0],
+      "B"
+    );
+
+    const projected = projectRootsWithDisplayNames(roots, preferences);
+    expect(projected.map((item) => item.path)).toEqual(roots.map((item) => item.path));
+    expect(projected.map((item) => item.name)).toEqual(roots.map((item) => item.name));
+    expect(projected.map((item) => item.lastUsedMs)).toEqual([20, 10, 5]);
+    expect(projected.map((item) => item.displayName)).toEqual(["B", "alpha", "gamma"]);
+    expect(roots.some((item) => "displayName" in item)).toBe(false);
+  });
+
+  test("toggles only the exact canonical path without mutating prior state", () => {
+    const empty = createEmptyAgentSidebarPreferences();
+    const collapsed = toggleAgentProjectCollapsed(empty, "/Project");
+    const alsoCollapsed = toggleAgentProjectCollapsed(collapsed, "/project");
+    const expandedAgain = toggleAgentProjectCollapsed(alsoCollapsed, "/Project");
+
+    expect(empty.collapsedProjectRoots).toEqual(new Set());
+    expect(collapsed.collapsedProjectRoots).toEqual(new Set(["/Project"]));
+    expect(alsoCollapsed.collapsedProjectRoots).toEqual(new Set(["/Project", "/project"]));
+    expect(expandedAgain.collapsedProjectRoots).toEqual(new Set(["/project"]));
+  });
+});

--- a/frontend/src/services/agentSidebarPreferences.ts
+++ b/frontend/src/services/agentSidebarPreferences.ts
@@ -1,0 +1,212 @@
+import type { RecentProjectRoot } from "@/services/agentRuntimeService";
+
+export const AGENT_SIDEBAR_PREFERENCES_VERSION = 1 as const;
+export const AGENT_SIDEBAR_PREFERENCES_STORAGE_PREFIX = "maple:agent-sidebar-preferences:v1:";
+
+export type AgentSidebarPreferencesStorage = Pick<Storage, "getItem" | "setItem">;
+
+export interface AgentSidebarPreferences {
+  collapsedProjectRoots: ReadonlySet<string>;
+  projectDisplayNameOverrides: ReadonlyMap<string, string>;
+}
+
+export interface AgentSidebarPreferencesV1 {
+  version: typeof AGENT_SIDEBAR_PREFERENCES_VERSION;
+  collapsedProjectRoots: string[];
+  projectDisplayNameOverrides: Array<{
+    path: string;
+    displayName: string;
+  }>;
+}
+
+export type AgentProjectRootView<TRoot extends RecentProjectRoot = RecentProjectRoot> = TRoot & {
+  displayName: string;
+};
+
+export function createEmptyAgentSidebarPreferences(): AgentSidebarPreferences {
+  return {
+    collapsedProjectRoots: new Set(),
+    projectDisplayNameOverrides: new Map()
+  };
+}
+
+export function agentSidebarPreferencesStorageKey(userId: string): string {
+  if (!isNonBlankString(userId)) {
+    throw new Error("Agent sidebar preferences require an authenticated user");
+  }
+  return `${AGENT_SIDEBAR_PREFERENCES_STORAGE_PREFIX}${encodeURIComponent(userId)}`;
+}
+
+export function loadAgentSidebarPreferences(
+  userId: string,
+  storage: AgentSidebarPreferencesStorage | null = getBrowserStorage()
+): AgentSidebarPreferences {
+  const empty = createEmptyAgentSidebarPreferences();
+  if (!storage) return empty;
+
+  let stored: string | null;
+  try {
+    stored = storage.getItem(agentSidebarPreferencesStorageKey(userId));
+  } catch {
+    return empty;
+  }
+  if (!stored) return empty;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return empty;
+  }
+  if (!isRecord(parsed) || parsed.version !== AGENT_SIDEBAR_PREFERENCES_VERSION) {
+    return empty;
+  }
+
+  const collapsedProjectRoots = new Set<string>();
+  if (Array.isArray(parsed.collapsedProjectRoots)) {
+    for (const path of parsed.collapsedProjectRoots) {
+      if (isNonBlankString(path)) collapsedProjectRoots.add(path);
+    }
+  }
+
+  const projectDisplayNameOverrides = new Map<string, string>();
+  if (Array.isArray(parsed.projectDisplayNameOverrides)) {
+    for (const entry of parsed.projectDisplayNameOverrides) {
+      if (
+        !isRecord(entry) ||
+        !isNonBlankString(entry.path) ||
+        typeof entry.displayName !== "string"
+      ) {
+        continue;
+      }
+      const displayName = entry.displayName.trim();
+      if (displayName) projectDisplayNameOverrides.set(entry.path, displayName);
+    }
+  }
+
+  return { collapsedProjectRoots, projectDisplayNameOverrides };
+}
+
+export function saveAgentSidebarPreferences(
+  userId: string,
+  preferences: AgentSidebarPreferences,
+  storage: AgentSidebarPreferencesStorage | null = getBrowserStorage()
+): boolean {
+  if (!storage) return false;
+
+  const collapsedProjectRoots = new Set<string>();
+  for (const path of preferences.collapsedProjectRoots) {
+    if (isNonBlankString(path)) collapsedProjectRoots.add(path);
+  }
+
+  const projectDisplayNameOverrides = new Map<string, string>();
+  for (const [path, candidate] of preferences.projectDisplayNameOverrides) {
+    if (!isNonBlankString(path) || typeof candidate !== "string") continue;
+    const displayName = candidate.trim();
+    if (displayName) projectDisplayNameOverrides.set(path, displayName);
+  }
+
+  const serialized: AgentSidebarPreferencesV1 = {
+    version: AGENT_SIDEBAR_PREFERENCES_VERSION,
+    collapsedProjectRoots: [...collapsedProjectRoots],
+    projectDisplayNameOverrides: [...projectDisplayNameOverrides].map(([path, displayName]) => ({
+      path,
+      displayName
+    }))
+  };
+
+  try {
+    storage.setItem(agentSidebarPreferencesStorageKey(userId), JSON.stringify(serialized));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function projectRootsWithDisplayNames<TRoot extends RecentProjectRoot>(
+  roots: readonly TRoot[],
+  preferences: AgentSidebarPreferences
+): AgentProjectRootView<TRoot>[] {
+  return roots.map((root) => ({
+    ...root,
+    displayName: projectDisplayName(root, preferences.projectDisplayNameOverrides)
+  }));
+}
+
+export function toggleAgentProjectCollapsed(
+  preferences: AgentSidebarPreferences,
+  path: string
+): AgentSidebarPreferences {
+  assertProjectPath(path);
+  const collapsedProjectRoots = new Set(preferences.collapsedProjectRoots);
+  if (collapsedProjectRoots.has(path)) {
+    collapsedProjectRoots.delete(path);
+  } else {
+    collapsedProjectRoots.add(path);
+  }
+  return {
+    collapsedProjectRoots,
+    projectDisplayNameOverrides: preferences.projectDisplayNameOverrides
+  };
+}
+
+export function renameAgentProjectDisplayName(
+  preferences: AgentSidebarPreferences,
+  root: Pick<RecentProjectRoot, "path" | "name">,
+  nextName: string
+): AgentSidebarPreferences {
+  assertProjectPath(root.path);
+  const displayName = nextName.trim();
+  if (!displayName) throw new Error("Project name cannot be empty.");
+
+  const projectDisplayNameOverrides = new Map(preferences.projectDisplayNameOverrides);
+  if (displayName === nativeProjectDisplayName(root)) {
+    projectDisplayNameOverrides.delete(root.path);
+  } else {
+    projectDisplayNameOverrides.set(root.path, displayName);
+  }
+
+  return {
+    collapsedProjectRoots: preferences.collapsedProjectRoots,
+    projectDisplayNameOverrides
+  };
+}
+
+function projectDisplayName(
+  root: Pick<RecentProjectRoot, "path" | "name">,
+  overrides: ReadonlyMap<string, string>
+): string {
+  const override = overrides.get(root.path);
+  if (typeof override === "string" && override.trim()) return override.trim();
+  return nativeProjectDisplayName(root);
+}
+
+function nativeProjectDisplayName(root: Pick<RecentProjectRoot, "path" | "name">): string {
+  if (isNonBlankString(root.name)) return root.name;
+  return basename(root.path);
+}
+
+function basename(path: string): string {
+  return path.split(/[\\/]/).filter(Boolean).pop() || path;
+}
+
+function assertProjectPath(path: string): void {
+  if (!isNonBlankString(path)) throw new Error("Project path cannot be empty.");
+}
+
+function isNonBlankString(value: unknown): value is string {
+  return typeof value === "string" && value.trim().length > 0;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getBrowserStorage(): AgentSidebarPreferencesStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/services/agentSidebarPresentation.test.ts
+++ b/frontend/src/services/agentSidebarPresentation.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  agentSidebarToggleLabel,
+  agentSidebarVisualStatus,
+  agentTaskAccessibleLabel,
+  aggregateAgentSidebarStatus,
+  type AgentSidebarAggregateStatus
+} from "./agentSidebarPresentation";
+
+describe("Agent sidebar aggregate presentation", () => {
+  test("counts running and unread tasks independently", () => {
+    expect(
+      aggregateAgentSidebarStatus(new Set(["running-a", "running-b"]), new Set(["unread-a"]))
+    ).toEqual({ runningCount: 2, unreadCount: 1 });
+  });
+
+  test.each([
+    [{ runningCount: 0, unreadCount: 0 }, "idle"],
+    [{ runningCount: 2, unreadCount: 0 }, "running"],
+    [{ runningCount: 0, unreadCount: 2 }, "unread"],
+    [{ runningCount: 1, unreadCount: 3 }, "running"]
+  ] as const)("uses visual priority for %o", (status, expected) => {
+    expect(agentSidebarVisualStatus(status)).toBe(expected);
+  });
+
+  test("uses the idle priority when aggregate Agent status is absent", () => {
+    expect(agentSidebarVisualStatus()).toBe("idle");
+  });
+
+  test.each([
+    [{ runningCount: 0, unreadCount: 0 }, "Open Agent sidebar"],
+    [{ runningCount: 1, unreadCount: 0 }, "Open Agent sidebar, 1 task running"],
+    [{ runningCount: 2, unreadCount: 0 }, "Open Agent sidebar, 2 tasks running"],
+    [{ runningCount: 0, unreadCount: 1 }, "Open Agent sidebar, 1 completed task unread"],
+    [{ runningCount: 0, unreadCount: 2 }, "Open Agent sidebar, 2 completed tasks unread"],
+    [
+      { runningCount: 1, unreadCount: 2 },
+      "Open Agent sidebar, 1 task running, 2 completed tasks unread"
+    ]
+  ] satisfies ReadonlyArray<readonly [AgentSidebarAggregateStatus, string]>)(
+    "builds a counted accessible label for %o",
+    (status, expected) => {
+      expect(agentSidebarToggleLabel(status)).toBe(expected);
+    }
+  );
+
+  test("keeps the shared sidebar label when Agent status is absent", () => {
+    expect(agentSidebarToggleLabel()).toBe("Open sidebar");
+  });
+});
+
+describe("Agent task accessible labels", () => {
+  test.each([
+    [{ running: false, unread: false }, "Investigate login"],
+    [{ running: true, unread: false }, "Investigate login, running"],
+    [{ running: false, unread: true }, "Investigate login, completed, unread"],
+    [{ running: true, unread: true }, "Investigate login, running, completed, unread"]
+  ] as const)("preserves status text for %o", (status, expected) => {
+    expect(agentTaskAccessibleLabel("Investigate login", status)).toBe(expected);
+  });
+});

--- a/frontend/src/services/agentSidebarPresentation.test.ts
+++ b/frontend/src/services/agentSidebarPresentation.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  agentProjectProgressLabel,
+  agentProjectTaskSummaryLabel,
   agentSidebarToggleLabel,
   agentSidebarVisualStatus,
   agentTaskAccessibleLabel,
@@ -58,5 +60,24 @@ describe("Agent task accessible labels", () => {
     [{ running: true, unread: true }, "Investigate login, running, completed, unread"]
   ] as const)("preserves status text for %o", (status, expected) => {
     expect(agentTaskAccessibleLabel("Investigate login", status)).toBe(expected);
+  });
+});
+
+describe("Agent sidebar info-card labels", () => {
+  test.each([
+    [0, 0, "0 tasks"],
+    [1, 0, "1 task"],
+    [1, 1, "1 task · 1 unread"],
+    [3, 2, "3 tasks · 2 unread"]
+  ] as const)("formats %i project tasks with %i unread", (taskCount, unreadCount, expected) => {
+    expect(agentProjectTaskSummaryLabel(taskCount, unreadCount)).toBe(expected);
+  });
+
+  test.each([
+    [0, "No tasks in progress"],
+    [1, "1 task in progress"],
+    [3, "3 tasks in progress"]
+  ] as const)("formats an in-progress project count of %i", (count, expected) => {
+    expect(agentProjectProgressLabel(count)).toBe(expected);
   });
 });

--- a/frontend/src/services/agentSidebarPresentation.ts
+++ b/frontend/src/services/agentSidebarPresentation.ts
@@ -1,0 +1,56 @@
+export type AgentSidebarAggregateStatus = Readonly<{
+  runningCount: number;
+  unreadCount: number;
+}>;
+
+export type AgentSidebarAggregateVisualStatus = "idle" | "running" | "unread";
+
+export interface AgentTaskAccessibleStatus {
+  running: boolean;
+  unread: boolean;
+}
+
+export function aggregateAgentSidebarStatus(
+  runningSessionIds: ReadonlySet<string>,
+  completedUnreadSessionIds: ReadonlySet<string>
+): AgentSidebarAggregateStatus {
+  return {
+    runningCount: runningSessionIds.size,
+    unreadCount: completedUnreadSessionIds.size
+  };
+}
+
+export function agentSidebarVisualStatus(
+  status?: AgentSidebarAggregateStatus
+): AgentSidebarAggregateVisualStatus {
+  if (!status) return "idle";
+  if (status.runningCount > 0) return "running";
+  if (status.unreadCount > 0) return "unread";
+  return "idle";
+}
+
+export function agentSidebarToggleLabel(status?: AgentSidebarAggregateStatus): string {
+  if (!status) return "Open sidebar";
+
+  const details: string[] = [];
+
+  if (status.runningCount > 0) {
+    details.push(`${status.runningCount} ${pluralize("task", status.runningCount)} running`);
+  }
+  if (status.unreadCount > 0) {
+    details.push(`${status.unreadCount} completed ${pluralize("task", status.unreadCount)} unread`);
+  }
+
+  return details.length > 0 ? `Open Agent sidebar, ${details.join(", ")}` : "Open Agent sidebar";
+}
+
+export function agentTaskAccessibleLabel(title: string, status: AgentTaskAccessibleStatus): string {
+  const details: string[] = [];
+  if (status.running) details.push("running");
+  if (status.unread) details.push("completed, unread");
+  return details.length > 0 ? `${title}, ${details.join(", ")}` : title;
+}
+
+function pluralize(noun: string, count: number): string {
+  return count === 1 ? noun : `${noun}s`;
+}

--- a/frontend/src/services/agentSidebarPresentation.ts
+++ b/frontend/src/services/agentSidebarPresentation.ts
@@ -51,6 +51,17 @@ export function agentTaskAccessibleLabel(title: string, status: AgentTaskAccessi
   return details.length > 0 ? `${title}, ${details.join(", ")}` : title;
 }
 
+export function agentProjectTaskSummaryLabel(taskCount: number, unreadCount: number): string {
+  const taskCountLabel = `${taskCount} ${pluralize("task", taskCount)}`;
+  return unreadCount > 0 ? `${taskCountLabel} · ${unreadCount} unread` : taskCountLabel;
+}
+
+export function agentProjectProgressLabel(inProgressCount: number): string {
+  return inProgressCount > 0
+    ? `${inProgressCount} ${pluralize("task", inProgressCount)} in progress`
+    : "No tasks in progress";
+}
+
 function pluralize(noun: string, count: number): string {
   return count === 1 ? noun : `${noun}s`;
 }

--- a/frontend/src/utils/path.test.ts
+++ b/frontend/src/utils/path.test.ts
@@ -24,10 +24,26 @@ describe("truncatePathMiddle", () => {
     ).toBe("C:\\Users\\Admin\\…\\Maple\\Sidebar");
   });
 
+  it("removes an extended-length drive prefix before truncating", () => {
+    expect(
+      truncatePathMiddle(
+        "\\\\?\\C:\\Users\\Admin\\Documents\\OpenSecretCloud\\Maple\\worktrees\\Maple\\Sidebar"
+      )
+    ).toBe("C:\\Users\\Admin\\…\\Maple\\Sidebar");
+  });
+
   it("keeps the server, share, and final segments of a UNC path", () => {
     expect(
       truncatePathMiddle(
         "\\\\fileserver\\engineering\\teams\\desktop\\OpenSecretCloud\\worktrees\\Maple\\sidebar"
+      )
+    ).toBe("\\\\fileserver\\engineering\\…\\Maple\\sidebar");
+  });
+
+  it("converts an extended-length UNC prefix before truncating", () => {
+    expect(
+      truncatePathMiddle(
+        "\\\\?\\UNC\\fileserver\\engineering\\teams\\desktop\\OpenSecretCloud\\worktrees\\Maple\\sidebar"
       )
     ).toBe("\\\\fileserver\\engineering\\…\\Maple\\sidebar");
   });

--- a/frontend/src/utils/path.test.ts
+++ b/frontend/src/utils/path.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import { truncatePathMiddle } from "./path";
+
+describe("truncatePathMiddle", () => {
+  it("leaves a short path unchanged", () => {
+    const path = "/Users/admin/Projects/Maple";
+
+    expect(truncatePathMiddle(path)).toBe(path);
+  });
+
+  it("keeps the first and last two segments of a long POSIX path", () => {
+    expect(
+      truncatePathMiddle(
+        "/Users/admin/Documents/OpenSecretCloud/Maple/worktrees/agent-mode-sidebar/maple"
+      )
+    ).toBe("/Users/admin/…/agent-mode-sidebar/maple");
+  });
+
+  it("keeps the drive and the first and last two segments of a Windows path", () => {
+    expect(
+      truncatePathMiddle(
+        "C:\\Users\\Admin\\Documents\\OpenSecretCloud\\Maple\\worktrees\\Maple\\Sidebar"
+      )
+    ).toBe("C:\\Users\\Admin\\…\\Maple\\Sidebar");
+  });
+
+  it("keeps the server, share, and final segments of a UNC path", () => {
+    expect(
+      truncatePathMiddle(
+        "\\\\fileserver\\engineering\\teams\\desktop\\OpenSecretCloud\\worktrees\\Maple\\sidebar"
+      )
+    ).toBe("\\\\fileserver\\engineering\\…\\Maple\\sidebar");
+  });
+
+  it("preserves a trailing separator", () => {
+    expect(
+      truncatePathMiddle(
+        "/Users/admin/Documents/OpenSecretCloud/Maple/worktrees/agent-mode-sidebar/maple/"
+      )
+    ).toBe("/Users/admin/…/agent-mode-sidebar/maple/");
+  });
+
+  it.each(["/", "C:\\", "\\\\fileserver\\engineering", "relative-project"])(
+    "leaves the root or short path %s unchanged",
+    (path) => {
+      expect(truncatePathMiddle(path)).toBe(path);
+    }
+  );
+
+  it("uses the provided threshold while retaining whole path segments", () => {
+    expect(truncatePathMiddle("one/two/three/four/five", 20)).toBe("one/two/…/four/five");
+  });
+
+  it("reduces retained leading segments before slicing through folder names", () => {
+    expect(
+      truncatePathMiddle(
+        "/Users/an-unusually-long-account-name/Documents/OpenSecretCloud/Maple/worktrees/sidebar",
+        40
+      )
+    ).toBe("/Users/…/worktrees/sidebar");
+  });
+
+  it("preserves whole segments in a common four-segment path", () => {
+    expect(truncatePathMiddle("/Users/an-unusually-long-account-name/Projects/Maple", 32)).toBe(
+      "/Users/…/Projects/Maple"
+    );
+  });
+
+  it("bounds a path with an unusually long component while retaining both ends", () => {
+    const path =
+      "/Users/an-unusually-long-account-name/Projects/an-unusually-long-maple-project-name";
+    const result = truncatePathMiddle(path, 20);
+
+    expect(Array.from(result)).toHaveLength(20);
+    expect(result.startsWith("/Users/an-")).toBe(true);
+    expect(result.endsWith("ject-name")).toBe(true);
+    expect(result.match(/…/g)).toHaveLength(1);
+  });
+});

--- a/frontend/src/utils/path.ts
+++ b/frontend/src/utils/path.ts
@@ -10,6 +10,19 @@ function characterCount(value: string): number {
   return Array.from(value).length;
 }
 
+function normalizeWindowsPathForDisplay(path: string): string {
+  const extendedPathPrefix = "\\\\?\\";
+  if (!path.startsWith(extendedPathPrefix)) return path;
+
+  const unprefixedPath = path.slice(extendedPathPrefix.length);
+  if (unprefixedPath.toUpperCase().startsWith("UNC\\")) {
+    return `\\\\${unprefixedPath.slice(4)}`;
+  }
+  if (/^[A-Za-z]:[\\/]/.test(unprefixedPath)) return unprefixedPath;
+
+  return path;
+}
+
 function truncateCharactersMiddle(value: string, maxLength: number): string {
   const characters = Array.from(value);
   if (characters.length <= maxLength) return value;
@@ -45,15 +58,16 @@ export function truncatePathMiddle(
   path: string,
   maxLength = DEFAULT_PATH_TRUNCATION_LENGTH
 ): string {
+  const displayPath = normalizeWindowsPathForDisplay(path);
   const normalizedMaxLength = Number.isFinite(maxLength)
     ? Math.max(0, Math.floor(maxLength))
     : DEFAULT_PATH_TRUNCATION_LENGTH;
-  if (characterCount(path) <= normalizedMaxLength) return path;
+  if (characterCount(displayPath) <= normalizedMaxLength) return displayPath;
 
-  const separator = pathSeparator(path);
-  const prefixLength = pathPrefixLength(path);
-  const prefix = path.slice(0, prefixLength);
-  const remainder = path.slice(prefixLength);
+  const separator = pathSeparator(displayPath);
+  const prefixLength = pathPrefixLength(displayPath);
+  const prefix = displayPath.slice(0, prefixLength);
+  const remainder = displayPath.slice(prefixLength);
   const hasTrailingSeparator = /[\\/]$/.test(remainder);
   const segments = remainder.split(/[\\/]+/).filter(Boolean);
 
@@ -70,5 +84,5 @@ export function truncatePathMiddle(
     if (characterCount(candidate) <= normalizedMaxLength) return candidate;
   }
 
-  return truncateCharactersMiddle(path, normalizedMaxLength);
+  return truncateCharactersMiddle(displayPath, normalizedMaxLength);
 }

--- a/frontend/src/utils/path.ts
+++ b/frontend/src/utils/path.ts
@@ -1,0 +1,74 @@
+const DEFAULT_PATH_TRUNCATION_LENGTH = 48;
+const VISIBLE_SEGMENT_CANDIDATES = [
+  [2, 2],
+  [1, 2],
+  [2, 1],
+  [1, 1]
+] as const;
+
+function characterCount(value: string): number {
+  return Array.from(value).length;
+}
+
+function truncateCharactersMiddle(value: string, maxLength: number): string {
+  const characters = Array.from(value);
+  if (characters.length <= maxLength) return value;
+  if (maxLength <= 0) return "";
+  if (maxLength === 1) return "…";
+
+  const visibleCharacterCount = maxLength - 1;
+  const leadingCharacterCount = Math.ceil(visibleCharacterCount / 2);
+  const trailingCharacterCount = Math.floor(visibleCharacterCount / 2);
+  const leadingCharacters = characters.slice(0, leadingCharacterCount).join("");
+  const trailingCharacters =
+    trailingCharacterCount > 0 ? characters.slice(-trailingCharacterCount).join("") : "";
+
+  return `${leadingCharacters}…${trailingCharacters}`;
+}
+
+function pathSeparator(path: string): "/" | "\\" {
+  const driveSeparator = path.match(/^[A-Za-z]:([\\/])/);
+  if (driveSeparator?.[1] === "\\") return "\\";
+  if (driveSeparator?.[1] === "/") return "/";
+  if (path.startsWith("\\\\") || (!path.includes("/") && path.includes("\\"))) return "\\";
+  return "/";
+}
+
+function pathPrefixLength(path: string): number {
+  if (/^[A-Za-z]:[\\/]/.test(path)) return 3;
+  if (path.startsWith("\\\\") || path.startsWith("//")) return 2;
+  if (path.startsWith("/") || path.startsWith("\\")) return 1;
+  return 0;
+}
+
+export function truncatePathMiddle(
+  path: string,
+  maxLength = DEFAULT_PATH_TRUNCATION_LENGTH
+): string {
+  const normalizedMaxLength = Number.isFinite(maxLength)
+    ? Math.max(0, Math.floor(maxLength))
+    : DEFAULT_PATH_TRUNCATION_LENGTH;
+  if (characterCount(path) <= normalizedMaxLength) return path;
+
+  const separator = pathSeparator(path);
+  const prefixLength = pathPrefixLength(path);
+  const prefix = path.slice(0, prefixLength);
+  const remainder = path.slice(prefixLength);
+  const hasTrailingSeparator = /[\\/]$/.test(remainder);
+  const segments = remainder.split(/[\\/]+/).filter(Boolean);
+
+  for (const [leadingSegmentCount, trailingSegmentCount] of VISIBLE_SEGMENT_CANDIDATES) {
+    if (leadingSegmentCount + trailingSegmentCount >= segments.length) continue;
+
+    const shortenedPath = `${prefix}${[
+      ...segments.slice(0, leadingSegmentCount),
+      "…",
+      ...segments.slice(-trailingSegmentCount)
+    ].join(separator)}`;
+    const candidate = hasTrailingSeparator ? `${shortenedPath}${separator}` : shortenedPath;
+
+    if (characterCount(candidate) <= normalizedMaxLength) return candidate;
+  }
+
+  return truncateCharactersMiddle(path, normalizedMaxLength);
+}

--- a/frontend/src/utils/utils.test.tsx
+++ b/frontend/src/utils/utils.test.tsx
@@ -1,0 +1,47 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+
+import { useIsCoarsePointer } from "./utils";
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+
+function CoarsePointerProbe() {
+  return <span>{useIsCoarsePointer() ? "coarse" : "fine"}</span>;
+}
+
+describe("useIsCoarsePointer", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+
+    if (originalWindow) {
+      Object.defineProperty(globalThis, "window", originalWindow);
+    } else {
+      Reflect.deleteProperty(globalThis, "window");
+    }
+  });
+
+  test("detects a secondary coarse pointer on a hybrid device", () => {
+    const matchMedia = mock((query: string) => ({
+      matches: query.includes("(any-pointer: coarse)"),
+      addEventListener: mock(() => {}),
+      removeEventListener: mock(() => {})
+    }));
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { matchMedia },
+      writable: true
+    });
+
+    act(() => {
+      renderer = create(<CoarsePointerProbe />);
+    });
+
+    expect(renderer?.toJSON()).toMatchObject({ children: ["coarse"] });
+    expect(matchMedia).toHaveBeenCalledWith(
+      "(pointer: coarse), (any-pointer: coarse), (hover: none)"
+    );
+  });
+});

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -89,6 +89,40 @@ export function useIsLandscapeMobile() {
   return matches;
 }
 
+/**
+ * Detect layouts whose primary pointer cannot rely on precise hover affordances.
+ * This intentionally includes both coarse pointers and devices without hover so
+ * controls remain discoverable on wide touchscreens and pen-first devices.
+ */
+export function useIsCoarsePointer() {
+  const QUERY = "(pointer: coarse), (hover: none)";
+
+  const [matches, setMatches] = useState(() =>
+    typeof window !== "undefined" ? window.matchMedia(QUERY).matches : false
+  );
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(QUERY);
+    const handleMediaChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+
+    if ("addEventListener" in mediaQuery) {
+      mediaQuery.addEventListener("change", handleMediaChange);
+    } else {
+      (mediaQuery as MediaQueryList).addListener(handleMediaChange);
+    }
+
+    return () => {
+      if ("removeEventListener" in mediaQuery) {
+        mediaQuery.removeEventListener("change", handleMediaChange);
+      } else {
+        (mediaQuery as MediaQueryList).removeListener(handleMediaChange);
+      }
+    };
+  }, []);
+
+  return matches;
+}
+
 export function useClickOutside(
   ref: React.RefObject<HTMLElement>,
   callback: (event: MouseEvent | TouchEvent) => void

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -90,7 +90,7 @@ export function useIsLandscapeMobile() {
 }
 
 export function useIsCoarsePointer() {
-  const QUERY = "(pointer: coarse), (hover: none)";
+  const QUERY = "(pointer: coarse), (any-pointer: coarse), (hover: none)";
 
   const [matches, setMatches] = useState(() =>
     typeof window !== "undefined" ? window.matchMedia(QUERY).matches : false

--- a/frontend/src/utils/utils.ts
+++ b/frontend/src/utils/utils.ts
@@ -89,11 +89,6 @@ export function useIsLandscapeMobile() {
   return matches;
 }
 
-/**
- * Detect layouts whose primary pointer cannot rely on precise hover affordances.
- * This intentionally includes both coarse pointers and devices without hover so
- * controls remain discoverable on wide touchscreens and pen-first devices.
- */
 export function useIsCoarsePointer() {
   const QUERY = "(pointer: coarse), (hover: none)";
 


### PR DESCRIPTION
## Changelog

- Tightened project and task row spacing, with equal spacing between a project and its first task and larger separation between projects.
- Unified selected and hover styling, with status indicators and action buttons aligned on the right.
- Click a project name to expand or collapse its task list.
- Persisted project expand/collapse state per account on the current device.
- Added project display-name renaming without renaming or moving the underlying folder.
- Added rich status popovers for projects and tasks, showing project context, task counts, in-progress status, unread counts, and folder paths.
- Middle-truncated long folder paths while retaining their beginning and ending segments.
- Made folder paths in popovers open the project in the OS file browser.
- Improved visibility of unread tasks with green indicators and project-level unread counts.
- Shows an in-progress spinner or unread indicator on the sidebar button when the sidebar is closed.
- Changed the Add Project icon to a folder with a plus.

## Scope and behavior

This is a UI-focused Agent Mode change with one desktop capability update for the existing Tauri opener plugin and one new Radix UI dependency. It adds no Rust commands and does not change backend services, the Agent runtime, database schemas, or remote APIs. There are no intentional Chat Mode behavior changes; the shared tooltip primitive now portals its content, so its existing consumers remain part of regression review.

### Project disclosure and naming

- The folder icon and project name form one disclosure control. Activating it only expands or collapses that project's task list; it does not switch project context, create a task, or clear the active task.
- Collapse state and project display-name overrides use versioned, account-scoped `localStorage`. Newly discovered projects default to expanded, malformed or stale data is ignored safely, and preferences remain local to the current device.
- A renamed project is a Maple display-name override keyed by its canonical path. The underlying folder and native recent-project record are not renamed or moved.

### Status popovers and folder paths

- Non-compact fine-pointer project popovers show the display name, task and unread counts, in-progress count, and folder path.
- Non-compact fine-pointer task popovers show the task title, project display name, in-progress state, and folder path.
- Long POSIX, Windows, UNC, and extended-length Windows paths are shortened in the middle while preserving recognizable leading and trailing segments.
- Clicking a popover path uses the existing Tauri opener plugin to reveal and select the exact project root in the OS file browser. Failures produce a non-destructive notification; no backend endpoint or new Rust command was added.
- Popovers are hover-oriented desktop surfaces and are disabled on compact or coarse-pointer layouts. The project menu remains the keyboard-accessible route to open the folder.

### Running and unread status

- Running and unread task indicators move to the right edge. On non-compact fine-pointer layouts, the task action area replaces the indicator during hover or keyboard focus without shifting the title; compact or coarse-pointer layouts keep the larger controls visible.
- Collapsed projects summarize running or unread work from their tasks.
- When the sidebar is closed, its reopen button shows a running spinner while visible Agent work is running or pending; otherwise it shows an unread dot. Its accessible label reports both exact counts when both states exist.
- A collapsed project row may show the existing transient loading spinner while a task is being selected. Project popover counts and the closed-sidebar aggregate count only actual or pending Agent runs rather than selection loading.
- The existing Agent unread state remains transient React state. It is not stored in `localStorage` or Goose SQLite and resets when Agent Mode remounts or the app restarts. This PR improves its presentation and closes a race that could leave a newly selected task marked unread after an asynchronous load.

## Code review focus

- `agentSidebarPreferences.ts`: versioned account isolation, safe malformed-data handling, canonical-path identity, and no writes during startup projection.
- `AgentMode.tsx`: disclosure versus drag/action event boundaries, status aggregation, unread clearing, and hover-card state across project/task selection.
- `AgentSidebarInfoCard.tsx` and `utils/path.ts`: in-progress presentation, path shortening, exact-path accessibility text, and folder-action propagation.
- `agentSidebarPresentation.ts` and `Sidebar.tsx`: count grammar, accessible labels, visible-session filtering, and running-over-unread visual priority.
- `ui/hover-card.tsx` and `ui/tooltip.tsx`: portal layering, collision handling, dismissal, and regressions on other shared tooltip consumers.
- `agentProjectFolder.ts` and the Tauri capability change: opener permission scope, exact path forwarding, and error handling.
- Sidebar theme tokens and row states in both light and dark modes.

## Manual QA

- [ ] Verify project/task density and spacing in light and dark modes, including selected, unselected, hovered, focused, and open-menu rows.
- [ ] Click the folder icon or project name to expand/collapse. Confirm the active task and project context do not change, action buttons do not toggle disclosure, and the last project responds immediately.
- [ ] Reload after collapsing projects. Confirm state restores for the same account, a newly added project defaults to expanded, and signing out/remounting under another account does not inherit the preference.
- [ ] Rename a project. Verify the dialog is prefilled, surrounding whitespace is trimmed, blank names are rejected, duplicate display names are allowed, the project row/composer selector/menus/dialogs/popovers update, and the filesystem folder name remains unchanged after reload.
- [ ] Hover every project and task row on desktop. Verify project cards for zero/one/many tasks, unread tasks, and in-progress tasks; verify task cards for idle and in-progress states, project context, long titles, and long paths.
- [ ] Click the folder path from both project and task popovers. Confirm the exact project root is revealed and selected in the OS file browser and the sidebar does not collapse or start a drag.
- [ ] Verify a project whose directory name ends in whitespace forwards its exact canonical root when creating a task and opening its folder.
- [ ] Verify idle, running, and unread task indicators. On hover/focus, confirm actions replace the indicator without moving the task title, then restore when interaction ends.
- [ ] Collapse a project containing running or unread tasks, then close the sidebar. Verify status rolls up correctly and updates live; when running and unread coexist, running has visual priority while the accessible label reports both counts.
- [ ] Complete a task while viewing another task, confirm it becomes unread, then open or restart it and confirm the task dot, project count/indicator, project popover count, and closed-sidebar unread indicator clear. Confirm failed/cancelled runs do not become unread and completion during task selection does not leave the selected task unread.
- [ ] Verify a normal project click still toggles disclosure, deliberate dragging reorders, Escape cancels a drag, and edge dragging auto-scrolls without triggering project actions.
- [ ] Traverse project/task actions by keyboard. Verify Enter/Space disclosure, menu operation, folder opening through the project menu, and that hover cards do not trap focus.
- [ ] On compact fine-pointer and hybrid/coarse-pointer layouts, confirm actions remain visible and hover cards are suppressed.
- [ ] With reduced motion enabled, confirm spinner/ping, hover-card, row-transition, and reorder animations are disabled while their static states remain visible.
- [ ] Verify locked Agent controls preserve disclosure and status visibility while restricted actions remain disabled.
- [ ] Verify the Add Project control uses the folder-plus icon and has an accessible label.
- [ ] Confirm Chat Mode has no new status indicators or sidebar behavior changes.

## Validation

- Prettier check
- Production frontend build
- `bun run typecheck`
- `bun run lint` — 0 errors; 13 existing warnings
- `bun test` — 584 passed
- `git diff --check`
- Repository pre-commit hook reran formatting, production build, and the full test suite successfully

Fixes #738
