### PR TITLE
feat(agent): brand Agent Mode system prompt as Maple

### DIFF
--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -3,6 +3,7 @@ mod developer_tools;
 mod macos_login_path;
 pub(crate) mod provider;
 mod shell_permission;
+mod system_prompt;
 mod tool_context;
 mod web_permission;
 mod web_tools;
@@ -4415,6 +4416,17 @@ where
         .get_or_create_agent_with_runtime_context(session.id.clone(), runtime_context)
         .await
         .map_err(|e| format!("Failed to load Agent for task {}: {e}", session.id))?;
+
+    // Freshly created agents inherit goose's stock identity prompt, which
+    // names goose and AAIF even though users only ever meet Maple's Agent
+    // Mode. Brand the base prompt as Maple the moment the agent is created;
+    // cached agents keep the override for their whole lifetime.
+    if manager_result.agent_created {
+        manager_result
+            .agent
+            .override_system_prompt(system_prompt::MAPLE_SYSTEM_PROMPT_TEMPLATE.to_string())
+            .await;
+    }
 
     // Goose's built-in registry cannot reconstruct Maple's caller-owned
     // provider. Its default-provider fallback uses the runtime-global model and

--- a/frontend/src-tauri/src/agent/system_prompt.rs
+++ b/frontend/src-tauri/src/agent/system_prompt.rs
@@ -1,0 +1,142 @@
+//! Maple-branded system prompt for Agent Mode.
+//!
+//! The pinned goose runtime identifies itself as "goose, created by AAIF
+//! (Agentic AI Foundation)". That identity is wrong for Maple users: they
+//! interact with Maple's Agent Mode and do not know what goose is.
+//! [`MAPLE_SYSTEM_PROMPT_TEMPLATE`] is a line-for-line copy of the pinned
+//! goose `crates/goose/src/prompts/system.md` with only the two-line identity
+//! header rebranded. Every dynamic section (turn context, extensions,
+//! tool-count suggestion, response guidelines) is preserved byte-for-byte so
+//! the rendered prompt keeps goose's exact structure and prompt-cache
+//! stability.
+//!
+//! When bumping the goose pin in `Cargo.toml`, diff this template against the
+//! pinned `crates/goose/src/prompts/system.md`; only the first two lines may
+//! differ. `template_keeps_stock_structure_and_maple_branding` enforces that
+//! contract.
+
+/// System prompt template applied to every freshly created Agent Mode agent
+/// via goose's `Agent::override_system_prompt`.
+pub(crate) const MAPLE_SYSTEM_PROMPT_TEMPLATE: &str = r#"You are a general-purpose AI agent called Maple, created by Maple AI.
+You run in the Maple app's Agent Mode; users know you simply as Maple.
+
+{% if moim_system_prompt_block is defined %}
+{{ moim_system_prompt_block }}
+{% endif %}
+
+{% if include_extensions and not code_execution_mode %}
+
+# Extensions
+
+Extensions provide additional tools and context from different data sources and applications.
+You can dynamically enable or disable extensions as needed to help complete tasks.
+
+{% if (extensions is defined) and extensions %}
+Because you dynamically load extensions, your conversation history may refer
+to interactions with extensions that are not currently active. The currently
+active extensions are below. Each of these extensions provides tools that are
+in your tool specification.
+
+{% for extension in extensions %}
+
+## {{extension.name}}
+
+{% if extension.has_resources %}
+{{extension.name}} supports resources.
+{% endif %}
+{% if extension.instructions %}### Instructions
+{{extension.instructions}}{% endif %}
+{% endfor %}
+
+{% else %}
+No extensions are defined. You should let the user know that they should add extensions.
+{% endif %}
+{% endif %}
+
+{% if include_extensions and extension_tool_limits is defined and not code_execution_mode %}
+{% with (extension_count, tool_count) = extension_tool_limits  %}
+# Suggestion
+
+The user has {{extension_count}} extensions with {{tool_count}} tools enabled, exceeding recommended limits ({{max_extensions}} extensions or {{max_tools}} tools).
+Consider asking if they'd like to disable some extensions to improve tool selection accuracy.
+{% endwith %}
+{% endif %}
+
+# Response Guidelines
+
+Use Markdown formatting for all responses.
+"#;
+
+#[cfg(test)]
+mod tests {
+    use super::MAPLE_SYSTEM_PROMPT_TEMPLATE;
+    use goose::agents::prompt_manager::PromptManager;
+
+    #[test]
+    fn renders_maple_identity_with_stock_structure() {
+        // Render through goose's real PromptManager so a template that
+        // upstream's mini template engine rejects fails loudly here.
+        let mut manager = PromptManager::new();
+        manager.set_system_prompt_override(MAPLE_SYSTEM_PROMPT_TEMPLATE.to_string());
+        let rendered = manager.builder().build();
+
+        assert!(
+            rendered.starts_with(
+                "You are a general-purpose AI agent called Maple, created by Maple AI."
+            ),
+            "rendered prompt lost the Maple identity header: {rendered}"
+        );
+        for section in [
+            "# Turn Context",
+            "# Extensions",
+            "# Response Guidelines",
+            "Use Markdown formatting for all responses.",
+        ] {
+            assert!(
+                rendered.contains(section),
+                "rendered prompt lost stock goose section {section:?}: {rendered}"
+            );
+        }
+    }
+
+    #[test]
+    fn template_keeps_stock_structure_and_maple_branding() {
+        // Branding: Maple identity only, no upstream identity leaks. The
+        // goose turn-context block (which mentions goose machinery) comes
+        // from goose at render time and is intentionally out of scope here. The
+        // stock template variable `moim_system_prompt_block` must stay intact,
+        // so blank it out before scanning for the "Block" creator brand.
+        let template = MAPLE_SYSTEM_PROMPT_TEMPLATE.replace("moim_system_prompt_block", "turnctx");
+        let template = template.to_lowercase();
+        for leak in ["goose", "aaif", "block"] {
+            assert!(
+                !template.contains(leak),
+                "template leaks upstream brand {leak:?}"
+            );
+        }
+
+        // Structure: every dynamic block of the pinned stock
+        // crates/goose/src/prompts/system.md must survive in byte-exact form.
+        for marker in [
+            "{% if moim_system_prompt_block is defined %}",
+            "{{ moim_system_prompt_block }}",
+            "{% if include_extensions and not code_execution_mode %}",
+            "# Extensions",
+            "{% for extension in extensions %}",
+            "## {{extension.name}}",
+            "{% if extension.has_resources %}",
+            "{{extension.instructions}}{% endif %}",
+            "No extensions are defined. You should let the user know that they should add extensions.",
+            "{% if include_extensions and extension_tool_limits is defined and not code_execution_mode %}",
+            "{% with (extension_count, tool_count) = extension_tool_limits  %}",
+            "# Suggestion",
+            "# Response Guidelines",
+            "Use Markdown formatting for all responses.",
+        ] {
+            assert!(
+                MAPLE_SYSTEM_PROMPT_TEMPLATE.contains(marker),
+                "template drifted from the pinned stock goose system.md: missing {marker:?}"
+            );
+        }
+    }
+}

--- a/frontend/src-tauri/src/agent/system_prompt.rs
+++ b/frontend/src-tauri/src/agent/system_prompt.rs
@@ -12,8 +12,9 @@
 //!
 //! When bumping the goose pin in `Cargo.toml`, diff this template against the
 //! pinned `crates/goose/src/prompts/system.md`; only the first two lines may
-//! differ. `template_keeps_stock_structure_and_maple_branding` enforces that
-//! contract.
+//! differ. `body_matches_pinned_goose_system_prompt_byte_for_byte` compares
+//! this template against goose's compile-time-embedded stock `system.md` and
+//! fails on any such drift until the Maple header is re-applied.
 
 /// System prompt template applied to every freshly created Agent Mode agent
 /// via goose's `Agent::override_system_prompt`.
@@ -71,6 +72,7 @@ Use Markdown formatting for all responses.
 mod tests {
     use super::MAPLE_SYSTEM_PROMPT_TEMPLATE;
     use goose::agents::prompt_manager::PromptManager;
+    use goose::prompt_template::get_template;
 
     #[test]
     fn renders_maple_identity_with_stock_structure() {
@@ -99,10 +101,33 @@ mod tests {
         }
     }
 
+    /// Everything after the two-line identity header.
+    fn template_body(template: &str) -> &str {
+        template
+            .splitn(3, '\n')
+            .nth(2)
+            .expect("template must have a two-line identity header plus a body")
+    }
+
     #[test]
-    fn template_keeps_stock_structure_and_maple_branding() {
-        // Branding: Maple identity only, no upstream identity leaks. The
-        // goose turn-context block (which mentions goose machinery) comes
+    fn body_matches_pinned_goose_system_prompt_byte_for_byte() {
+        // goose's get_template embeds the prompts directory at compile time,
+        // so default_content is the exact pinned upstream system.md and is
+        // unaffected by any on-disk user prompt override.
+        let stock = get_template("system.md")
+            .expect("the pinned goose crate ships system.md")
+            .default_content;
+        assert_eq!(
+            template_body(MAPLE_SYSTEM_PROMPT_TEMPLATE),
+            template_body(&stock),
+            "Maple's system prompt drifted from the pinned goose system.md; \
+             re-diff the template and re-apply only the two-line Maple header"
+        );
+    }
+
+    #[test]
+    fn template_has_maple_branding_without_upstream_identity() {
+        // The goose turn-context block (which mentions goose machinery) comes
         // from goose at render time and is intentionally out of scope here. The
         // stock template variable `moim_system_prompt_block` must stay intact,
         // so blank it out before scanning for the "Block" creator brand.
@@ -112,30 +137,6 @@ mod tests {
             assert!(
                 !template.contains(leak),
                 "template leaks upstream brand {leak:?}"
-            );
-        }
-
-        // Structure: every dynamic block of the pinned stock
-        // crates/goose/src/prompts/system.md must survive in byte-exact form.
-        for marker in [
-            "{% if moim_system_prompt_block is defined %}",
-            "{{ moim_system_prompt_block }}",
-            "{% if include_extensions and not code_execution_mode %}",
-            "# Extensions",
-            "{% for extension in extensions %}",
-            "## {{extension.name}}",
-            "{% if extension.has_resources %}",
-            "{{extension.instructions}}{% endif %}",
-            "No extensions are defined. You should let the user know that they should add extensions.",
-            "{% if include_extensions and extension_tool_limits is defined and not code_execution_mode %}",
-            "{% with (extension_count, tool_count) = extension_tool_limits  %}",
-            "# Suggestion",
-            "# Response Guidelines",
-            "Use Markdown formatting for all responses.",
-        ] {
-            assert!(
-                MAPLE_SYSTEM_PROMPT_TEMPLATE.contains(marker),
-                "template drifted from the pinned stock goose system.md: missing {marker:?}"
             );
         }
     }


### PR DESCRIPTION
## Why

Maple embeds goose for Agent Mode but never overrides its system prompt, so the agent still self-identified as **"goose, created by AAIF (Agentic AI Foundation)"** — the agent would even call itself "goose" when a user asked who it was, despite users only ever knowing Maple's Agent Mode.

## What changes

- **New `frontend/src-tauri/src/agent/system_prompt.rs`** with `MAPLE_SYSTEM_PROMPT_TEMPLATE`: a line-for-line copy of the pinned goose `crates/goose/src/prompts/system.md` where only the two-line identity header is rebranded:
  > You are a general-purpose AI agent called Maple, created by Maple AI.
  > You run in the Maple app's Agent Mode; users know you simply as Maple.

  Every dynamic goose section (turn context, extensions, tool-count suggestion, response guidelines) is preserved byte-for-byte, so rendering, extension projection, and prompt-cache stability stay identical to upstream.
- **`agent.rs`**: apply the override via goose's `Agent::override_system_prompt` inside `get_or_create_session_agent` when `agent_created`, next to the existing Maple provider-restore block. Cached agents keep the override for their whole lifetime. There is intentionally no config/env path, matching the rest of Maple's caller-owned agent setup.

## Tests

- `renders_maple_identity_with_stock_structure` — renders the template through goose's real `PromptManager` and asserts the Maple header plus all stock sections survive rendering.
- `template_keeps_stock_structure_and_maple_branding` — asserts the template never mentions goose/AAIF/Block and keeps every stock dynamic block byte-exact. **When bumping the goose pin in `Cargo.toml`, diff the template against the pinned `system.md`; only the first two lines may differ** — this test is the drift guard for that contract.

Verified in the pinned Nix shell: `cargo fmt` / `just rust-lint` (clippy `-D warnings`) and `cargo test --all-targets` — 289 tests pass (an unrelated `macos_login_path` process-timeout test is flaky under parallel load and passes on re-run).

## Known follow-ups (not fixed here)

1. **Turn-context block**: goose renders its own `# Turn Context` section at runtime (`agents/moim.rs`), whose text still says "generated by goose". That string lives outside the prompt template and has no override hook; fixing it needs an upstream goose change.
2. **Subagent / tiny-model prompts**: goose's `subagent_system.md` ("spawned by the main goose agent") and `tiny_model_system.md` still name goose. They're internal-facing (subagent runs, small-model calls) and likewise have no Maple override API.
3. **Pre-existing clippy warning**: `await_holding_lock` in `agent.rs` permission registration surfaces with `cargo clippy --all-targets`; untouched by this change.
