### PR TITLE
Make Chat and Agent sidebars resizable

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -155,7 +155,7 @@ import {
   resolveAgentModelContextLimit,
   resolveAgentModelVisionCapability
 } from "@/services/agentModels";
-import { SIDEBAR_GRID_COLUMNS_CLASS, getSidebarLayoutStyle } from "@/constants/layout";
+import { ResizableSidebarLayout } from "@/components/ResizableSidebarLayout";
 import {
   cn,
   POWERFUL_MODEL_ALIAS,
@@ -379,6 +379,7 @@ export function AgentMode({ userId }: { userId: string }) {
   const isCompactLayout = isMobile || isLandscapeMobile;
   const isTouchLayout = isCompactLayout || isCoarsePointer;
   const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
+  const [isSidebarTransitioning, setIsSidebarTransitioning] = useState(false);
   const [sidebarPreferences, setSidebarPreferences] = useState<AgentSidebarPreferences>(() =>
     loadAgentSidebarPreferences(userId)
   );
@@ -2273,7 +2274,6 @@ export function AgentMode({ userId }: { userId: string }) {
     [isCompactLayout, sendMessage]
   );
 
-  const sidebarLayoutStyle = getSidebarLayoutStyle({ offsetContent: isSidebarOpen });
   const removeSessionFromState = useCallback(
     (sessionId: string) => {
       deletedSessionIdsRef.current.add(sessionId);
@@ -2703,52 +2703,54 @@ export function AgentMode({ userId }: { userId: string }) {
   }
 
   return (
-    <div
-      style={sidebarLayoutStyle}
-      className={cn(
-        "grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden bg-background",
-        isSidebarOpen ? SIDEBAR_GRID_COLUMNS_CLASS : ""
-      )}
+    <ResizableSidebarLayout
+      isCompactLayout={isCompactLayout}
+      isOpen={isSidebarOpen}
+      mode="agent"
+      onOpenChange={setIsSidebarOpen}
+      onTransitionChange={setIsSidebarTransitioning}
+      userId={userId}
+      sidebar={
+        <Sidebar
+          isOpen={isSidebarOpen}
+          mode="agent"
+          navigationContent={
+            <MemoizedAgentSidebarContent
+              activeSessionId={
+                pendingSessionSelectionId && pendingSessionSelectionId !== NEW_SESSION_PENDING_KEY
+                  ? pendingSessionSelectionId
+                  : activeSessionId
+              }
+              collapsedProjectRoots={sidebarPreferences.collapsedProjectRoots}
+              isTouchLayout={isTouchLayout}
+              projectRoot={projectRoot}
+              recentRoots={displayProjectRoots}
+              completedUnreadSessionIds={completedUnreadSessionIds}
+              disabled={areAgentSettingsLocked}
+              inProgressSessionIds={agentRunningSessionIds}
+              runningSessionIds={runningSessionIds}
+              sessions={visibleSessions}
+              onChooseProjectRoot={chooseProjectRoot}
+              onCreateSession={handleCreateSessionForProject}
+              onProjectDisclosureToggle={handleToggleProjectDisclosure}
+              onProjectOrderChange={saveProjectRootOrder}
+              onProjectRename={handlePromptProjectRename}
+              onProjectRemove={handlePromptProjectRemoval}
+              onRevealProjectRoot={handleRevealProjectRoot}
+              onSessionDelete={setSessionToDelete}
+              onSessionSelect={handleSelectSession}
+            />
+          }
+          isNewItemTemporarilyDisabled={isTaskTransitionPending}
+          onNewItem={
+            areAgentSettingsLockedOutsideTaskTransition || !projectRoot
+              ? undefined
+              : handleCreateSession
+          }
+          onToggle={toggleSidebar}
+        />
+      }
     >
-      <Sidebar
-        isOpen={isSidebarOpen}
-        mode="agent"
-        navigationContent={
-          <MemoizedAgentSidebarContent
-            activeSessionId={
-              pendingSessionSelectionId && pendingSessionSelectionId !== NEW_SESSION_PENDING_KEY
-                ? pendingSessionSelectionId
-                : activeSessionId
-            }
-            collapsedProjectRoots={sidebarPreferences.collapsedProjectRoots}
-            isTouchLayout={isTouchLayout}
-            projectRoot={projectRoot}
-            recentRoots={displayProjectRoots}
-            completedUnreadSessionIds={completedUnreadSessionIds}
-            disabled={areAgentSettingsLocked}
-            inProgressSessionIds={agentRunningSessionIds}
-            runningSessionIds={runningSessionIds}
-            sessions={visibleSessions}
-            onChooseProjectRoot={chooseProjectRoot}
-            onCreateSession={handleCreateSessionForProject}
-            onProjectDisclosureToggle={handleToggleProjectDisclosure}
-            onProjectOrderChange={saveProjectRootOrder}
-            onProjectRename={handlePromptProjectRename}
-            onProjectRemove={handlePromptProjectRemoval}
-            onRevealProjectRoot={handleRevealProjectRoot}
-            onSessionDelete={setSessionToDelete}
-            onSessionSelect={handleSelectSession}
-          />
-        }
-        isNewItemTemporarilyDisabled={isTaskTransitionPending}
-        onNewItem={
-          areAgentSettingsLockedOutsideTaskTransition || !projectRoot
-            ? undefined
-            : handleCreateSession
-        }
-        onToggle={toggleSidebar}
-      />
-
       {projectToRename ? (
         <RenameAgentProjectDialog
           key={projectToRename.path}
@@ -2874,7 +2876,7 @@ export function AgentMode({ userId }: { userId: string }) {
       </AlertDialog>
 
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
-        {!isSidebarOpen && (
+        {!isSidebarOpen && !isSidebarTransitioning && (
           <div className="fixed left-4 top-[9.5px] z-20 flex items-center gap-1.5">
             <SidebarToggle onToggle={toggleSidebar} agentStatus={agentSidebarStatus} />
             <MapleWordmark
@@ -2997,7 +2999,7 @@ export function AgentMode({ userId }: { userId: string }) {
           ) : null}
         </section>
       </div>
-    </div>
+    </ResizableSidebarLayout>
   );
 }
 

--- a/frontend/src/components/AuthenticatedHomeContent.tsx
+++ b/frontend/src/components/AuthenticatedHomeContent.tsx
@@ -11,7 +11,10 @@ import { useLocation, useRouter } from "@tanstack/react-router";
 import { useOpenSecret } from "@opensecret/react";
 import { ProjectDetailView } from "@/components/ProjectDetailView";
 import { UnifiedChat } from "@/components/UnifiedChat";
-import { PersistentHomeNavigationContext } from "@/contexts/PersistentHomeNavigationContext";
+import {
+  PersistentHomeNavigationContext,
+  useAccountSidebarOpenState
+} from "@/contexts/PersistentHomeNavigationContext";
 import { AgentSessionSelectionMemory } from "@/services/agentSessionSelection";
 
 const TRANSIENT_HOME_SEARCH_PARAMS = ["team_setup", "credits_success", "api_settings"];
@@ -56,7 +59,7 @@ export function PersistentHomeNavigationProvider({ children }: { children: React
   const homeHrefRef = useRef(initialHomeHref);
   const homeHrefUserIdRef = useRef(userId);
   const skipNextHomeCaptureRef = useRef(false);
-  const [sidebarOpen, setSidebarOpen] = useState<boolean | null>(null);
+  const [sidebarOpen, setSidebarOpen] = useAccountSidebarOpenState(userId);
   const [agentSessionSelection] = useState(() => new AgentSessionSelectionMemory());
 
   const captureHomeHref = useCallback(() => {
@@ -124,7 +127,7 @@ export function PersistentHomeNavigationProvider({ children }: { children: React
       setSidebarOpen,
       agentSessionSelection
     }),
-    [agentSessionSelection, returnToHome, sidebarOpen]
+    [agentSessionSelection, returnToHome, setSidebarOpen, sidebarOpen]
   );
 
   return (

--- a/frontend/src/components/ProjectDetailView.tsx
+++ b/frontend/src/components/ProjectDetailView.tsx
@@ -15,6 +15,7 @@ import {
 import { useOpenSecret, type Conversation } from "@opensecret/react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
+import { ResizableSidebarLayout } from "@/components/ResizableSidebarLayout";
 import { useIsMobile, useIsLandscapeMobile } from "@/utils/utils";
 import { useSelectedProjectState } from "@/state/useLocalState";
 import { Button } from "@/components/ui/button";
@@ -46,7 +47,6 @@ import { DeleteChatDialog } from "@/components/DeleteChatDialog";
 import { BulkDeleteDialog } from "@/components/BulkDeleteDialog";
 import { MoveChatsDialog } from "@/components/MoveChatsDialog";
 import { listAllConversationProjects } from "@/utils/paginatedLists";
-import { SIDEBAR_GRID_COLUMNS_CLASS, SIDEBAR_LAYOUT_STYLE } from "@/constants/layout";
 import { usePersistentSidebarState } from "@/contexts/PersistentHomeNavigationContext";
 import { useChatRuntimeStore } from "@/contexts/ChatRuntimeContext";
 import {
@@ -164,6 +164,7 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
   const runtimeStore = useChatRuntimeStore<Conversation, unknown>();
 
   const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
+  const [isSidebarTransitioning, setIsSidebarTransitioning] = useState(false);
   const wasLandscapeMobileRef = useRef(isLandscapeMobile);
 
   useEffect(() => {
@@ -513,31 +514,39 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
 
   if (isProjectPending && !project) {
     return (
-      <div
-        style={SIDEBAR_LAYOUT_STYLE}
-        className={`grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden ${
-          isSidebarOpen ? SIDEBAR_GRID_COLUMNS_CLASS : ""
-        }`}
+      <ResizableSidebarLayout
+        isCompactLayout={isCompactLayout}
+        isOpen={isSidebarOpen}
+        mode="chat"
+        onOpenChange={setIsSidebarOpen}
+        onTransitionChange={setIsSidebarTransitioning}
+        sidebar={<Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />}
+        userId={userId}
       >
-        <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />
-        <div className="flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background">
+        <div className="relative flex min-h-0 min-w-0 flex-1 items-center justify-center bg-background">
+          {!isSidebarOpen && !isSidebarTransitioning ? (
+            <div className="fixed left-4 top-[9.5px] z-20">
+              <SidebarToggle onToggle={toggleSidebar} />
+            </div>
+          ) : null}
           <p className="text-sm text-muted-foreground">Loading project...</p>
         </div>
-      </div>
+      </ResizableSidebarLayout>
     );
   }
 
   return (
-    <div
-      style={SIDEBAR_LAYOUT_STYLE}
-      className={`grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden ${
-        isSidebarOpen ? SIDEBAR_GRID_COLUMNS_CLASS : ""
-      }`}
+    <ResizableSidebarLayout
+      isCompactLayout={isCompactLayout}
+      isOpen={isSidebarOpen}
+      mode="chat"
+      onOpenChange={setIsSidebarOpen}
+      onTransitionChange={setIsSidebarTransitioning}
+      sidebar={<Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />}
+      userId={userId}
     >
-      <Sidebar isOpen={isSidebarOpen} onToggle={toggleSidebar} />
-
       <div className="relative flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden bg-background">
-        {!isSidebarOpen ? (
+        {!isSidebarOpen && !isSidebarTransitioning ? (
           <div className="fixed left-4 top-[9.5px] z-20">
             <SidebarToggle onToggle={toggleSidebar} />
           </div>
@@ -911,6 +920,6 @@ export function ProjectDetailView({ projectId }: ProjectDetailViewProps) {
         onConfirm={handleMoveSelectedConversations}
         isMoving={isBulkMoving}
       />
-    </div>
+    </ResizableSidebarLayout>
   );
 }

--- a/frontend/src/components/ResizableSidebarLayout.test.tsx
+++ b/frontend/src/components/ResizableSidebarLayout.test.tsx
@@ -1,0 +1,315 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { useState } from "react";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+
+import { ResizableSidebarLayout } from "./ResizableSidebarLayout";
+
+class FakeWindow extends EventTarget {
+  innerWidth = 1_000;
+  prefersReducedMotion = false;
+  readonly storage = new Map<string, string>();
+  readonly timers = new Map<number, TimerHandler>();
+  private nextTimerId = 1;
+
+  readonly localStorage = {
+    getItem: (key: string) => this.storage.get(key) ?? null,
+    setItem: (key: string, value: string) => this.storage.set(key, value)
+  };
+
+  clearTimeout = (timerId: number) => {
+    this.timers.delete(timerId);
+  };
+
+  setTimeout = (handler: TimerHandler) => {
+    const timerId = this.nextTimerId++;
+    this.timers.set(timerId, handler);
+    return timerId;
+  };
+
+  matchMedia = () =>
+    ({
+      addEventListener: () => {},
+      matches: this.prefersReducedMotion,
+      removeEventListener: () => {}
+    }) as unknown as MediaQueryList;
+
+  runTimer(timerId: number) {
+    const handler = this.timers.get(timerId);
+    this.timers.delete(timerId);
+    if (typeof handler === "function") handler();
+  }
+}
+
+class PointerCaptureTarget {
+  readonly captured = new Set<number>();
+  readonly releases: number[] = [];
+
+  hasPointerCapture(pointerId: number): boolean {
+    return this.captured.has(pointerId);
+  }
+
+  releasePointerCapture(pointerId: number): void {
+    this.releases.push(pointerId);
+    this.captured.delete(pointerId);
+  }
+
+  setPointerCapture(pointerId: number): void {
+    this.captured.add(pointerId);
+  }
+}
+
+const originalGlobals = {
+  document: Object.getOwnPropertyDescriptor(globalThis, "document"),
+  window: Object.getOwnPropertyDescriptor(globalThis, "window")
+};
+
+function setGlobal(name: "document" | "window", value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    value,
+    writable: true
+  });
+}
+
+function restoreGlobal(name: "document" | "window", descriptor: PropertyDescriptor | undefined) {
+  if (descriptor) Object.defineProperty(globalThis, name, descriptor);
+  else Reflect.deleteProperty(globalThis, name);
+}
+
+function pointerEvent(target: PointerCaptureTarget, pointerId: number, clientX: number) {
+  return {
+    button: 0,
+    clientX,
+    currentTarget: target,
+    isPrimary: true,
+    pointerId,
+    preventDefault: mock(() => {})
+  };
+}
+
+function FakeSidebar({ isOpen, onToggle }: { isOpen: boolean; onToggle: () => void }) {
+  return <button data-sidebar-open={isOpen} onClick={onToggle} />;
+}
+
+function Harness({
+  isCompactLayout = false,
+  mode = "chat",
+  userId
+}: {
+  isCompactLayout?: boolean;
+  mode?: "agent" | "chat";
+  userId?: string;
+}) {
+  const [isOpen, setIsOpen] = useState(true);
+  return (
+    <ResizableSidebarLayout
+      data-testid="layout"
+      isCompactLayout={isCompactLayout}
+      isOpen={isOpen}
+      mode={mode}
+      onOpenChange={setIsOpen}
+      sidebar={<FakeSidebar isOpen={isOpen} onToggle={() => setIsOpen((open) => !open)} />}
+      userId={userId}
+    >
+      <main data-open={isOpen} />
+    </ResizableSidebarLayout>
+  );
+}
+
+describe("resizable sidebar layout", () => {
+  let renderer: ReactTestRenderer | null = null;
+  let fakeWindow: FakeWindow;
+
+  const layout = (): ReactTestInstance => {
+    if (!renderer) throw new Error("layout did not mount");
+    const root = renderer.root
+      .findAllByProps({ "data-testid": "layout" })
+      .find((node) => node.type === "div");
+    if (!root) throw new Error("layout root did not mount");
+    return root;
+  };
+
+  const resizeHandle = (): ReactTestInstance => renderer!.root.findByProps({ role: "separator" });
+  const main = (): ReactTestInstance => renderer!.root.findByType("main");
+  const sidebarButton = (): ReactTestInstance => renderer!.root.findByType("button");
+  const keyEvent = (key: string, shiftKey = false) => ({
+    key,
+    preventDefault: mock(() => {}),
+    shiftKey
+  });
+
+  beforeEach(() => {
+    fakeWindow = new FakeWindow();
+    setGlobal("window", fakeWindow);
+    setGlobal("document", { body: { style: { cursor: "", userSelect: "" } } });
+  });
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+    restoreGlobal("document", originalGlobals.document);
+    restoreGlobal("window", originalGlobals.window);
+  });
+
+  test("exposes an accessible separator and supports keyboard resizing", () => {
+    act(() => {
+      renderer = create(<Harness />);
+    });
+
+    expect(resizeHandle().props).toMatchObject({
+      "aria-label": "Resize Chat sidebar",
+      "aria-orientation": "vertical",
+      "aria-valuemax": 400,
+      "aria-valuemin": 240,
+      "aria-valuenow": 296,
+      tabIndex: 0
+    });
+
+    act(() => resizeHandle().props.onKeyDown(keyEvent("ArrowLeft")));
+    expect(layout().props.style["--sidebar-width"]).toBe("288px");
+    act(() => resizeHandle().props.onKeyDown(keyEvent("ArrowRight", true)));
+    expect(layout().props.style["--sidebar-width"]).toBe("320px");
+    act(() => resizeHandle().props.onKeyDown(keyEvent("Home")));
+    expect(layout().props.style["--sidebar-width"]).toBe("240px");
+    act(() => resizeHandle().props.onKeyDown(keyEvent("End")));
+    expect(layout().props.style["--sidebar-width"]).toBe("400px");
+    act(() => resizeHandle().props.onDoubleClick());
+    expect(layout().props.style["--sidebar-width"]).toBe("296px");
+    act(() => resizeHandle().props.onKeyDown(keyEvent("Enter")));
+    expect(main().props["data-open"]).toBe(false);
+  });
+
+  test("keeps the panel, divider, and grid edge together through live collapse and reversal", () => {
+    act(() => {
+      renderer = create(<Harness />);
+    });
+    const target = new PointerCaptureTarget();
+
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 1, 296)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 1, 200)));
+    expect(layout().props.style["--sidebar-width"]).toBe("240px");
+    expect(layout().props.style["--sidebar-grid-template"]).toBe("240px minmax(0, 1fr)");
+    expect(layout().props.className).not.toContain("transition-[grid-template-columns]");
+
+    act(() => resizeHandle().props.onPointerUp(pointerEvent(target, 1, 296)));
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 2, 296)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 2, 120)));
+    expect(main().props["data-open"]).toBe(false);
+    expect(target.captured.has(2)).toBe(true);
+    expect(layout().props.style["--sidebar-width"]).toBe("296px");
+    expect(layout().props.style["--sidebar-grid-template"]).toBe("0px minmax(0, 1fr)");
+
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 2, 121)));
+    expect(main().props["data-open"]).toBe(true);
+    expect(target.captured.has(2)).toBe(true);
+    expect(layout().props.style["--sidebar-width"]).toBe("296px");
+    expect(layout().props.style["--sidebar-grid-template"]).toBe("240px minmax(0, 1fr)");
+
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 2, 280)));
+    expect(layout().props.style["--sidebar-width"]).toBe("296px");
+    expect(layout().props.style["--sidebar-grid-template"]).toBe("280px minmax(0, 1fr)");
+    expect(layout().props.className).toContain("transition-[grid-template-columns]");
+  });
+
+  test("uses the final release coordinate in both directions", () => {
+    act(() => {
+      renderer = create(<Harness />);
+    });
+    const target = new PointerCaptureTarget();
+
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 3, 296)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 3, 120)));
+    act(() => resizeHandle().props.onPointerUp(pointerEvent(target, 3, 121)));
+    expect(main().props["data-open"]).toBe(true);
+    expect(layout().props.style["--sidebar-width"]).toBe("296px");
+    expect(layout().props.style["--sidebar-grid-template"]).toBe("240px minmax(0, 1fr)");
+    expect(target.releases).toEqual([3]);
+
+    const timer = [...fakeWindow.timers.keys()][0];
+    act(() => fakeWindow.runTimer(timer));
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 4, 240)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 4, 121)));
+    act(() => resizeHandle().props.onPointerUp(pointerEvent(target, 4, 120)));
+    expect(main().props["data-open"]).toBe(false);
+    expect(target.releases).toEqual([3, 4]);
+  });
+
+  test("restores the open state after cancellation and window blur", () => {
+    act(() => {
+      renderer = create(<Harness />);
+    });
+    const target = new PointerCaptureTarget();
+
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 5, 296)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 5, 120)));
+    act(() => resizeHandle().props.onPointerCancel(pointerEvent(target, 5, 120)));
+    expect(main().props["data-open"]).toBe(true);
+    expect(target.releases).toEqual([5]);
+
+    const transitionTimer = [...fakeWindow.timers.keys()][0];
+    act(() => fakeWindow.runTimer(transitionTimer));
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 6, 296)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 6, 120)));
+    act(() => {
+      fakeWindow.dispatchEvent(new Event("blur"));
+    });
+    expect(main().props["data-open"]).toBe(true);
+    expect(target.releases).toEqual([5, 6]);
+  });
+
+  test("finishes a collapse on its original animation timer", () => {
+    act(() => {
+      renderer = create(<Harness />);
+    });
+    const target = new PointerCaptureTarget();
+
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 7, 296)));
+    act(() => resizeHandle().props.onPointerMove(pointerEvent(target, 7, 120)));
+    const transitionTimer = [...fakeWindow.timers.keys()][0];
+    act(() => resizeHandle().props.onPointerUp(pointerEvent(target, 7, 120)));
+    expect([...fakeWindow.timers.keys()]).toEqual([transitionTimer]);
+
+    act(() => fakeWindow.runTimer(transitionTimer));
+    expect(layout().props.className).not.toContain("transition-[grid-template-columns]");
+    expect(sidebarButton().props["data-sidebar-open"]).toBe(false);
+  });
+
+  test("skips retained transitions when motion is reduced", () => {
+    fakeWindow.prefersReducedMotion = true;
+    act(() => {
+      renderer = create(<Harness />);
+    });
+
+    act(() => sidebarButton().props.onClick());
+    expect(layout().props.style["--sidebar-grid-template"]).toBe("0px minmax(0, 1fr)");
+    expect(layout().props.className).not.toContain("transition-[grid-template-columns]");
+    expect(sidebarButton().props["data-sidebar-open"]).toBe(false);
+  });
+
+  test("does not render desktop resize controls in compact layouts", () => {
+    act(() => {
+      renderer = create(<Harness isCompactLayout />);
+    });
+
+    expect(renderer!.root.findAllByProps({ role: "separator" })).toHaveLength(0);
+    expect(layout().props.className).not.toContain("grid-cols-[var(--sidebar-grid-template)]");
+  });
+
+  test("shares the persisted width between Agent and Chat", () => {
+    act(() => {
+      renderer = create(<Harness mode="chat" userId="account/a" />);
+    });
+    const target = new PointerCaptureTarget();
+
+    act(() => resizeHandle().props.onPointerDown(pointerEvent(target, 8, 296)));
+    act(() => resizeHandle().props.onPointerUp(pointerEvent(target, 8, 360)));
+    expect(layout().props.style["--sidebar-width"]).toBe("360px");
+
+    act(() => renderer?.unmount());
+    renderer = null;
+    act(() => {
+      renderer = create(<Harness mode="agent" userId="account/a" />);
+    });
+    expect(layout().props.style["--sidebar-width"]).toBe("360px");
+  });
+});

--- a/frontend/src/components/ResizableSidebarLayout.tsx
+++ b/frontend/src/components/ResizableSidebarLayout.tsx
@@ -1,0 +1,508 @@
+import {
+  cloneElement,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type HTMLAttributes,
+  type KeyboardEvent,
+  type PointerEvent,
+  type ReactElement,
+  type ReactNode
+} from "react";
+
+import { Sidebar } from "@/components/Sidebar";
+import { SIDEBAR_GRID_COLUMNS_CLASS } from "@/constants/layout";
+import {
+  RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX,
+  RESIZABLE_SIDEBAR_KEYBOARD_LARGE_STEP_PX,
+  RESIZABLE_SIDEBAR_KEYBOARD_STEP_PX,
+  RESIZABLE_SIDEBAR_MIN_WIDTH_PX,
+  clampSidebarWidth,
+  loadSidebarWidth,
+  saveSidebarWidth,
+  sidebarDragUpdate,
+  sidebarMaximumWidth
+} from "@/services/sidebarWidth";
+import type { WorkspaceMode } from "@/services/workspaceModePreference";
+import { cn } from "@/utils/utils";
+
+const COLLAPSE_TRANSITION_MS = 150;
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+type SidebarDragPresentation = {
+  active: boolean;
+  collapsed: boolean;
+  panelWidthPx: number | null;
+  transition: boolean;
+};
+
+type ResizableSidebarLayoutProps = Omit<HTMLAttributes<HTMLDivElement>, "children"> & {
+  children: ReactNode;
+  isCompactLayout: boolean;
+  isOpen: boolean;
+  mode: WorkspaceMode;
+  onOpenChange: (isOpen: boolean) => void;
+  onTransitionChange?: (isTransitioning: boolean) => void;
+  sidebar: ReactElement<React.ComponentProps<typeof Sidebar>>;
+  userId?: string | null;
+};
+
+type DragSession = {
+  bodyCursor: string;
+  bodyUserSelect: string;
+  collapsed: boolean;
+  hasToggledCollapse: boolean;
+  panelWidthPx: number;
+  pointerId: number;
+  startPointerX: number;
+  startWidthPx: number;
+  target: HTMLDivElement;
+  transitionUntil: number;
+  widthPx: number;
+};
+
+type SidebarResizeHandleProps = {
+  active: boolean;
+  disabled: boolean;
+  isOpen: boolean;
+  isVisuallyCollapsed: boolean;
+  layoutWidthPx: number;
+  maximumWidthPx: number;
+  mode: WorkspaceMode;
+  onCommit: (widthPx: number) => void;
+  onDragPresentationChange: (presentation: SidebarDragPresentation) => void;
+  onOpenChange: (isOpen: boolean) => void;
+  onWidthChange: (widthPx: number | null) => void;
+  prefersReducedMotion: boolean;
+  transition: boolean;
+  widthPx: number;
+};
+
+function viewportMaximumWidth(): number {
+  return sidebarMaximumWidth(typeof window === "undefined" ? 0 : window.innerWidth);
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [matches, setMatches] = useState(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia(REDUCED_MOTION_QUERY).matches
+  );
+
+  useEffect(() => {
+    if (typeof window.matchMedia !== "function") return;
+    const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+    const handleChange = (event: MediaQueryListEvent) => setMatches(event.matches);
+    if ("addEventListener" in mediaQuery) {
+      mediaQuery.addEventListener("change", handleChange);
+      return () => mediaQuery.removeEventListener("change", handleChange);
+    }
+    (mediaQuery as MediaQueryList).addListener(handleChange);
+    return () => (mediaQuery as MediaQueryList).removeListener(handleChange);
+  }, []);
+
+  return matches;
+}
+
+export function ResizableSidebarLayout({
+  children,
+  className,
+  isCompactLayout,
+  isOpen,
+  mode,
+  onOpenChange,
+  onTransitionChange,
+  sidebar,
+  style,
+  userId,
+  ...rootProps
+}: ResizableSidebarLayoutProps) {
+  const [preferredWidthPx, setPreferredWidthPx] = useState(() =>
+    userId ? loadSidebarWidth(userId) : RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX
+  );
+  const [transientWidthPx, setTransientWidthPx] = useState<number | null>(null);
+  const [maximumWidthPx, setMaximumWidthPx] = useState(viewportMaximumWidth);
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const [dragPresentation, setDragPresentation] = useState<SidebarDragPresentation>(() => ({
+    active: false,
+    collapsed: !isOpen,
+    panelWidthPx: null,
+    transition: false
+  }));
+  const previousIsOpenRef = useRef(isOpen);
+
+  useEffect(() => {
+    setPreferredWidthPx(userId ? loadSidebarWidth(userId) : RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX);
+    setTransientWidthPx(null);
+  }, [userId]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const updateMaximumWidth = () => setMaximumWidthPx(viewportMaximumWidth());
+    window.addEventListener("resize", updateMaximumWidth);
+    return () => window.removeEventListener("resize", updateMaximumWidth);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (isCompactLayout) {
+      previousIsOpenRef.current = isOpen;
+      setDragPresentation({
+        active: false,
+        collapsed: !isOpen,
+        panelWidthPx: null,
+        transition: false
+      });
+      return;
+    }
+    if (previousIsOpenRef.current === isOpen) return;
+    previousIsOpenRef.current = isOpen;
+    setDragPresentation((current) =>
+      current.active || (current.collapsed === !isOpen && current.transition)
+        ? current
+        : {
+            active: false,
+            collapsed: !isOpen,
+            panelWidthPx: null,
+            transition: !prefersReducedMotion
+          }
+    );
+  }, [isCompactLayout, isOpen, prefersReducedMotion]);
+
+  useLayoutEffect(() => {
+    if (!prefersReducedMotion || !dragPresentation.transition) return;
+    setDragPresentation((current) => ({
+      ...current,
+      panelWidthPx: null,
+      transition: false
+    }));
+    if (!dragPresentation.active) setTransientWidthPx(null);
+  }, [dragPresentation.active, dragPresentation.transition, prefersReducedMotion]);
+
+  useLayoutEffect(() => {
+    onTransitionChange?.(
+      !isCompactLayout && (dragPresentation.active || dragPresentation.transition)
+    );
+  }, [dragPresentation.active, dragPresentation.transition, isCompactLayout, onTransitionChange]);
+
+  useEffect(() => {
+    if (!dragPresentation.transition) return;
+    const timeout = window.setTimeout(() => {
+      setDragPresentation((current) => ({
+        ...current,
+        panelWidthPx: null,
+        transition: false
+      }));
+    }, COLLAPSE_TRANSITION_MS);
+    return () => window.clearTimeout(timeout);
+  }, [dragPresentation.collapsed, dragPresentation.transition]);
+
+  const handleCommit = useCallback(
+    (widthPx: number) => {
+      const nextWidthPx = clampSidebarWidth(widthPx, maximumWidthPx);
+      setPreferredWidthPx(nextWidthPx);
+      setTransientWidthPx(null);
+      if (userId) saveSidebarWidth(userId, nextWidthPx);
+    },
+    [maximumWidthPx, userId]
+  );
+  const preferredEffectiveWidthPx = clampSidebarWidth(preferredWidthPx, maximumWidthPx);
+  const effectiveWidthPx = isCompactLayout
+    ? RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX
+    : transientWidthPx === null
+      ? preferredEffectiveWidthPx
+      : clampSidebarWidth(transientWidthPx, maximumWidthPx);
+  const panelWidthPx =
+    dragPresentation.panelWidthPx === null
+      ? effectiveWidthPx
+      : Math.max(effectiveWidthPx, dragPresentation.panelWidthPx);
+  const retainSidebarShell = dragPresentation.active || dragPresentation.transition;
+  const renderSidebarOpen = isOpen || retainSidebarShell;
+  const layoutWidthPx =
+    isCompactLayout || dragPresentation.collapsed || !renderSidebarOpen ? 0 : effectiveWidthPx;
+  const layoutStyle = {
+    "--sidebar-width": `${panelWidthPx}px`,
+    "--sidebar-grid-template": `${layoutWidthPx}px minmax(0, 1fr)`
+  } as CSSProperties;
+  const renderedSidebar = useMemo(
+    () => cloneElement(sidebar, { isOpen: renderSidebarOpen }),
+    [renderSidebarOpen, sidebar]
+  );
+
+  return (
+    <div
+      {...rootProps}
+      style={{ ...style, ...layoutStyle }}
+      className={cn(
+        "relative grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden bg-background",
+        !isCompactLayout && SIDEBAR_GRID_COLUMNS_CLASS,
+        dragPresentation.transition &&
+          "md:transition-[grid-template-columns] md:duration-150 md:ease-out motion-reduce:transition-none",
+        className
+      )}
+    >
+      <div className={isCompactLayout ? "contents" : "relative min-h-0 min-w-0 overflow-hidden"}>
+        {renderedSidebar}
+      </div>
+      <SidebarResizeHandle
+        active={dragPresentation.active}
+        disabled={isCompactLayout}
+        isOpen={isOpen}
+        isVisuallyCollapsed={dragPresentation.collapsed}
+        layoutWidthPx={layoutWidthPx}
+        maximumWidthPx={maximumWidthPx}
+        mode={mode}
+        onCommit={handleCommit}
+        onDragPresentationChange={setDragPresentation}
+        onOpenChange={onOpenChange}
+        onWidthChange={setTransientWidthPx}
+        prefersReducedMotion={prefersReducedMotion}
+        transition={dragPresentation.transition}
+        widthPx={effectiveWidthPx}
+      />
+      {children}
+    </div>
+  );
+}
+
+function SidebarResizeHandle({
+  active,
+  disabled,
+  isOpen,
+  isVisuallyCollapsed,
+  layoutWidthPx,
+  maximumWidthPx,
+  mode,
+  onCommit,
+  onDragPresentationChange,
+  onOpenChange,
+  onWidthChange,
+  prefersReducedMotion,
+  transition,
+  widthPx
+}: SidebarResizeHandleProps) {
+  const dragSessionRef = useRef<DragSession | null>(null);
+
+  const clearDragSession = useCallback((): DragSession | null => {
+    const session = dragSessionRef.current;
+    if (!session) return null;
+    dragSessionRef.current = null;
+    if (session.target.hasPointerCapture(session.pointerId)) {
+      session.target.releasePointerCapture(session.pointerId);
+    }
+    if (typeof document !== "undefined") {
+      document.body.style.cursor = session.bodyCursor;
+      document.body.style.userSelect = session.bodyUserSelect;
+    }
+    return session;
+  }, []);
+
+  const cancelDrag = useCallback(() => {
+    const session = clearDragSession();
+    if (!session) return;
+    if (session.collapsed) onOpenChange(true);
+    onWidthChange(null);
+    onDragPresentationChange({
+      active: false,
+      collapsed: false,
+      panelWidthPx: session.hasToggledCollapse
+        ? Math.max(session.startWidthPx, session.widthPx)
+        : null,
+      transition: session.hasToggledCollapse && !prefersReducedMotion
+    });
+  }, [
+    clearDragSession,
+    onDragPresentationChange,
+    onOpenChange,
+    onWidthChange,
+    prefersReducedMotion
+  ]);
+
+  useEffect(() => {
+    if (disabled) {
+      cancelDrag();
+      return;
+    }
+    if (typeof window === "undefined") return;
+    window.addEventListener("blur", cancelDrag);
+    return () => window.removeEventListener("blur", cancelDrag);
+  }, [cancelDrag, disabled]);
+
+  useEffect(
+    () => () => {
+      const session = clearDragSession();
+      if (session?.collapsed) onOpenChange(true);
+    },
+    [clearDragSession, onOpenChange]
+  );
+
+  if (disabled) return null;
+
+  const updateDrag = (session: DragSession, pointerX: number) => {
+    const previousWidthPx = session.widthPx;
+    const update = sidebarDragUpdate(
+      session.startWidthPx,
+      session.startPointerX,
+      pointerX,
+      maximumWidthPx
+    );
+    session.widthPx = update.widthPx;
+    const collapsedChanged = session.collapsed !== update.isCollapsed;
+    if (collapsedChanged) {
+      session.collapsed = update.isCollapsed;
+      session.hasToggledCollapse = true;
+      session.panelWidthPx = Math.max(session.panelWidthPx, previousWidthPx, update.widthPx);
+      session.transitionUntil = prefersReducedMotion ? 0 : Date.now() + COLLAPSE_TRANSITION_MS;
+      onOpenChange(!update.isCollapsed);
+    }
+    const transition = session.transitionUntil > Date.now();
+    if (!transition) session.panelWidthPx = update.widthPx;
+    onWidthChange(update.widthPx);
+    onDragPresentationChange({
+      active: true,
+      collapsed: update.isCollapsed,
+      panelWidthPx: transition ? Math.max(session.panelWidthPx, update.widthPx) : null,
+      transition
+    });
+    return { ...update, transition };
+  };
+
+  const handlePointerDown = (event: PointerEvent<HTMLDivElement>) => {
+    if (
+      !isOpen ||
+      transition ||
+      dragSessionRef.current ||
+      event.button !== 0 ||
+      event.isPrimary === false
+    )
+      return;
+    event.preventDefault();
+    try {
+      event.currentTarget.setPointerCapture(event.pointerId);
+    } catch {
+      return;
+    }
+    dragSessionRef.current = {
+      bodyCursor: typeof document === "undefined" ? "" : document.body.style.cursor,
+      bodyUserSelect: typeof document === "undefined" ? "" : document.body.style.userSelect,
+      collapsed: false,
+      hasToggledCollapse: false,
+      panelWidthPx: widthPx,
+      pointerId: event.pointerId,
+      startPointerX: event.clientX,
+      startWidthPx: widthPx,
+      target: event.currentTarget,
+      transitionUntil: 0,
+      widthPx
+    };
+    onDragPresentationChange({
+      active: true,
+      collapsed: false,
+      panelWidthPx: null,
+      transition: false
+    });
+    if (typeof document !== "undefined") {
+      document.body.style.cursor = "col-resize";
+      document.body.style.userSelect = "none";
+    }
+  };
+
+  const handlePointerMove = (event: PointerEvent<HTMLDivElement>) => {
+    const session = dragSessionRef.current;
+    if (!session || session.pointerId !== event.pointerId) return;
+    updateDrag(session, event.clientX);
+  };
+
+  const handlePointerUp = (event: PointerEvent<HTMLDivElement>) => {
+    const session = dragSessionRef.current;
+    if (!session || session.pointerId !== event.pointerId) return;
+    const update = updateDrag(session, event.clientX);
+    clearDragSession();
+    if (update.isCollapsed) {
+      onWidthChange(null);
+      onDragPresentationChange({
+        active: false,
+        collapsed: true,
+        panelWidthPx: update.transition ? session.panelWidthPx : null,
+        transition: update.transition
+      });
+      return;
+    }
+    onCommit(update.widthPx);
+    onDragPresentationChange({
+      active: false,
+      collapsed: false,
+      panelWidthPx: update.transition ? Math.max(session.panelWidthPx, update.widthPx) : null,
+      transition: update.transition
+    });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      if (dragSessionRef.current) return;
+      onOpenChange(!isOpen);
+      return;
+    }
+    if (event.key === "Escape" && dragSessionRef.current) {
+      event.preventDefault();
+      cancelDrag();
+      return;
+    }
+    if (!isOpen) return;
+
+    let nextWidthPx: number | null = null;
+    const stepPx = event.shiftKey
+      ? RESIZABLE_SIDEBAR_KEYBOARD_LARGE_STEP_PX
+      : RESIZABLE_SIDEBAR_KEYBOARD_STEP_PX;
+    if (event.key === "ArrowLeft") nextWidthPx = widthPx - stepPx;
+    if (event.key === "ArrowRight") nextWidthPx = widthPx + stepPx;
+    if (event.key === "Home") nextWidthPx = RESIZABLE_SIDEBAR_MIN_WIDTH_PX;
+    if (event.key === "End") nextWidthPx = maximumWidthPx;
+    if (nextWidthPx === null) return;
+
+    event.preventDefault();
+    onCommit(clampSidebarWidth(nextWidthPx, maximumWidthPx));
+  };
+
+  const sidebarName = mode === "agent" ? "Agent sidebar" : "Chat sidebar";
+
+  return (
+    <div
+      role="separator"
+      aria-label={`Resize ${sidebarName}`}
+      aria-orientation="vertical"
+      aria-valuemax={maximumWidthPx}
+      aria-valuemin={RESIZABLE_SIDEBAR_MIN_WIDTH_PX}
+      aria-valuenow={widthPx}
+      aria-valuetext={
+        isVisuallyCollapsed
+          ? `Collapsed ${sidebarName}; drag right to reopen`
+          : isOpen
+            ? `${widthPx} pixels`
+            : `Collapsed; last width ${widthPx} pixels`
+      }
+      tabIndex={0}
+      className={cn(
+        "absolute inset-y-0 z-30 w-2 -translate-x-1 touch-none outline-none after:absolute after:inset-y-0 after:left-1/2 after:w-px after:-translate-x-1/2 after:bg-border/40 after:transition-colors hover:after:bg-border focus-visible:after:w-0.5 focus-visible:after:bg-ring motion-reduce:after:transition-none",
+        isOpen || active ? "cursor-col-resize" : "pointer-events-none",
+        transition &&
+          "transition-[left] duration-150 ease-out motion-reduce:transition-none after:w-0.5 after:bg-[hsl(var(--maple-primary))]"
+      )}
+      style={{ left: isOpen || active || transition ? layoutWidthPx : 4 }}
+      onDoubleClick={() => {
+        if (isOpen) onCommit(RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX);
+      }}
+      onKeyDown={handleKeyDown}
+      onLostPointerCapture={cancelDrag}
+      onPointerCancel={cancelDrag}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerUp}
+    />
+  );
+}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import {
   Search,
   SquarePenIcon,
-  ArrowLeftFromLine,
+  PanelLeft,
   Loader2,
   Menu,
   XCircle,
@@ -32,11 +32,7 @@ import {
   useSelectedProjectState,
   useSidebarSearchState
 } from "@/state/useLocalState";
-import {
-  SIDEBAR_LAYOUT_STYLE,
-  SIDEBAR_MAX_WIDTH_CLASS,
-  SIDEBAR_WIDTH_CLASS
-} from "@/constants/layout";
+import { SIDEBAR_MAX_WIDTH_CLASS, SIDEBAR_WIDTH_CLASS } from "@/constants/layout";
 import { isTauriDesktop } from "@/utils/platform";
 import { useOpenSecret } from "@opensecret/react";
 import { FEATURE_FLAGS, flagsClient, isForcedOn } from "@/services/flags";
@@ -336,7 +332,6 @@ export function Sidebar({
   return (
     <div
       ref={sidebarRef}
-      style={SIDEBAR_LAYOUT_STYLE}
       className={cn([
         "fixed md:static landscape-short:fixed z-10 h-full overflow-x-hidden overflow-y-hidden",
         isOpen ? `block ${SIDEBAR_WIDTH_CLASS}` : "hidden"
@@ -359,9 +354,9 @@ export function Sidebar({
               type="button"
               className="flex h-9 w-9 shrink-0 items-center justify-center text-foreground transition-colors hover:text-foreground/70"
               onClick={onToggle}
-              aria-label="Close sidebar"
+              aria-label={isAgentMode ? "Collapse Agent sidebar" : "Close sidebar"}
             >
-              <ArrowLeftFromLine className="h-4 w-4" />
+              <PanelLeft className="h-4 w-4" />
             </button>
           </div>
           {(showAgentMode || isAgentMode) && (

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -34,6 +34,7 @@ import { v4 as uuidv4 } from "uuid";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { Sidebar, SidebarToggle } from "@/components/Sidebar";
+import { ResizableSidebarLayout } from "@/components/ResizableSidebarLayout";
 import { MapleWordmark } from "@/components/MapleWordmark";
 import { useIsMobile, useIsLandscapeMobile } from "@/utils/utils";
 import { fileToDataURL } from "@/utils/file";
@@ -97,11 +98,6 @@ import {
   projectedUserTurnScrollTop,
   type ChatProjectionScrollLease
 } from "@/components/chatProjectionScroll";
-import {
-  getSidebarLayoutStyle,
-  SIDEBAR_AWARE_FIXED_CENTER_CLASS,
-  SIDEBAR_GRID_COLUMNS_CLASS
-} from "@/constants/layout";
 import type {
   InputTextContent,
   OutputTextContent,
@@ -183,7 +179,7 @@ import {
   unregisterChatOptimisticMessage
 } from "@/services/chatOptimisticMessageOwnership";
 
-const CHAT_ALERT_CLASS = `fixed top-16 left-1/2 -translate-x-1/2 z-50 w-full max-w-2xl px-4 ${SIDEBAR_AWARE_FIXED_CENTER_CLASS}`;
+const CHAT_ALERT_CLASS = "absolute top-16 left-1/2 z-50 w-full max-w-2xl -translate-x-1/2 px-4";
 const STREAM_EVENT_DEBUG_STORAGE_KEY = "maple:sse-debug";
 
 function isStreamEventDebugLoggingEnabled(): boolean {
@@ -1715,6 +1711,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const draftProjectId = activeRuntime.composer.draftProjectId;
   const isGenerating = activeRuntime.isGenerating;
   const [isSidebarOpen, setIsSidebarOpen] = usePersistentSidebarState(isCompactLayout);
+  const [isSidebarTransitioning, setIsSidebarTransitioning] = useState(false);
   const error = activeRuntime.error;
   const [titleJustUpdatedKey, setTitleJustUpdatedKey] = useState<ChatRuntimeKey | null>(null);
   const titleJustUpdated = Boolean(
@@ -4977,18 +4974,18 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
     }
   };
 
-  const sidebarLayoutStyle = getSidebarLayoutStyle({ offsetContent: isSidebarOpen });
-
   return (
-    <div
-      style={sidebarLayoutStyle}
+    <ResizableSidebarLayout
       data-runtime-key={runtimeStore.resolveKey(activeRuntimeKey)}
       data-generating={isGenerating ? "true" : "false"}
-      className={`grid h-dvh min-h-0 w-full grid-cols-1 overflow-hidden ${isSidebarOpen ? SIDEBAR_GRID_COLUMNS_CLASS : ""}`}
+      isCompactLayout={isCompactLayout}
+      isOpen={isSidebarOpen}
+      mode="chat"
+      onOpenChange={setIsSidebarOpen}
+      onTransitionChange={setIsSidebarTransitioning}
+      sidebar={<Sidebar chatId={chatId} isOpen={isSidebarOpen} onToggle={toggleSidebar} />}
+      userId={os.auth.user?.user.id}
     >
-      {/* Use the existing Sidebar component */}
-      <Sidebar chatId={chatId} isOpen={isSidebarOpen} onToggle={toggleSidebar} />
-
       {/* Main Content */}
       <div className="flex flex-col flex-1 min-w-0 min-h-0 bg-background overflow-hidden relative">
         {/* Error message - fixed at top below header, always visible */}
@@ -5023,7 +5020,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
         )}
 
         {/* Sidebar toggle + wordmark — fixed except on compact layouts while chatting (two-row header below) */}
-        {!isSidebarOpen && !(isCompactLayout && messages.length > 0) && (
+        {!isSidebarOpen && !isSidebarTransitioning && !(isCompactLayout && messages.length > 0) && (
           <div className="fixed left-4 top-[9.5px] z-20 flex items-center gap-1.5">
             <SidebarToggle onToggle={toggleSidebar} />
             <MapleWordmark
@@ -5689,6 +5686,6 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
           className="hidden"
         />
       </div>
-    </div>
+    </ResizableSidebarLayout>
   );
 }

--- a/frontend/src/constants/layout.ts
+++ b/frontend/src/constants/layout.ts
@@ -1,25 +1,5 @@
-import type { CSSProperties } from "react";
-
 export const SIDEBAR_WIDTH_PX = 296;
-
-const SIDEBAR_WIDTH = `${SIDEBAR_WIDTH_PX}px`;
-const SIDEBAR_CONTENT_CENTER_OFFSET = `${SIDEBAR_WIDTH_PX / 2}px`;
-
-export const SIDEBAR_LAYOUT_STYLE = {
-  "--sidebar-width": SIDEBAR_WIDTH,
-  "--sidebar-grid-template": `${SIDEBAR_WIDTH} minmax(0, 1fr)`,
-  "--sidebar-content-center-offset": SIDEBAR_CONTENT_CENTER_OFFSET
-} as CSSProperties;
-
-export function getSidebarLayoutStyle({ offsetContent = true } = {}) {
-  return {
-    ...SIDEBAR_LAYOUT_STYLE,
-    "--sidebar-content-center-offset": offsetContent ? SIDEBAR_CONTENT_CENTER_OFFSET : "0px"
-  } as CSSProperties;
-}
 
 export const SIDEBAR_GRID_COLUMNS_CLASS = "md:grid-cols-[var(--sidebar-grid-template)]";
 export const SIDEBAR_WIDTH_CLASS = "w-[var(--sidebar-width)]";
 export const SIDEBAR_MAX_WIDTH_CLASS = "max-w-[var(--sidebar-width)]";
-export const SIDEBAR_AWARE_FIXED_CENTER_CLASS =
-  "md:left-[calc(50%_+_var(--sidebar-content-center-offset))]";

--- a/frontend/src/contexts/PersistentHomeNavigationContext.test.tsx
+++ b/frontend/src/contexts/PersistentHomeNavigationContext.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { useState, type Dispatch, type SetStateAction } from "react";
+
+import { AgentSessionSelectionMemory } from "@/services/agentSessionSelection";
+import {
+  PersistentHomeNavigationContext,
+  useAccountSidebarOpenState,
+  usePersistentSidebarState
+} from "./PersistentHomeNavigationContext";
+
+type SidebarOpenStorage = Pick<Storage, "getItem" | "setItem">;
+
+class MemoryStorage implements SidebarOpenStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+type SidebarControls = {
+  firstOpen: boolean;
+  secondOpen: boolean;
+  setFirstOpen: (isOpen: boolean) => void;
+  setSecondOpen: (isOpen: boolean) => void;
+};
+
+let controls: SidebarControls | null = null;
+let persistedControls: {
+  setValue: Dispatch<SetStateAction<boolean | null>>;
+  value: boolean | null;
+} | null = null;
+
+function SidebarProbe() {
+  const [firstOpen, setFirstOpen] = usePersistentSidebarState(false);
+  const [secondOpen, setSecondOpen] = usePersistentSidebarState(false);
+  controls = { firstOpen, secondOpen, setFirstOpen, setSecondOpen };
+  return <span>{`${firstOpen}:${secondOpen}`}</span>;
+}
+
+function SidebarHarness() {
+  const [sidebarOpen, setSidebarOpen] = useState<boolean | null>(null);
+  const [agentSessionSelection] = useState(() => new AgentSessionSelectionMemory());
+
+  return (
+    <PersistentHomeNavigationContext.Provider
+      value={{
+        agentSessionSelection,
+        returnToHome: () => {},
+        setSidebarOpen,
+        sidebarOpen
+      }}
+    >
+      <SidebarProbe />
+    </PersistentHomeNavigationContext.Provider>
+  );
+}
+
+function PersistedSidebarProbe({
+  storage,
+  userId
+}: {
+  storage: SidebarOpenStorage;
+  userId: string | null;
+}) {
+  const [value, setValue] = useAccountSidebarOpenState(userId, storage);
+  persistedControls = { setValue, value };
+  return <span>{String(value)}</span>;
+}
+
+describe("persistent sidebar state", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+    controls = null;
+    persistedControls = null;
+  });
+
+  test("shares one open state across Chat and Agent", () => {
+    act(() => {
+      renderer = create(<SidebarHarness />);
+    });
+
+    expect(renderer?.toJSON()).toMatchObject({ children: ["true:true"] });
+    act(() => controls?.setFirstOpen(false));
+    expect(renderer?.toJSON()).toMatchObject({ children: ["false:false"] });
+    act(() => controls?.setSecondOpen(true));
+    expect(renderer?.toJSON()).toMatchObject({ children: ["true:true"] });
+  });
+
+  test("restores closed state across remounts without crossing accounts", () => {
+    const storage = new MemoryStorage();
+
+    act(() => {
+      renderer = create(<PersistedSidebarProbe storage={storage} userId="account/a" />);
+    });
+    act(() => persistedControls?.setValue(false));
+    expect(renderer?.toJSON()).toMatchObject({ children: ["false"] });
+
+    act(() => renderer?.unmount());
+    act(() => {
+      renderer = create(<PersistedSidebarProbe storage={storage} userId="account/a" />);
+    });
+    expect(renderer?.toJSON()).toMatchObject({ children: ["false"] });
+
+    act(() => {
+      renderer?.update(<PersistedSidebarProbe storage={storage} userId="account/b" />);
+    });
+    expect(renderer?.toJSON()).toMatchObject({ children: ["null"] });
+    act(() => persistedControls?.setValue(true));
+
+    act(() => {
+      renderer?.update(<PersistedSidebarProbe storage={storage} userId="account/a" />);
+    });
+    expect(renderer?.toJSON()).toMatchObject({ children: ["false"] });
+
+    const keysBeforeLogout = [...storage.values.keys()];
+    act(() => {
+      renderer?.update(<PersistedSidebarProbe storage={storage} userId={null} />);
+    });
+    act(() => persistedControls?.setValue(false));
+    expect([...storage.values.keys()]).toEqual(keysBeforeLogout);
+  });
+});

--- a/frontend/src/contexts/PersistentHomeNavigationContext.ts
+++ b/frontend/src/contexts/PersistentHomeNavigationContext.ts
@@ -1,5 +1,32 @@
-import { createContext, useCallback, useContext, type Dispatch, type SetStateAction } from "react";
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useState,
+  type Dispatch,
+  type SetStateAction
+} from "react";
 import type { AgentSessionSelectionMemory } from "@/services/agentSessionSelection";
+import {
+  loadSidebarOpenPreference,
+  saveSidebarOpenPreference
+} from "@/services/sidebarOpenPreference";
+
+type SidebarOpenStorage = Pick<Storage, "getItem" | "setItem">;
+
+type AccountSidebarOpenState = {
+  userId: string | null;
+  value: boolean | null;
+};
+
+function loadSidebarOpenState(
+  userId: string | null,
+  storage?: SidebarOpenStorage | null
+): boolean | null {
+  return userId ? loadSidebarOpenPreference(userId, storage) : null;
+}
 
 export type PersistentHomeNavigation = {
   returnToHome: (options?: { replace?: boolean }) => void;
@@ -18,6 +45,46 @@ export function usePersistentHomeNavigation() {
     );
   }
   return context;
+}
+
+export function useAccountSidebarOpenState(
+  userId: string | null,
+  storage?: SidebarOpenStorage | null
+): readonly [boolean | null, Dispatch<SetStateAction<boolean | null>>] {
+  const [accountState, setAccountState] = useState<AccountSidebarOpenState>(() => ({
+    userId,
+    value: loadSidebarOpenState(userId, storage)
+  }));
+  const value =
+    accountState.userId === userId ? accountState.value : loadSidebarOpenState(userId, storage);
+  const setValue = useCallback<Dispatch<SetStateAction<boolean | null>>>(
+    (nextValue) => {
+      setAccountState((current) => {
+        const currentValue =
+          current.userId === userId ? current.value : loadSidebarOpenState(userId, storage);
+        return {
+          userId,
+          value: typeof nextValue === "function" ? nextValue(currentValue) : nextValue
+        };
+      });
+    },
+    [storage, userId]
+  );
+
+  useLayoutEffect(() => {
+    if (accountState.userId === userId) return;
+    setAccountState({ userId, value: loadSidebarOpenState(userId, storage) });
+  }, [accountState.userId, storage, userId]);
+
+  useEffect(() => {
+    if (!accountState.userId) return;
+    const { userId: stateUserId, value: stateValue } = accountState;
+    if (typeof stateValue === "boolean") {
+      saveSidebarOpenPreference(stateUserId, stateValue, storage);
+    }
+  }, [accountState, storage]);
+
+  return [value, setValue] as const;
 }
 
 export function usePersistentSidebarState(

--- a/frontend/src/services/sidebarOpenPreference.test.ts
+++ b/frontend/src/services/sidebarOpenPreference.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { loadSidebarOpenPreference, saveSidebarOpenPreference } from "./sidebarOpenPreference";
+
+type SidebarOpenStorage = Pick<Storage, "getItem" | "setItem">;
+
+class MemoryStorage implements SidebarOpenStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+describe("sidebar open preference", () => {
+  test("round-trips one open state per account", () => {
+    const storage = new MemoryStorage();
+
+    expect(saveSidebarOpenPreference("account/a", false, storage)).toBe(true);
+    expect(saveSidebarOpenPreference("account/b", true, storage)).toBe(true);
+    expect([...storage.values.keys()]).toEqual([
+      "maple:sidebar-open:v1:account%2Fa",
+      "maple:sidebar-open:v1:account%2Fb"
+    ]);
+    expect(loadSidebarOpenPreference("account/a", storage)).toBe(false);
+    expect(loadSidebarOpenPreference("account/b", storage)).toBe(true);
+  });
+
+  test("recovers from invalid and unavailable storage", () => {
+    const storage = new MemoryStorage();
+
+    expect(loadSidebarOpenPreference("account", storage)).toBeNull();
+    saveSidebarOpenPreference("account", false, storage);
+    const key = [...storage.values.keys()][0];
+    storage.values.set(key, "not json");
+    expect(loadSidebarOpenPreference("account", storage)).toBeNull();
+    storage.values.set(key, JSON.stringify({ version: 2, isOpen: false }));
+    expect(loadSidebarOpenPreference("account", storage)).toBeNull();
+
+    const unavailable: SidebarOpenStorage = {
+      getItem: () => {
+        throw new Error("unavailable");
+      },
+      setItem: () => {
+        throw new Error("unavailable");
+      }
+    };
+    expect(loadSidebarOpenPreference("account", unavailable)).toBeNull();
+    expect(saveSidebarOpenPreference("account", false, unavailable)).toBe(false);
+  });
+});

--- a/frontend/src/services/sidebarOpenPreference.ts
+++ b/frontend/src/services/sidebarOpenPreference.ts
@@ -1,0 +1,70 @@
+const SIDEBAR_OPEN_VERSION = 1 as const;
+
+type SidebarOpenStorage = Pick<Storage, "getItem" | "setItem">;
+
+type StoredSidebarOpen = {
+  version: typeof SIDEBAR_OPEN_VERSION;
+  isOpen: boolean;
+};
+
+function sidebarOpenStorageKey(userId: string): string {
+  if (typeof userId !== "string" || !userId.trim()) {
+    throw new Error("Sidebar state requires an authenticated user");
+  }
+  return `maple:sidebar-open:v${SIDEBAR_OPEN_VERSION}:${encodeURIComponent(userId)}`;
+}
+
+export function loadSidebarOpenPreference(
+  userId: string,
+  storage: SidebarOpenStorage | null = browserStorage()
+): boolean | null {
+  if (!storage) return null;
+
+  try {
+    const stored = storage.getItem(sidebarOpenStorageKey(userId));
+    if (!stored) return null;
+    const parsed: unknown = JSON.parse(stored);
+    return isStoredSidebarOpen(parsed) ? parsed.isOpen : null;
+  } catch {
+    return null;
+  }
+}
+
+export function saveSidebarOpenPreference(
+  userId: string,
+  isOpen: boolean,
+  storage: SidebarOpenStorage | null = browserStorage()
+): boolean {
+  if (!storage) return false;
+
+  const value: StoredSidebarOpen = {
+    version: SIDEBAR_OPEN_VERSION,
+    isOpen
+  };
+
+  try {
+    storage.setItem(sidebarOpenStorageKey(userId), JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function isStoredSidebarOpen(value: unknown): value is StoredSidebarOpen {
+  return (
+    value !== null &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    (value as Record<string, unknown>).version === SIDEBAR_OPEN_VERSION &&
+    typeof (value as Record<string, unknown>).isOpen === "boolean"
+  );
+}
+
+function browserStorage(): SidebarOpenStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}

--- a/frontend/src/services/sidebarWidth.test.ts
+++ b/frontend/src/services/sidebarWidth.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX,
+  clampSidebarWidth,
+  loadSidebarWidth,
+  saveSidebarWidth,
+  sidebarDragUpdate,
+  sidebarMaximumWidth
+} from "./sidebarWidth";
+
+type SidebarWidthStorage = Pick<Storage, "getItem" | "setItem">;
+
+class MemoryStorage implements SidebarWidthStorage {
+  readonly values = new Map<string, string>();
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+describe("sidebar width persistence", () => {
+  test("uses one versioned width per account", () => {
+    const storage = new MemoryStorage();
+
+    expect(saveSidebarWidth("account/a", 360, storage)).toBe(true);
+    expect(saveSidebarWidth("account/b", 420, storage)).toBe(true);
+    expect([...storage.values.keys()]).toEqual([
+      "maple:sidebar-width:v1:account%2Fa",
+      "maple:sidebar-width:v1:account%2Fb"
+    ]);
+    expect(loadSidebarWidth("account/a", storage)).toBe(360);
+    expect(loadSidebarWidth("account/b", storage)).toBe(420);
+  });
+
+  test("recovers from invalid and unavailable storage", () => {
+    const storage = new MemoryStorage();
+
+    expect(loadSidebarWidth("account", storage)).toBe(RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX);
+    saveSidebarWidth("account", 400, storage);
+    const key = [...storage.values.keys()][0];
+    storage.values.set(key, "not json");
+    expect(loadSidebarWidth("account", storage)).toBe(RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX);
+    storage.values.set(key, JSON.stringify({ version: 2, widthPx: 400 }));
+    expect(loadSidebarWidth("account", storage)).toBe(RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX);
+
+    const unavailable: SidebarWidthStorage = {
+      getItem: () => {
+        throw new Error("unavailable");
+      },
+      setItem: () => {
+        throw new Error("unavailable");
+      }
+    };
+    expect(loadSidebarWidth("account", unavailable)).toBe(RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX);
+    expect(saveSidebarWidth("account", 400, unavailable)).toBe(false);
+  });
+});
+
+describe("sidebar width constraints", () => {
+  test("calculates the responsive maximum and clamps restored widths", () => {
+    expect(sidebarMaximumWidth(800)).toBe(320);
+    expect(sidebarMaximumWidth(1_200)).toBe(480);
+    expect(sidebarMaximumWidth(2_000)).toBe(480);
+    expect(clampSidebarWidth(480, sidebarMaximumWidth(800))).toBe(320);
+    expect(clampSidebarWidth(200, sidebarMaximumWidth(800))).toBe(240);
+  });
+
+  test("holds at the minimum and toggles at the midpoint in both directions", () => {
+    expect(sidebarDragUpdate(320, 320, 240, 480)).toEqual({
+      widthPx: 240,
+      isCollapsed: false
+    });
+    expect(sidebarDragUpdate(320, 320, 121, 480)).toEqual({
+      widthPx: 240,
+      isCollapsed: false
+    });
+    expect(sidebarDragUpdate(320, 320, 120, 480)).toEqual({
+      widthPx: 240,
+      isCollapsed: true
+    });
+  });
+});

--- a/frontend/src/services/sidebarWidth.ts
+++ b/frontend/src/services/sidebarWidth.ts
@@ -1,0 +1,128 @@
+import { SIDEBAR_WIDTH_PX } from "@/constants/layout";
+
+const RESIZABLE_SIDEBAR_WIDTH_VERSION = 1 as const;
+export const RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX = SIDEBAR_WIDTH_PX;
+export const RESIZABLE_SIDEBAR_MIN_WIDTH_PX = 240;
+export const RESIZABLE_SIDEBAR_MAX_WIDTH_PX = 480;
+const RESIZABLE_SIDEBAR_COLLAPSE_WIDTH_PX = RESIZABLE_SIDEBAR_MIN_WIDTH_PX / 2;
+export const RESIZABLE_SIDEBAR_KEYBOARD_STEP_PX = 8;
+export const RESIZABLE_SIDEBAR_KEYBOARD_LARGE_STEP_PX = 32;
+
+type SidebarWidthStorage = Pick<Storage, "getItem" | "setItem">;
+
+type StoredSidebarWidth = {
+  version: typeof RESIZABLE_SIDEBAR_WIDTH_VERSION;
+  widthPx: number;
+};
+
+type SidebarDragUpdate = {
+  widthPx: number;
+  isCollapsed: boolean;
+};
+
+function sidebarWidthStorageKey(userId: string): string {
+  if (typeof userId !== "string" || !userId.trim()) {
+    throw new Error("Sidebar width requires an authenticated user");
+  }
+  return `maple:sidebar-width:v${RESIZABLE_SIDEBAR_WIDTH_VERSION}:${encodeURIComponent(userId)}`;
+}
+
+export function loadSidebarWidth(
+  userId: string,
+  storage: SidebarWidthStorage | null = browserStorage()
+): number {
+  if (!storage) return RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+
+  let stored: string | null;
+  try {
+    stored = storage.getItem(sidebarWidthStorageKey(userId));
+  } catch {
+    return RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+  }
+  if (!stored) return RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stored);
+  } catch {
+    return RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+  }
+  if (
+    !isRecord(parsed) ||
+    parsed.version !== RESIZABLE_SIDEBAR_WIDTH_VERSION ||
+    typeof parsed.widthPx !== "number" ||
+    !Number.isFinite(parsed.widthPx)
+  ) {
+    return RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+  }
+
+  return clampSidebarWidth(parsed.widthPx, RESIZABLE_SIDEBAR_MAX_WIDTH_PX);
+}
+
+export function saveSidebarWidth(
+  userId: string,
+  widthPx: number,
+  storage: SidebarWidthStorage | null = browserStorage()
+): boolean {
+  if (!storage) return false;
+
+  const value: StoredSidebarWidth = {
+    version: RESIZABLE_SIDEBAR_WIDTH_VERSION,
+    widthPx: clampSidebarWidth(widthPx, RESIZABLE_SIDEBAR_MAX_WIDTH_PX)
+  };
+
+  try {
+    storage.setItem(sidebarWidthStorageKey(userId), JSON.stringify(value));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function sidebarMaximumWidth(viewportWidthPx: number): number {
+  if (!Number.isFinite(viewportWidthPx) || viewportWidthPx <= 0) {
+    return RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+  }
+  return Math.max(
+    RESIZABLE_SIDEBAR_MIN_WIDTH_PX,
+    Math.min(RESIZABLE_SIDEBAR_MAX_WIDTH_PX, Math.floor(viewportWidthPx * 0.4))
+  );
+}
+
+export function clampSidebarWidth(widthPx: number, maximumWidthPx: number): number {
+  const maximum = Number.isFinite(maximumWidthPx)
+    ? Math.max(
+        RESIZABLE_SIDEBAR_MIN_WIDTH_PX,
+        Math.min(RESIZABLE_SIDEBAR_MAX_WIDTH_PX, maximumWidthPx)
+      )
+    : RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+  const width = Number.isFinite(widthPx) ? widthPx : RESIZABLE_SIDEBAR_DEFAULT_WIDTH_PX;
+  return Math.round(Math.max(RESIZABLE_SIDEBAR_MIN_WIDTH_PX, Math.min(maximum, width)));
+}
+
+export function sidebarDragUpdate(
+  startWidthPx: number,
+  startPointerX: number,
+  pointerX: number,
+  maximumWidthPx: number
+): SidebarDragUpdate {
+  const rawWidthPx = startWidthPx + (pointerX - startPointerX);
+  const hasFiniteWidth = Number.isFinite(rawWidthPx);
+  return {
+    widthPx: clampSidebarWidth(rawWidthPx, maximumWidthPx),
+    isCollapsed: hasFiniteWidth && rawWidthPx <= RESIZABLE_SIDEBAR_COLLAPSE_WIDTH_PX
+  };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function browserStorage(): SidebarWidthStorage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
## What

- adds shared resizable desktop sidebar behavior to Chat and Agent Mode, including project views
- pauses at the 240px minimum, then animates closed at the 120px midpoint without waiting for pointer release
- keeps pointer capture active so dragging back across the midpoint reverses the animation
- persists one account-scoped expanded width and open/closed state shared by Chat and Agent Mode
- restores the collapsed state after relaunch whether it was closed by dragging or by the collapse button
- adds keyboard-accessible resize controls, reduced-motion handling, and an arrow-free sidebar icon

## Why

The Chat and Agent layouts were driven by fixed CSS variables and had no durable resizable sidebar state. Switching modes should preserve one sidebar width and open/closed state for the current account.

The shared layout controller now keeps the sidebar panel, divider, grid edge, and main content synchronized throughout resize, collapse, and reversal.

## Impact

Frontend-only. No backend, API, schema, Rust, or filesystem-persistence changes.

## Validation

- `bun run build`
- `bun test` — 603 passed
- focused ESLint — passed
- unsigned macOS QA build — manually validated

Closes #739
