### PR TITLE
fix(agent): keep New Task stable during task switches

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -686,23 +686,29 @@ export function AgentMode({ userId }: { userId: string }) {
   const activeRunId = activeSessionId ? (activeRunsBySession[activeSessionId] ?? null) : null;
   const activePendingSendKey = activeSessionId || NEW_SESSION_PENDING_KEY;
   const isSubmitting = pendingSendSessionIds.has(activePendingSendKey);
-  const isSessionSelectionPending = pendingSessionSelectionId !== null;
+  const isTaskSelectionPending =
+    pendingSessionSelectionId !== null && pendingSessionSelectionId !== NEW_SESSION_PENDING_KEY;
+  const isNewTaskCreationPending = pendingSessionSelectionId === NEW_SESSION_PENDING_KEY;
+  // Existing-task loads and their follow-up project trust lookup block actions without
+  // visually dimming the global New Task control.
+  const isTaskTransitionPending = isTaskSelectionPending || isProjectSkillsTrustLoading;
   const isProjectOrderSaving = projectOrderState.pendingRequestId !== null;
   const isProjectSkillsTrustSaving = projectSkillsTrustSavingDecision !== null;
-  const areAgentSettingsLocked =
+  const areAgentSettingsLockedOutsideTaskTransition =
     !isAuthTransitionReady ||
     isInitializing ||
     isStarting ||
     isPermissionModeUpdating ||
-    isSessionSelectionPending ||
+    isNewTaskCreationPending ||
     isSubmitting ||
     isProjectOrderSaving ||
     isProjectRootRegistrationPending ||
     isProjectRemovalPending ||
     isAgentModelCatalogLoading ||
-    isProjectSkillsTrustLoading ||
     isProjectSkillsTrustSaving ||
     projectSkillsTrustPrompt !== null;
+  const areAgentSettingsLocked =
+    areAgentSettingsLockedOutsideTaskTransition || isTaskTransitionPending;
   const hasStartedAgentSession =
     hasAgentUserMessage(timelineItems) ||
     sessions.some((session) => session.id === activeSessionId && session.messageCount > 0);
@@ -2479,7 +2485,12 @@ export function AgentMode({ userId }: { userId: string }) {
             onSessionSelect={handleSelectSession}
           />
         }
-        onNewItem={areAgentSettingsLocked || !projectRoot ? undefined : handleCreateSession}
+        isNewItemTemporarilyDisabled={isTaskTransitionPending}
+        onNewItem={
+          areAgentSettingsLockedOutsideTaskTransition || !projectRoot
+            ? undefined
+            : handleCreateSession
+        }
         onToggle={toggleSidebar}
       />
 

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -9,6 +9,7 @@ import {
   FolderInput
 } from "lucide-react";
 import { Button } from "./ui/button";
+import { SidebarNewItemButton } from "./SidebarNewItemButton";
 import { useLocation, useRouter } from "@tanstack/react-router";
 import { ChatHistoryList } from "./ChatHistoryList";
 import { AccountMenu } from "./AccountMenu";
@@ -55,6 +56,7 @@ export function Sidebar({
   isOpen,
   mode = "chat",
   navigationContent,
+  isNewItemTemporarilyDisabled = false,
   onNewItem,
   onToggle
 }: {
@@ -62,6 +64,7 @@ export function Sidebar({
   isOpen: boolean;
   mode?: WorkspaceMode;
   navigationContent?: ReactNode;
+  isNewItemTemporarilyDisabled?: boolean;
   onNewItem?: () => void;
   onToggle: () => void;
 }) {
@@ -369,15 +372,15 @@ export function Sidebar({
             </div>
           )}
           <div className="flex flex-col gap-2 px-4">
-            <button
-              type="button"
-              className="flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm text-[hsl(var(--maple-primary-strong))] transition-colors hover:text-[hsl(var(--maple-primary))] disabled:cursor-not-allowed disabled:opacity-50 dark:text-[hsl(var(--maple-primary))] dark:hover:text-[hsl(var(--maple-primary-strong))]"
-              disabled={isAgentMode && !onNewItem}
+            <SidebarNewItemButton
+              hasAction={Boolean(onNewItem)}
+              isAgentMode={isAgentMode}
+              isTemporarilyDisabled={isNewItemTemporarilyDisabled}
               onClick={() => void addItem()}
             >
               <SquarePenIcon className="h-4 w-4 shrink-0" />
               {isAgentMode ? "New Task" : "New Chat"}
-            </button>
+            </SidebarNewItemButton>
             {!isAgentMode && (
               <button
                 type="button"

--- a/frontend/src/components/SidebarNewItemButton.test.tsx
+++ b/frontend/src/components/SidebarNewItemButton.test.tsx
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SidebarNewItemButton } from "./SidebarNewItemButton";
+
+function renderButton({
+  hasAction,
+  isAgentMode = true,
+  isTemporarilyDisabled = false
+}: {
+  hasAction: boolean;
+  isAgentMode?: boolean;
+  isTemporarilyDisabled?: boolean;
+}): string {
+  return renderToStaticMarkup(
+    <SidebarNewItemButton
+      hasAction={hasAction}
+      isAgentMode={isAgentMode}
+      isTemporarilyDisabled={isTemporarilyDisabled}
+      onClick={() => {}}
+    >
+      {isAgentMode ? "New Task" : "New Chat"}
+    </SidebarNewItemButton>
+  );
+}
+
+describe("SidebarNewItemButton", () => {
+  test("keeps the New Chat presentation unchanged without an Agent action", () => {
+    const markup = renderButton({ hasAction: false, isAgentMode: false });
+
+    expect(markup).toContain("New Chat");
+    expect(markup).not.toContain('disabled=""');
+    expect(markup).not.toContain("opacity-50");
+  });
+
+  test("keeps an available New Task button enabled and at full opacity", () => {
+    const markup = renderButton({ hasAction: true });
+
+    expect(markup).not.toContain('disabled=""');
+    expect(markup).not.toContain("opacity-50");
+  });
+
+  test("blocks task creation without dimming during an existing-task selection", () => {
+    const markup = renderButton({ hasAction: true, isTemporarilyDisabled: true });
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).not.toContain("opacity-50");
+  });
+
+  test("keeps unavailable New Task buttons disabled and dimmed", () => {
+    const markup = renderButton({ hasAction: false });
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain("opacity-50");
+  });
+
+  test("keeps another unavailable state dimmed during task selection", () => {
+    const markup = renderButton({ hasAction: false, isTemporarilyDisabled: true });
+
+    expect(markup).toContain('disabled=""');
+    expect(markup).toContain("opacity-50");
+  });
+});

--- a/frontend/src/components/SidebarNewItemButton.tsx
+++ b/frontend/src/components/SidebarNewItemButton.tsx
@@ -1,0 +1,34 @@
+import type { ReactNode } from "react";
+
+import { cn } from "@/utils/utils";
+
+export function SidebarNewItemButton({
+  children,
+  hasAction,
+  isAgentMode,
+  isTemporarilyDisabled = false,
+  onClick
+}: {
+  children: ReactNode;
+  hasAction: boolean;
+  isAgentMode: boolean;
+  isTemporarilyDisabled?: boolean;
+  onClick: () => void;
+}) {
+  const isDisabled = isAgentMode && (!hasAction || isTemporarilyDisabled);
+  const isVisuallyDisabled = isAgentMode && !hasAction;
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        "flex w-full items-center justify-start gap-2 py-1.5 pr-1 pl-0 text-sm text-[hsl(var(--maple-primary-strong))] transition-colors hover:text-[hsl(var(--maple-primary))] disabled:cursor-not-allowed dark:text-[hsl(var(--maple-primary))] dark:hover:text-[hsl(var(--maple-primary-strong))]",
+        isVisuallyDisabled && "opacity-50"
+      )}
+      disabled={isDisabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary

- Keep the top-level New Task button visually stable while an existing Agent task and its follow-up project-trust state load.
- Preserve native disabled behavior and stale-selection fencing, including cross-project switches.
- Keep genuinely unavailable states such as no project, initialization, and new-task creation visibly dimmed.
- Add focused disabled/opacity regression coverage.

## Validation

- nix develop .#ci -c ./scripts/ci/frontend.sh — 524 tests passed
- Production frontend build
- git diff --check
- Fresh correctness and UX reviews
- Synthetic merge with open PR #745

End-to-end smoke was intentionally skipped; this is ready for local flicker testing.

Fixes #747