### PR TITLE
fix(desktop): restore and focus main window

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4596,6 +4596,8 @@ dependencies = [
  "libc",
  "log",
  "maple-proxy",
+ "objc2-app-kit",
+ "objc2-foundation 0.3.2",
  "once_cell",
  "opensecret",
  "openssl",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -74,6 +74,12 @@ tempfile = "3"
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
 
+[target.'cfg(target_os = "macos")'.dependencies]
+# Let AppKit persist the frame in its native point coordinate space. This
+# avoids physical-pixel scaling errors on Retina and mixed-DPI displays.
+objc2-app-kit = { version = "0.3.2", default-features = false, features = ["std", "NSWindow"] }
+objc2-foundation = { version = "0.3.2", default-features = false, features = ["std", "NSString"] }
+
 [target.'cfg(target_os = "ios")'.dependencies]
 # We build ONNX Runtime 1.23.2 from source for iOS (see scripts/build-ios-onnxruntime.sh)
 # We disable download-binaries and copy-dylibs since we link our own xcframework

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -24,7 +24,66 @@ async fn restart_for_update(app_handle: tauri::AppHandle) -> Result<(), String> 
     log::info!("User requested restart for update");
     let lifecycle = app_handle.state::<agent_host::AgentHostLifecycle>();
     lifecycle.shutdown_for_update(&app_handle).await?;
-    app_handle.restart();
+    app_handle.request_restart();
+    Ok(())
+}
+
+#[cfg(desktop)]
+fn reveal_main_window(app_handle: &tauri::AppHandle) {
+    #[cfg(target_os = "macos")]
+    if let Err(error) = app_handle.show() {
+        log::warn!("Failed to unhide Maple: {error}");
+    }
+
+    let Some(window) = app_handle.get_webview_window("main") else {
+        log::warn!("Cannot reveal Maple because the main window is unavailable");
+        return;
+    };
+
+    if let Err(error) = window.unminimize() {
+        log::warn!("Failed to unminimize the main window: {error}");
+    }
+    if let Err(error) = window.show() {
+        log::warn!("Failed to show the main window: {error}");
+    }
+    if let Err(error) = window.set_focus() {
+        log::warn!("Failed to focus the main window: {error}");
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn enable_main_window_frame_autosave(app_handle: &tauri::AppHandle) {
+    use objc2_app_kit::NSWindow;
+    use objc2_foundation::NSString;
+
+    let Some(window) = app_handle.get_webview_window("main") else {
+        log::warn!("Cannot enable frame autosave because the main window is unavailable");
+        return;
+    };
+
+    let ns_window = match window.ns_window() {
+        Ok(ns_window) => ns_window.cast::<NSWindow>(),
+        Err(error) => {
+            log::warn!("Failed to access the native main window: {error}");
+            return;
+        }
+    };
+
+    // SAFETY: Tauri returns the live NSWindow backing this WebviewWindow. This
+    // setup callback runs on the macOS main thread and the pointer is used only
+    // for the duration of this call.
+    let Some(ns_window) = (unsafe { ns_window.as_ref() }) else {
+        log::warn!("Cannot enable frame autosave because the native main window is null");
+        return;
+    };
+
+    let autosave_name = NSString::from_str("MapleMainWindow");
+    if !ns_window.setFrameUsingName(&autosave_name) {
+        ns_window.center();
+    }
+    if !ns_window.setFrameAutosaveName(&autosave_name) {
+        log::warn!("AppKit rejected the main window frame autosave name");
+    }
 }
 
 #[cfg(desktop)]
@@ -40,6 +99,17 @@ fn get_pending_update_failure() -> Result<Option<String>, String> {
 
 #[cfg(desktop)]
 fn handle_desktop_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEvent) {
+    if matches!(&event, tauri::RunEvent::Ready) {
+        reveal_main_window(app_handle);
+        return;
+    }
+
+    #[cfg(target_os = "macos")]
+    if matches!(&event, tauri::RunEvent::Reopen { .. }) {
+        reveal_main_window(app_handle);
+        return;
+    }
+
     let tauri::RunEvent::ExitRequested { code, api, .. } = event else {
         return;
     };
@@ -71,6 +141,8 @@ fn handle_desktop_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEven
 fn handle_deep_link_event(url: &str, app: &tauri::AppHandle) {
     // OAuth callbacks carry bearer tokens in the query string, so never log the raw URL.
     log::info!("[Deep Link] Received callback");
+    #[cfg(desktop)]
+    reveal_main_window(app);
     // Forward the URL to the frontend
     match app.emit_to("main", "deep-link-received", url.to_string()) {
         Ok(_) => log::info!("[Deep Link] Event emitted successfully"),
@@ -85,6 +157,7 @@ pub fn run() {
         .plugin(tauri_plugin_single_instance::init(|app, _argv, _cwd| {
             // argv can contain a custom-scheme callback URL with OAuth bearer tokens.
             log::info!("Single instance detected for {}", app.package_info().name);
+            reveal_main_window(app);
         }))
         .plugin(tauri_plugin_log::Builder::default().level(log::LevelFilter::Info).build())
         .plugin(tauri_plugin_deep_link::init())
@@ -143,6 +216,9 @@ pub fn run() {
             get_pending_update_failure,
         ])
         .setup(|app| {
+            #[cfg(target_os = "macos")]
+            enable_main_window_frame_autosave(app.handle());
+
             legacy_tts_cleanup::schedule(app.handle());
 
             let service = agent_host::build_service(app.handle())?;

--- a/frontend/src-tauri/tauri.macos.conf.json
+++ b/frontend/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
+  "app": {
+    "windows": [
+      {
+        "title": "Maple - Private AI Chat",
+        "width": 1200,
+        "height": 800,
+        "minWidth": 800,
+        "minHeight": 600,
+        "resizable": true,
+        "fullscreen": false,
+        "center": false,
+        "visible": false
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- Persist the macOS main-window frame with native AppKit autosave, restoring before the hidden window is revealed so Retina and mixed-DPI geometry remains stable.
- Explicitly unhide, unminimize, show, and focus the main window on startup, Dock reopen, OAuth deep links, and second-instance launches.
- Use request_restart after update shutdown so restart follows the normal Tauri lifecycle.

## Validation

- Exact packaged Maple.app: seeded non-centered 900x650 frame preserved across two launch/quit cycles.
- Nix checks: Cargo formatting, 264 Rust tests passed with 1 model-backed test ignored, and Clippy completed with only existing patched-Tao warnings.
- Pre-commit: Prettier, frontend production build, 524 Bun tests, and Rust checks passed.
- Managed workspace full-stack smoke passed.
- macOS app, DMG, and updater archive bundled; the expected final updater-signing step could not run because the local private key is not present.

## Review

Three independent review tracks covered native lifecycle and activation, packaged behavior, and cross-platform/build scope. Qualifying macOS centering and Retina/plugin issues were addressed. A Linux-only minimized-window focus timing limitation was left out because it is medium severity and not a quick low-complexity fix.

## Local test

1. Move and resize Maple, quit with Cmd-Q, reopen, and confirm the exact frame.
2. Hide or minimize Maple, then reopen via Dock, OAuth callback, or a second launch and confirm it raises.
3. Exercise an updater restart when an update is available.