### PR TITLE
docs: add agent development and validation guidance

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -141,9 +141,37 @@ Select only affected module filters for the edit loop; run the complete locked R
 
 Use a local open-source OpenSecret backend or an explicitly configured development API. Use a disposable account and non-sensitive fixtures. If remote rollout has not enabled Agent Mode for that account, set `VITE_FORCE_FEATURE_FLAGS=agent_mode` in untracked `frontend/.env.local` and restart the frontend server.
 
-1. Record the commit SHA, `VITE_OPEN_SECRET_API_URL`, selected model ID, build profile, and whether `.local/tauri-workspace.json` is active. Record the effective Tauri identifier, dev URL, exact executable/application path, frontend-server PID, and native PID.
-2. Create a disposable project directory with a `README.md` containing a unique marker. Record the exact directory so cleanup cannot target a broader path.
+1. Record the commit SHA, `VITE_OPEN_SECRET_API_URL`, selected model ID when relevant, build profile, and whether `.local/tauri-workspace.json` is active. Record the effective Tauri identifier, dev URL, exact executable/application path, frontend-server PID, and native PID.
+2. When the scenario needs project content, create a disposable project directory with a `README.md` containing a unique marker. Record the exact directory so cleanup cannot target a broader path.
 3. Launch from the repository root with `nix develop -c just desktop-dev`. Operate the native window belonging to the recorded PID and identifier, never a browser tab or another installed app named Maple.
+
+Every Agent Mode UI change requires an exact native-app smoke because the web
+build does not exercise this desktop-only path. Keep the smoke proportional to
+the changed boundary and classify it by behavior, not file path:
+
+- For presentation-only changes confined to icons, copy, spacing, or markup for
+  already-derived timeline state, exercise the exact changed states and
+  interactions in the native app. Sign in, open Agent Mode, and navigate only
+  as far as the changed state requires. Check relevant loading, streaming,
+  completed, error, or permission presentation plus keyboard, focus,
+  accessibility, theme, and layout behavior as applicable. Use a minimal
+  read-only prompt when runtime data is needed. Do not create files, approve
+  shell execution, switch accounts, or run restart/logout lifecycle exercises
+  unless the changed UI depends on those boundaries. If event mapping, state
+  derivation, timeline grouping or merging, status transitions, action handlers,
+  IPC calls, permission callbacks, or account/session/run ownership changed,
+  this is not presentation-only. If permission presentation itself changed,
+  trigger one disposable request, deny it, and verify that no mutation occurred.
+- For runtime, tool, permission, cancellation, persistence, task ownership,
+  session switching, restart, logout, app-exit, authentication, or account
+  isolation changes, run the applicable full-baseline steps below. Run the
+  complete baseline when the change is cross-cutting or its affected lifecycle
+  boundaries cannot be isolated. For a narrower change within one of these
+  areas, run the affected steps and explicitly report what was not exercised.
+
+For changes requiring full lifecycle coverage, continue through the remaining
+baseline:
+
 4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task.
 5. Send: `Read README.md using the read tool. Reply only with the exact marker. Do not use shell.` Confirm the visible user row, tool activity, exact marker result, final answer, and completed terminal state.
 6. Send: `Create agent-smoke-output.txt containing exactly <marker> using the write tool. Do not use shell.` Confirm a single pending permission card. Choose `Deny once`; verify the card settles as denied, the run terminates coherently, and the file does not exist.
@@ -152,7 +180,12 @@ Use a local open-source OpenSecret backend or an explicitly configured developme
 9. Create a second task, switch between tasks during a streamed response, and confirm events remain with their owning task. Relaunch the exact app and verify local task order/history plus the selected task restore without duplicating the terminal message.
 10. Exercise restart, logout, and app exit. Confirm active work is drained, native authentication is cleared on logout, no old-account runtime or tool context can be used afterward, and no Agent/ACP child or listener from the exact tested app remains after exit. If account isolation changed, repeat with a second disposable account and verify neither account can see or mutate the other's tasks/configuration.
 
-When the change is narrower, run the complete baseline above once, then add boundary-specific proof:
+Use steps 4–5 for core run, stream, and completion behavior; 6–7 for write and
+permission behavior; 8 for shell cancellation and descendant cleanup; 9 for
+task ownership, switching, persistence, and relaunch; and 10 for restart,
+logout, app exit, authentication, and account isolation.
+
+After the applicable baseline coverage, add boundary-specific proof:
 
 - MCP: follow `docs/agent-mode-mcp.md` with its pinned Everything-server fixture over each affected transport; verify the unique marker through request, arguments, result, answer, disable, and failure paths.
 - ACP: follow `docs/agent-mode-acp.md`, but re-check the live Cargo pin and implementation first. Verify socket ownership, allowed-root rejection, caller-only permission routing, disconnect/cancel cleanup, and bounded overflow behavior with the actual client in scope.

--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: change-maple-agent-mode
+description: Develop, debug, review, and test Maple Agent Mode across its React UI, Tauri command and event bridge, account-scoped native runtime, embedded Goose integration, OpenSecret provider, developer tools, permissions, skills, MCP, and ACP adapter. Use for any change involving AgentMode, agent runtime lifecycle or persistence, Goose pins or prompts, model/tool streaming, cancellation, local filesystem or shell tools, project trust, MCP servers, external ACP callers, or Agent account isolation.
+---
+
+# Change Maple Agent Mode
+
+Work from the Maple repository root. Read root `AGENTS.md`, the current source, nearby tests, and relevant docs before editing. Treat `frontend/src-tauri/Cargo.toml`, `frontend/src-tauri/Cargo.lock`, the implementation, and test suite as authoritative when historical prose disagrees.
+
+Use `$develop-maple` for general repository setup and ordinary Maple conventions. Use `$validate-maple` for complete CI-equivalent, packaged, or cross-platform validation, and `$review-maple-security` when a change touches credentials, authorization, privileged tools, process execution, local IPC, or another trust boundary.
+
+Do not commit, push, open a PR, merge, release, or clean unrelated work unless the user explicitly requests it.
+
+## Understand the Runtime Before Changing It
+
+Keep Maple's two inference paths distinct:
+
+- Research chat is a browser-capable React path. `UnifiedChat.tsx` uses the OpenAI JavaScript client with `@opensecret/react`'s authenticated and encrypted `aiCustomFetch`, targeting OpenSecret's Conversations and Responses APIs.
+- Agent Mode is desktop-only. `AgentMode.tsx` calls typed frontend services, which invoke Tauri commands and receive `agent-event` envelopes. Native Rust owns `MapleAgentService`, the embedded Goose managers and local sessions, Maple's provider, developer tools, permissions, and cancellation. `MapleProvider` sends encrypted OpenSecret SDK requests to `/v1/chat/completions`.
+- ACP is a secondary local adapter over the same `MapleAgentService`. It must not initialize a second Goose runtime or call through the Tauri adapter.
+- The local OpenAI-compatible proxy is a separate user-facing feature. Neither Research chat nor Agent Mode should silently route through it.
+- Agent Mode, Goose, native OpenSecret auth, MCP, and ACP compile only for desktop. Mobile retains shared React functionality and selected native facilities such as document extraction, not Agent Mode.
+
+Maple locally persists Agent tasks, project configuration, MCP snapshots, and Goose session history under an opaque account scope. OpenSecret remains authoritative for account identity, authentication, encrypted inference, model/backend policy, and web search or extraction. Do not confuse local Agent history with server-persisted Research conversations.
+
+## Put Changes at the Owning Boundary
+
+Use these seams:
+
+- `frontend/src/components/AgentMode.tsx` and `frontend/src/components/agent/`: presentation, interaction state, accessible controls, and projection of native events. Do not enforce security only here.
+- `frontend/src/services/agentRuntimeService.ts`: typed Tauri commands/events, user-operation fencing, and logout/account-transition coordination.
+- `frontend/src/services/mapleApiAuthService.ts`: browser/native credential reconciliation. Do not copy this logic into components.
+- `frontend/src-tauri/src/agent_tauri.rs`: the stable Desktop command and event adapter. Keep it thin.
+- `frontend/src-tauri/src/agent_host.rs`: operations spanning the core runtime and ACP, including stop, restart, clear, exit, and update shutdown.
+- `frontend/src-tauri/src/agent.rs`: transport-neutral Agent domain state, account handles, Goose/session orchestration, persistence, run ownership, timelines, MCP and skills attachment, and permission routing. Do not import Tauri or ACP protocol types into this core.
+- `frontend/src-tauri/src/agent/provider.rs`: Goose-provider request construction, encrypted inference transport, streaming, bounded error handling, retry policy, and cancellation.
+- `frontend/src-tauri/src/maple_api.rs`: account-scoped native OpenSecret SDK sessions, backend identity validation, atomic credential replacement, and refresh reconciliation.
+- `frontend/src-tauri/src/agent/developer_tools.rs`: Maple's privileged read, write, edit, image, shell, and backend web-tool implementations. Add privileged tools here rather than exposing an unmediated Goose tool path.
+- `frontend/src-tauri/src/agent/{shell_permission,web_permission,tool_context,web_tools}.rs`: automatic policy, secret-bearing execution context, public-URL admission, provenance, and output bounds.
+- `frontend/src-tauri/src/agent/system_prompt.rs`: the narrowly rebranded copy of the pinned Goose system prompt.
+- `frontend/src-tauri/src/agent_acp.rs`: ACP framing, Unix socket ownership, connection/session leases, caller-owned permissions, and adapter-specific environment allowlists.
+
+Put behavior in OpenSecret instead when it must be authoritative against a modified client, shared by multiple clients, durable across devices, or part of the public API, authentication, confidential-compute, model, provider, search, or extraction contract. Coordinate the open-source backend and SDK rather than emulating missing enforcement in Maple.
+
+## Preserve Trust and Lifecycle Invariants
+
+### Account and credential isolation
+
+- Bind every native operation to the requested user's opaque account scope and current handle generation. Reject stale handles and cross-account sessions.
+- Validate candidate native credentials against the backend before publishing them. Preserve atomic replacement and prevent a late refresh from overwriting a newer browser or native token pair.
+- Synchronize auth before authenticated Tauri calls. On logout or account switch, block new operations, drain Agent/ACP, then clear native auth and account-bound local proxy credentials.
+- Never put OpenSecret access or refresh tokens into Goose configuration, prompts, tool arguments, child environments, logs, or error strings.
+
+### Runtime, session, and run lifecycle
+
+- Keep one authoritative native runtime for the signed-in account. Serialize start, stop, restart, clear, exit, and update operations across Agent and ACP.
+- Claim a session before changing its title, model, permission mode, extensions, or tool context. Reject concurrent mutation rather than racing it.
+- Define ownership for every spawned task, listener, stream, permission request, cancellation token, and secret-bearing context. Ensure every terminal path cancels, joins, revokes, persists or repairs history, emits an authoritative terminal event, and removes active state in the intended order.
+- Fence frontend async work by account, session, run, and revision/generation. Navigation may change the visible task but must not redirect an existing run's events.
+- Preserve the session model lock after history exists. Treat a model change as a new task unless product requirements explicitly change that contract.
+- Keep bounded event queues fail-loud. Never let Desktop or ACP backpressure Goose indefinitely or silently present a truncated stream as complete.
+
+### Permissions and privileged tools
+
+- Keep Goose live in `SmartApprove` so every sensitive tool reaches Maple's policy boundary. Persist the user-facing `Read only` (`smart_approve`) or `Allow all` (`auto`) choice separately.
+- Reset Maple's Goose permission file so `read`, `shell`, `edit`, `write`, `read_image`, `web_search`, and `open_url` route through `ask_before`; only `load_skill` is always allowed.
+- Automatic classifiers may approve only narrowly established safe behavior. Timeout, provider failure, malformed output, ambiguity, secret access, mutation, network access, or arbitrary execution must fail closed to interactive approval.
+- Preserve one-shot, run-scoped permission capabilities. The calling surface owns unresolved permissions: Desktop for Desktop runs and ACP for ACP runs. Never expose one actionable request to both.
+- Bound shell time and output; kill the process group or job object on cancellation, revocation, timeout, or overflow. A child receiving ephemeral credentials must not outlive its parent command.
+- Treat paths, shell commands, MCP definitions, headers, environment values, model output, URLs, extracted pages, and tool results as untrusted. Revalidate at the native enforcing boundary.
+- Admit `open_url` only for normalized public HTTPS URLs. Preserve private, loopback, link-local, metadata, credential-bearing, and malformed URL rejection, bounded output, per-session provenance, and explicit untrusted-evidence notices.
+
+### Skills, projects, MCP, and ACP
+
+- Keep project roots canonical and account-scoped. Project removal, ordering, history, and trust decisions must not mutate another account or silently re-add a removed root.
+- Load project instructions and skills only after the user trusts that canonical project. Keep the skills client transient so Goose cannot reconstruct it later with an untrusted real working directory.
+- Validate and freeze MCP definitions into each session. Preserve reserved names, unsafe-environment rejection, header normalization, owner-only storage where supported, and the warning that obscured stored values are not encrypted at rest.
+- Keep ACP disabled by default and Unix-only until its implementation changes. Require absolute admitted roots, owner-only socket access, bounded frames/connections/outbound work, exact session leases, and explicit environment allowlists. Revocation or disconnect must make captured tool context unusable.
+- Never describe `read_only` ACP configuration as a sandbox. It is caller-mediated permission policy; a caller can still approve mutation.
+
+### Provider and privacy behavior
+
+- Preserve authenticated encrypted transport through the OpenSecret SDK. `MapleProvider` must not own token storage or refresh.
+- Retry only failures that are safe before the first successful streamed item. Do not repeat deterministic client failures or side effects speculatively.
+- Keep parser errors, HTTP bodies, provider details, decrypted SSE data, prompts, tool results, and private file contents out of logs and user-facing error strings. Return bounded, categorized errors.
+- Preserve cancellation through Goose, provider transport, SDK operations, tools, and terminal history repair.
+
+## Follow the Change Workflow
+
+1. Inspect `git status --short --branch`, current SHA, `origin/master`, and the complete existing diff. Preserve unrelated work and do not switch branches over a dirty tree.
+2. Trace the request through UI, frontend bridge, Tauri adapter, core service, Goose, provider/tools, persistence, and backend. Identify which boundaries do not need to change.
+3. Write down the account owner, session owner, run owner, permission owner, cancellation path, persistence point, terminal event, and cleanup path for the proposed behavior before editing concurrent code.
+4. Add or update the smallest transport-neutral core behavior first, then adapters/wire types, then UI projection. Keep adapters from reaching through one another.
+5. Add regression tests for success plus stale account/session/run, cancellation, duplicate/concurrent calls, partial failure, restart/reload, and bounded-input behavior relevant to the change.
+6. Update public docs when behavior or compatibility changes. Mark historical smoke evidence as historical and never copy an old dependency pin into current instructions.
+7. Inspect the final diff for secret logging, unbounded data, bypassed permissions, detached tasks, stale completion, cross-account access, and behavior that belongs in OpenSecret.
+
+For a Goose bump, obtain the exact revision from
+`frontend/src-tauri/Cargo.toml`, inspect that revision in a real git checkout,
+update `frontend/src-tauri/Cargo.lock`, and compare
+`frontend/src-tauri/src/agent/system_prompt.rs` byte-for-byte with the pinned
+Goose `crates/goose/src/prompts/system.md`. Only Maple's two identity lines may
+differ. Re-run the prompt-drift test and every affected provider, permission,
+tool, MCP, session, and lifecycle test. Do not reason from an unversioned source
+archive or current Goose `main`.
+
+## Run Targeted Tests
+
+Run frontend tests without loading `.env.local`:
+
+```bash
+cd frontend
+bun --no-env-file test src/components/AgentMode.test.ts
+bun --no-env-file test \
+  src/services/agentRuntimeService.test.ts \
+  src/services/mapleApiAuthService.test.ts \
+  src/services/agentAuthLifecycle.test.ts \
+  src/services/agentOperationFence.test.ts
+```
+
+Add the focused service tests matching the change, such as `agentTimeline`, `agentThoughtRunLifecycle`, `agentModels`, `agentMcpServers`, `agentProjectOrdering`, `agentSessionSelection`, `agentConnectionsAvailability`, or `flags`.
+
+Run Rust tests by affected module while iterating:
+
+```bash
+cd frontend/src-tauri
+cargo test --locked 'agent::tests::'
+cargo test --locked 'agent::provider::tests::'
+cargo test --locked 'agent::developer_tools::tests::'
+cargo test --locked 'agent::shell_permission::tests::'
+cargo test --locked 'agent::web_permission::tests::'
+cargo test --locked 'agent::web_tools::tests::'
+cargo test --locked 'maple_api::tests::'
+cargo test --locked 'agent_host::tests::'
+cargo test --locked 'agent_acp::tests::'
+```
+
+Select only affected module filters for the edit loop; run the complete locked Rust suite before handing off a native change. For any Agent Mode change, also run formatting, linting, typechecking, and builds required by `$validate-maple`. Unit tests do not replace a real desktop smoke.
+
+## Perform the Exact Desktop Smoke
+
+Use a local open-source OpenSecret backend or an explicitly configured development API. Use a disposable account and non-sensitive fixtures. If remote rollout has not enabled Agent Mode for that account, set `VITE_FORCE_FEATURE_FLAGS=agent_mode` in untracked `frontend/.env.local` and restart the frontend server.
+
+1. Record the commit SHA, `VITE_OPEN_SECRET_API_URL`, selected model ID, build profile, and whether `.local/tauri-workspace.json` is active. Record the effective Tauri identifier, dev URL, exact executable/application path, frontend-server PID, and native PID.
+2. Create a disposable project directory with a `README.md` containing a unique marker. Record the exact directory so cleanup cannot target a broader path.
+3. Launch from the repository root with `nix develop -c just desktop-dev`. Operate the native window belonging to the recorded PID and identifier, never a browser tab or another installed app named Maple.
+4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task.
+5. Send: `Read README.md using the read tool. Reply only with the exact marker. Do not use shell.` Confirm the visible user row, tool activity, exact marker result, final answer, and completed terminal state.
+6. Send: `Create agent-smoke-output.txt containing exactly <marker> using the write tool. Do not use shell.` Confirm a single pending permission card. Choose `Deny once`; verify the card settles as denied, the run terminates coherently, and the file does not exist.
+7. Repeat the write request and choose `Allow once`. Verify one settled permission card, exact on-disk contents, a visible tool result, final answer, and completed state. Do not use `Allow all` merely to make the smoke easier.
+8. Send: `Run the shell command sleep 30 and do nothing else.` Approve the shell request, wait until the tool is running, then press Cancel. Confirm the UI reaches a cancelled terminal state, no permission remains actionable, a reload shows repaired coherent history, and process inspection shows no shell descendant owned by that run after cancellation.
+9. Create a second task, switch between tasks during a streamed response, and confirm events remain with their owning task. Relaunch the exact app and verify local task order/history plus the selected task restore without duplicating the terminal message.
+10. Exercise restart, logout, and app exit. Confirm active work is drained, native authentication is cleared on logout, no old-account runtime or tool context can be used afterward, and no Agent/ACP child or listener from the exact tested app remains after exit. If account isolation changed, repeat with a second disposable account and verify neither account can see or mutate the other's tasks/configuration.
+
+When the change is narrower, run the complete baseline above once, then add boundary-specific proof:
+
+- MCP: follow `docs/agent-mode-mcp.md` with its pinned Everything-server fixture over each affected transport; verify the unique marker through request, arguments, result, answer, disable, and failure paths.
+- ACP: follow `docs/agent-mode-acp.md`, but re-check the live Cargo pin and implementation first. Verify socket ownership, allowed-root rejection, caller-only permission routing, disconnect/cancel cleanup, and bounded overflow behavior with the actual client in scope.
+- Provider or streaming: exercise first-byte failure, partial stream, cancellation, context-limit failure, and reload without exposing decrypted bodies.
+- Auth or lifecycle: exercise token refresh, logout during a run, account switch, restart, and app exit while inspecting only sanitized logs and exact owned processes.
+- Skills or project trust: test trusted and untrusted canonical roots, restart, removal, and account isolation.
+
+Clean up only the exact disposable project, account data, processes, listeners, and test server instances created for the smoke. Report automated, artifact, runtime, integration, and untested evidence separately. Never call a web build, Rust test, or successful app launch an Agent Mode end-to-end pass.
+
+## Hand Off the Change
+
+Report the behavior and owning boundary, affected account/session/run and trust invariants, files changed, exact commands and results, exact native smoke identity and observations, backend/model configuration used, and every untested platform or integration. State whether the tree remains uncommitted and unpushed.

--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -1,13 +1,17 @@
 ---
 name: change-maple-agent-mode
-description: Develop, debug, review, and test Maple Agent Mode across its React UI, Tauri command and event bridge, account-scoped native runtime, embedded Goose integration, OpenSecret provider, developer tools, permissions, skills, MCP, and ACP adapter. Use for any change involving AgentMode, agent runtime lifecycle or persistence, Goose pins or prompts, model/tool streaming, cancellation, local filesystem or shell tools, project trust, MCP servers, external ACP callers, or Agent account isolation.
+description: Develop and debug Maple Agent Mode across its React UI, Tauri command and event bridge, account-scoped native runtime, embedded Goose integration, OpenSecret provider, developer tools, permissions, skills, MCP, and ACP adapter. Use when implementing or debugging AgentMode, agent runtime lifecycle or persistence, Goose pins or prompts, model/tool streaming, cancellation, local filesystem or shell tools, project trust, MCP servers, external ACP callers, or Agent account isolation.
 ---
 
 # Change Maple Agent Mode
 
 Work from the Maple repository root. Read root `AGENTS.md`, the current source, nearby tests, and relevant docs before editing. Treat `frontend/src-tauri/Cargo.toml`, `frontend/src-tauri/Cargo.lock`, the implementation, and test suite as authoritative when historical prose disagrees.
 
-Use `$develop-maple` for general repository setup and ordinary Maple conventions. Use `$validate-maple` for complete CI-equivalent, packaged, or cross-platform validation, and `$review-maple-security` when a change touches credentials, authorization, privileged tools, process execution, local IPC, or another trust boundary.
+Root `AGENTS.md` owns repository setup and ordinary conventions. Use
+`$validate-maple` for complete CI-equivalent, packaged, or cross-platform
+validation, and `$review-maple-security` when a change touches credentials,
+authorization, privileged tools, process execution, local IPC, or another
+trust boundary.
 
 Do not commit, push, open a PR, merge, release, or clean unrelated work unless the user explicitly requests it.
 
@@ -64,9 +68,20 @@ Put behavior in OpenSecret instead when it must be authoritative against a modif
 
 - Keep Goose live in `SmartApprove` so every sensitive tool reaches Maple's policy boundary. Persist the user-facing `Read only` (`smart_approve`) or `Allow all` (`auto`) choice separately.
 - Reset Maple's Goose permission file so `read`, `shell`, `edit`, `write`, `read_image`, `web_search`, and `open_url` route through `ask_before`; only `load_skill` is always allowed.
-- Automatic classifiers may approve only narrowly established safe behavior. Timeout, provider failure, malformed output, ambiguity, secret access, mutation, network access, or arbitrary execution must fail closed to interactive approval.
+- Derive current policy per tool from its permission configuration, automatic
+  handler, classifier, and executor. Distinguish always-allowed, automatic,
+  classifier-approved, and caller-approved paths; do not generalize one tool's
+  classifier or URL policy to another.
+- Automatic policy may approve only explicitly defined operations. On a
+  classifier-backed path, timeout, failure, or ambiguity falls back to caller
+  approval; otherwise follow the explicit per-tool policy.
 - Preserve one-shot, run-scoped permission capabilities. The calling surface owns unresolved permissions: Desktop for Desktop runs and ACP for ACP runs. Never expose one actionable request to both.
-- Bound shell time and output; kill the process group or job object on cancellation, revocation, timeout, or overflow. A child receiving ephemeral credentials must not outlive its parent command.
+- Bound shell time and output. Treat process-group or job-object cleanup as
+  best-effort containment of the current child tree, not a hard credential
+  boundary. On normal cancellation, revocation, timeout, or overflow, revoke
+  the context, request tree termination through the owned process-group or job
+  handle, and reap the wrapped child. If hard non-survival is required, keep
+  credentials out of arbitrary child environments.
 - Treat paths, shell commands, MCP definitions, headers, environment values, model output, URLs, extracted pages, and tool results as untrusted. Revalidate at the native enforcing boundary.
 - Admit `open_url` only for normalized public HTTPS URLs. Preserve private, loopback, link-local, metadata, credential-bearing, and malformed URL rejection, bounded output, per-session provenance, and explicit untrusted-evidence notices.
 
@@ -106,44 +121,49 @@ archive or current Goose `main`.
 
 ## Run Targeted Tests
 
-Run frontend tests without loading `.env.local`:
+Run the smallest relevant frontend set without Bun's automatic dotenv loading:
 
 ```bash
-cd frontend
-bun --no-env-file test src/components/AgentMode.test.ts
-bun --no-env-file test \
-  src/services/agentRuntimeService.test.ts \
-  src/services/mapleApiAuthService.test.ts \
-  src/services/agentAuthLifecycle.test.ts \
-  src/services/agentOperationFence.test.ts
+nix develop .#ci -c bash -c \
+  'cd frontend && bun --no-env-file test ./src/components/AgentMode.test.ts'
 ```
 
-Add the focused service tests matching the change, such as `agentTimeline`, `agentThoughtRunLifecycle`, `agentModels`, `agentMcpServers`, `agentProjectOrdering`, `agentSessionSelection`, `agentConnectionsAvailability`, or `flags`.
+Add only the service tests matching the changed boundary, such as runtime/auth
+lifecycle, operation fencing, timeline, models, MCP, project/session selection,
+or connection availability.
 
 Run Rust tests by affected module while iterating:
 
 ```bash
-cd frontend/src-tauri
-cargo test --locked 'agent::tests::'
-cargo test --locked 'agent::provider::tests::'
-cargo test --locked 'agent::developer_tools::tests::'
-cargo test --locked 'agent::shell_permission::tests::'
-cargo test --locked 'agent::web_permission::tests::'
-cargo test --locked 'agent::web_tools::tests::'
-cargo test --locked 'maple_api::tests::'
-cargo test --locked 'agent_host::tests::'
-cargo test --locked 'agent_acp::tests::'
+nix develop .#ci -c bash -c \
+  'cd frontend/src-tauri && cargo test --locked "agent::provider::tests::"'
 ```
 
-Select only affected module filters for the edit loop; run the complete locked Rust suite before handing off a native change. For any Agent Mode change, also run formatting, linting, typechecking, and builds required by `$validate-maple`. Unit tests do not replace a real desktop smoke.
+Replace the example filter with the affected module and add adjacent filters
+only when their boundary changed. Run the complete locked Rust suite before
+handing off a native change. For any Agent Mode change, also run formatting,
+linting, typechecking, and builds required by `$validate-maple`. Unit tests do
+not replace a real desktop smoke.
 
 ## Perform the Exact Desktop Smoke
 
-Use a local open-source OpenSecret backend or an explicitly configured development API. Use a disposable account and non-sensitive fixtures. If remote rollout has not enabled Agent Mode for that account, set `VITE_FORCE_FEATURE_FLAGS=agent_mode` in untracked `frontend/.env.local` and restart the frontend server.
+Use a local open-source OpenSecret backend or an explicitly configured
+development API. Use a disposable account and non-sensitive fixtures. In a
+standalone checkout, if remote rollout has not enabled Agent Mode for that
+account, set `VITE_FORCE_FEATURE_FLAGS=agent_mode` in the untracked
+`frontend/.env.local` and restart the frontend server. Do not edit an
+externally managed environment file; use its owning environment's configuration
+path or report the scenario unavailable.
 
 1. Record the commit SHA, `VITE_OPEN_SECRET_API_URL`, selected model ID when relevant, build profile, and whether `.local/tauri-workspace.json` is active. Record the effective Tauri identifier, dev URL, exact executable/application path, frontend-server PID, and native PID.
 2. When the scenario needs project content, create a disposable project directory with a `README.md` containing a unique marker. Record the exact directory so cleanup cannot target a broader path.
-3. Launch from the repository root with `nix develop -c just desktop-dev`. Operate the native window belonging to the recorded PID and identifier, never a browser tab or another installed app named Maple.
+3. Read the active Tauri `devUrl` and inspect its listener before launch. If it
+   is occupied, stop the process only when you can prove it belongs to this
+   checkout, using its owning lifecycle mechanism where one exists; otherwise
+   use another overlay or port. Launch from the repository root with
+   `nix develop -c just desktop-dev`. Operate the native window belonging to
+   the recorded PID and identifier, never a browser tab or another installed
+   app named Maple.
 
 Every Agent Mode UI change requires an exact native-app smoke because the web
 build does not exercise this desktop-only path. Keep the smoke proportional to

--- a/.agents/skills/change-maple-agent-mode/agents/openai.yaml
+++ b/.agents/skills/change-maple-agent-mode/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Change Maple Agent Mode"
+  short_description: "Protect Agent Mode lifecycle invariants"
+  default_prompt: "Use $change-maple-agent-mode to implement or review this Agent Mode change."

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -1,0 +1,148 @@
+---
+name: develop-maple
+description: Develop and debug Maple features and fixes across its React/Vite frontend and Tauri/Rust application. Use for local setup, choosing the Maple-versus-OpenSecret boundary, implementing ordinary UI, state, API-client, native command, desktop, or mobile changes, running focused tests, and preparing a reviewable handoff. Route comprehensive smoke/platform validation, security review, Agent Mode work, and releases to Maple's specialized sibling skills.
+---
+
+# Develop Maple
+
+Work from the `OpenSecretCloud/Maple` repository root. Treat `justfile`, `frontend/package.json`, `flake.nix`, `scripts/ci/`, and `.github/workflows/` as the command sources of truth. Check them again when they disagree with prose documentation.
+
+## Route Specialized Work
+
+- Use `$validate-maple` for full validation, packaged-app smoke tests, cross-platform builds, or release-artifact verification.
+- Use `$review-maple-security` for security audits or changes involving authentication, authorization, attestation, OAuth/deep links, credentials, storage, CSP, local proxy exposure, filesystem/shell access, or trust boundaries.
+- Use `$change-maple-agent-mode` for Goose, Agent Mode runtime/UI, tool permissions, MCP, ACP, subagents, or agent persistence.
+- Use `$release-maple` for version bumps, tags, publishing, release CI, or distribution. Never use `just release` during ordinary development.
+
+Keep the current task scoped when one of these skills is unnecessary. Do not claim specialized validation that was not run.
+
+## Establish a Safe Baseline
+
+1. Inspect `git status --short --branch`, the current branch, and recent history.
+2. Preserve all existing changes. Never reset, overwrite, or reformat unrelated work.
+3. For newly requested isolated work, base it on current `origin/master` unless the user specifies another base. Do not switch branches over a dirty checkout.
+4. Read root `AGENTS.md`, relevant docs, nearby implementation, tests, and current dependency/API versions before designing the change.
+5. State the intended behavior and the smallest affected boundary before editing.
+
+Do not commit, push, open a PR, merge, tag, publish, or release unless the user explicitly requests that action.
+
+## Use the Pinned Development Environment
+
+Prefer Nix so local tools match CI:
+
+```bash
+nix develop
+./setup-hooks.sh
+just install
+```
+
+The flake pins Bun, Rust, and platform tooling. Use Bun for frontend dependencies; do not create npm, Yarn, or pnpm lockfiles.
+
+Configure a local API without committing secrets:
+
+```bash
+test -e frontend/.env.local || cp frontend/.env.example frontend/.env.local
+```
+
+Set `VITE_OPEN_SECRET_API_URL` to the OpenSecret API under test. Set the billing or feature-flag API URLs only when exercising those integrations. Keep `.env.local` untracked, never put secrets in `VITE_*` values, and do not overwrite an existing developer configuration.
+
+Use `nix develop -c <command>` when an interactive shell is inconvenient. Use `nix develop -c just clean-local` to clean this checkout; do not run raw `cargo clean` from the Nix shell because Cargo intermediates may be shared.
+
+## Choose the Correct Boundary
+
+Keep in Maple:
+
+- React presentation, navigation, accessible interaction, view-local state, and client-side orchestration.
+- Tauri commands, OS integration, application lifecycle, packaging, and explicitly local-only features.
+- Client adaptation to an already-defined OpenSecret API contract.
+
+Keep in OpenSecret:
+
+- Authentication and authorization enforcement.
+- Shared durable state and behavior that must agree across clients.
+- Model/provider policy, confidential-compute enforcement, and public API semantics.
+- Validation that must remain authoritative when a client is modified or bypassed.
+
+Do not emulate missing server enforcement in Maple. If the work changes an API contract, coordinate the open-source backend and SDK changes, preserve compatible failure behavior where practical, and test Maple against the exact backend revision. Configure external billing and flags services through their public API URLs; do not depend on their source trees.
+
+## Follow the Existing Architecture
+
+- Put React, routes, contexts, and browser-facing services under `frontend/src/`.
+- Put privileged/native behavior under `frontend/src-tauri/src/` and expose the narrowest typed Tauri command or event needed by the UI.
+- Use `@opensecret/react` and the existing OpenSecret client paths for authentication, encryption, and API calls. Do not duplicate protocol or cryptographic logic in components.
+- Follow nearby state ownership, cancellation, error, and cleanup patterns. Preserve account isolation and handle logout, navigation, retries, and stale async completion explicitly.
+- Treat all network, file, deep-link, shell, tool, and Tauri-command inputs as untrusted. Validate again at the enforcing boundary.
+- Keep feature flags as rollout/UI controls, never authorization controls.
+- Preserve accessibility semantics, keyboard behavior, focus handling, loading states, and actionable errors.
+- Do not edit `frontend/src/routeTree.gen.ts` manually; let TanStack Router regenerate it.
+- Treat generated mobile projects and platform patches as intentional source. Change them only when the platform behavior requires it and verify the relevant target.
+- Update `frontend/bun.lock` or `frontend/src-tauri/Cargo.lock` with dependency
+  changes. Explain new dependencies and avoid broad upgrades during an
+  unrelated fix.
+- Never log plaintext prompts, decrypted content, tokens, session keys, credentials, or sensitive file contents.
+
+## Run the Development Loop
+
+Choose the lightest runtime that exercises the changed boundary:
+
+```bash
+just dev          # browser UI at port 5173
+just desktop-dev  # Tauri desktop app with ONNX Runtime provisioning
+```
+
+For iOS work, prepare the pinned runtime and select the target explicitly:
+
+```bash
+just ios-build-onnxruntime
+just ios-dev-sim "iPhone 16 Pro"
+# or: just ios-dev-device "Device Name"
+```
+
+Run direct `bun` and `bun tauri` commands from `frontend/`, not the repository root. Prefer `just desktop-dev` over raw `bun tauri dev` because the recipe provisions the platform ONNX Runtime.
+
+During implementation:
+
+1. Add or update the smallest behavior-focused test near the changed logic.
+2. Reproduce failures deterministically; do not weaken assertions to make them pass.
+3. Keep UI and Rust changes independently understandable when possible.
+4. Inspect runtime logs for the exact app/build under test. Do not attach to another installed Maple build by display name alone.
+
+## Run Focused Checks
+
+For frontend changes:
+
+```bash
+cd frontend
+bun test path/to/test.ts             # focused loop
+bun run format:check
+bun run lint
+bun run typecheck
+bun run test
+bun run build
+```
+
+For Rust/Tauri changes:
+
+```bash
+cd frontend/src-tauri
+cargo fmt --check
+cargo clippy -- -D warnings
+cargo test --all-targets
+```
+
+There is no `just test` recipe. The pre-commit hook is useful but does not replace ESLint, Clippy, CI-equivalent checks, or runtime smoke testing.
+
+Before handoff, run `git diff --check`, inspect the complete diff and status, and invoke `$validate-maple` when the risk or requested proof exceeds these focused checks.
+
+## Hand Off Precisely
+
+Report:
+
+- The behavior changed and why it belongs in Maple.
+- The files and trust boundaries affected.
+- Exact commands run and their results.
+- Runtime/platform smoke evidence, clearly separated from automated tests.
+- Any platform, API, signing, external-service, or credential limitation not exercised.
+- Whether the tree remains uncommitted and unpushed.
+
+Do not describe a web build as desktop proof, a unit test as end-to-end proof, or an unsigned/local artifact as a release artifact.

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -113,11 +113,11 @@ For frontend changes:
 
 ```bash
 cd frontend
-bun test path/to/test.ts             # focused loop
+bun --no-env-file test path/to/test.ts
 bun run format:check
 bun run lint
 bun run typecheck
-bun run test
+bun --no-env-file test
 bun run build
 ```
 
@@ -126,8 +126,8 @@ For Rust/Tauri changes:
 ```bash
 cd frontend/src-tauri
 cargo fmt --check
-cargo clippy -- -D warnings
-cargo test --all-targets
+./scripts/run-with-desktop-onnxruntime.sh cargo clippy --locked -- -D warnings
+./scripts/run-with-desktop-onnxruntime.sh cargo test --locked --all-targets
 ```
 
 There is no `just test` recipe. The pre-commit hook is useful but does not replace ESLint, Clippy, CI-equivalent checks, or runtime smoke testing.

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: develop-maple
-description: Develop and debug Maple features and fixes across its React/Vite frontend and Tauri/Rust application. Use for local setup, choosing the Maple-versus-OpenSecret boundary, implementing ordinary UI, state, API-client, native command, desktop, or mobile changes, running focused tests, and preparing a reviewable handoff. Route comprehensive smoke/platform validation, security review, Agent Mode work, and releases to Maple's specialized sibling skills.
+description: Develop and debug ordinary non-Agent-Mode Maple features and fixes across its React/Vite frontend and Tauri/Rust application. Use for local setup, choosing the Maple-versus-OpenSecret boundary, implementing UI, state, API-client, native command, desktop, or mobile changes, running focused tests, and preparing a reviewable handoff. Route comprehensive validation, security review, Agent Mode work, and releases to Maple's specialized sibling skills.
 ---
 
 # Develop Maple

--- a/.agents/skills/develop-maple/agents/openai.yaml
+++ b/.agents/skills/develop-maple/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Develop Maple"
+  short_description: "Plan and implement Maple changes safely"
+  default_prompt: "Use $develop-maple to plan and implement this Maple change."

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -24,12 +24,13 @@ store, submit for review, or alter a rollout merely to see whether it works.
 
 ## Prepare the version
 
-1. Work from a clean checkout of current `master` and compare the checked-in
-   version with the latest published release:
+1. Prepare the bump on a clean focused branch based on current `origin/master`;
+   do not switch another worktree to `master` or force its owning worktree off
+   that branch. Compare the checked-in version with the latest release:
 
    ```bash
-   git switch master
-   git pull --ff-only origin master
+   git fetch origin master
+   git merge-base --is-ancestor origin/master HEAD
    current_version="$(nix develop .#ci -c just get-version | tail -n 1)"
    released_version="$(gh api repos/OpenSecretCloud/Maple/releases/latest --jq '.tag_name | ltrimstr("v")')"
    printf 'current=%s released=%s\n' "$current_version" "$released_version"
@@ -54,8 +55,10 @@ store, submit for review, or alter a rollout merely to see whether it works.
    gates and submit the isolated bump through normal review when authorized.
    Do not use `just release`; it creates a local tag before the reviewed GitHub
    flow.
-6. After the bump merges, return to `master`, pull with `--ff-only`, and wait
-   for every required workflow on the merged commit. Release only that commit.
+6. After the bump merges, use or create a clean worktree on `master`. If another
+   worktree already owns that branch, use its checkout instead of forcing or
+   stealing it. Pull with `--ff-only` and wait for every required workflow on
+   the merged commit. Release only that commit; preflight verifies it again.
 
 ## Run preflight
 

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -1,15 +1,31 @@
 ---
 name: release-maple
-description: Prepare, publish, and verify a Maple GitHub release from master. Use when asked to cut, create, publish, monitor, or finish a Maple release, including preparing a missing version bump through the pinned Nix and just workflow, generating GitHub release notes, creating the release tag, monitoring release CI, retrying genuinely transient failures, verifying artifacts, and confirming Zapstore publication.
+description: Prepare, publish, monitor, and verify a Maple release from current master. Use when asked to bump a release version, cut or create a GitHub release, verify signed artifacts and updater metadata, monitor downstream publication, or prepare an explicitly authorized App Store, TestFlight, Google Play, or billing-API handoff.
 ---
 
 # Release Maple
 
-Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing a release as a production action: report the intended tag and commit before creating it, then stay with all workflows until they succeed or a real defect is identified.
+Treat every release step as a production action. Do not use this workflow for
+routine validation. Before a write, state the exact repository, version, tag,
+commit, external effect, and authority provided by the user.
 
-## Prepare Version
+## Know the triggers
 
-1. Start from a clean, current `master`. Compare `just get-version` with the latest published release:
+- A push to `master` starts production-shaped desktop, Android, iOS, web,
+  frontend, and Rust workflows. The iOS master workflow uploads its verified
+  IPA to TestFlight automatically.
+- Creating a GitHub Release starts the cross-platform release workflow. A
+  successful release workflow triggers Zapstore publication.
+- GitHub Release creation does not itself submit the release IPA or AAB to
+  Apple App Store review or Google Play.
+
+Never push or merge `master`, create a release, retry a workflow, upload to a
+store, submit for review, or alter a rollout merely to see whether it works.
+
+## Prepare the version
+
+1. Work from a clean checkout of current `master` and compare the checked-in
+   version with the latest published release:
 
    ```bash
    git switch master
@@ -19,8 +35,12 @@ Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing 
    printf 'current=%s released=%s\n' "$current_version" "$released_version"
    ```
 
-2. If `current_version` is newer than `released_version`, keep the existing version. Never bump it again merely because a release was requested.
-3. If they are equal, prepare the intended next version through the repository helpers. Proceed directly only when the user's current request explicitly names the version or patch/minor/major level. Otherwise ask which version to stage and recommend a patch bump. If the user explicitly delegates the choice, use patch; never infer a minor or major bump from the commit list. After the choice is established, run exactly one of:
+2. If `current_version` is newer, retain it. Never bump again merely because a
+   release was requested.
+3. If versions are equal, establish the intended next version. Proceed when
+   the user names an exact version or patch/minor/major level. If the user
+   delegates the choice, use patch; do not infer minor or major from commits.
+4. On a focused branch, run exactly one repository helper:
 
    ```bash
    nix develop .#ci -c just update-version X.Y.Z
@@ -29,36 +49,48 @@ Run this workflow from the `OpenSecretCloud/Maple` repository. Treat publishing 
    nix develop .#ci -c just bump-major
    ```
 
-4. Review the generated manifest and lockfile diff, then commit it on a focused branch, push it, and open a PR. Do not use `just release`; it creates a local tag before the reviewed GitHub release flow.
-5. Wait for required PR checks, merge the bump, switch back to `master`, pull with `--ff-only`, and wait for every required master workflow to succeed. Then continue with preflight. Never release from the bump branch or before the merged commit's CI is green.
+5. Review all manifest, Apple project, Android version-code, and
+   `frontend/src-tauri/Cargo.lock` changes. Run the applicable Maple validation
+   gates and submit the isolated bump through normal review when authorized.
+   Do not use `just release`; it creates a local tag before the reviewed GitHub
+   flow.
+6. After the bump merges, return to `master`, pull with `--ff-only`, and wait
+   for every required workflow on the merged commit. Release only that commit.
 
-## Preflight
+## Run preflight
 
-1. Run the bundled preflight from the repository root:
+Run the bundled fail-closed preflight from the repository root:
 
-   ```bash
-   preflight="$(.agents/skills/release-maple/scripts/preflight.sh)"
-   printf '%s\n' "$preflight" | jq .
-   tag="$(printf '%s' "$preflight" | jq -r .tag)"
-   previous_tag="$(printf '%s' "$preflight" | jq -r .previous_tag)"
-   head_sha="$(printf '%s' "$preflight" | jq -r .head_sha)"
-   ```
+```bash
+preflight="$(.agents/skills/release-maple/scripts/preflight.sh)"
+printf '%s\n' "$preflight" | jq .
+tag="$(printf '%s' "$preflight" | jq -r .tag)"
+previous_tag="$(printf '%s' "$preflight" | jq -r .previous_tag)"
+head_sha="$(printf '%s' "$preflight" | jq -r .head_sha)"
+```
 
-2. Stop if preflight fails. Fix the branch/version/CI issue through the normal PR process before releasing. Never overwrite a tag or release.
-3. Preview GitHub's generated title and notes:
+The script requires a clean current `master`, exact manifest version parity, a
+newer version and unused tag, and successful required workflows for the exact
+commit. Stop on any failure; correct it through the normal reviewed process.
+Never overwrite or move a release tag.
 
-   ```bash
-   gh api --method POST repos/OpenSecretCloud/Maple/releases/generate-notes \
-     -f tag_name="$tag" \
-     -f target_commitish="$head_sha" \
-     -f previous_tag_name="$previous_tag" | jq -r '.name, .body'
-   ```
+Preview GitHub's generated notes:
 
-4. Confirm the notes span the intended changes and the reported commit is still `origin/master`.
+```bash
+gh api --method POST repos/OpenSecretCloud/Maple/releases/generate-notes \
+  -f tag_name="$tag" \
+  -f target_commitish="$head_sha" \
+  -f previous_tag_name="$previous_tag" | jq -r '.name, .body'
+```
 
-## Publish
+Confirm the notes span the intended changes and recheck that `head_sha` is
+still `origin/master`. Present the tag, commit, previous tag, and notes to the
+user before creating the release unless the current request already gives
+unambiguous authority for that exact release.
 
-Create and publish the release exactly once. This creates the tag, matching the standard GitHub release GUI flow:
+## Publish once
+
+Create the GitHub Release exactly once. This creates the tag in the same flow:
 
 ```bash
 gh release create "$tag" \
@@ -68,124 +100,100 @@ gh release create "$tag" \
   --generate-notes
 ```
 
-Do not create or push a separate local tag first. Record the release URL and confirm the resulting release and workflow point to `head_sha`.
+Do not create or push a local tag first. Record the release URL and confirm the
+release and workflow resolve to `head_sha`.
 
-## Monitor Release CI
+## Monitor release CI
 
-1. Find the new `Release` run for the tag and commit:
+Find and watch the new `Release` run:
 
-   ```bash
-   gh run list --repo OpenSecretCloud/Maple --workflow Release --event release \
-     --commit "$head_sha" --limit 10 \
-     --json databaseId,displayTitle,headSha,status,conclusion,url
-   ```
+```bash
+gh run list --repo OpenSecretCloud/Maple --workflow Release --event release \
+  --commit "$head_sha" --limit 10 \
+  --json databaseId,displayTitle,headSha,status,conclusion,url
 
-2. Watch it through every platform build, artifact upload, reproducibility verifier, `latest.json`, full release verification, and verification-guide publication:
+gh run watch RELEASE_RUN_ID \
+  --repo OpenSecretCloud/Maple --exit-status --compact
+```
 
-   ```bash
-   gh run watch RELEASE_RUN_ID --repo OpenSecretCloud/Maple --exit-status --compact
-   ```
+Stay with every platform build, signature/canonical proof, artifact upload,
+updater `latest.json`, aggregate verification, and verification-guide step.
+Packaging success alone is not runtime smoke; inspect the workflow's actual
+verification and attestation results.
 
-3. If it fails, inspect the failed job logs before acting:
+On failure, read the failed logs before acting:
 
-   ```bash
-   gh run view RELEASE_RUN_ID --repo OpenSecretCloud/Maple --log-failed
-   ```
+```bash
+gh run view RELEASE_RUN_ID --repo OpenSecretCloud/Maple --log-failed
+```
 
-4. Retry only failures proven to be transient infrastructure problems, such as interrupted cache/network downloads. Wait for the run to become terminal, then use:
+Retry only a terminal failure proven to be transient infrastructure trouble:
 
-   ```bash
-   gh run rerun RELEASE_RUN_ID --repo OpenSecretCloud/Maple --failed
-   ```
+```bash
+gh run rerun RELEASE_RUN_ID --repo OpenSecretCloud/Maple --failed
+```
 
-5. Do not retry version mismatches, proof mismatches, signing failures, missing credentials, or deterministic build failures as if they were transient. Diagnose and report them. Do not delete or recreate the published release without explicit user direction.
-6. Continue watching the same run until its latest attempt concludes `success`. A failed attempt may create a skipped Zapstore workflow; this is expected and is not the final Zapstore result.
+Do not classify version/proof mismatches, deterministic builds, signing
+failures, missing credentials, or integrity checks as transient. Do not delete
+or recreate a published release without separate explicit direction.
 
-## Verify Zapstore
+## Verify downstream publication
 
-`Publish to Zapstore` starts only after the `Release` workflow completes successfully. Find the newest non-skipped workflow for `head_sha`, then watch it through `Verify and install zsp` and `Publish to Zapstore`:
+Zapstore starts only after the `Release` workflow succeeds. Select the newest
+non-skipped run for the exact commit and watch it:
 
 ```bash
 gh run list --repo OpenSecretCloud/Maple --workflow 'Publish to Zapstore' \
   --commit "$head_sha" --limit 10 \
   --json databaseId,status,conclusion,headSha,createdAt,url
 
-gh run watch ZAPSTORE_RUN_ID --repo OpenSecretCloud/Maple --exit-status --compact
+gh run watch ZAPSTORE_RUN_ID \
+  --repo OpenSecretCloud/Maple --exit-status --compact
 ```
 
-Treat pinned Go/zsp verification failures as integrity failures unless logs clearly show transient transport trouble.
+Treat pinned Go/zsp verification failures as integrity failures unless logs
+prove a transient transport problem.
 
-## Final Verification
-
-Confirm the release is published, targets the intended commit/tag, and has artifacts:
+Verify the published release and its assets:
 
 ```bash
 gh release view "$tag" --repo OpenSecretCloud/Maple \
   --json tagName,name,isDraft,isPrerelease,publishedAt,targetCommitish,url,assets
 ```
 
-Report the release URL, tag, commit SHA, main workflow URL and attempt count, Zapstore workflow URL, any retry and its evidence, and final success. Do not call the release complete while any required workflow is queued or running.
+Do not call the release complete while a required workflow is queued or
+running.
 
-## Manual Post-GitHub Release Distribution
+## Store and API handoff
 
-The GitHub and Zapstore workflows do not complete distribution through Apple or Google stores. Treat every item in this section as a manual human action. Do not open a store UI, upload a build, submit for review, or change a rollout unless the user explicitly authorizes that action at the time.
+Apple and Google actions remain manual production operations. Do not open a
+store console, choose a track, add testers, upload a build, answer compliance
+questions, submit for review, release an approved version, or change a rollout
+without explicit authorization for that exact action.
 
-Keep release-specific facts separate from general instructions. Record exact build numbers, version codes, review outcomes, and rollout choices only after a human or the relevant store confirms them.
+For an authorized handoff:
 
-### Apple TestFlight and App Store
+1. Identify the artifact from the exact tag and commit.
+2. Verify its digest, platform signature, application/bundle ID, visible
+   version, build/version code, and repository release proof.
+3. Record the destination application, tester group or release track,
+   countries/audience, rollout choice, and any review/compliance state before
+   submission.
+4. After the store reports a result, distinguish upload, processing, testing,
+   review, approval, rollout, and public availability. Do not infer one state
+   from another.
+5. If the approved client version is gated by a configured billing API, verify
+   that API recognizes the exact `vX.Y.Z` version. Any service-side version-gate
+   change or deployment is outside this repository and requires its own
+   reviewed workflow and authority.
 
-Recorded handoff fact from July 26, 2026:
+Keep time-specific build numbers, review outcomes, blockers, and rollout facts
+in the release handoff or issue that owns them, not in this evergreen skill.
 
-- [x] In App Store Connect TestFlight, the user added the `Maple Beta Testers` external tester group to the most recent Maple `master` build/version. No exact build number has been recorded here.
+## Report
 
-User-reported App Store Connect setup actions for v3.3.0:
-
-1. [x] The user created the new App Store version `3.3.0`.
-2. [x] The user populated `What's New` from the prepared v3.3.0 release summary.
-3. [x] The user attached the same current `master` build used for TestFlight. No exact build number has been recorded here.
-4. [x] The user saved the App Store version changes.
-5. [x] The user selected the action to add the version for review.
-6. [x] App Store Connect accepted the preparation and review transitions required before submission. Exact intermediate status names were not recorded here.
-7. [x] The user submitted v3.3.0 for App Review.
-8. [x] Apple approved v3.3.0 on July 27, 2026. The exact build number and release-control outcome have not been recorded here.
-
-Steps 1-8 record user-reported actions and Apple's approval. They do not establish the exact build number, intermediate status names, release-control outcome, or public App Store availability. A human must explicitly confirm those details before they are recorded as complete.
-
-Remaining human checklist:
-
-- [ ] Confirm the selected build has finished App Store Connect processing and has no blocking validation, export-compliance, or encryption questions.
-- [ ] If App Store Connect requires Beta App Review for external testing, complete the required beta metadata and submit the build for Beta App Review; record the result.
-- [ ] Confirm the approved build is available to the intended external testers and enable or publish the public TestFlight link when the user chooses to release it publicly.
-- [ ] For App Store submission, select the intended build and complete the version metadata, screenshots, privacy details, age rating, review information, export compliance, and any other required declarations.
-- [ ] Ask the user to choose the App Store release control, such as manual release, automatic release after approval, or a scheduled/phased release, before submission.
-- [x] Submit v3.3.0 for App Review and record Apple's approval. The exact build number and chosen release control remain unrecorded.
-- [ ] Confirm the approved v3.3.0 build's release-control outcome and public App Store availability.
-
-After Apple approves a Maple version, update the billing server's approved-version gate before treating Apple distribution as complete:
-
-1. In `OpenSecretCloud/maple-billing-server`, update `APPROVED_VERSION` in `src/routes/maple/products.rs` to the exact Apple-approved Maple version, including the `v` prefix. Do not approve a staged but unapproved version.
-2. Run the billing repository's pinned Nix validation with `nix develop -c just check`, then submit the isolated bump through a reviewed pull request.
-3. Merge and deploy the billing change only with explicit authorization. A merge deploys the development billing service automatically; production deployment remains a separate manual workflow.
-4. After production deployment, verify that `/v1/maple/products?version=vX.Y.Z` reports the products as available for the newly approved version, then record the billing commit, deployment, and verification result.
-
-### Google Play
-
-Recorded Google Play Console workflow for v3.3.0:
-
-1. [x] The user downloaded the signed `app-universal-release.aab` for v3.3.0.
-2. [x] In Internal testing, the user uploaded the AAB, allowed the release details to auto-fill, used the GitHub release summary as the release notes, and saved and published the internal release without errors.
-3. [x] After refreshing Google Play Console, the user promoted the internal release to Open testing and completed the required `Next` and `Save` steps until it was ready. The user chose not to continue to Publishing overview at that point.
-4. [x] The user returned to Internal testing, selected promotion to Production, and repeated the required save and next steps to attempt the production promotion.
-5. [ ] Production promotion did not succeed. Google Play blocked it with: `Your app does not support 16 KB memory page sizes.` Treat this as an active regression-investigation blocker, not as a published production release.
-
-The completed items above record human-performed console actions only. They do not establish that v3.3.0 reached Production. A human must confirm any later blocker resolution, production submission, review, rollout, and publication before those states are recorded as complete.
-
-Prerequisites and remaining human checklist:
-
-- [ ] Identify the signed `app-universal-release.aab` attached to the exact GitHub release tag and commit. Verify its GitHub artifact digest and the release reproducibility evidence before uploading it.
-- [ ] Confirm access to the correct Google Play Console application and verify that Play App Signing and the expected upload-key configuration are in place.
-- [ ] Confirm the AAB's application ID and version code are correct and that the version code has not already been used in Google Play.
-- [ ] Ask the user which track to use, such as internal testing, closed testing, open testing, or production, and whether any staged rollout is intended.
-- [ ] Create the release in the chosen track, upload the verified AAB, add the appropriate release notes, and resolve any Play Console warnings or required declarations.
-- [ ] Present the final track, version code, countries or audience, rollout percentage, and Play Console review summary to the user before submission.
-- [ ] Submit or roll out the Google Play release only with explicit user authorization, then record the resulting review and publication status.
+Report the version, tag, exact commit, release URL, main workflow URL and
+attempt count, Zapstore workflow URL, artifact verification result, any retry
+and supporting evidence, authorized store/API actions, and every boundary that
+remains unverified. Separate repository release completion from store
+distribution and live application availability.

--- a/.agents/skills/release-maple/agents/openai.yaml
+++ b/.agents/skills/release-maple/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Release Maple"
   short_description: "Publish and verify a Maple GitHub release"
-  default_prompt: "Use $release-maple to publish and verify the next Maple release."
+  default_prompt: "Use $release-maple to prepare or verify the explicitly requested Maple release."

--- a/.agents/skills/review-maple-security/SKILL.md
+++ b/.agents/skills/review-maple-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: review-maple-security
-description: Review Maple changes and current behavior across authentication, account isolation, local persistence, Tauri IPC and capabilities, OAuth and deep links, the Local OpenAI Proxy, Agent Mode tools and permissions, MCP, ACP, streaming concurrency, secrets, logging, and configurable API endpoints. Use for security audits, threat modeling, security-sensitive code review, regression assessment, or implementation planning when a Maple change crosses a browser, native, filesystem, process, local-network, account, or OpenSecret API trust boundary.
+description: Review Maple security across authentication, account isolation, local persistence, Tauri IPC and capabilities, OAuth and deep links, the Local OpenAI Proxy, Agent Mode tools and permissions, MCP, ACP, streaming concurrency, secrets, logging, and configurable API endpoints. Use for explicit security audits, threat modeling, security-sensitive code review, or regression assessment.
 ---
 
 # Review Maple Security
@@ -191,8 +191,18 @@ containment separately when it is part of the required policy.
 
 Require these invariants:
 
-- Keep Goose routed through action-required boundaries so Maple applies current policy to every tool call.
-- Treat classifier input as untrusted. Fail closed on ambiguity, provider failure, timeout, invalid structured output, cancellation, secret reads, scripts, builds/tests, network access, or possible mutation.
+- Derive a per-tool policy matrix from permission configuration, automatic
+  handling, classifiers, and executors. Distinguish always-allowed, automatic,
+  classifier-approved, and caller-approved paths. Do not generalize one
+  classifier or URL policy to another. Read-only is a consent and integrity
+  policy, not confidentiality or filesystem containment.
+- Treat classifier input as untrusted. On classifier-backed paths, ambiguity,
+  failure, timeout, invalid structured output, or cancellation must fall back
+  to caller approval. Establish explicit tool-specific rules for sensitive
+  reads, mutation, arbitrary execution, and network access.
+- Treat remote `read_image` as a separate network boundary. Review URL
+  admission, redirects, credentials and private destinations, size and time
+  bounds, and downloader behavior; never infer that `open_url` policy applies.
 - Bind every permission response to exact account generation, session, run, calling surface, request ID, and payload. Make IDs one-shot; reject unknown, duplicate, reused, late, cross-surface, disconnected, and cancelled responses.
 - Apply a more restrictive mode before fallible asynchronous setup or persistence so one last permissive action cannot slip through.
 - Keep Desktop and ACP events, approvals, status, and cancellation isolated. Do not make ACP runs actionable through the Desktop Tauri projection.
@@ -293,9 +303,9 @@ Require every request, stream, timer, retry, load, cancellation, and delayed cal
 
 Keep in the open-source OpenSecret backend:
 
-- token validation and account identity;
-- authorization for persisted data and account-owned resources;
-- entitlements, usage limits, billing enforcement, and API-key permissions;
+- authentication, account identity, and authorization for persisted or
+  account-owned resources;
+- protected-route enforcement and inference-usage capture;
 - provider/model routing and server-authoritative response semantics; and
 - one-time auth-code exchange or other server-enforced protocol guarantees.
 

--- a/.agents/skills/review-maple-security/SKILL.md
+++ b/.agents/skills/review-maple-security/SKILL.md
@@ -1,0 +1,351 @@
+---
+name: review-maple-security
+description: Review Maple changes and current behavior across authentication, account isolation, local persistence, Tauri IPC and capabilities, OAuth and deep links, the Local OpenAI Proxy, Agent Mode tools and permissions, MCP, ACP, streaming concurrency, secrets, logging, and configurable API endpoints. Use for security audits, threat modeling, security-sensitive code review, regression assessment, or implementation planning when a Maple change crosses a browser, native, filesystem, process, local-network, account, or OpenSecret API trust boundary.
+---
+
+# Review Maple Security
+
+Review the current source, not remembered findings. Separate policy, consent, containment, and server authorization. Treat Maple as an open-source client of OpenSecret; discuss billing and feature flags only through their public API/configuration contracts.
+
+Default to read-only investigation when asked to review, audit, diagnose, or threat-model. Do not implement, commit, push, open issues, or make incident claims unless the user separately authorizes the relevant action and the evidence supports it.
+
+## Establish the Review Baseline
+
+1. Read `AGENTS.md`, the requested diff or files, nearby tests, and applicable docs.
+2. Record `git status --short --branch`, `git rev-parse HEAD`, the comparison base, and whether the checkout has unrelated changes. Never clean or rewrite them.
+3. Re-check current command and dependency sources: `justfile`, `frontend/package.json`, `frontend/src-tauri/Cargo.toml`, lockfiles, `scripts/ci/`, and `.github/workflows/`.
+4. Identify whether the request is:
+
+   - a read-only audit of current behavior;
+   - a review of a bounded diff;
+   - a proposed security design; or
+   - validation of an implemented fix.
+
+5. State the assets, attacker position, trust boundaries, and deployment assumptions before assigning severity.
+
+Do not infer deployment state from repository source. Do not infer runtime behavior from a passing build. Do not infer authorization from hidden UI or a feature flag.
+
+## Use an Evidence Taxonomy
+
+Label every material claim with the strongest evidence actually obtained:
+
+- **Source-confirmed:** current checked-out code directly implements the behavior.
+- **Test-confirmed:** a focused or full automated test exercised the behavior.
+- **Runtime-confirmed:** the exact web or native application demonstrated it locally.
+- **Deployment-confirmed:** the relevant deployed service, policy, or artifact was inspected.
+- **Inferred risk:** the consequence follows from confirmed primitives, but the full exploit path was not demonstrated.
+- **Unverified:** a required dependency, platform, deployment, or attacker precondition was not inspected.
+
+Call something an incident, compromise, or production exposure only with live evidence. A source-confirmed risky primitive is not proof that it was exploited or deployed insecurely.
+
+For each finding, report:
+
+1. Severity and confidence.
+2. Exact source or runtime evidence.
+3. Required attacker access and preconditions.
+4. User, confidentiality, integrity, availability, or billing consequence.
+5. Existing mitigations and why they do or do not close the path.
+6. The narrowest responsible fix boundary: Maple frontend, Maple native Rust, OpenSecret backend, or coordinated API change.
+7. Required regression and smoke evidence.
+
+Omit speculative findings that cannot survive this structure. Record important
+unknowns as task-local unverified boundaries. Keep findings in the current
+task's review output or another destination the user explicitly authorizes.
+Keep only durable security standards and review methodology in this skill and
+`AGENTS.md`.
+
+## Map the Trust Boundaries
+
+Trace data and authority across every boundary touched by the change:
+
+```text
+user/browser or WebView
+  -> React state, storage, and OpenSecret SDK
+  -> Tauri IPC and plugin capabilities
+  -> native Rust state, filesystem, keyring, processes, and listeners
+  -> OpenSecret API and other configured public API endpoints
+
+Agent prompt or remote content
+  -> Maple permission policy
+  -> Goose tool request
+  -> Maple developer tool, MCP process/server, or ACP caller
+  -> local files, shell, network, and credentials
+```
+
+Treat renderer input, model output, MCP output, ACP input, remote content, persisted JSON, URLs, paths, and environment values as untrusted at their receiving boundary. Validate again where authority is exercised.
+
+## Review Authentication and Account Lifecycles
+
+Inspect these source areas when authentication, user state, native providers, logout, deletion, or account switching is relevant:
+
+- `frontend/src/services/mapleApiAuthService.ts`
+- `frontend/src/services/agentAuthLifecycle.ts`
+- `frontend/src/services/agentOperationFence.ts`
+- `frontend/src/services/agentRuntimeService.ts`
+- `frontend/src-tauri/src/maple_api.rs`
+- `frontend/src/components/RootRuntimeLayout.tsx`
+- every logout, guest-upgrade, verification, and account-deletion path
+
+Require these invariants:
+
+- Verify token ownership against the backend before publishing native credentials for an expected user.
+- Serialize native credential installation, refresh reconciliation, and clearing. Fence late refreshes with immutable client identity and generation.
+- Bind long-lived native handles and in-flight operations to an opaque account scope plus revocable generation; never silently rebind them to a new account.
+- Include user identity in query/cache keys and remount account-owned providers on transition.
+- Drain old-account Agent, ACP, proxy, timers, requests, controllers, and object URLs before activating a new account.
+- Retain failed cleanup targets so rapid A -> B -> C transitions cannot skip A or B.
+- Perform required local credential cleanup before losing the authenticated context needed to identify the owner. Make rollback or fail-closed behavior explicit when cleanup fails.
+- Avoid new direct `os.signOut()` calls. Route sign-out, guest conversion, verification transitions, and deletion through one reviewed lifecycle sequence.
+- Treat `localStorage` and `sessionStorage` as sensitive client storage, not a native trust anchor or secure vault.
+
+Exercise success, cancellation, failure, timeout, token refresh during validation, wrong-user tokens, repeated logout, rapid account switching, and app exit/update. Check every `await` for stale account ownership before subsequent mutation.
+
+## Review Local Persistence and Secrets
+
+Inspect where state is stored, who can read it, when it roams, and how precisely it is deleted.
+
+- Key user-sensitive Agent config, sessions, recent roots, trust decisions, caches, and runtime data by account scope.
+- Keep device/path-specific state in app-local-data when roaming it could affect another device.
+- Treat a hashed user ID as namespacing, not authorization or encryption.
+- Treat Unix mode `0600` files and `0700` directories as defense in depth, not encrypted storage.
+- Treat persisted MCP environment values, HTTP headers, proxy keys, and other
+  credentials as sensitive. Verify storage, fallback, and deletion guarantees
+  from the implementation; do not infer encryption from file permissions or
+  opaque serialization.
+- Prefer secure platform credential storage where the product contract requires it. Specify fallback and hard-clear behavior; do not silently report success while a stale credential remains.
+- Write credential-bearing files through a restrictive same-directory temporary file, sync it, and atomically replace the destination. Avoid write-then-chmod windows.
+- Scope history clearing, session deletion, and account deletion to the exact target. Preserve unrelated account data and unrelated app configuration.
+- Re-check canonicalization, symlink behavior, traversal, file type, file size, and deletion boundaries for every renderer- or agent-controlled path.
+
+Never include real tokens, passwords, prompts, private paths, encrypted user seeds, MCP secrets, or full credential-bearing URLs in tests, logs, screenshots, or reports. Use explicit non-secret fixtures.
+
+## Review Tauri and Native Authority
+
+Inspect:
+
+- `frontend/src-tauri/src/lib.rs`
+- `frontend/src-tauri/tauri.conf.json`
+- `frontend/src-tauri/capabilities/*.json`
+- every added or changed `#[tauri::command]`
+- every intended platform-specific `generate_handler!` registration and its
+  `cfg` gates
+- plugin dependency and initialization changes
+- renderer `@tauri-apps/*` imports and raw `plugin:*` calls
+- the typed frontend service, caller, and native implementation together
+
+Require native validation for all renderer-controlled accounts, paths, URLs, ports, sizes, enum values, identifiers, and lifecycle capabilities. Frontend validation is user experience, not enforcement.
+
+Ask whether the change:
+
+- expands the invoke handler, plugin set, CSP, `connect-src`, opener allowlist, filesystem scope, dialog access, deep-link handling, or mobile capabilities;
+- exposes secrets in command responses, errors, emitted events, logs, argv, or process environments;
+- permits stale or cross-account native handles;
+- holds lifecycle locks across the right async boundaries and awaits shutdown before restart;
+- preserves desktop/mobile compile gates;
+- validates native URLs and sockets rather than trusting a frontend-created configuration; and
+- changes a privileged behavior without exact-app runtime proof.
+
+Keep security-sensitive local effects in native Rust: process launch, MCP connection, filesystem mutation, local listeners, credential persistence, deep-link ingestion, updater/restart, and account-bound native sessions. Minimize capabilities rather than compensating with renderer checks.
+
+Application-defined Rust commands and plugin commands are separate authority
+paths. Under the repository's default Tauri build configuration,
+`generate_handler!` registration exposes a custom command to local WebViews
+independently of plugin capability entries. A filesystem plugin scope constrains
+filesystem plugin calls; it does not constrain `std::fs`, Tokio filesystem, or
+another local effect inside a custom Rust command. Require custom commands to
+canonicalize and bound paths, verify account and lifecycle ownership, reject
+unintended file types and sizes, and sanitize results in Rust. Add plugin
+permissions only when the renderer needs that plugin API, and never cite a
+plugin scope as proof that a custom command is contained.
+
+Require focused native-validation and typed-caller tests. When no checked-in
+React-to-IPC integration test covers a privileged path, require a manual smoke
+through the exact application, real UI entry point, intended command, native
+effect, and a representative rejection case.
+
+Treat untrusted Markdown and external URLs as a renderer boundary. Preserve sanitization before trusted transforms, suppress remote images unless intentionally supported, confirm external navigation, and review any sanitizer schema, raw HTML, KaTeX/highlight, CSP, or opener change together.
+
+## Review Agent Mode, Tools, MCP, and ACP
+
+Read the current implementation and docs together:
+
+- `frontend/src-tauri/src/agent.rs`
+- `frontend/src-tauri/src/agent/`
+- `frontend/src-tauri/src/agent_acp.rs`
+- `frontend/src-tauri/src/agent_host.rs`
+- `frontend/src-tauri/src/agent_tauri.rs`
+- `docs/agent-mode-mcp.md`
+- `docs/agent-mode-acp.md`
+
+Keep these concepts separate:
+
+- **Permission policy:** which tool calls Maple or a caller consents to.
+- **Containment:** which resources an allowed tool can actually access.
+- **Credential scope:** which secrets an allowed process receives and for how long.
+- **Surface ownership:** whether Desktop or an ACP caller owns events, approvals, and cancellation.
+
+Do not describe Read-only/SmartApprove, allowed project roots, Unix socket
+permissions, or process-group cleanup as an operating-system sandbox. A
+project-root grant is not per-tool filesystem confinement; enforce and test
+containment separately when it is part of the required policy.
+
+Require these invariants:
+
+- Keep Goose routed through action-required boundaries so Maple applies current policy to every tool call.
+- Treat classifier input as untrusted. Fail closed on ambiguity, provider failure, timeout, invalid structured output, cancellation, secret reads, scripts, builds/tests, network access, or possible mutation.
+- Bind every permission response to exact account generation, session, run, calling surface, request ID, and payload. Make IDs one-shot; reject unknown, duplicate, reused, late, cross-surface, disconnected, and cancelled responses.
+- Apply a more restrictive mode before fallible asynchronous setup or persistence so one last permissive action cannot slip through.
+- Keep Desktop and ACP events, approvals, status, and cancellation isolated. Do not make ACP runs actionable through the Desktop Tauri projection.
+- Bound event queues and surface overflow as truncation/error; a slow client must not block runtime cleanup.
+- Allowlist and bound tool-context environment keys and values. Scrub same-named ambient variables, linearize revocation with process launch, and revoke before future spawn.
+- Treat STDIO MCP as arbitrary local code execution. Preserve executable-plus-argument tokenization without a shell. Saving may remain inert; enabling or connecting is the execution boundary.
+- Freeze the complete MCP executable/endpoint/environment/header definition into the session snapshot. Do not retroactively send changed credentials to old sessions.
+- Keep project skill discovery disabled until the canonical project root has an explicit trust decision. Fail closed when trust or the root cannot be loaded.
+- Treat a same-user ACP endpoint as a local trust boundary, not independent application authentication. Explain which same-user processes can connect and what credentials/tools they can reach.
+
+Preserve intended power features when they are product choices. Assess whether
+their consent and containment match the documented threat model rather than
+assuming intentional execution authority violates the design.
+
+## Review the Local OpenAI Proxy
+
+Inspect `frontend/src-tauri/src/proxy.rs`, `frontend/src/services/proxyService.ts`, the settings UI, all startup/logout callers, and tests as one boundary.
+
+Require these defaults unless an explicit product decision changes them:
+
+- bind to loopback;
+- disable CORS;
+- disable auto-start; and
+- keep browser reachability separate from Maple's saved credential.
+
+When CORS is disabled, verify browser-controlled `Origin` and `Sec-Fetch-Site` requests are rejected before a saved key can be spent. Omitting CORS response headers alone is insufficient. When CORS is enabled for browser compatibility, require every inference request to provide its own bearer key and remove saved-key fallback.
+
+Review host, port, CORS mode, saved credential, auto-start, owner account, and backend URL as one security object. Validate bind hosts and endpoints natively. Allow plaintext HTTP only for explicit loopback development; reject embedded URL credentials and unexpected path, query, or fragment components unless the API contract requires them.
+
+Serialize start, save, stop, reset, and auto-start. Await listener teardown before rebinding. Fence API-key creation and delayed startup with account identity plus auth generation so logout/reset cannot be followed by a stale completion that restarts an old account's proxy. Scrub the local listener and credential before best-effort remote key revocation.
+
+Treat non-loopback service exposure as a separate feature requiring explicit authentication, transport security, network threat modeling, and billing-abuse analysis. A warning label alone is not native enforcement.
+
+## Review OAuth and Deep Links
+
+Inspect both sides of every flow:
+
+- OAuth initiation and SDK callback handling;
+- `frontend/src/routes/auth.$provider.callback.tsx`;
+- `frontend/src/components/AppleAuthProvider.tsx`;
+- `frontend/src/components/DeepLinkHandler.tsx`;
+- native deep-link registration, forwarding, and single-instance handling.
+
+Require exact scheme, authority, path, provider, parameter, and redirect validation. Bind completion atomically to a pending native-generated state, provider, PKCE verifier, expiry, and one-time use. Reject unsolicited, duplicate, stale, malformed, or cross-provider callbacks.
+
+Never log raw callback URLs, single-instance argv, codes, access tokens, refresh tokens, state, nonce, or sensitive query strings. Prefer a short-lived one-use authorization code exchanged by the intended native client over bearer tokens in a custom URI. Treat custom schemes as interceptable on platforms where handler ownership is not cryptographically verified; prefer verified App/Universal Links when redesigning the flow.
+
+Validate internal redirects independently and reject absolute, scheme-relative, backslash-confused, or normalized traversal forms. Do not treat safe navigation as proof that the authentication handoff itself is bound correctly.
+
+## Review Endpoints and Attested Transport
+
+Inspect the browser and native OpenSecret clients independently:
+
+- `frontend/src/app.tsx`
+- `frontend/src/ai/OpenAIContext.tsx`
+- `frontend/src/services/mapleApiAuthService.ts`
+- `frontend/src-tauri/src/maple_api.rs`
+- `frontend/src-tauri/src/agent/provider.rs`
+- the pinned JavaScript and Rust OpenSecret SDK versions and lockfiles
+
+Preserve the OpenSecret SDK's encrypted and attested transport. Do not replace `aiCustomFetch` or the native SDK client with raw browser/native fetch merely to make a request work. Avoid layering automatic client retries over Maple operations that may have server-side effects; keep retry ownership explicit.
+
+Review development and production enclave URLs and PCR/attestation allowlists together. Reject an endpoint that is not HTTPS unless it is an explicit loopback development address. Reject URL credentials and unexpected paths, queries, or fragments at the native authority boundary. Treat source-configured PCR values as policy, not proof that a live enclave currently matches; perform live attestation before making deployment claims.
+
+Do not assume the browser and native SDK pins have identical features, request schemas, refresh behavior, attestation behavior, or error handling. For an OpenSecret API contract change, validate both clients. Keep decrypted upstream errors and response bodies out of logs and user-facing native errors; expose bounded categories unless safe detail is deliberately part of the public contract.
+
+When backend confirmation is needed, inspect the current open-source OpenSecret repository and follow its `AGENTS.md` and relevant skills. Do not infer its authorization, transport, or deployment behavior solely from Maple's caller.
+
+## Review Secrets, Logs, and Errors
+
+Search both sides of a changed boundary for `console.*`, Rust `log::*`, string interpolation, Tauri events, structured errors, telemetry, clipboard flows, URLs, process arguments, and child environments.
+
+- Log operation type, bounded identifiers, status, duration, and safe error categories—not tokens, API keys, auth codes, nonces, credential-bearing URLs, prompts, documents, model output, headers, environment values, or decrypted provider bodies.
+- Assume error objects can contain request URLs, response bodies, headers, or SDK internals. Sanitize at the boundary before logging or returning them.
+- Never forward a secret from renderer storage into argv or a process-global environment. Give an approved child only the exact bounded values needed for its lifetime.
+- Avoid echoing sensitive native config back to an untrusted renderer when a redacted status or opaque handle is sufficient.
+- Keep clipboard and external-navigation actions explicit and user initiated when content may contain credentials or private data.
+- Test both expected failures and logging failures. Inspect captured logs and emitted events for absence of fixture secrets, not merely for presence of an error message.
+
+Use unique fake canary values in tests so accidental propagation is detectable without exposing real credentials.
+
+## Review Streaming and Concurrency
+
+Inspect `ChatRuntimeContext`, `chatRuntimeStore`, `UnifiedChat`, stream coalescing, retry recovery, Agent event routing, and any affected async service.
+
+Require every request, stream, timer, retry, load, cancellation, and delayed callback to capture immutable owner identity plus generation/run token. Re-check ownership after every `await` before mutation.
+
+- Treat the selected chat as a projection, not the owner of background work.
+- Flush attempt-owned buffered deltas while ownership is valid, clear ownership, then abort.
+- Treat EOF without an explicit terminal event as truncation, not success.
+- Remove only attempt-owned optimistic/response items during retry recovery.
+- Reconcile ambiguous failures against server state before restoring input or resending.
+- Rekey draft-to-conversation state atomically; never replace an active destination or strand destination-owned attachments, recording, composer state, or object URLs.
+- Bind shared scroll and view state to a projection key/lease so delayed A -> B -> A work cannot mutate the wrong view.
+- Dispose account-owned stores, controllers, timers, and object URLs on account transition.
+
+## Choose Maple or OpenSecret
+
+Keep in the open-source OpenSecret backend:
+
+- token validation and account identity;
+- authorization for persisted data and account-owned resources;
+- entitlements, usage limits, billing enforcement, and API-key permissions;
+- provider/model routing and server-authoritative response semantics; and
+- one-time auth-code exchange or other server-enforced protocol guarantees.
+
+Keep in Maple:
+
+- presentation, accessibility, navigation, drafts, and client orchestration;
+- account-keyed client caches and safe projection of server state;
+- Tauri lifecycle and explicitly local OS integrations; and
+- native enforcement for local files, processes, credentials, IPC, listeners, Agent tools, MCP, and ACP.
+
+Do not use billing status, feature flags, hidden routes, or disabled controls as
+authorization. Configure billing and feature flags as external dev/prod HTTP
+API endpoints when a test needs them and assess only their public contracts.
+Treat every `VITE_*` value as public build-time configuration, never a secret.
+
+For coordinated changes, make the backend contract secure and backward-compatible first, then update Maple through the pinned OpenSecret SDK or a reviewed API adapter. Avoid duplicating backend authorization or provider behavior in the renderer.
+
+## Validate in Proportion to Risk
+
+Use `$validate-maple` for the complete test and exact-application workflow. During a security review, select focused tests first, then run the repository's CI-equivalent suites before declaring an implementation ready:
+
+```bash
+nix develop .#ci -c ./scripts/ci/frontend.sh
+nix develop .#ci -c ./scripts/ci/rust.sh
+```
+
+Run dependency advisory checks only with available, trusted tooling and without changing lockfiles. Separate advisory presence, production reachability, exploitability, and accepted exceptions. Report when an audit tool or advisory database could not be refreshed.
+
+Add boundary-specific proof:
+
+- **Auth/account:** wrong-user credentials, refresh during validation, A -> B -> C, cleanup failure/retry, logout with pending operations, deletion ordering, restart.
+- **Deep link:** exact valid callback, wrong scheme/authority/path/provider, missing or stale state, duplicate/replay, malformed parameters, safe redirect, and no credential logging.
+- **Proxy:** CORS-off `Origin` POST and `Sec-Fetch-Site` GET rejection; originless local success; CORS-on preflight with `Authorization`; no saved fallback; non-loopback rejection or explicit secure mode; invalid backend endpoints; start/stop/restart; auto-start; offline logout; delayed-start race.
+- **Agent permissions:** classifier ambiguity/failure, Auto -> Read-only mid-run, unknown/duplicate/reused/late responses, cross-surface attempts, cancellation/disconnect, event overflow.
+- **MCP/ACP:** inert save versus execution, deterministic STDIO and Streamable HTTP fixture, enable/disable, failed connection, immutable session snapshot, secret revocation, same-user client boundary, caller disconnect.
+- **Persistence:** account A/B isolation, precise history/data deletion, roaming versus device-local behavior, restrictive permissions, keyring hard-clear failure, symlink/path cases.
+- **Streaming:** simultaneous A/B runs, rapid A -> B -> A, hidden completion, cancel with pending deltas, ambiguous retry, draft rekey collision, account teardown, stale timers and loads.
+
+For native behavior, test the exact checkout-built binary or bundle identifier and verify its configured backend URL, executable path, proxy port, and listener PID before automation. Do not target an application only by the display name `Maple`. Distinguish unit tests, build success, runtime smoke, platform coverage, and deployment checks in the final report.
+
+## Deliver the Review
+
+Lead with actionable findings ordered by severity. Use exact file/function references and concise attack narratives. Then list:
+
+- confirmed protections that materially constrain the threat;
+- unverified platforms or deployment assumptions;
+- validation run and results;
+- current worktree/base state; and
+- the smallest recommended next action.
+
+If no confirmed findings remain, say so plainly and report the boundaries not
+verified for this task. Never convert an intended power feature, dependency
+warning, or source-only hypothesis into a production incident claim.

--- a/.agents/skills/review-maple-security/agents/openai.yaml
+++ b/.agents/skills/review-maple-security/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Review Maple Security"
+  short_description: "Review Maple across trust boundaries"
+  default_prompt: "Use $review-maple-security to review this Maple change for security regressions."

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: validate-maple
-description: Validate Maple changes with risk-tiered frontend, Rust, web, desktop, mobile, integration, and exact-application checks. Use when testing, smoke-testing, reproducing, preparing a handoff, or deciding what evidence a Maple change requires, especially for Tauri IPC, Agent Mode, the local proxy, authentication, deep links, PDF/OCR, mobile behavior, CI, build tooling, or release artifacts.
+description: Run comprehensive or CI-equivalent Maple validation across frontend, Rust, web, desktop, mobile, integration, and exact-application boundaries. Use when comprehensive, smoke, packaged, or cross-platform evidence is requested, and when runtime evidence crosses Tauri IPC, Agent Mode, the local proxy, authentication, deep links, PDF/OCR, mobile behavior, or build tooling.
 ---
 
 # Validate Maple
@@ -91,11 +91,12 @@ Run commands from the repository root unless the command changes directory expli
 ### Focused frontend test
 
 ```bash
-cd frontend
-bun --no-env-file test src/path/to/changed.test.ts
+nix develop .#ci -c bash -lc \
+  'cd frontend && bun --no-env-file test ./src/path/to/changed.test.ts'
 ```
 
-Use `--no-env-file` so local secrets and endpoint overrides do not silently affect unit tests.
+Use `--no-env-file` to disable Bun's automatic dotenv loading. Variables
+already exported by the calling shell still apply.
 
 ### Complete frontend checks
 
@@ -112,6 +113,20 @@ MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh
 ```
 
 Use `pr` for contributor validation. Record the compiled OpenSecret, billing, and feature-flag endpoint configuration when those endpoints affect the scenario. A successful web build proves bundling, not browser behavior.
+
+To claim browser smoke for that artifact, serve the resulting `frontend/dist`
+with the checked-in preview command, then open that preview rather than the
+development server:
+
+```bash
+nix develop .#ci -c bash -lc \
+  'cd frontend && bun --no-env-file run preview'
+```
+
+Record the preview origin, server PID and checkout, compiled endpoints, browser
+storage/profile, and account/data scope. Use a disposable account only when
+sign-in or user data is required. Opening `just dev` is configured
+development-runtime evidence, not smoke evidence for the built artifact.
 
 ### Rust checks
 
@@ -196,7 +211,7 @@ selected OpenSecret backend by
 including required migrations, then launch Maple from this checkout with:
 
 ```bash
-just desktop-dev
+nix develop -c just desktop-dev
 ```
 
 `just desktop-dev` consumes the configured development endpoints and applies
@@ -204,6 +219,20 @@ the active `.local/tauri-workspace.json` overlay when present. It is the path
 for a configured local-backend desktop smoke; it is not evidence about a fixed
 PR package. Record the exact identity fields below, use a disposable account,
 and exercise the relevant backend operation.
+
+Before launch, read the active Tauri `devUrl` and inspect its listener. If it is
+occupied, stop the process only when you can prove it belongs to this checkout,
+using its owning lifecycle mechanism where one exists; otherwise select another
+overlay or port. When packaged behavior and the overlay identity are both
+required, build with:
+
+```bash
+nix develop -c just desktop-build-debug-overlay
+```
+
+On macOS, verify the produced app's `CFBundleIdentifier` from its actual
+`Contents/Info.plist` before launch. Do not infer the identifier from the config
+file alone.
 
 For privileged IPC, manually trigger the real React user action, observe the
 Tauri command and native validation, verify the exact filesystem/process/native
@@ -223,6 +252,12 @@ Before any desktop GUI smoke test, record:
 7. Disposable account and test-data scope.
 
 Target the recorded identifier and path. Never select or terminate an app only by the display name `Maple`; multiple checkouts can share it. If an overlay is active, use it consistently for build, launch, automation, and cleanup.
+
+A package with the standard identifier can share installed Maple state and
+single-instance identity. Do not launch it against non-disposable state. Use a
+package whose overlay-derived identifier you verified is distinct, or a
+disposable OS account or VM when the standard package identity itself is under
+test.
 
 Distinguish these targets:
 
@@ -253,6 +288,9 @@ Choose only scenarios relevant to the change, but cross every changed boundary.
 - For MCP, follow `docs/agent-mode-mcp.md`: use the pinned Everything server, send a unique marker, verify server request, arguments, result, and final answer, then disable or stop the server and verify a clear failure.
 - Verify that stale sessions cannot cross account boundaries when session or
   account ownership changed.
+- Before local-proxy smoke, choose and verify an unused checkout-specific
+  loopback port. After start, verify that the recorded Maple PID owns the
+  listener; do not assume the default port is available.
 
 ### PDF and OCR
 

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -1,0 +1,274 @@
+---
+name: validate-maple
+description: Validate Maple changes with risk-tiered frontend, Rust, web, desktop, mobile, integration, and exact-application checks. Use when testing, smoke-testing, reproducing, preparing a handoff, or deciding what evidence a Maple change requires, especially for Tauri IPC, Agent Mode, the local proxy, authentication, deep links, PDF/OCR, mobile behavior, CI, build tooling, or release artifacts.
+---
+
+# Validate Maple
+
+Prove the behavior that changed. Treat automated checks, successful builds, and observed runtime behavior as different evidence. Never call a build or unit-test pass an end-to-end test.
+
+## Establish scope and identity
+
+1. Read `AGENTS.md`, the relevant source, nearby tests, and the applicable workflow or script before choosing commands.
+2. Inspect `git status`, the diff, and the base commit. Preserve unrelated user changes.
+3. Classify risk by behavior, not file path. Code under `frontend/src/` can invoke Tauri commands and require native validation even though PR change detection may classify it as web-only.
+4. Identify every boundary the change crosses: browser, Tauri IPC, Rust, local process, filesystem, keyring, OpenSecret API, configurable billing or feature-flag API endpoint, operating system, or packaged resource.
+5. Record the untested boundaries before running checks. Add proof as it is obtained.
+
+Use the repository's pinned Nix environments. Do not install substitute global tools merely to make a check pass.
+
+## Choose the validation tier
+
+Use the highest tier triggered by the change. Add lower-tier checks rather than replacing them.
+
+### Tier 0: documentation and inert metadata
+
+Use for prose, comments, or metadata that cannot affect a build or runtime.
+
+- Review the rendered or consumed result, links, examples, and commands.
+- Run `nix flake check` when changing the flake, GitHub Actions, or release metadata.
+- Escalate to the owning tier when documentation changes an executable example, environment contract, or generated input.
+
+### Tier 1: isolated frontend behavior
+
+Use for pure React, TypeScript, CSS, state, and browser behavior with no native or service boundary.
+
+- Run focused Bun tests while iterating.
+- Run the complete frontend CI script before handoff.
+- Build the PR-configured web artifact.
+- Smoke the changed state in a real browser. Cover loading, empty, success, error, and disabled states when relevant.
+- Test keyboard operation, focus, accessible labels, light/dark themes, and narrow/wide layouts when the change can affect them.
+
+### Tier 2: API, account, persistence, and streaming integration
+
+Use when behavior depends on an OpenSecret server, authentication, account state, conversation persistence, billing API endpoint, feature-flag API endpoint, or streamed responses.
+
+- Complete Tier 1.
+- Use a local OpenSecret backend or an explicitly configured dev server.
+- Configure billing and feature flags only as external API endpoints when the scenario needs them; otherwise leave optional integrations out of scope and say so.
+- Use disposable accounts and non-sensitive fixtures.
+- Exercise login, logout, account switching, request start, partial stream, cancellation, failure, reload, and restored history as applicable.
+- Verify that late responses from an old account or session cannot mutate the new one.
+- Inspect logs for failures without copying tokens, secrets, prompts, or private content into the report.
+
+### Tier 3: native desktop and packaged behavior
+
+Use for Tauri IPC, Rust, Agent Mode, MCP, local proxy, keyring, filesystem/dialogs, deep links, updater behavior, PDF/OCR, process lifecycle, or packaged resources.
+
+- Complete the relevant lower tiers.
+- Run Rust format/lint and locked tests.
+- Build on every affected desktop operating system. Do not treat one host as proof for another.
+- Launch the exact executable or application bundle produced for the test.
+- Exercise the native boundary through the UI, then corroborate it with process, listener, filesystem, and sanitized-log evidence as applicable.
+- Re-test cancellation, restart, logout, and account switching when a long-lived process or listener is involved.
+
+For a custom Tauri command, trace the Rust declaration, every intended
+platform-specific `generate_handler!` registration and `cfg` gate, the typed
+frontend service, and the caller. Review plugin dependency, initialization, and
+capability changes as a separate authority path. Under the repository's default
+Tauri build configuration, registering a custom command exposes it to local
+WebViews independently of plugin capability entries. Filesystem plugin scopes
+apply to filesystem plugin calls; they do not constrain filesystem access
+performed inside an application-defined Rust command. Test that command's
+native account, path, type, size, and lifecycle enforcement directly. If no
+checked-in React-to-IPC integration test covers the path, an exact-app manual
+smoke from the user action through the native result is required.
+
+### Tier 4: mobile, release, signing, and distribution
+
+Use for iOS, Android, signing, updater metadata, installers, entitlements, or distribution behavior.
+
+- Complete the relevant lower tiers.
+- Build and run on the affected simulator, emulator, or physical device; a compiled archive alone is not runtime proof.
+- Validate lifecycle changes such as background/foreground, picker or microphone permissions, and OAuth or payment return links when touched.
+- Treat fake signing as build-path evidence only.
+- Route publishing, signing, versioning, release creation, and distribution work to `$release-maple`. Do not push or merge merely to trigger release workflows.
+
+## Run canonical automated checks
+
+Run commands from the repository root unless the command changes directory explicitly.
+
+### Focused frontend test
+
+```bash
+cd frontend
+bun --no-env-file test src/path/to/changed.test.ts
+```
+
+Use `--no-env-file` so local secrets and endpoint overrides do not silently affect unit tests.
+
+### Complete frontend checks
+
+```bash
+nix develop .#ci -c ./scripts/ci/frontend.sh
+```
+
+This script installs locked frontend dependencies and runs formatting, linting, typechecking, and Bun tests. It removes `frontend/node_modules` and ignores local `.env*` files while it runs. Commit or preserve relevant local work before invoking it. It does **not** build the application.
+
+### Web production build
+
+```bash
+MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh
+```
+
+Use `pr` for contributor validation. Record the compiled OpenSecret, billing, and feature-flag endpoint configuration when those endpoints affect the scenario. A successful web build proves bundling, not browser behavior.
+
+### Rust checks
+
+```bash
+nix develop .#ci -c just rust-lint
+nix develop .#ci -c ./scripts/ci/rust.sh
+```
+
+The lint recipe runs `cargo fmt --check` and Clippy with warnings denied. The CI script provisions Linux ONNX Runtime when needed and runs `cargo test --all-targets --locked`. Neither command launches Maple.
+
+### Repository configuration checks
+
+```bash
+nix flake check
+```
+
+This validates pinned tool versions, GitHub Actions syntax, and release metadata. Run it for changes to `flake.nix`, `flake.lock`, workflows, CI scripts, or release configuration. It is not a substitute for product tests.
+
+Do not cite the pre-commit hook as complete proof: it omits frontend lint and Rust format/Clippy, and its Rust tests depend on staged file patterns.
+
+## Build the affected platform
+
+Use these commands to mirror PR artifact builds. Then launch and smoke the result separately.
+
+These scripts deliberately hide local `.env*` files and compile fixed PR
+endpoint profiles. Their artifacts are PR packaging evidence; they do not prove
+that Maple works with the OpenSecret backend configured in
+`frontend/.env.local`.
+
+### macOS desktop
+
+```bash
+nix develop .#ci -c ./scripts/ci/desktop-pr.sh
+```
+
+### Linux desktop
+
+```bash
+MAPLE_TAURI_FAKE_UPDATER_SIGNING=1 nix develop .#desktop-linux -c ./scripts/ci/desktop-pr.sh
+```
+
+### Windows desktop
+
+Run on real Windows from Git Bash/MSYS:
+
+```bash
+./scripts/ci/desktop-windows-pr.sh
+```
+
+### Android
+
+Run on x86_64 Linux:
+
+```bash
+MAPLE_ANDROID_FAKE_SIGNING=1 MAPLE_ANDROID_WEB_ENVIRONMENT=pr nix develop .#android -c ./scripts/ci/android-release.sh
+```
+
+### iOS
+
+Run on macOS with the supported Xcode toolchain:
+
+```bash
+nix develop .#apple -c ./scripts/ci/ios-onnxruntime.sh
+nix develop .#apple -c ./scripts/ci/ios-pr.sh
+```
+
+Treat PR artifact workflows as compile/package evidence. They do not launch the built app. Treat artifact attestations as provenance evidence only when the attestation step actually succeeds.
+
+## Smoke a configured local backend
+
+Preserve existing configuration. Create a local environment file only when it
+is absent:
+
+```bash
+test -e frontend/.env.local || cp frontend/.env.example frontend/.env.local
+```
+
+Never replace an existing `frontend/.env.local`; it may be externally managed
+or contain checkout-specific endpoints and application identity. Start the
+selected OpenSecret backend by
+[its public repository guide](https://github.com/OpenSecretCloud/opensecret),
+including required migrations, then launch Maple from this checkout with:
+
+```bash
+just desktop-dev
+```
+
+`just desktop-dev` consumes the configured development endpoints and applies
+the active `.local/tauri-workspace.json` overlay when present. It is the path
+for a configured local-backend desktop smoke; it is not evidence about a fixed
+PR package. Record the exact identity fields below, use a disposable account,
+and exercise the relevant backend operation.
+
+For privileged IPC, manually trigger the real React user action, observe the
+Tauri command and native validation, verify the exact filesystem/process/native
+effect, and exercise a representative denied input. This manual exact-app smoke
+is required when no checked-in integration test crosses React, IPC, and Rust.
+
+## Prove exact application identity
+
+Before any desktop GUI smoke test, record:
+
+1. Commit SHA, build profile, build command, and active Tauri configuration overlay.
+2. Compiled OpenSecret, billing, and feature-flag endpoint configuration.
+3. Exact executable or `.app` path.
+4. Actual bundle/application identifier. The standard identifier is `cloud.opensecret.maple`, but an overlay can change it.
+5. Dev-server URL and owning PID. The standard Tauri dev URL is port `5173`, but an overlay can change it.
+6. Native application PID and, when relevant, local proxy port plus listener-owning PID.
+7. Disposable account and test-data scope.
+
+Target the recorded identifier and path. Never select or terminate an app only by the display name `Maple`; multiple checkouts can share it. If an overlay is active, use it consistently for build, launch, automation, and cleanup.
+
+Distinguish these targets:
+
+- A browser tab proves web behavior only.
+- A raw `tauri dev` executable can prove native development behavior but not packaged resources, signing, updater, installer, or bundle registration.
+- A packaged application proves only the scenarios actually observed after launching that exact artifact.
+
+If debug packaging emits an application and then exits nonzero because `TAURI_SIGNING_PRIVATE_KEY` is absent, report the packaging failure. You may separately smoke the emitted application, but do not call the build successful.
+
+Clean up only the exact PIDs, listeners, temporary accounts, and artifacts created by the test. Never kill processes by generic app name or perform broad cleanup.
+
+## Smoke critical native surfaces
+
+Choose only scenarios relevant to the change, but cross every changed boundary.
+
+### Agent Mode, MCP, and local proxy
+
+- Run Agent Mode in the desktop app; it is unavailable in the web build.
+- Verify start, useful intermediate state, permission handling, cancellation, completion, restart, and shutdown.
+- Confirm process and listener ownership before and after cancellation, logout, account switch, and app exit.
+- For MCP, follow `docs/agent-mode-mcp.md`: use the pinned Everything server, send a unique marker, verify server request, arguments, result, and final answer, then disable or stop the server and verify a clear failure.
+- Verify that stale sessions cannot cross account boundaries.
+
+### PDF and OCR
+
+- Test a text PDF, scanned PDF, mixed PDF, malformed or locked input, and applicable size/page limits.
+- Exercise cold and warm model-cache paths when OCR behavior changes.
+- Run the ignored model-backed test only when its external model prerequisites are available, following `docs/pdf-ocr.md`; label it separately from the default Rust suite.
+- Verify cancellation and recovery from extraction failures through the exact app.
+
+### Deep links and native services
+
+- Invoke the real link against the recorded bundle identifier; do not merely paste its payload into an internal route.
+- Verify cold start and already-running behavior where relevant.
+- Exercise real dialogs, filesystem access, keyring, updater, microphone, and packaged resources on each affected platform.
+
+## Report evidence without inflation
+
+Write the handoff in five buckets:
+
+1. **Automated:** exact command, platform, and pass/fail result.
+2. **Artifact:** exact build command and produced artifact; state that it was not runtime evidence unless launched.
+3. **Runtime:** exact app identity, platform, endpoint configuration, account/data scope, and scenarios observed.
+4. **Integration:** backend or external API endpoint used and the boundary exercised, without secrets.
+5. **Untested or blocked:** platform, boundary, ignored test, signing path, or failure not covered.
+
+Call a result “end-to-end” only when the real user entry point and every relevant production boundary were exercised. Otherwise name the narrower evidence: unit, render, typecheck, build, package, browser smoke, native smoke, or integration smoke.
+
+For security-sensitive changes, run `$review-maple-security` in addition to this skill. Keep validation and security review distinct: passing tests do not establish that a design is safe.

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -241,10 +241,18 @@ Choose only scenarios relevant to the change, but cross every changed boundary.
 ### Agent Mode, MCP, and local proxy
 
 - Run Agent Mode in the desktop app; it is unavailable in the web build.
-- Verify start, useful intermediate state, permission handling, cancellation, completion, restart, and shutdown.
-- Confirm process and listener ownership before and after cancellation, logout, account switch, and app exit.
+- For presentation-only Agent Mode changes, exercise the exact changed states,
+  interactions, accessibility, focus, theme, and layout in the native app. Do
+  not add file writes, shell execution, account switching, or lifecycle
+  manipulation merely to populate the UI.
+- For behavioral changes, verify the applicable start, intermediate state,
+  permission, cancellation, completion, restart, and shutdown boundaries. Run
+  `$change-maple-agent-mode` for the proportional lifecycle matrix.
+- Confirm process and listener ownership before and after cancellation, logout,
+  account switch, and app exit when those long-lived boundaries are affected.
 - For MCP, follow `docs/agent-mode-mcp.md`: use the pinned Everything server, send a unique marker, verify server request, arguments, result, and final answer, then disable or stop the server and verify a clear failure.
-- Verify that stale sessions cannot cross account boundaries.
+- Verify that stale sessions cannot cross account boundaries when session or
+  account ownership changed.
 
 ### PDF and OCR
 

--- a/.agents/skills/validate-maple/agents/openai.yaml
+++ b/.agents/skills/validate-maple/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Validate Maple"
+  short_description: "Run risk-based Maple checks and smoke tests"
+  default_prompt: "Use $validate-maple to validate this Maple change at the right depth."

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,15 +10,21 @@ agent should know before changing Maple. Task-specific procedures live under
    changes and do not switch branches or rewrite history in a dirty checkout.
 2. Read the relevant source and tests before proposing placement. Do not treat
    historical design documents as stronger evidence than current code.
-3. Enter the pinned environment with `nix develop`. Install dependencies with
+3. Before creating configuration or starting or stopping services, determine
+   whether an external development environment owns this checkout's ignored
+   environment files, local Tauri overlay, ports, or processes. Preserve those
+   resources and follow that environment's lifecycle instructions. Standalone
+   setup and startup examples apply only when no external orchestrator owns the
+   affected resource.
+4. Enter the pinned environment with `nix develop`. Install dependencies with
    `just install` and enable the repository hook with `./setup-hooks.sh`.
-4. If `frontend/.env.local` is absent, create it with
+5. If `frontend/.env.local` is absent, create it with
    `test -e frontend/.env.local || cp frontend/.env.example frontend/.env.local`.
    Never overwrite an existing file: it may be externally managed or contain
    checkout-specific backend and application configuration. Record the
    selected OpenSecret, feature-flags, and billing endpoints in smoke-test
    evidence; never put secrets in `VITE_*` variables.
-5. Choose the runtime you actually need: `just dev` is web-only;
+6. Choose the runtime you actually need: `just dev` is web-only;
    `just desktop-dev` is the Tauri application and is required for Agent Mode
    and other native behavior.
 
@@ -56,10 +62,10 @@ checks for every affected client path.
   runtime, provider adapter, developer tools, permissions, trusted project
   skills, and system-prompt policy. Keep public TypeScript contracts
   Maple-owned; do not leak Goose, RMCP, or ACP types through the Tauri API.
-- OpenSecret owns authentication truth, encrypted persistence, entitlements,
-  usage accounting, provider credentials/routing, model canonicalization, and
-  server-side authorization. Maple flags and billing state may shape UX, but
-  are never authorization boundaries.
+- OpenSecret owns authentication and authorization truth, encrypted
+  persistence, provider credentials and routing, model canonicalization,
+  protected-route enforcement, and inference-usage capture. Maple may present
+  billing and flags API state, but it is not authorization or accounting truth.
 
 Prefer the narrowest existing layer. If a change crosses React, Tauri, an SDK,
 and OpenSecret, write down the contract at each boundary before editing.
@@ -141,8 +147,11 @@ review methodology in this guide and its skills.
 - Use the versions and platform dependencies pinned by `flake.nix`; do not add
   an alternate toolchain bootstrap to project docs or CI.
 - Use Bun from `frontend/`; use Cargo from `frontend/src-tauri/`.
-- Prefer `just desktop-dev` and desktop build recipes because they provision
-  the pinned ONNX Runtime and honor an active local Tauri config overlay.
+- Prefer repository desktop recipes because they provision the pinned ONNX
+  Runtime. `just desktop-dev` applies an active local Tauri config overlay;
+  standard desktop build recipes retain the standard application identity.
+  Use `just desktop-build-debug-overlay` when an unsigned, overlay-configured
+  package is required.
 - Use `just clean-local`. Raw `cargo clean` may erase a shared Nix Cargo build
   directory used by other checkouts.
 - Follow existing React, TypeScript, Rust, error, test, and accessibility

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,264 @@
+# Maple agent guide
+
+This file applies to the entire repository. It defines the durable rules an
+agent should know before changing Maple. Task-specific procedures live under
+`.agents/skills/`; load the matching skill before doing that work.
+
+## Start here
+
+1. Confirm the checkout, branch, and worktree state. Preserve unrelated user
+   changes and do not switch branches or rewrite history in a dirty checkout.
+2. Read the relevant source and tests before proposing placement. Do not treat
+   historical design documents as stronger evidence than current code.
+3. Enter the pinned environment with `nix develop`. Install dependencies with
+   `just install` and enable the repository hook with `./setup-hooks.sh`.
+4. If `frontend/.env.local` is absent, create it with
+   `test -e frontend/.env.local || cp frontend/.env.example frontend/.env.local`.
+   Never overwrite an existing file: it may be externally managed or contain
+   checkout-specific backend and application configuration. Record the
+   selected OpenSecret, feature-flags, and billing endpoints in smoke-test
+   evidence; never put secrets in `VITE_*` variables.
+5. Choose the runtime you actually need: `just dev` is web-only;
+   `just desktop-dev` is the Tauri application and is required for Agent Mode
+   and other native behavior.
+
+## Product and runtime map
+
+Maple is a React/Vite application packaged with Tauri for desktop and mobile.
+OpenSecret is its required backend. Keep these runtime paths distinct:
+
+- Research chat: React -> OpenAI JavaScript client ->
+  `@opensecret/react` encrypted custom fetch -> OpenSecret Responses and
+  Conversations APIs.
+- Desktop Agent Mode: React -> Maple-owned Tauri commands/events ->
+  `MapleAgentService` -> embedded pinned Goose -> `MapleProvider` -> Rust
+  OpenSecret SDK -> `/v1/chat/completions`.
+- ACP: an external client edge over a protected local socket into the same
+  Maple Agent service. ACP is not Agent Mode's internal abstraction.
+- Local proxy: a separate user-facing OpenAI-compatible relay. Research chat
+  and Agent Mode do not internally route through it.
+
+The browser client and native Agent Mode use independently pinned OpenSecret
+SDKs. Do not assume their versions, transports, retries, or API coverage are
+identical. A backend contract change that Maple consumes needs compatibility
+checks for every affected client path.
+
+## Code ownership and placement
+
+- `frontend/src/routes`, `components`, `contexts`, and `state` own routing,
+  presentation, account-scoped UI state, drafts, and interaction behavior.
+- `frontend/src/services` owns browser-side API/Tauri bridges and lifecycle
+  orchestration. It is not a place to reimplement backend authorization.
+- `frontend/src-tauri/src` owns privileged device behavior: filesystem and
+  process access, native networking, local listeners, deep links, PDF/OCR,
+  credential-bearing native clients, and OS integration.
+- `frontend/src-tauri/src/agent.rs` and `agent/` own the transport-neutral Agent
+  runtime, provider adapter, developer tools, permissions, trusted project
+  skills, and system-prompt policy. Keep public TypeScript contracts
+  Maple-owned; do not leak Goose, RMCP, or ACP types through the Tauri API.
+- OpenSecret owns authentication truth, encrypted persistence, entitlements,
+  usage accounting, provider credentials/routing, model canonicalization, and
+  server-side authorization. Maple flags and billing state may shape UX, but
+  are never authorization boundaries.
+
+Prefer the narrowest existing layer. If a change crosses React, Tauri, an SDK,
+and OpenSecret, write down the contract at each boundary before editing.
+
+For every added or changed privileged Tauri command:
+
+1. Put the local privileged effect in `frontend/src-tauri/src` behind a narrow
+   Rust command. Treat its renderer arguments as untrusted and enforce account,
+   canonical path, allowed-root, file-type, size, and lifecycle constraints at
+   the native authority boundary as applicable.
+2. Register the command in every intended platform's `generate_handler!` list,
+   preserve the surrounding `cfg` gates, and verify it is not exposed on an
+   unintended target.
+3. Put the typed renderer bridge in `frontend/src/services` and use an explicit
+   platform guard. Components should consume that bridge instead of growing a
+   second native contract.
+4. Inspect `frontend/src-tauri/Cargo.toml`, plugin initialization,
+   `frontend/src-tauri/tauri.conf.json`, CSP, and
+   `frontend/src-tauri/capabilities/*.json` separately. Plugin permissions and
+   application-defined Rust commands are different authority paths. With the repository's default
+   Tauri build configuration, `generate_handler!` registration is the exposure
+   boundary for a custom command used by local WebViews; plugin capability
+   entries do not narrow that access. Filesystem plugin scopes constrain
+   filesystem plugin calls; they do not constrain `std::fs`, Tokio filesystem,
+   or other local effects performed by a custom Rust command.
+   Enforce a custom command's scope in Rust, and do not broaden a plugin
+   permission unless the renderer directly needs that plugin API.
+5. Add focused tests for native validation and the typed caller. Where no
+   checked-in React-to-IPC integration test exists, manually exercise the exact
+   desktop app from UI entry point through IPC to the native effect, including
+   a representative rejection case.
+
+## Security and privacy invariants
+
+- Treat the WebView and all Tauri command arguments as untrusted. Revalidate
+  account identity, paths, URLs, sizes, ports, enum values, and lifecycle
+  ownership in Rust before a privileged effect.
+- Never log access or refresh tokens, API keys, raw deep-link URLs, prompts,
+  response contents, MCP headers/environments, or decrypted backend payloads.
+  Sanitize native errors before emitting them to the renderer.
+- Credential-bearing backend URLs must be HTTPS, except explicit loopback HTTP
+  in development. Reject embedded credentials, unexpected paths, query
+  strings, and fragments.
+- Preserve account isolation. Every user-sensitive runtime, cache, file,
+  pending operation, event, and query key needs an account owner or opaque
+  account scope. After every `await`, late work must prove it still owns the
+  current account/session/run before publishing state.
+- Account transition and secure logout must stop and drain Agent/ACP, stop and
+  scrub the local proxy, clear billing session tokens, clear native auth, and
+  dispose account-owned UI state in the established order. Do not add a direct
+  sign-out shortcut that bypasses cleanup.
+- Project roots grant context and trust; they are not filesystem containment.
+  Read-only Agent mode is a consent policy, not an OS sandbox.
+- Permission grants are one-use capabilities bound to the exact account,
+  session, run, calling surface, request, and payload. Unknown, duplicate,
+  late, cancelled, or cross-surface responses fail closed.
+- Shell/web permission classifiers fail closed. Cancellation, revocation,
+  timeout, and output overflow must terminate spawned process groups and
+  revoke credential-bearing tool contexts before another launch.
+- STDIO MCP is intentional arbitrary local-code execution. Saving a definition
+  is inert; enabling it launches the executable. Never pass its command through
+  a shell. Treat persisted MCP configuration as sensitive; verify storage,
+  fallback, and deletion guarantees from the implementation.
+- Keep local-proxy defaults loopback-only, CORS-off, and auto-start-off. Browser
+  reachability and saved-key fallback must remain mutually exclusive.
+- Model output and remote Markdown are untrusted. Preserve sanitization,
+  external-link confirmation, CSP, Tauri capability, and opener restrictions.
+- `VITE_*` is public build-time configuration. Provider credentials and
+  administrative billing/flags credentials never belong in Maple.
+
+For auth, proxy, Agent tooling, native capabilities, filesystem or process
+access, deep links, or persistence, load `$review-maple-security` before
+changing code. Keep resulting findings in the task's review output or another
+explicitly authorized destination. Keep only durable security standards and
+review methodology in this guide and its skills.
+
+## Development conventions
+
+- Use the versions and platform dependencies pinned by `flake.nix`; do not add
+  an alternate toolchain bootstrap to project docs or CI.
+- Use Bun from `frontend/`; use Cargo from `frontend/src-tauri/`.
+- Prefer `just desktop-dev` and desktop build recipes because they provision
+  the pinned ONNX Runtime and honor an active local Tauri config overlay.
+- Use `just clean-local`. Raw `cargo clean` may erase a shared Nix Cargo build
+  directory used by other checkouts.
+- Follow existing React, TypeScript, Rust, error, test, and accessibility
+  patterns in the nearest code. Do not perform drive-by migrations.
+- Preserve explicit cancellation and ownership tokens in concurrent code.
+  Navigation, the currently selected chat, and component lifetime are not
+  sufficient ownership proofs for background streams.
+- Clean SSE iterator EOF without the protocol's terminal event is truncation,
+  not success. Retry cleanup removes only state created by that attempt.
+- A Goose dependency bump requires re-diffing Maple's system prompt and
+  reviewing the intentional prompt-drift test.
+
+Do not edit generated files by hand, including
+`frontend/src/routeTree.gen.ts`. Regenerate platform projects or lockfiles with
+their repository workflow, inspect all generated deltas, and never hide them
+with `git update-index --assume-unchanged`.
+
+## Validation is proportional evidence
+
+Start focused, then run the complete gate for the layers changed:
+
+```bash
+# Frontend format, lint, typecheck, and Bun tests
+nix develop .#ci -c ./scripts/ci/frontend.sh
+
+# Locked Rust tests for all targets (with Linux ONNX provisioning)
+nix develop .#ci -c ./scripts/ci/rust.sh
+
+# Rust formatting and strict Clippy when Rust changed
+nix develop .#ci -c just rust-lint
+
+# PR-shaped web artifact when web build/config changed
+MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh
+
+# Flake/toolchain/workflow metadata; this does not run application tests
+nix flake check
+```
+
+The pre-commit hook is useful but is not full CI parity. Unit tests, a web
+build, a native package build, and a GUI smoke test are different evidence.
+This repository has no general checked-in browser, packaged-app, or
+React-to-Tauri-command integration harness; never claim those checks prove
+runtime integration. A privileged IPC change requires a manual exact-app smoke
+through the UI, command, native validation, and resulting local effect.
+
+PR artifact scripts deliberately ignore local `.env*` files and compile fixed
+PR endpoints. They prove PR packaging, not a configured local-backend runtime.
+For the latter, preserve the checkout's `frontend/.env.local`, use
+`just desktop-dev`, and record its active overlay, compiled endpoints, exact
+executable or application identifier, and backend identity.
+
+For a smoke test, state exactly what was exercised and record the commit SHA,
+configuration profile, compiled API/flags/billing endpoints, executable or
+`.app` path and bundle identifier, backend identity, account class, and any
+unverified boundary. Web smoke does not cover Tauri or Agent Mode. Native build
+jobs produce packages but do not launch them. Use `$validate-maple` for the
+change-to-evidence matrix and full-stack smoke procedure.
+
+## External services and full-stack work
+
+- Run OpenSecret using that repository's own instructions and migrations, then
+  point `VITE_OPEN_SECRET_API_URL` to it. Do not copy backend secrets into
+  Maple.
+- Feature flags and billing are independent API clients. Configure their dev
+  or production URLs as appropriate. A working chat does not prove that a
+  flag-gated or billing-gated feature works.
+- Keep local OAuth/verification callbacks on the expected Vite origin unless
+  deliberately changing and testing the backend callback contract.
+- Use deterministic unique-marker prompts and assert exact results where
+  possible. Do not commit test identities, tokens, response captures, or other
+  live-service evidence.
+
+## Review and authority
+
+Review for behavior, accessibility, failure recovery, account isolation,
+security boundaries, and honest test coverage—not only for compilation. Cite
+source evidence for security claims and distinguish code-confirmed facts from
+deployment configuration or live-environment observations.
+
+Routine development never authorizes releases, signing, store submission,
+deployment, or changes to live services. Never push to `master` as a validation
+step: a master push starts production-shaped signed builds and can upload iOS
+artifacts to TestFlight. Creating a GitHub Release triggers release builds and
+downstream publication. Use `$release-maple` only when the user explicitly
+requests release work, and report the tag and commit before publishing.
+
+## Skills
+
+- `$develop-maple`: setup, placement, implementation loop, and common web,
+  desktop, mobile, and backend-integration work.
+- `$validate-maple`: focused tests, CI parity, exact-app smoke, full-stack
+  smoke, and evidence reporting.
+- `$change-maple-agent-mode`: Agent Mode, ACP, Goose/provider, permissions,
+  tools, MCP, trust, cancellation, and lifecycle work.
+- `$review-maple-security`: security-sensitive design, implementation, or
+  review across auth, accounts, native capabilities, proxy, deep links,
+  persistence, Agent Mode, and rendering.
+- `$release-maple`: version preparation, release preflight, publication, and
+  release-workflow verification. Production authority is required.
+
+## Maintaining this guidance
+
+Treat this guide and the repository skills as living operational documentation,
+not infallible rules. Re-check prescriptive language against the current source,
+tooling, and architecture. If guidance appears stale, materially wrong,
+unnecessarily absolute, or repeatedly creates development friction, surface the
+mismatch and confirm the intended correction with the user before changing it.
+Do not churn guidance for stylistic preferences or isolated nits; do narrow
+words such as "always" or "never" when they claim more than the invariant
+actually requires.
+
+Update the relevant guide or skill in the same branch when a material change
+adds, removes, or rearchitects a workflow, ownership boundary, validation path,
+or recurring development procedure. If you discover unrelated drift, keep the
+current task scoped and propose a standalone change with evidence and reasoning.
+Add a new skill when a genuinely reusable workflow does not fit an existing one;
+otherwise prefer improving or consolidating current guidance. Ground every
+update in current source or executed workflow experience, keep it concise, and
+validate every command or path it prescribes.

--- a/README.md
+++ b/README.md
@@ -27,6 +27,9 @@ existing file: it may be externally managed or contain checkout-specific
 backend and application configuration. Inspect its source before changing its
 values.
 
+The common recipes below assume the active Nix shell. For an independent call,
+prefix a recipe with `nix develop -c`.
+
 Select the intended OpenSecret API in the ignored `frontend/.env.local`:
 
 ```dotenv
@@ -77,6 +80,7 @@ just                    # List recipes
 just install            # Install frontend dependencies
 just dev                # Web dev server
 just desktop-dev        # Desktop dev application
+just desktop-build-debug-overlay # Unsigned debug package with local overlay
 just build              # Local web build
 just format             # Format frontend source
 just lint               # Lint frontend source
@@ -126,9 +130,13 @@ then exercise the user entry point through Tauri IPC to the native result.
 Desktop recipes provision ONNX Runtime automatically:
 
 ```bash
-just desktop-build
-just desktop-build-debug
+just desktop-build                 # Standard application identity
+just desktop-build-debug           # Standard application identity
+just desktop-build-debug-overlay   # Requires .local/tauri-workspace.json
 ```
+
+Only the overlay recipe applies `.local/tauri-workspace.json` while packaging.
+Use it when a checkout-specific bundle identity is part of the smoke test.
 
 Linux desktop builds require the system libraries supplied by the Nix shell.
 For an already-built binary in a headless display environment, WebKit may need:
@@ -151,7 +159,8 @@ just ios-dev-device 'Your iPhone'
 `just ios-fix-arch` mutates the generated Xcode project. Inspect and either
 commit or deliberately restore generated changes; do not hide them from Git.
 
-Android development uses the Android shell:
+Android development is supported from x86_64 Linux; the `.#android` shell is
+not exposed on macOS:
 
 ```bash
 nix develop .#android -c just android-build

--- a/README.md
+++ b/README.md
@@ -1,373 +1,213 @@
-# Maple AI Frontend
+# Maple
 
-Uses [bun](https://bun.sh/) for development and [Tauri](https://tauri.app/) for desktop app builds.
+Maple is an open-source AI client built with React, Vite, and Tauri. It runs as
+a web application and as native desktop/mobile applications, and uses
+[OpenSecret](https://github.com/OpenSecretCloud/opensecret) for confidential
+authentication, inference, conversations, and related APIs.
 
-## Prerequisites
+Research chat and desktop Agent Mode are different client paths. Research chat
+uses the TypeScript OpenSecret SDK with the Responses and Conversations APIs;
+Agent Mode embeds Goose and uses the Rust OpenSecret SDK through Tauri. The
+local OpenAI-compatible proxy is a separate user-facing service.
 
-1. Install [Bun](https://bun.sh/):
+## Quick start
+
+The supported development environment is the Nix flake. It pins Bun, Rust,
+platform tools, and native dependencies used by the repository.
+
 ```bash
-curl -fsSL https://bun.sh/install | bash
-```
-
-2. Install Rust and its dependencies:
-```bash
-curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-```
-
-3. Install system dependencies:
-
-### macOS
-```bash
-# Install Xcode Command Line Tools
-xcode-select --install
-
-# Install additional dependencies via Homebrew
-brew install openssl@3
-```
-
-### Linux (Ubuntu/Debian)
-```bash
-sudo apt update
-sudo apt install libwebkit2gtk-4.1-dev \
-    build-essential \
-    curl \
-    wget \
-    file \
-    libssl-dev \
-    libgtk-3-dev \
-    libayatana-appindicator3-dev \
-    librsvg2-dev
-```
-
-4. Add required Rust targets for universal macOS builds:
-```bash
-rustup target add aarch64-apple-darwin x86_64-apple-darwin
-```
-
-## Setup
-
-1. Clone the repository and run the setup script:
-```bash
+nix develop
 ./setup-hooks.sh
-```
-
-This configures Git to use the project's pre-commit hook. Managed
-`opensecret-workspaces` checkouts enable the same hook automatically. The hook
-checks formatting, builds the frontend, runs frontend tests, and runs Rust tests
-when Tauri files are staged. When Nix is installed, the hook enters the pinned
-CI development shell automatically, including from macOS GUI environments that
-do not inherit the user's shell `PATH`. Without Nix, it uses compatible Bun and
-Cargo tools already available on `PATH`.
-
-## Development
-
-### Using Just Commands
-
-This project uses [just](https://github.com/casey/just) for common development tasks:
-
-```bash
-# List all available commands
-just
-
-# Install dependencies
 just install
-
-# Start development server
-just dev
-
-# Build the project
-just build
-
-# Format code
-just format
-
-# Run tests
-just test
-
-# Get current version
-just get-version
+test -e frontend/.env.local || cp frontend/.env.example frontend/.env.local
 ```
 
-### Manual Development
+This creates `frontend/.env.local` only when it is absent. Never overwrite an
+existing file: it may be externally managed or contain checkout-specific
+backend and application configuration. Inspect its source before changing its
+values.
 
-1. Install dependencies:
-```bash
-bun install
-```
+Select the intended OpenSecret API in the ignored `frontend/.env.local`:
 
-2. Start the development server:
-```bash
-# For web development only
-bun run dev
-
-# For desktop app development
-bun tauri dev
-```
-
-Expects a `VITE_OPEN_SECRET_API_URL` environment variable to be set. For local
-OpenSecret development, copy `frontend/.env.example` to `frontend/.env.local`
-and point it at the local API:
-
-```bash
+```dotenv
 VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
 ```
 
-The public OpenSecret client id defaults to Maple's project id
-`ba5a14b5-d915-47b1-b7b1-afda52bc5fc6`, so `VITE_CLIENT_ID` is only needed to
-override the default. (See `.env.example`)
+The public Maple client ID is already present in `.env.example`. All `VITE_*`
+values are shipped to the client and must never contain secrets.
 
-## Building
-
-### Shared Rust build cache with Nix
-
-Local Maple Nix shells use Cargo's separate build directory support to share
-Rust intermediate artifacts across Maple checkouts. Final artifacts remain in
-the current checkout under `frontend/src-tauri/target`, so existing Tauri,
-debugger, and packaging paths do not change.
-
-The default cache is separated by host system and pinned Rust version:
-
-```text
-$HOME/.cache/opensecret-workspaces/cargo-build/maple/<nix-system>/rust-<version>
-```
-
-An existing `CARGO_BUILD_BUILD_DIR` takes precedence. To temporarily restore
-Cargo's traditional checkout-local layout, set
-`MAPLE_DISABLE_SHARED_CARGO_BUILD_DIR=1` before entering `nix develop`. CI does
-not enable the local shared cache automatically.
-
-Raw `cargo clean` removes both the checkout's target directory and the
-configured shared build directory. To clean only the current checkout without
-invalidating other Maple workspaces, run:
+Start the runtime you intend to exercise:
 
 ```bash
-nix develop -c just clean-local
+just dev          # Browser/web development only
+just desktop-dev  # Tauri desktop, including Agent Mode and native features
 ```
 
-### Desktop Builds
+`just desktop-dev` is preferred over a raw `bun tauri dev`: it provisions the
+pinned ONNX Runtime and applies a local Tauri configuration overlay when one is
+present.
 
-Use the `just` commands for desktop builds:
+## API configuration
+
+`frontend/.env.example` documents Maple's public configuration surface:
+
+- `VITE_OPEN_SECRET_API_URL` selects the required OpenSecret backend.
+- `VITE_CLIENT_ID` overrides Maple's public project ID when developing against
+  another OpenSecret project.
+- `VITE_OS_FLAGS_BASE_URL` selects an optional feature-flags API.
+- `VITE_MAPLE_BILLING_API_URL` selects an optional billing API.
+- `VITE_FORCE_FEATURE_FLAGS` is a local preview override, not authorization.
+
+Flags and billing are independent clients; configure their dev or production
+API URLs for the environment being tested. A working OpenSecret chat does not
+prove billing- or flag-gated behavior. Provider credentials and administrative
+API keys belong on their servers, never in Maple.
+
+To use a local backend, follow
+[OpenSecret's own setup guide](https://github.com/OpenSecretCloud/opensecret),
+including its SQL migration step, and keep the default frontend origin unless
+you also intend to change and validate OAuth/verification callback handling.
+
+## Common commands
+
+Run commands from the repository root:
 
 ```bash
-# Release build
+just                    # List recipes
+just install            # Install frontend dependencies
+just dev                # Web dev server
+just desktop-dev        # Desktop dev application
+just build              # Local web build
+just format             # Format frontend source
+just lint               # Lint frontend source
+just rust-check         # Check the Tauri Rust crate
+just rust-lint          # Rust formatting check and strict Clippy
+just clean-local        # Clean only this checkout's Cargo artifacts
+```
+
+Bun commands run from `frontend/`; Cargo commands run from
+`frontend/src-tauri/`. Raw `cargo clean` can remove a shared Nix Cargo build
+directory, so use `just clean-local`.
+
+## Validation
+
+Use the checked-in CI entry points rather than reconstructing them:
+
+```bash
+# Frozen install, formatting, ESLint, typecheck, and Bun tests
+nix develop .#ci -c ./scripts/ci/frontend.sh
+
+# Locked all-target Rust tests
+nix develop .#ci -c ./scripts/ci/rust.sh
+
+# PR-configured web artifact
+MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh
+
+# Nix/toolchain/workflow metadata; not application tests
+nix flake check
+```
+
+There is no general checked-in browser, packaged-app, or React-to-Tauri-command
+integration harness. Unit tests and package builds do not prove GUI, native,
+backend, billing, flags, or IPC integration. A privileged IPC change therefore
+requires a manual smoke test through the exact desktop application and native
+effect. For change-specific test selection and a repeatable evidence format,
+use `.agents/skills/validate-maple/`.
+
+PR build scripts deliberately ignore local `.env*` files and compile fixed PR
+endpoints. They prove PR packaging, not integration with the backend configured
+in `frontend/.env.local`. To smoke an exact desktop development application
+against that configured backend, use `just desktop-dev`, record the active
+Tauri overlay, endpoint configuration, executable and application identifier,
+then exercise the user entry point through Tauri IPC to the native result.
+
+## Platform development
+
+Desktop recipes provision ONNX Runtime automatically:
+
+```bash
 just desktop-build
-
-# Debug build
 just desktop-build-debug
-
-# If you encounter CC-related errors in a Nix shell, use the -no-cc variants:
-just desktop-build-no-cc
-just desktop-build-debug-no-cc
 ```
 
-Or use `bun tauri build` directly:
-```bash
-# Standard build
-bun tauri build
-
-# For universal macOS build (Apple Silicon + Intel)
-bun tauri build --target universal-apple-darwin
-```
-
-#### Linux: ONNX Runtime Setup
-
-Linux builds bundle ONNX Runtime 1.23.2 for PDF OCR. `just desktop-build` provisions it automatically. Before invoking `bun tauri build` directly, download the pinned shared library:
+Linux desktop builds require the system libraries supplied by the Nix shell.
+For an already-built binary in a headless display environment, WebKit may need:
 
 ```bash
-cd frontend/src-tauri
-./scripts/provide-linux-onnxruntime.sh
-```
-
-This downloads the pinned ONNX Runtime release, verifies its SHA-256 checksum, and extracts it to `frontend/src-tauri/onnxruntime-linux/` (which is gitignored). The script is idempotent — it skips the download if the library already exists.
-
-> **Note:** CI workflows and the desktop `just` recipes call this script automatically. Run it manually only when invoking the lower-level Tauri commands directly.
-
-#### Linux: Running in Headless/Virtual Display Environments
-
-If you're running the built Maple binary in a headless environment (e.g., CI, virtual display with Xvfb), WebKit may fail to render content. Set these environment variables before launching:
-
-```bash
-export WEBKIT_DISABLE_COMPOSITING_MODE=1
-export WEBKIT_DISABLE_DMABUF_RENDERER=1
+WEBKIT_DISABLE_COMPOSITING_MODE=1 \
+WEBKIT_DISABLE_DMABUF_RENDERER=1 \
 DISPLAY=:0 ./frontend/src-tauri/target/debug/maple
 ```
 
-These are set automatically when using `nix develop` (via `flake.nix`).
+Apple development uses the pinned Apple shell and repository recipes:
 
-If you need a new set of icons: 
+```bash
+just ios-build-onnxruntime
+just ios-dev
+just ios-dev-sim 'iPhone 16 Pro'
+just ios-dev-device 'Your iPhone'
+```
 
+`just ios-fix-arch` mutates the generated Xcode project. Inspect and either
+commit or deliberately restore generated changes; do not hide them from Git.
+
+Android development uses the Android shell:
+
+```bash
+nix develop .#android -c just android-build
 ```
-bun run tauri icon [path/to/png]
-```
+
+The CI scripts under `scripts/ci/` are the authority for PR and release-shaped
+platform builds. Some are platform-specific, remove build outputs or
+`node_modules`, and deliberately ignore local `.env*` files in favor of fixed
+PR/release endpoints; read a script before running it locally.
+
+## Architecture and feature documentation
+
+- [`docs/agent-mode-mcp.md`](docs/agent-mode-mcp.md) explains MCP configuration
+  and includes a deterministic feature smoke test.
+- [`docs/agent-mode-acp.md`](docs/agent-mode-acp.md) documents the ACP edge and
+  its trust model.
+- [`docs/pdf-ocr.md`](docs/pdf-ocr.md) covers the local PDF/OCR pipeline.
+- [`AGENTS.md`](AGENTS.md) defines placement, security, testing, and review
+  standards for contributors and coding agents.
+- [`.agents/skills/`](.agents/skills/) contains task-specific development,
+  validation, security, Agent Mode, and release procedures.
+
+`frontend/src/routeTree.gen.ts` and native platform projects contain generated
+content. Use their generators and review the resulting diff rather than editing
+generated output opportunistically.
 
 ## Releases
 
-### Setting up Signing Keys
+Release preparation and publication are production actions. A push to
+`master` starts production-shaped signed workflows and can upload an iOS build
+to TestFlight; creating a GitHub Release starts the release pipeline and
+downstream publication. Do not use either as routine validation.
 
-#### Tauri Updater Signing
-1. Generate a new signing key:
-```bash
-cargo tauri signer generate
-```
-This will create the tauri public and private key.
+Use `.agents/skills/release-maple/` for version parity, tag safety, workflow
+monitoring, artifact verification, and explicit store handoff. Do not use the
+legacy `just release` recipe to create an unreviewed local tag.
 
-2. Add the public key to `src-tauri/tauri.conf.json` in the `updater.pubkey` field
-3. Add the private key to GitHub Actions secrets:
-   - Go to repository Settings → Secrets and variables → Actions
-   - Create a new secret named `TAURI_SIGNING_PRIVATE_KEY`
-   - Create another secret named `TAURI_SIGNING_PRIVATE_KEY_PASSWORD` if your key has a password
-   - Paste the private key from the tauri command.
+When the OpenSecret enclave changes, update and review the corresponding
+`pcr0DevValues` or `pcr0Values` in `frontend/src/app.tsx` as part of the
+attestation compatibility change.
 
-#### Apple Developer Certificate (for macOS builds)
-For proper macOS builds and notarization, you need to set up the following GitHub secrets:
+Version changes update:
 
-1. `APPLE_CERTIFICATE` - Base64-encoded p12 certificate
-   ```bash
-   base64 -i YourCertificate.p12 | pbcopy  # Copies to clipboard
-   ```
-
-2. `APPLE_CERTIFICATE_PASSWORD` - Password for the certificate
-3. `KEYCHAIN_PASSWORD` - Password for the temporary keychain (can be any secure password)
-4. `APPLE_ID` - Your Apple Developer account email
-5. `APPLE_PASSWORD` - Your Apple Developer account password or app-specific password
-6. `APPLE_TEAM_ID` - Your Apple Developer team ID
-
-#### Azure Artifact Signing (for Windows builds)
-Windows release builds use Microsoft Azure Artifact Signing through GitHub
-Actions OIDC. No Azure client secret is required.
-
-Add these GitHub Actions secrets:
-
-| GitHub secret | Source |
-|---------------|--------|
-| `AZURE_CLIENT_ID` | Microsoft Entra app registration "Application (client) ID". |
-| `AZURE_TENANT_ID` | Microsoft Entra "Directory (tenant) ID". |
-| `AZURE_SUBSCRIPTION_ID` | Azure subscription ID that contains the Artifact Signing account. |
-| `AZURE_ARTIFACT_SIGNING_ENDPOINT` | Artifact Signing account endpoint. |
-| `AZURE_ARTIFACT_SIGNING_ACCOUNT_NAME` | Artifact Signing account name. |
-| `AZURE_ARTIFACT_SIGNING_CERTIFICATE_PROFILE_NAME` | Certificate profile name under the Artifact Signing account. |
-| `AZURE_ARTIFACT_SIGNING_EXPECTED_SUBJECT` | Expected signer certificate Subject DN for that certificate profile. |
-
-The Entra application must also have a federated credential for this GitHub
-environment:
-
-```text
-repo:OpenSecretCloud/Maple:environment:windows-signing
-```
-
-In the Azure portal, add it under Microsoft Entra ID -> App registrations ->
-the CI application -> Certificates & secrets -> Federated credentials. Use:
-
-- Organization: `OpenSecretCloud`
-- Repository: `Maple`
-- Entity type: `Environment`
-- Environment name: `windows-signing`
-- Audience: `api://AzureADTokenExchange`
-
-If the portal asks for raw values instead of GitHub-specific fields, use:
-
-- Issuer: `https://token.actions.githubusercontent.com`
-- Subject: `repo:OpenSecretCloud/Maple:environment:windows-signing`
-- Audience: `api://AzureADTokenExchange`
-
-Assign the same Entra application/service principal the `Artifact Signing
-Certificate Profile Signer` role on the Artifact Signing account, resource
-group, or subscription. The role assignment is what authorizes the OIDC-auth'd
-GitHub runner to sign with the certificate profile.
-
-The expected signer subject should match the X.509 signer certificate subject
-reported by `Get-AuthenticodeSignature`. It is usually visible on the Artifact
-Signing certificate profile as the Subject DN derived from the completed identity
-validation, for example `CN=Example Corp, O=Example Corp, L=City, S=State, C=US`.
-Do not pin the leaf certificate thumbprint for this check; Artifact Signing
-manages certificate lifecycle and can issue rotated certificates for the same
-profile identity.
-
-The Windows release job builds `maple.exe` first, Authenticode-signs it, bundles
-the NSIS installer from that signed executable, Authenticode-signs the installer,
-then creates the Tauri updater `.sig` for the final signed installer bytes. This
-ordering is required because Authenticode signing changes the file being signed;
-the Tauri updater signature must be generated after the final Windows installer
-signature is applied.
-
-Windows release verification currently checks the final signed installer bytes,
-the final Tauri updater signature, and the pinned runtime DLL proofs. It does not
-yet try to canonicalize Authenticode-signed Windows binaries back to an unsigned
-baseline.
-
-### To Create a Release
-
-#### Version Management
-Use the provided `just` commands to manage version updates:
-
-```bash
-# Bump patch version (e.g., 1.0.0 → 1.0.1)
-just bump-patch
-
-# Bump minor version (e.g., 1.0.0 → 1.1.0)
-just bump-minor
-
-# Bump major version (e.g., 1.0.0 → 2.0.0)
-just bump-major
-
-# Set a specific version
-just update-version 1.2.3
-
-# Create a release with automatic git tag
-just release 1.2.3
-```
-
-These commands automatically update all necessary files:
 - `frontend/package.json`
 - `frontend/src-tauri/tauri.conf.json`
 - `frontend/src-tauri/Cargo.toml`
 - `frontend/src-tauri/gen/apple/project.yml`
 - `frontend/src-tauri/gen/apple/maple_iOS/Info.plist`
-- `Cargo.lock` (via cargo check)
+- `frontend/src-tauri/Cargo.lock`
 
-Android `versionCode` is internal and increments by one for each Play Store upload.
-Use `just update-android-counter` for another internal/test build with the same visible version.
+## Contributing
 
-#### Creating a GitHub Release
-1. Use one of the version commands above to update the version
-2. Create a new release in GitHub:
-   - Go to Releases → Draft a new release
-   - Create a new tag (e.g., `v0.1.0`)
-   - Set a release title and description
-   - Publish the release
+Keep changes focused, follow the nearest established patterns, add regression
+coverage at the owning layer, and report exactly which checks and runtime paths
+you exercised. Security-sensitive changes should distinguish source-confirmed
+facts from deployment assumptions and live-environment observations.
 
-The GitHub Actions workflow will automatically:
-- Build the app for all platforms
-- Sign the builds
-- Upload the artifacts to the release
-- Create and upload `latest.json` for auto-updates
-
-## Updating PCR0 values
-
-If there's a new version of the enclave pushed to staging or prod, append the new PCR0 value to the `pcr0Values` or `pcr0DevValues` arrays in `frontend/src/app.tsx`.
-
-## iOS Development
-
-Run in emulator: 
-
-```bash
-dotenv -e .env.local -- bun run tauri ios dev 'iPhone 16 Pro'
-```
-
-Run on a connected phone: 
-
-```bash
-dotenv -e .env.local -- bun run tauri ios build
-```
-
-### Ignoring Local XCode Project Changes
-
-To prevent committing automatic changes to the XCode project file during local development:
-
-```bash
-# Tell Git to ignore changes to the file
-git update-index --assume-unchanged frontend/src-tauri/gen/apple/maple.xcodeproj/project.pbxproj
-
-# When you need to commit changes to this file, use:
-git update-index --no-assume-unchanged frontend/src-tauri/gen/apple/maple.xcodeproj/project.pbxproj
-```
+Before opening a pull request, run the applicable full gates above and inspect
+`git diff --check`. See `AGENTS.md` for the complete change and review standard.

--- a/docs/android-platform-checks-analysis.md
+++ b/docs/android-platform-checks-analysis.md
@@ -1,5 +1,9 @@
 # Android Platform Checks Analysis
 
+> Historical implementation analysis. File paths, status markers, and code
+> examples may be stale. Use current source, `AGENTS.md`, and the applicable
+> `.agents/skills/` workflow as the authority for new development and testing.
+
 ## Overview
 This document contains a comprehensive analysis of all platform-specific checks in the Maple codebase that need to be evaluated for Android support. Each instance is documented with its location, current behavior, and recommendations for Android handling.
 
@@ -663,7 +667,7 @@ listen<string>("deep-link-received", (event) => {
 3. **Rust deep link handler** - Set up in `lib.rs` to emit events to frontend
 4. **Frontend listener** - `DeepLinkHandler.tsx` listens for `deep-link-received` events
 5. **Payment/auth URLs** - Using `isMobile()` for correct URL generation
-6. **Digital Asset Links** - `assetlinks.json` deployed with upload key SHA256
+6. **Digital Asset Links** - `assetlinks.json` deployed with the configured signing fingerprints
 7. **App verification** - Android verified ownership of trymaple.ai domain
 8. **Testing** - Both custom scheme and HTTPS deep links tested and working
 
@@ -681,7 +685,7 @@ listen<string>("deep-link-received", (event) => {
 - [x] ✅ `android:launchMode="singleTask"` already set
 
 #### 2. Digital Asset Links Configuration ✅ COMPLETED
-- [x] ✅ Created `.well-known/assetlinks.json` file with upload key SHA256
+- [x] ✅ Created `.well-known/assetlinks.json` with the configured signing fingerprints
 - [x] ✅ Deployed to https://trymaple.ai/.well-known/assetlinks.json
 - [x] ✅ Android verified domain ownership automatically
 - [x] ✅ HTTPS deep links tested and working without chooser dialog
@@ -838,33 +842,16 @@ If using Google Play App Signing:
 
 ### Step 5: Create assetlinks.json for Deep Linking ✅ COMPLETED
 
-Created `frontend/public/.well-known/assetlinks.json`:
-
-```json
-[{
-  "relation": ["delegate_permission/common.handle_all_urls"],
-  "target": {
-    "namespace": "android_app",
-    "package_name": "cloud.opensecret.maple",
-    "sha256_cert_fingerprints": [
-      "C6:12:09:59:0A:27:73:F9:EA:EC:80:0A:C1:09:07:54:4A:56:6C:62:A5:68:7D:DF:9D:B3:DE:91:19:E4:3B:2A"
-    ]
-  }
-}]
-```
+The checked-in `frontend/public/.well-known/assetlinks.json` is the source of
+truth for the configured package and signing fingerprints.
 
 **Status**: ✅ Deployed to https://trymaple.ai/.well-known/assetlinks.json
 
-**Current Configuration**:
-- ✅ Contains upload key SHA256 only (for direct APK distribution)
-- ⏳ **TODO: Google Play SHA256** - Needs to be added when Play Store is configured
+**Current checked-in configuration**:
+- Contains both configured signing fingerprints. Verify the live deployed file
+  separately when Android link handling is in scope.
 
-**Next Steps for Google Play Store**:
-1. Create app in Google Play Console
-2. Upload first AAB: `bun tauri android build -- --aab`
-3. Enable Play App Signing (recommended)
-4. Get Google's SHA256 from Console (Setup → App Integrity → App signing)
-5. Update `assetlinks.json` to include both fingerprints:
+**Signing-reference shape**:
    ```json
    "sha256_cert_fingerprints": [
      "C6:12:09:59:0A:27:73:F9:EA:EC:80:0A:C1:09:07:54:4A:56:6C:62:A5:68:7D:DF:9D:B3:DE:91:19:E4:3B:2A",  // Upload key
@@ -941,7 +928,7 @@ Store in GitHub Secrets:
 - `ANDROID_KEY_PASSWORD`: Your keystore password
 - `ANDROID_KEY_ALIAS`: `upload`
 
-`.github/workflows/android.yml`:
+`.github/workflows/android-build.yml`:
 ```yaml
 - name: Setup Android signing
   run: |

--- a/docs/conversations-api-implementation.md
+++ b/docs/conversations-api-implementation.md
@@ -1,5 +1,10 @@
 # Conversations/Responses API Implementation Guide
 
+> Historical implementation guide. Maple's current Responses, persistence,
+> streaming, and tool behavior has evolved beyond portions of this document.
+> Use current source, `AGENTS.md`, and the applicable `.agents/skills/` workflow
+> as the authority.
+
 ## Overview
 
 This document describes the implementation of OpenAI's Conversations/Responses API in Maple's UnifiedChat component, building on the foundation established in [unified-chat-refactor.md](./unified-chat-refactor.md).
@@ -13,9 +18,9 @@ The Conversations/Responses API provides server-side conversation state manageme
 - **Stateless client**: No localStorage dependencies, pure server-driven state
 - **Automatic context management**: Server handles conversation history and token limits
 
-## Key Differences from POC
+## Key Differences from the Historical Prototype
 
-While the proof-of-concept in `responses-poc` demonstrates the API capabilities, our production implementation differs in several key ways:
+The production implementation differed from the historical prototype in several key ways:
 
 1. **Component Architecture**: All logic stays in UnifiedChat.tsx (no Context providers)
 2. **Title Generation**: Backend generates titles automatically (no frontend generation)
@@ -1240,7 +1245,7 @@ const loadLegacyChats = async () => {
 ## Security Notes
 
 - All encryption handled by SDK's custom fetch
-- JWT authentication automatic
+- Authentication and encrypted transport handled by the SDK custom fetch
 - No sensitive data in localStorage
 - Server validates all conversation access
 
@@ -1249,7 +1254,8 @@ const loadLegacyChats = async () => {
 This implementation guide was developed by analyzing multiple sources across the OpenSecret ecosystem. Here are all the key references that provided the knowledge for this implementation:
 
 ### 1. OpenSecret Backend Documentation
-- **File**: `/Users/tony/Dev/OpenSecret/opensecret/docs/responses-implementation.md`
+- **Source**: the public `OpenSecretCloud/opensecret` repository; current
+  `src/web/responses/` source supersedes this historical guide
 - **Content**: Detailed backend implementation of conversations/responses API
 - **Key Insights**:
   - Backend auto-generates titles from first message
@@ -1257,34 +1263,21 @@ This implementation guide was developed by analyzing multiple sources across the
   - Implements OpenAI-compatible endpoints
 
 ### 2. OpenSecret SDK Implementation
-- **Directory**: `/Users/tony/Dev/OpenSecret/OpenSecret-SDK/`
+- **Source**: the public OpenSecret SDK version pinned by
+  `frontend/package.json`
 - **Key Files**:
   - `src/lib/api.ts` - Core API functions including conversations/responses endpoints
   - `src/lib/ai.ts` - Custom fetch wrapper with encryption support
   - `src/lib/test/integration/ai.test.ts` - Comprehensive integration tests showing API usage
   - `package.json` - Shows OpenAI v5.20.0+ dependency requirement
 - **Key Insights**:
-  - Custom fetch handles JWT auth and encryption automatically
+  - Custom fetch handles authentication and encryption automatically
   - Includes conversation CRUD operations
   - Supports both streaming and non-streaming responses
   - Has pagination support for conversation items
 
-### 3. Proof of Concept Implementation
-- **Directory**: `/Users/tony/Dev/Personal/responses-poc/`
-- **Key Files**:
-  - `frontend/src/contexts/ConversationContext.tsx` - Complete conversation management implementation
-  - `frontend/src/hooks/useConversation.ts` - React hook for conversation state
-  - `frontend/src/lib/openai-client.ts` - OpenAI client configuration
-  - `frontend/src/lib/streaming.ts` - SSE stream processing
-  - `frontend/src/components/ChatInterface.tsx` - UI implementation
-- **Key Insights**:
-  - Polling mechanism for cross-device sync
-  - Message deduplication strategy
-  - Streaming event handling patterns
-  - Local vs server ID management
-
-### 4. Current Maple Project Structure
-- **Directory**: `/Users/tony/Dev/OpenSecret/maple/`
+### 3. Current Maple Project Structure
+- **Directory**: this repository root
 - **Key Files**:
   - `frontend/src/components/UnifiedChat.tsx` - Current monolithic chat component
   - `frontend/src/components/Sidebar.tsx` - Existing sidebar using localStorage
@@ -1295,7 +1288,7 @@ This implementation guide was developed by analyzing multiple sources across the
   - Query parameter-based routing (no navigation)
   - Event-based communication between components
 
-### 5. Integration Test Insights
+### 4. Integration Test Insights
 
 From the SDK integration tests (`ai.test.ts`), we learned:
 

--- a/docs/tool-call-immediate-rendering.md
+++ b/docs/tool-call-immediate-rendering.md
@@ -1,5 +1,9 @@
 # Tool Call Immediate Rendering Refactor
 
+> Historical refactor note. Event names, source locations, and observed gaps
+> may no longer match the current implementation. Use current source,
+> `AGENTS.md`, and the applicable `.agents/skills/` workflow as the authority.
+
 ## Problem Statement
 
 Tool calls don't render immediately during streaming in UnifiedChat. Currently:

--- a/docs/unified-chat-refactor.md
+++ b/docs/unified-chat-refactor.md
@@ -1,5 +1,9 @@
 # Unified Chat Refactor - Phase 1
 
+> Historical refactor note. It describes an earlier architecture and migration
+> phase, not the complete current chat contract. Use current source,
+> `AGENTS.md`, and the applicable `.agents/skills/` workflow as the authority.
+
 ## Overview
 
 This document describes the initial refactor of Maple's chat interface in preparation for migrating from the current localStorage-based chat system to OpenAI's Conversations/Responses API.
@@ -87,7 +91,8 @@ We maintained backward compatibility:
 
 **New Files**:
 - `frontend/src/components/UnifiedChat.tsx` - The unified chat component
-- `frontend/src/routes/index.backup.tsx` - Backup of original index
+- Historical backup of the original index (the backup file is no longer part of
+  the repository)
 
 **Modified Files**:
 - `frontend/src/routes/index.tsx` - Simplified to show Marketing or UnifiedChat based on auth

--- a/justfile
+++ b/justfile
@@ -72,6 +72,14 @@ desktop-dev:
 desktop-build-debug:
     cd frontend && src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri build --debug
 
+# Build an unsigned debug desktop package with the required local Tauri overlay
+desktop-build-debug-overlay:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    test -f .local/tauri-workspace.json || { echo "missing .local/tauri-workspace.json" >&2; exit 1; }
+    cd frontend
+    src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri build --debug --no-sign --config ../.local/tauri-workspace.json --config '{"bundle":{"createUpdaterArtifacts":false}}'
+
 # Build Tauri desktop release (with CC unset for compatibility)
 desktop-build-no-cc:
     cd frontend && unset CC && src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri build


### PR DESCRIPTION
## Summary

- add repository-wide agent guidance covering architecture ownership, development conventions, security and privacy invariants, validation expectations, review boundaries, and ongoing guidance maintenance
- add focused skills for ordinary Maple development, validation and smoke testing, Agent Mode changes, and security review
- refresh the release skill and README around the current Nix, CI, desktop, mobile, OpenSecret, and release workflows
- mark older implementation notes as historical and remove stale personal-path and time-specific operational references
- keep billing and feature flags documented only as configurable external API boundaries

## Testing

- Maple pre-commit hook
  - Prettier formatting check
  - production frontend build
  - Bun test suite: 592 passed
- official skill validator for all five skills
- validated skill metadata, repository paths, and local Markdown links
- `bash -n .agents/skills/release-maple/scripts/preflight.sh`
- `git diff --check`
