### PR TITLE
Fix anonymous signup Account ID handoff

### DIFF
--- a/frontend/src/components/RootRuntimeLayout.test.tsx
+++ b/frontend/src/components/RootRuntimeLayout.test.tsx
@@ -56,7 +56,7 @@ function ChatStoreProbe({ onStore }: { onStore: (store: unknown) => void }) {
 }
 
 describe("RootRuntimeLayout", () => {
-  test("keeps only the OAuth callback route mounted when success authenticates a user", () => {
+  test("keeps the OAuth callback route mounted when success authenticates a user", () => {
     const processCallback = mock(() => {});
     const globalMounted = mock(() => {});
     const globalUnmounted = mock(() => {});
@@ -74,6 +74,42 @@ describe("RootRuntimeLayout", () => {
     expect(processCallback).toHaveBeenCalledTimes(1);
     expect(globalMounted).toHaveBeenCalledTimes(2);
     expect(globalUnmounted).toHaveBeenCalledTimes(1);
+
+    act(() => renderer.unmount());
+  });
+
+  test("keeps signup mounted while anonymous account creation authenticates the new user", () => {
+    const routeMounted = mock(() => {});
+    const routeUnmounted = mock(() => {});
+    const signup = <LifecycleProbe onMount={routeMounted} onUnmount={routeUnmounted} />;
+    let renderer: ReactTestRenderer;
+
+    act(() => {
+      renderer = create(
+        <RootRuntimeLayout
+          userId={null}
+          pathname="/signup"
+          authenticatedHome={null}
+          routeContent={signup}
+          accountScopedUi={null}
+        />
+      );
+    });
+
+    act(() => {
+      renderer.update(
+        <RootRuntimeLayout
+          userId="new-anonymous-user"
+          pathname="/signup"
+          authenticatedHome={null}
+          routeContent={signup}
+          accountScopedUi={null}
+        />
+      );
+    });
+
+    expect(routeMounted).toHaveBeenCalledTimes(1);
+    expect(routeUnmounted).not.toHaveBeenCalled();
 
     act(() => renderer.unmount());
   });

--- a/frontend/src/components/RootRuntimeLayout.tsx
+++ b/frontend/src/components/RootRuntimeLayout.tsx
@@ -10,6 +10,7 @@ type RootRuntimeLayoutProps = {
 };
 
 const OAUTH_CALLBACK_PATH = /^\/auth\/([^/]+)\/callback\/?$/;
+const SIGNUP_PATH = /^\/signup\/?$/;
 
 function getAccountScopeKey(userId: string | null): string {
   return userId === null ? "account:signed-out" : `account:user:${userId}`;
@@ -17,15 +18,21 @@ function getAccountScopeKey(userId: string | null): string {
 
 function getRouteScopeKey(pathname: string, accountScopeKey: string): string {
   const callbackMatch = OAUTH_CALLBACK_PATH.exec(pathname);
-  return callbackMatch ? `route:oauth-callback:${callbackMatch[1]}` : `route:${accountScopeKey}`;
+  if (callbackMatch) return `route:oauth-callback:${callbackMatch[1]}`;
+
+  // Anonymous signup must retain its component-local Account ID while
+  // signUpGuest transitions auth from signed out to the newly created user.
+  if (SIGNUP_PATH.test(pathname)) return "route:signup";
+
+  return `route:${accountScopeKey}`;
 }
 
 /**
  * Keeps account-scoped chat state around the persistent authenticated home and
- * ordinary routed content. The OAuth callback route alone stays outside that
- * provider so it survives the signed-out-to-user transition and its one-shot
- * effect cannot replay. Global account-scoped UI retains its previous remount
- * behavior.
+ * ordinary routed content. The OAuth callback route stays outside that provider
+ * so its one-shot effect cannot replay. Signup also retains its route state long
+ * enough to show a newly created anonymous user's Account ID. Global
+ * account-scoped UI retains its previous remount behavior.
  */
 export function RootRuntimeLayout({
   userId,
@@ -37,15 +44,17 @@ export function RootRuntimeLayout({
   const accountScopeKey = getAccountScopeKey(userId);
   const routeScopeKey = getRouteScopeKey(pathname, accountScopeKey);
   const isOAuthCallback = OAUTH_CALLBACK_PATH.test(pathname);
+  const isSignup = SIGNUP_PATH.test(pathname);
+  const isAuthTransitionRoute = isOAuthCallback || isSignup;
   const keyedRouteContent = <Fragment key={routeScopeKey}>{routeContent}</Fragment>;
 
   return (
     <>
       <ChatRuntimeProvider key={`chat:${accountScopeKey}`}>
         {authenticatedHome}
-        {!isOAuthCallback ? keyedRouteContent : null}
+        {!isAuthTransitionRoute ? keyedRouteContent : null}
       </ChatRuntimeProvider>
-      {isOAuthCallback ? keyedRouteContent : null}
+      {isAuthTransitionRoute ? keyedRouteContent : null}
       <Fragment key={`global:${accountScopeKey}`}>{accountScopedUi}</Fragment>
     </>
   );

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -1,4 +1,4 @@
-import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-router";
+import { createFileRoute, Link, useLocation, useNavigate, useRouter } from "@tanstack/react-router";
 import { useOpenSecret, type LoginResponse } from "@opensecret/react";
 import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
@@ -23,6 +23,7 @@ import { UserCircle } from "lucide-react";
 import { appUrl } from "@/config/domains";
 import { useRouteMeta } from "@/utils/routeMeta";
 import { getSafeInternalRedirect, navigateToSafeInternalRedirect } from "@/utils/internalRedirect";
+import { shouldRedirectAuthenticatedSignup } from "@/utils/signupRedirect";
 
 type SignupSearchParams = {
   next?: string;
@@ -51,6 +52,7 @@ function SignupPage() {
 
   const navigate = useNavigate();
   const router = useRouter();
+  const location = useLocation();
   const os = useOpenSecret();
   const { next, selected_plan, code } = Route.useSearch();
   const [signUpMethod, setSignUpMethod] = useState<SignUpMethod>(null);
@@ -66,7 +68,14 @@ function SignupPage() {
 
   // Redirect if already logged in (but not if we're showing guest credentials)
   useEffect(() => {
-    if (os.auth.user && !showGuestCredentials) {
+    if (
+      shouldRedirectAuthenticatedSignup({
+        isAuthenticated: !!os.auth.user,
+        isGuestSignup: signUpMethod === "guest",
+        isSignupRoute: location.pathname === "/signup",
+        showGuestCredentials
+      })
+    ) {
       if (selected_plan) {
         navigate({
           to: "/pricing",
@@ -83,7 +92,17 @@ function SignupPage() {
         }
       }
     }
-  }, [os.auth.user, navigate, next, selected_plan, code, showGuestCredentials, router]);
+  }, [
+    os.auth.user,
+    navigate,
+    next,
+    selected_plan,
+    code,
+    location.pathname,
+    signUpMethod,
+    showGuestCredentials,
+    router
+  ]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/frontend/src/utils/signupRedirect.test.ts
+++ b/frontend/src/utils/signupRedirect.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, test } from "bun:test";
+import { shouldRedirectAuthenticatedSignup } from "./signupRedirect";
+
+describe("shouldRedirectAuthenticatedSignup", () => {
+  test("does not redirect from the anonymous signup handoff", () => {
+    expect(
+      shouldRedirectAuthenticatedSignup({
+        isAuthenticated: true,
+        isGuestSignup: true,
+        isSignupRoute: true,
+        showGuestCredentials: false
+      })
+    ).toBe(false);
+  });
+
+  test("does not redirect while anonymous credentials are visible", () => {
+    expect(
+      shouldRedirectAuthenticatedSignup({
+        isAuthenticated: true,
+        isGuestSignup: true,
+        isSignupRoute: true,
+        showGuestCredentials: true
+      })
+    ).toBe(false);
+  });
+
+  test("still redirects an authenticated user outside the guest handoff", () => {
+    expect(
+      shouldRedirectAuthenticatedSignup({
+        isAuthenticated: true,
+        isGuestSignup: false,
+        isSignupRoute: true,
+        showGuestCredentials: false
+      })
+    ).toBe(true);
+  });
+
+  test("does not redirect a transient signup outlet while navigation leaves the route", () => {
+    expect(
+      shouldRedirectAuthenticatedSignup({
+        isAuthenticated: true,
+        isGuestSignup: false,
+        isSignupRoute: false,
+        showGuestCredentials: false
+      })
+    ).toBe(false);
+  });
+});

--- a/frontend/src/utils/signupRedirect.ts
+++ b/frontend/src/utils/signupRedirect.ts
@@ -1,0 +1,15 @@
+type AuthenticatedSignupRedirectState = {
+  isAuthenticated: boolean;
+  isGuestSignup: boolean;
+  isSignupRoute: boolean;
+  showGuestCredentials: boolean;
+};
+
+export function shouldRedirectAuthenticatedSignup({
+  isAuthenticated,
+  isGuestSignup,
+  isSignupRoute,
+  showGuestCredentials
+}: AuthenticatedSignupRedirectState): boolean {
+  return isSignupRoute && isAuthenticated && !isGuestSignup && !showGuestCredentials;
+}


### PR DESCRIPTION
## Summary

- keep anonymous signup mounted across the signed-out to authenticated transition so the generated Account ID remains available
- prevent the generic authenticated-signup redirect from overriding the Account ID dialog and its explicit pricing navigation
- preserve the existing OAuth callback exactly-once mount behavior and ordinary account-scoped resets
- add focused lifecycle and redirect regression coverage

## Root cause

The account-scoped root layout intentionally remounts ordinary routes when auth changes. That behavior fixed OAuth callback replay in #715 by exempting the OAuth callback, but anonymous signup was still treated as an ordinary route. When signUpGuest authenticated the new user, the signup component remounted and lost the generated UUID before the credentials dialog could render. A transient outlet remount while leaving signup could also let the generic authenticated-user redirect win over the explicit pricing navigation.

## Validation

- complete local web flow: warnings, password creation, Account ID dialog with non-empty UUID, required backup acknowledgment, and successful navigation to /pricing
- managed workspace smoke passed for OpenSecret, Postgres, Continuum, Tinfoil extended health, and billing
- 592 frontend tests passed
- production TypeScript and Vite build passed
- formatting passed
- lint passed with 0 errors and 13 pre-existing warnings
- signed pre-commit hook passed

No backend, SDK, billing, OAuth payload, or token-storage behavior changed.