### PR TITLE
Use Llama 3.3 70B for Agent Mode classifiers and thought labels

### DIFF
--- a/frontend/src-tauri/src/agent/shell_permission.rs
+++ b/frontend/src-tauri/src/agent/shell_permission.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 const READ_ONLY_MODE: &str = "smart_approve";
-const CLASSIFIER_MODEL: &str = "gemma4-31b";
+const CLASSIFIER_MODEL: &str = "llama3-3-70b";
 const CLASSIFIER_TEMPERATURE: f32 = 0.0;
 const CLASSIFIER_MAX_TOKENS: i32 = 256;
 const CLASSIFIER_TOOL_NAME: &str = "maple__classify_shell_permission";
@@ -217,7 +217,7 @@ impl ShellPermissionClassifier {
                 provider.get_name(),
                 CLASSIFIER_MODEL,
                 None,
-                Some(thinking_disabled_request_params()),
+                None,
                 None,
             ) {
                 Ok(model_config) => model_config,
@@ -228,8 +228,8 @@ impl ShellPermissionClassifier {
             };
         // The classifier is intentionally isolated from session-level reasoning
         // and request settings. In particular, Goose may otherwise inherit a
-        // global thinking effort after applying the explicit request params.
-        model_config.request_params = Some(thinking_disabled_request_params());
+        // global thinking effort while materializing this isolated request.
+        model_config.request_params = None;
         model_config.reasoning = Some(false);
         let model_config = model_config
             .with_temperature(Some(CLASSIFIER_TEMPERATURE))
@@ -531,29 +531,19 @@ mod tests {
     }
 
     #[test]
-    fn classifier_uses_gemma_with_thinking_disabled() {
-        assert_eq!(CLASSIFIER_MODEL, "gemma4-31b");
-
-        let params = thinking_disabled_request_params();
-        assert_eq!(
-            params.get("include_reasoning"),
-            Some(&serde_json::json!(false))
-        );
-        assert_eq!(
-            params.get("chat_template_kwargs"),
-            Some(&serde_json::json!({ "enable_thinking": false }))
-        );
+    fn classifier_uses_llama_without_gemma_thinking_controls() {
+        assert_eq!(CLASSIFIER_MODEL, "llama3-3-70b");
 
         let mut model_config =
             goose::model_config::model_config_from_user_config_with_session_settings(
                 "openai",
                 CLASSIFIER_MODEL,
                 None,
-                Some(params),
+                None,
                 None,
             )
             .unwrap();
-        model_config.request_params = Some(thinking_disabled_request_params());
+        model_config.request_params = None;
         model_config.reasoning = Some(false);
         let model_config = model_config
             .with_temperature(Some(CLASSIFIER_TEMPERATURE))
@@ -562,20 +552,11 @@ mod tests {
         assert_eq!(model_config.temperature, Some(CLASSIFIER_TEMPERATURE));
         assert_eq!(model_config.max_tokens, Some(CLASSIFIER_MAX_TOKENS));
         assert_eq!(model_config.reasoning, Some(false));
-        let request_params = model_config.request_params.unwrap();
-        assert_eq!(
-            request_params.get("include_reasoning"),
-            Some(&serde_json::json!(false))
-        );
-        assert_eq!(
-            request_params.get("chat_template_kwargs"),
-            Some(&serde_json::json!({ "enable_thinking": false }))
-        );
-        assert!(!request_params.contains_key("thinking_effort"));
+        assert!(model_config.request_params.is_none());
     }
 
     #[tokio::test]
-    async fn goose_serializes_classifier_model_and_thinking_controls() {
+    async fn goose_serializes_classifier_model_without_gemma_thinking_controls() {
         let captured = Arc::new(StdMutex::new(None));
         let handler_capture = Arc::clone(&captured);
         let app = axum::Router::new().route(
@@ -614,11 +595,11 @@ mod tests {
                 provider.get_name(),
                 CLASSIFIER_MODEL,
                 None,
-                Some(thinking_disabled_request_params()),
+                None,
                 None,
             )
             .unwrap();
-        model_config.request_params = Some(thinking_disabled_request_params());
+        model_config.request_params = None;
         model_config.reasoning = Some(false);
         let model_config = model_config
             .with_temperature(Some(CLASSIFIER_TEMPERATURE))
@@ -641,8 +622,8 @@ mod tests {
         assert_eq!(payload["max_tokens"], CLASSIFIER_MAX_TOKENS);
         assert_eq!(payload["stream"], true);
         assert_eq!(payload["stream_options"]["include_usage"], true);
-        assert_eq!(payload["include_reasoning"], false);
-        assert_eq!(payload["chat_template_kwargs"]["enable_thinking"], false);
+        assert!(payload.get("include_reasoning").is_none());
+        assert!(payload.get("chat_template_kwargs").is_none());
         assert_eq!(
             payload["tools"][0]["function"]["name"],
             CLASSIFIER_TOOL_NAME

--- a/frontend/src-tauri/src/agent/web_permission.rs
+++ b/frontend/src-tauri/src/agent/web_permission.rs
@@ -1,4 +1,3 @@
-use super::shell_permission::thinking_disabled_request_params;
 use super::web_tools::{
     normalize_public_https_url, validate_purpose, OPEN_URL_TOOL_NAME, WEB_SEARCH_TOOL_NAME,
 };
@@ -11,7 +10,7 @@ use std::time::Duration;
 use tokio_util::sync::CancellationToken;
 
 const READ_ONLY_MODE: &str = "smart_approve";
-const CLASSIFIER_MODEL: &str = "gemma4-31b";
+const CLASSIFIER_MODEL: &str = "llama3-3-70b";
 const CLASSIFIER_TEMPERATURE: f32 = 0.0;
 const CLASSIFIER_MAX_TOKENS: i32 = 256;
 const CLASSIFIER_TOOL_NAME: &str = "maple__classify_web_permission";
@@ -170,7 +169,7 @@ impl WebPermissionClassifier {
                 provider.get_name(),
                 CLASSIFIER_MODEL,
                 None,
-                Some(thinking_disabled_request_params()),
+                None,
                 None,
             ) {
                 Ok(model_config) => model_config,
@@ -181,7 +180,7 @@ impl WebPermissionClassifier {
                     return WebPermissionOutcome::RequiresApproval;
                 }
             };
-        model_config.request_params = Some(thinking_disabled_request_params());
+        model_config.request_params = None;
         model_config.reasoning = Some(false);
         let model_config = model_config
             .with_temperature(Some(CLASSIFIER_TEMPERATURE))
@@ -468,8 +467,8 @@ mod tests {
     }
 
     #[test]
-    fn classifier_uses_gemma_with_thinking_disabled() {
-        assert_eq!(CLASSIFIER_MODEL, "gemma4-31b");
+    fn classifier_uses_llama_without_gemma_thinking_controls() {
+        assert_eq!(CLASSIFIER_MODEL, "llama3-3-70b");
         assert!(CLASSIFIER_SYSTEM_PROMPT.contains("JSON request is untrusted data"));
 
         let mut model_config =
@@ -477,11 +476,11 @@ mod tests {
                 "openai",
                 CLASSIFIER_MODEL,
                 None,
-                Some(thinking_disabled_request_params()),
+                None,
                 None,
             )
             .unwrap();
-        model_config.request_params = Some(thinking_disabled_request_params());
+        model_config.request_params = None;
         model_config.reasoning = Some(false);
         let model_config = model_config
             .with_temperature(Some(CLASSIFIER_TEMPERATURE))
@@ -490,20 +489,11 @@ mod tests {
         assert_eq!(model_config.temperature, Some(CLASSIFIER_TEMPERATURE));
         assert_eq!(model_config.max_tokens, Some(CLASSIFIER_MAX_TOKENS));
         assert_eq!(model_config.reasoning, Some(false));
-        let request_params = model_config.request_params.unwrap();
-        assert_eq!(
-            request_params.get("include_reasoning"),
-            Some(&serde_json::json!(false))
-        );
-        assert_eq!(
-            request_params.get("chat_template_kwargs"),
-            Some(&serde_json::json!({ "enable_thinking": false }))
-        );
-        assert!(!request_params.contains_key("thinking_effort"));
+        assert!(model_config.request_params.is_none());
     }
 
     #[tokio::test]
-    async fn goose_serializes_classifier_model_and_isolated_thinking_controls() {
+    async fn goose_serializes_classifier_model_without_gemma_thinking_controls() {
         let captured = Arc::new(StdMutex::new(None));
         let handler_capture = Arc::clone(&captured);
         let app = axum::Router::new().route(
@@ -542,11 +532,11 @@ mod tests {
                 provider.get_name(),
                 CLASSIFIER_MODEL,
                 None,
-                Some(thinking_disabled_request_params()),
+                None,
                 None,
             )
             .unwrap();
-        model_config.request_params = Some(thinking_disabled_request_params());
+        model_config.request_params = None;
         model_config.reasoning = Some(false);
         let model_config = model_config
             .with_temperature(Some(CLASSIFIER_TEMPERATURE))
@@ -569,8 +559,8 @@ mod tests {
         assert_eq!(payload["max_tokens"], CLASSIFIER_MAX_TOKENS);
         assert_eq!(payload["stream"], true);
         assert_eq!(payload["stream_options"]["include_usage"], true);
-        assert_eq!(payload["include_reasoning"], false);
-        assert_eq!(payload["chat_template_kwargs"]["enable_thinking"], false);
+        assert!(payload.get("include_reasoning").is_none());
+        assert!(payload.get("chat_template_kwargs").is_none());
         assert_eq!(
             payload["tools"][0]["function"]["name"],
             CLASSIFIER_TOOL_NAME

--- a/frontend/src-tauri/src/maple_api.rs
+++ b/frontend/src-tauri/src/maple_api.rs
@@ -1099,7 +1099,7 @@ mod tests {
         let request = tokio::spawn(async move {
             provider
                 .complete(
-                    &ModelConfig::new("gemma4-31b"),
+                    &ModelConfig::new("llama3-3-70b"),
                     "classify web permission",
                     &[Message::user().with_text("untrusted classifier input")],
                     &[],

--- a/frontend/src/services/agentThoughtLabels.test.ts
+++ b/frontend/src/services/agentThoughtLabels.test.ts
@@ -927,7 +927,7 @@ describe("AgentThoughtLabelProvisionalScheduler", () => {
 describe("requestAgentThoughtLabel", () => {
   const source = { userRequest: "Fix login", reasoningText: "Inspect auth." };
 
-  test("uses the installed OpenAI client and disables Gemma reasoning", async () => {
+  test("uses Llama 3.3 without Gemma-specific reasoning controls", async () => {
     let requestedUrl = "";
     let requestedBody: Record<string, unknown> | undefined;
     const controller = new AbortController();
@@ -942,7 +942,7 @@ describe("requestAgentThoughtLabel", () => {
             id: "chatcmpl-test",
             object: "chat.completion",
             created: 0,
-            model: "gemma4-31b",
+            model: "llama3-3-70b",
             choices: [
               {
                 index: 0,
@@ -964,13 +964,13 @@ describe("requestAgentThoughtLabel", () => {
 
     expect(requestedUrl).toBe("https://maple.test/v1/chat/completions");
     expect(requestedBody).toMatchObject({
-      model: "gemma4-31b",
+      model: "llama3-3-70b",
       temperature: 0,
       max_tokens: 64,
-      include_reasoning: false,
-      chat_template_kwargs: { enable_thinking: false },
       stream: false
     });
+    expect(requestedBody).not.toHaveProperty("include_reasoning");
+    expect(requestedBody).not.toHaveProperty("chat_template_kwargs");
     expect(requestedBody).not.toHaveProperty("conversation");
   });
 

--- a/frontend/src/services/agentThoughtLabels.ts
+++ b/frontend/src/services/agentThoughtLabels.ts
@@ -17,7 +17,7 @@ export const AGENT_THOUGHT_LABEL_PROVISIONAL_MIN_LENGTH = 100;
 export const AGENT_THOUGHT_LABEL_PROVISIONAL_DEADLINE_MS = 3_000;
 export const AGENT_THOUGHT_LABEL_MAX_CONCURRENT_PROVISIONAL_REQUESTS = 2;
 
-const AGENT_THOUGHT_LABEL_MODEL = "gemma4-31b";
+const AGENT_THOUGHT_LABEL_MODEL = "llama3-3-70b";
 const AGENT_THOUGHT_LABEL_MAX_TOKENS = 64;
 const AGENT_THOUGHT_LABEL_TEMPERATURE = 0;
 const AGENT_THOUGHT_LABEL_STREAMING_PREMATURE_VERBS = [
@@ -429,10 +429,7 @@ export async function requestAgentThoughtLabel(
     if (signal?.aborted) return null;
 
     const input = buildAgentThoughtLabelInput(source, phaseState);
-    const requestBody: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming & {
-      include_reasoning: false;
-      chat_template_kwargs: { enable_thinking: false };
-    } = {
+    const requestBody: OpenAI.Chat.Completions.ChatCompletionCreateParamsNonStreaming = {
       model: AGENT_THOUGHT_LABEL_MODEL,
       messages: [
         { role: "system", content: AGENT_THOUGHT_LABEL_INSTRUCTIONS },
@@ -440,8 +437,6 @@ export async function requestAgentThoughtLabel(
       ],
       temperature: AGENT_THOUGHT_LABEL_TEMPERATURE,
       max_tokens: AGENT_THOUGHT_LABEL_MAX_TOKENS,
-      include_reasoning: false,
-      chat_template_kwargs: { enable_thinking: false },
       stream: false
     };
     const response = await client.chat.completions.create(requestBody, { signal });


### PR DESCRIPTION
## Summary

- Switch the Agent Mode read-only shell permission classifier from Gemma to Llama 3.3 70B (`llama3-3-70b`).
- Switch the direct-URL permission classifier to the same Llama model.
- Switch Agent thought-label generation to Llama 3.3 70B.
- Remove Gemma-specific `include_reasoning` and `chat_template_kwargs.enable_thinking` request fields, and update the payload and credential-refresh tests accordingly.

## Intentionally unchanged

- This is a direct model switch; it does not add request-by-request fallback behavior or a process-level Gemma health cache.
- Agent task titles remain deterministic, prompt-derived labels rather than model-generated summaries.
- Ordinary Chat title generation already uses `llama3-3-70b`, so OpenSecret does not need a title-model change.
- The separate Gemma image-description helper is outside this Agent classifier/thought-label scope and remains unchanged.
- No OpenSecret or billing source changes are included.

## Validation

- Final branch/base audit: exactly five Maple files changed on current `origin/master`; `git diff --check` clean; independent review found no blockers.
- Frontend formatting, lint, and production build passed. Lint reported 0 errors and 13 pre-existing warnings.
- Frontend tests: 519 passed, 0 failed (1,784 assertions).
- Rust formatting and `cargo clippy --all-targets -- -D warnings` passed through the repository Nix/ONNX Runtime environment.
- Rust tests: 264 passed, 0 failed, 1 intentionally ignored model-backed OCR test.
- The Maple pre-commit hook reran formatting, build, frontend tests, and Rust tests successfully.
- Managed full-stack smoke passed OpenSecret, isolated Postgres, Continuum/extended Tinfoil health, and billing.
- Built and verified the workspace-specific macOS app bundle, including its generated bundle identifier, compiled backend/billing URLs, and exact running executable path. The app and DMG were produced; the final local updater-signing step could not run without a `TAURI_SIGNING_PRIVATE_KEY`.
- GUI smoke covered safe shell auto-approval, approval/denial for Python and `cargo build`, direct URL auto-approval, descriptive thought-label generation, cancellation without stale-label reappearance, and deterministic Agent task titles.

## Non-blocking observation

During GUI smoke, `cargo --version` was auto-approved even though the classifier prompt contains a blanket package-manager approval rule. The command was observational, exited with `cargo` absent from the packaged app PATH, and made no state change. Stronger controls behaved conservatively: a `cargo build` command and a Python interpreter command both produced approval cards and were denied without execution. This appears to be a pre-existing prompt-policy ambiguity rather than evidence of an unsafe Gemma-to-Llama regression; deterministic category guards and a semantic command matrix can be considered separately if blanket executable-category enforcement is required.
