### PR TITLE
Bump Maple version to 3.3.3

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.2",
+  "version": "3.3.3",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4619,7 +4619,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.2"
+version = "3.3.3"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.2"
+version = "3.3.3"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.2</string>
+	<string>3.3.3</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.2</string>
+	<string>3.3.3</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.2
-        CFBundleVersion: 3.3.2
+        CFBundleShortVersionString: 3.3.3
+        CFBundleVersion: 3.3.3
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.2",
+  "version": "3.3.3",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -97,7 +97,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028013
+      "versionCode": 2000028014
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- Bump Maple to v3.3.3.
- Advance Android versionCode to 2000028014.
- Contains no feature or Android 16 KB fix changes; this is only the next release version bump.

## Validation
- `/nix/var/nix/profiles/default/bin/nix develop .#ci -c just bump-patch`
- `git diff --check`
- `/nix/var/nix/profiles/default/bin/nix develop .#ci -c sh -c "cd frontend/src-tauri && cargo test --all-targets --locked -- --test-threads=1"` (303 passed, 2 ignored)

The standard pre-commit hook also passed Prettier and the production frontend build, but its parallel Rust test execution flakes on the existing `same_group_stdout_holder_is_killed_on_output_timeout` 500 ms process fixture. The focused test and the full serial suite pass.