### PR TITLE
build(android): target Android 16 / API 36

### DIFF
--- a/docs/android-platform-checks-analysis.md
+++ b/docs/android-platform-checks-analysis.md
@@ -988,7 +988,7 @@ Set the override in `tauri.conf.json`:
 - ✅ Google's SHA256 certificate obtained
 - ✅ assetlinks.json updated with both certificates
 - ✅ Privacy policy URL configured (https://opensecret.cloud/privacy)
-- ✅ API level 35 requirement met
+- ✅ API level 36 requirement met for the August 31, 2026 Google Play deadline
 
 ### Current Status:
 - **Internal Testing Release**: Version 1.3.2 (Build 1003002002) is live
@@ -1023,15 +1023,7 @@ To avoid conflicts with Tauri's automatic version code generation and Google Pla
 ### Build Warnings and Version Compatibility
 
 #### Current Warnings Observed:
-1. **Gradle Plugin Version**:
-   ```
-   WARNING: We recommend using a newer Android Gradle plugin to use compileSdk = 36
-   This Android Gradle plugin (8.5.1) was tested up to compileSdk = 34.
-   ```
-   - **Impact**: Build succeeds but may have compatibility issues
-   - **TODO**: Wait for Tauri to update their Android template or manually update Gradle plugin
-
-2. **Deprecated targetSdk in library DSL**:
+1. **Deprecated targetSdk in library DSL**:
    ```
    'targetSdk: Int?' is deprecated. Will be removed from library DSL in v9.0
    ```
@@ -1039,7 +1031,7 @@ To avoid conflicts with Tauri's automatic version code generation and Google Pla
    - **Impact**: Warning only, will need update when Gradle 9.0 releases
    - **TODO**: Wait for Tauri plugin updates
 
-3. **Unused Rust Functions**:
+2. **Unused Rust Functions**:
    ```
    warning: function `get_config_path` is never used
    warning: function `save_proxy_config` is never used
@@ -1048,12 +1040,14 @@ To avoid conflicts with Tauri's automatic version code generation and Google Pla
    - **TODO**: Clean up unused proxy functions or add #[cfg] attributes for desktop-only
 
 #### Version Information:
-- **Current Gradle**: 8.9
-- **Android Gradle Plugin**: 8.5.1
-- **compileSdk**: 35 (Updated for Google Play requirements)
-- **targetSdk**: 35 (Required by Google Play as of Aug 2025)
+- **Google Play requirement**: [API level 36 for app updates starting August 31, 2026](https://developer.android.com/google/play/requirements/target-sdk)
+- **Toolchain compatibility**: [AGP 8.10 supports API 36 and requires Gradle 8.11.1](https://developer.android.com/build/releases/agp-8-10-0-release-notes)
+- **Current Gradle**: 8.11.1
+- **Android Gradle Plugin**: 8.10.1
+- **compileSdk**: 36
+- **targetSdk**: 36 (Required by Google Play for updates starting Aug 31, 2026)
 - **minSdk**: 24 (Android 7.0+, covers 99%+ of devices)
-- **NDK**: r25c
+- **NDK**: 27.2.12479018
 
 #### Build Performance:
 - **Initial build time**: ~9-10 minutes (includes downloading dependencies)
@@ -1081,18 +1075,17 @@ To avoid conflicts with Tauri's automatic version code generation and Google Pla
 3. **NDK toolchain not found** - Fixed by adding NDK bin to PATH and setting env vars
 
 #### 📋 TODO for Production:
-1. **Update Gradle Plugin** when Tauri updates templates
-2. **Google Play Store Setup**:
+1. **Google Play Store Setup**:
    - Create developer account
    - Configure Play App Signing
    - Add Google's SHA256 to assetlinks.json
-3. **Version Management**:
+2. **Version Management**:
    - Implement automatic version bumping
    - Consider using semantic-release
-4. **Testing**:
+3. **Testing**:
    - Add Android emulator tests
    - Implement UI testing with Espresso
-5. **Optimization**:
+4. **Optimization**:
    - Consider using `--target` flags to build specific architectures only
    - Implement APK size optimization
    - Add ProGuard/R8 rules if needed

--- a/flake.nix
+++ b/flake.nix
@@ -34,16 +34,8 @@
           jdk = "21";
           xcode = "26.5";
           android = {
-            compileSdk = "35";
-            platforms = [
-              "34"
-              "35"
-              "36"
-            ];
-            buildTools = [
-              "35.0.0"
-              "34.0.0"
-            ];
+            compileSdk = "36";
+            buildTools = "35.0.0";
             ndk = "27.2.12479018";
           };
         };
@@ -505,8 +497,8 @@
         androidComposition =
           if supportsAndroidHost then
             pkgs.androidenv.composeAndroidPackages {
-              platformVersions = versions.android.platforms;
-              buildToolsVersions = versions.android.buildTools;
+              platformVersions = [ versions.android.compileSdk ];
+              buildToolsVersions = [ versions.android.buildTools ];
               ndkVersions = [ versions.android.ndk ];
               includeNDK = true;
               includeEmulator = false;

--- a/flake.nix
+++ b/flake.nix
@@ -33,9 +33,17 @@
           rust = "1.94.1";
           jdk = "21";
           xcode = "26.5";
-          android = {
+          android = rec {
             compileSdk = "36";
-            buildTools = "35.0.0";
+            platforms = [
+              "34"
+              "35"
+              compileSdk
+            ];
+            buildTools = [
+              "35.0.0"
+              "34.0.0"
+            ];
             ndk = "27.2.12479018";
           };
         };
@@ -497,8 +505,8 @@
         androidComposition =
           if supportsAndroidHost then
             pkgs.androidenv.composeAndroidPackages {
-              platformVersions = [ versions.android.compileSdk ];
-              buildToolsVersions = [ versions.android.buildTools ];
+              platformVersions = versions.android.platforms;
+              buildToolsVersions = versions.android.buildTools;
               ndkVersions = [ versions.android.ndk ];
               includeNDK = true;
               includeEmulator = false;

--- a/frontend/src-tauri/gen/android/app/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/app/build.gradle.kts
@@ -15,15 +15,17 @@ val tauriProperties = Properties().apply {
 val mapleUnsignedRelease = providers.gradleProperty("mapleUnsignedRelease")
     .map { it.toBoolean() }
     .orElse(false)
+val mapleCompileSdk = providers.gradleProperty("maple.compileSdk").get().toInt()
+val mapleTargetSdk = providers.gradleProperty("maple.targetSdk").get().toInt()
 
 android {
-    compileSdk = 35
+    compileSdk = mapleCompileSdk
     namespace = "cloud.opensecret.maple"
     defaultConfig {
         manifestPlaceholders["usesCleartextTraffic"] = "false"
         applicationId = "cloud.opensecret.maple"
         minSdk = 24
-        targetSdk = 35
+        targetSdk = mapleTargetSdk
         versionCode = tauriProperties.getProperty("tauri.android.versionCode", "1").toInt()
         versionName = tauriProperties.getProperty("tauri.android.versionName", "1.0")
     }

--- a/frontend/src-tauri/gen/android/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         mavenCentral()
     }
     dependencies {
-        classpath("com.android.tools.build:gradle:8.5.1")
+        classpath("com.android.tools.build:gradle:8.10.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.25")
     }
 }
@@ -19,4 +19,3 @@ allprojects {
 tasks.register("clean").configure {
     delete("build")
 }
-

--- a/frontend/src-tauri/gen/android/buildSrc/build.gradle.kts
+++ b/frontend/src-tauri/gen/android/buildSrc/build.gradle.kts
@@ -18,6 +18,5 @@ repositories {
 
 dependencies {
     compileOnly(gradleApi())
-    implementation("com.android.tools.build:gradle:8.5.1")
+    implementation("com.android.tools.build:gradle:8.10.1")
 }
-

--- a/frontend/src-tauri/gen/android/gradle.properties
+++ b/frontend/src-tauri/gen/android/gradle.properties
@@ -14,6 +14,8 @@ org.gradle.parallel=true
 org.gradle.daemon=true
 org.gradle.caching=true
 org.gradle.configureondemand=true
+maple.compileSdk=36
+maple.targetSdk=36
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn

--- a/frontend/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties
+++ b/frontend/src-tauri/gen/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Tue May 10 19:22:52 CST 2022
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -868,6 +868,61 @@ android_zipalign() {
   return 1
 }
 
+android_aapt2() {
+  local found
+
+  if command -v aapt2 >/dev/null 2>&1; then
+    command -v aapt2
+    return 0
+  fi
+
+  if [ -n "${ANDROID_HOME:-}" ]; then
+    found="$(
+      find -L "${ANDROID_HOME}/build-tools" -mindepth 2 -maxdepth 4 -type f -name aapt2 2>/dev/null \
+        | LC_ALL=C sort -V \
+        | tail -n 1 || true
+    )"
+    if [ -n "${found}" ]; then
+      printf '%s\n' "${found}"
+      return 0
+    fi
+  fi
+
+  echo "aapt2 is required to verify the Android target SDK." >&2
+  return 1
+}
+
+configured_android_target_sdk() {
+  local gradle_properties="${TAURI_DIR}/gen/android/gradle.properties"
+  local target_sdk
+
+  target_sdk="$(sed -n 's/^maple[.]targetSdk=//p' "${gradle_properties}")"
+  if ! [[ "${target_sdk}" =~ ^[0-9]+$ ]]; then
+    echo "Could not read maple.targetSdk from ${gradle_properties}." >&2
+    return 1
+  fi
+
+  printf '%s\n' "${target_sdk}"
+}
+
+verify_android_apk_target_sdk() {
+  local artifact="$1"
+  local aapt2 expected actual
+
+  aapt2="$(android_aapt2)"
+  expected="$(configured_android_target_sdk)"
+  actual="$("${aapt2}" dump badging "${artifact}" | sed -n "s/^targetSdkVersion:'\\([^']*\\)'.*/\\1/p")"
+
+  if [ "${actual}" != "${expected}" ]; then
+    echo "Android APK target SDK mismatch for ${artifact}." >&2
+    echo "expected=${expected}" >&2
+    echo "actual=${actual:-missing}" >&2
+    return 1
+  fi
+
+  printf 'verified-android-target-sdk  %s  %s\n' "${actual}" "$(basename "${artifact}")"
+}
+
 verify_android_onnxruntime_artifact() (
   set -euo pipefail
 

--- a/scripts/ci/android-pr.sh
+++ b/scripts/ci/android-pr.sh
@@ -116,6 +116,7 @@ while IFS= read -r -d '' file; do
 done < <(find "${TAURI_DIR}/gen/android/app/build/outputs/apk" -type f -name '*.apk' -print0 | LC_ALL=C sort -z)
 
 for artifact in "${android_artifacts[@]}"; do
+  verify_android_apk_target_sdk "${artifact}"
   verify_android_artifact_native_libraries "${artifact}"
   verify_android_onnxruntime_artifact "${artifact}"
 done

--- a/scripts/ci/android-release.sh
+++ b/scripts/ci/android-release.sh
@@ -357,6 +357,9 @@ else
 fi
 
 for artifact in "${android_artifacts[@]}"; do
+  if [[ "${artifact}" == *.apk ]]; then
+    verify_android_apk_target_sdk "${artifact}"
+  fi
   verify_android_artifact_native_libraries "${artifact}"
   verify_android_onnxruntime_artifact "${artifact}"
 done


### PR DESCRIPTION
## Summary

- target Android 16 / API 36 for Google Play's August 31, 2026 app-update requirement
- upgrade the generated Android project to AGP 8.10.1 + Gradle 8.11.1, the supported API 36 toolchain pair
- make API 36 the primary Nix SDK while retaining the older SDK platforms required by Android plugin dependencies
- centralize Gradle compile/target SDK values
- verify the packaged APK's `targetSdkVersion` in both PR and signed release builds so configuration drift fails CI
- refresh the Android build/release documentation

Google references: [Play target API requirement](https://developer.android.com/google/play/requirements/target-sdk), [AGP 8.10 compatibility](https://developer.android.com/build/releases/agp-8-10-0-release-notes).

## Android 16 behavior audit

Maple already applies system-bar insets for edge-to-edge rendering. Its Android manifest does not opt out of edge-to-edge, restrict orientation/resizability, or opt out of predictive back; the native Android code does not use the affected legacy back, scheduling, MediaStore, health-sensor, or local-network APIs.

## Verification

- `nix flake check --all-systems --no-build --print-build-logs`
- `nix develop -c just lint` (passes with 13 pre-existing warnings)
- `nix develop -c just build`
- pre-commit: Prettier, production build, 587 frontend tests
- `bash -n` for modified CI scripts
- target-SDK verifier positive fixture (36) and negative fixture (35)

The full x86_64 Linux APK/AAB build is delegated to the Android PR workflow because the Nix Android shell intentionally does not support this ARM macOS host.
