### PR TITLE
Continue Markdown lists in chat composers

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -66,6 +66,10 @@ import {
 } from "@/components/chat/ChatTurn";
 import { ChatCopyButton } from "@/components/chat/ChatCopyButton";
 import {
+  continueChatComposerList,
+  continueChatComposerListBeforeInput
+} from "@/components/chatComposerListContinuation";
+import {
   Select,
   SelectContent,
   SelectItem,
@@ -2266,6 +2270,10 @@ export function AgentMode({ userId }: { userId: string }) {
 
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if (event.nativeEvent.isComposing) return;
+      if ((event.shiftKey || isCompactLayout) && continueChatComposerList(event, setInput)) {
+        return;
+      }
       if (event.key === "Enter" && !event.shiftKey && !isCompactLayout) {
         event.preventDefault();
         void sendMessage();
@@ -2273,6 +2281,10 @@ export function AgentMode({ userId }: { userId: string }) {
     },
     [isCompactLayout, sendMessage]
   );
+
+  const handleBeforeInput = useCallback((event: React.FormEvent<HTMLTextAreaElement>) => {
+    continueChatComposerListBeforeInput(event, setInput);
+  }, []);
 
   const removeSessionFromState = useCallback(
     (sessionId: string) => {
@@ -2941,6 +2953,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={setInput}
                   onKeyDown={handleKeyDown}
+                  onBeforeInput={handleBeforeInput}
                   onManageMcpServers={handleManageMcpServers}
                   onMcpToggle={toggleMcpServer}
                   onModeChange={selectMode}
@@ -2984,6 +2997,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={setInput}
                   onKeyDown={handleKeyDown}
+                  onBeforeInput={handleBeforeInput}
                   onManageMcpServers={handleManageMcpServers}
                   onMcpToggle={toggleMcpServer}
                   onModeChange={selectMode}
@@ -4086,6 +4100,7 @@ interface AgentComposerProps {
   onCancelPrompt: () => void;
   onChooseProjectRoot: () => void;
   onInputChange: (value: string) => void;
+  onBeforeInput: (event: React.FormEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onManageMcpServers: () => void;
   onMcpToggle: (name: string, enabled: boolean) => void;
@@ -4115,6 +4130,7 @@ function AgentComposer({
   onCancelPrompt,
   onChooseProjectRoot,
   onInputChange,
+  onBeforeInput,
   onKeyDown,
   onManageMcpServers,
   onMcpToggle,
@@ -4162,6 +4178,7 @@ function AgentComposer({
         id="agent-message"
         value={input}
         onChange={(event) => onInputChange(event.target.value)}
+        onBeforeInput={onBeforeInput}
         onKeyDown={onKeyDown}
         disabled={isSendDisabled}
         placeholder="Ask Maple to work in this folder..."

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -62,6 +62,10 @@ import {
   ChatUserTurn
 } from "@/components/chat/ChatTurn";
 import { ChatCopyButton } from "@/components/chat/ChatCopyButton";
+import {
+  continueChatComposerList,
+  continueChatComposerListBeforeInput
+} from "@/components/chatComposerListContinuation";
 import { ModelSelector } from "@/components/ModelSelector";
 import { useBillingState, useModelState, useSelectedProjectState } from "@/state/useLocalState";
 import { isKnownFreePlan } from "@/billing/billingAccess";
@@ -4968,10 +4972,18 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // On desktop: Enter submits, Shift+Enter for new line
     // On mobile: Enter for new line, no keyboard shortcut to submit (use button)
+    if (e.nativeEvent.isComposing) return;
+    if ((e.shiftKey || isCompactLayout) && continueChatComposerList(e, setInput)) {
+      return;
+    }
     if (e.key === "Enter" && !e.shiftKey && !isCompactLayout) {
       e.preventDefault();
       handleSendMessage();
     }
+  };
+
+  const handleBeforeInput = (event: React.FormEvent<HTMLTextAreaElement>) => {
+    continueChatComposerListBeforeInput(event, setInput);
   };
 
   return (
@@ -5230,6 +5242,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
                         value={input}
                         onChange={(e) => setInput(e.target.value)}
                         onKeyDown={handleKeyDown}
+                        onBeforeInput={handleBeforeInput}
                         onPaste={handlePaste}
                         placeholder="Message Maple..."
                         disabled={isGenerating || isRecordingForActive}
@@ -5475,6 +5488,7 @@ export function UnifiedChat({ isVisible = true }: { isVisible?: boolean }) {
                       value={input}
                       onChange={(e) => setInput(e.target.value)}
                       onKeyDown={handleKeyDown}
+                      onBeforeInput={handleBeforeInput}
                       onPaste={handlePaste}
                       placeholder="Message Maple..."
                       disabled={isGenerating || isRecordingForActive}

--- a/frontend/src/components/chatComposerListContinuation.test.ts
+++ b/frontend/src/components/chatComposerListContinuation.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { chatComposerListEdit } from "./chatComposerListContinuation";
+import {
+  chatComposerListEdit,
+  restoreChatComposerListSelection
+} from "./chatComposerListContinuation";
 
 function editAtEnd(value: string) {
   return chatComposerListEdit(value, value.length, value.length);
@@ -117,5 +120,44 @@ describe("chatComposerListEdit", () => {
   test("continues again after the matching fence closes", () => {
     expect(editAtEnd("```\n- code\n```\n- real")?.value).toBe("```\n- code\n```\n- real\n- ");
     expect(editAtEnd("~~~~\n1. code\n~~~\n2. still code")).toBeNull();
+  });
+});
+
+describe("restoreChatComposerListSelection", () => {
+  test("scrolls a capped composer to a continuation inserted at the end", () => {
+    const selection: [number, number] = [-1, -1];
+    const textarea = {
+      scrollHeight: 640,
+      scrollTop: 120,
+      setSelectionRange(start: number, end: number) {
+        selection[0] = start;
+        selection[1] = end;
+      }
+    };
+
+    restoreChatComposerListSelection(
+      textarea,
+      { value: "- first\n- ", selectionStart: 10, selectionEnd: 10 },
+      true
+    );
+
+    expect(selection).toEqual([10, 10]);
+    expect(textarea.scrollTop).toBe(640);
+  });
+
+  test("does not jump to the bottom when editing in the middle of a draft", () => {
+    const textarea = {
+      scrollHeight: 640,
+      scrollTop: 120,
+      setSelectionRange() {}
+    };
+
+    restoreChatComposerListSelection(
+      textarea,
+      { value: "- first\n- second", selectionStart: 10, selectionEnd: 10 },
+      false
+    );
+
+    expect(textarea.scrollTop).toBe(120);
   });
 });

--- a/frontend/src/components/chatComposerListContinuation.test.ts
+++ b/frontend/src/components/chatComposerListContinuation.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+
+import { chatComposerListEdit } from "./chatComposerListContinuation";
+
+function editAtEnd(value: string) {
+  return chatComposerListEdit(value, value.length, value.length);
+}
+
+describe("chatComposerListEdit", () => {
+  test.each(["-", "*", "+"])("continues an unordered %s list", (marker) => {
+    const value = `${marker} first item`;
+
+    expect(editAtEnd(value)).toEqual({
+      value: `${value}\n${marker} `,
+      selectionStart: value.length + 3,
+      selectionEnd: value.length + 3
+    });
+  });
+
+  test.each([
+    ["- [ ] todo", "- [ ] "],
+    ["* [x] done", "* [ ] "],
+    ["\t+  [X]\tfinished", "\t+  [ ]\t"]
+  ])("continues task list %s with an unchecked item", (value, continuation) => {
+    expect(editAtEnd(value)).toEqual({
+      value: `${value}\n${continuation}`,
+      selectionStart: value.length + continuation.length + 1,
+      selectionEnd: value.length + continuation.length + 1
+    });
+  });
+
+  test.each([
+    ["  9) ninth item", "  10) "],
+    ["\t99. ninety-ninth", "\t100. "]
+  ])("increments ordered list %s and preserves its style", (value, continuation) => {
+    expect(editAtEnd(value)).toEqual({
+      value: `${value}\n${continuation}`,
+      selectionStart: value.length + continuation.length + 1,
+      selectionEnd: value.length + continuation.length + 1
+    });
+  });
+
+  test("continues the current list type in a mixed draft", () => {
+    const value = "- first\n\n1. second\n\n* third";
+    expect(editAtEnd(value)?.value).toBe(`${value}\n* `);
+  });
+
+  test("continues the list at the caret and replaces selected text", () => {
+    const value = "Intro\n1. first item selected";
+    const selectionStart = value.indexOf(" selected");
+
+    expect(chatComposerListEdit(value, selectionStart, value.length)).toEqual({
+      value: "Intro\n1. first item\n2. ",
+      selectionStart: selectionStart + 4,
+      selectionEnd: selectionStart + 4
+    });
+  });
+
+  test("replaces a selection spanning later lines", () => {
+    const value = "1. first selected\nsecond\nthird";
+    const selectionStart = value.indexOf(" selected");
+    const selectionEnd = value.indexOf("third");
+
+    expect(chatComposerListEdit(value, selectionStart, selectionEnd)).toEqual({
+      value: "1. first\n2. third",
+      selectionStart: selectionStart + 4,
+      selectionEnd: selectionStart + 4
+    });
+  });
+
+  test("moves text after the caret to the generated item", () => {
+    expect(chatComposerListEdit("- item", 2, 2)).toEqual({
+      value: "- \n- item",
+      selectionStart: 5,
+      selectionEnd: 5
+    });
+  });
+
+  test.each(["First\n  - ", "First\n\t3)  ", "First\n  * [x]  "])(
+    "ends an empty list item %s",
+    (value) => {
+      const lineStart = value.lastIndexOf("\n") + 1;
+      const indentation = value.slice(lineStart).match(/^[ \t]*/)?.[0] ?? "";
+      const caret = lineStart + indentation.length;
+      expect(editAtEnd(value)).toEqual({
+        value: `${value.slice(0, lineStart)}${indentation}`,
+        selectionStart: caret,
+        selectionEnd: caret
+      });
+    }
+  );
+
+  test("removes an empty marker and the selected following text", () => {
+    expect(chatComposerListEdit("- \nselected", 2, 11)).toEqual({
+      value: "",
+      selectionStart: 0,
+      selectionEnd: 0
+    });
+  });
+
+  test.each(["ordinary text", "prefix - item", "\\- escaped", "-not a list", "- - -", "* * * *"])(
+    "does not change non-list input %s",
+    (value) => {
+      expect(editAtEnd(value)).toBeNull();
+    }
+  );
+
+  test.each([
+    "```\n- code item",
+    "~~~ts\n1. code item",
+    "before\n````js\n* code item",
+    "before\n~~~\n+ code item"
+  ])("does not continue a list inside a fence", (value) => {
+    expect(editAtEnd(value)).toBeNull();
+  });
+
+  test("continues again after the matching fence closes", () => {
+    expect(editAtEnd("```\n- code\n```\n- real")?.value).toBe("```\n- code\n```\n- real\n- ");
+    expect(editAtEnd("~~~~\n1. code\n~~~\n2. still code")).toBeNull();
+  });
+});

--- a/frontend/src/components/chatComposerListContinuation.ts
+++ b/frontend/src/components/chatComposerListContinuation.ts
@@ -6,6 +6,22 @@ export interface ChatComposerListEdit {
   selectionEnd: number;
 }
 
+type ChatComposerSelectionTarget = Pick<
+  HTMLTextAreaElement,
+  "scrollHeight" | "scrollTop" | "setSelectionRange"
+>;
+
+export function restoreChatComposerListSelection(
+  textarea: ChatComposerSelectionTarget,
+  edit: ChatComposerListEdit,
+  shouldScrollToEnd: boolean
+): void {
+  textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+  if (shouldScrollToEnd) {
+    textarea.scrollTop = textarea.scrollHeight;
+  }
+}
+
 interface ListMarkerMatch {
   indentation: string;
   continuationPrefix: string;
@@ -113,6 +129,7 @@ function applyChatComposerListEdit(
   onInputChange: (value: string) => void
 ): void {
   const originalValue = textarea.value;
+  const shouldScrollToEnd = textarea.selectionEnd === originalValue.length;
   let replaceStart = 0;
   while (
     replaceStart < originalValue.length &&
@@ -143,7 +160,7 @@ function applyChatComposerListEdit(
 
   requestAnimationFrame(() => {
     if (textarea.isConnected && document.activeElement === textarea) {
-      textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+      restoreChatComposerListSelection(textarea, edit, shouldScrollToEnd);
     }
   });
 }

--- a/frontend/src/components/chatComposerListContinuation.ts
+++ b/frontend/src/components/chatComposerListContinuation.ts
@@ -1,0 +1,185 @@
+import type React from "react";
+
+export interface ChatComposerListEdit {
+  value: string;
+  selectionStart: number;
+  selectionEnd: number;
+}
+
+interface ListMarkerMatch {
+  indentation: string;
+  continuationPrefix: string;
+  itemText: string;
+}
+
+function listMarkerForLine(line: string): ListMarkerMatch | null {
+  const unordered = line.match(/^([ \t]*)([-+*])([ \t]+)(.*)$/);
+  if (unordered) {
+    const [, indentation, marker, spacing, itemText] = unordered;
+    const task = itemText.match(/^\[([ xX])\]([ \t]*)(.*)$/);
+    if (task && (task[2] || !task[3])) {
+      return {
+        indentation,
+        continuationPrefix: `${indentation}${marker}${spacing}[ ]${task[2]}`,
+        itemText: task[3]
+      };
+    }
+
+    return {
+      indentation,
+      continuationPrefix: `${indentation}${marker}${spacing}`,
+      itemText
+    };
+  }
+
+  const ordered = line.match(/^([ \t]*)(\d+)([.)])([ \t]+)(.*)$/);
+  if (!ordered) return null;
+
+  return {
+    indentation: ordered[1],
+    continuationPrefix: `${ordered[1]}${BigInt(ordered[2]) + 1n}${ordered[3]}${ordered[4]}`,
+    itemText: ordered[5]
+  };
+}
+
+function isInsideFence(value: string, lineStart: number): boolean {
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+
+  for (const line of value.slice(0, lineStart).split("\n")) {
+    if (fence) {
+      const closing = line.match(/^[ ]{0,3}(`+|~+)[ \t]*$/);
+      if (closing && closing[1][0] === fence.marker && closing[1].length >= fence.length) {
+        fence = null;
+      }
+      continue;
+    }
+
+    const opening = line.match(/^[ ]{0,3}(`{3,}|~{3,})/);
+    if (opening) {
+      fence = {
+        marker: opening[1][0] as "`" | "~",
+        length: opening[1].length
+      };
+    }
+  }
+
+  return fence !== null;
+}
+
+function isHorizontalRule(line: string): boolean {
+  const trimmed = line.trim();
+  return /^(?:-\s*){3,}$/.test(trimmed) || /^(?:\*\s*){3,}$/.test(trimmed);
+}
+
+export function chatComposerListEdit(
+  value: string,
+  selectionStart: number,
+  selectionEnd: number
+): ChatComposerListEdit | null {
+  const lineStart = value.lastIndexOf("\n", selectionStart - 1) + 1;
+  if (isInsideFence(value, lineStart)) return null;
+
+  const lineBreak = value.indexOf("\n", selectionStart);
+  const lineEnd = lineBreak === -1 ? value.length : lineBreak;
+  const line = value.slice(lineStart, lineEnd);
+  if (isHorizontalRule(line)) return null;
+
+  const lineBeforeSelection = value.slice(lineStart, selectionStart);
+  const match = listMarkerForLine(lineBeforeSelection);
+  if (!match) return null;
+
+  const fullLineMatch = listMarkerForLine(line);
+  if (fullLineMatch && fullLineMatch.itemText.trim() === "") {
+    const caret = lineStart + match.indentation.length;
+    return {
+      value: `${value.slice(0, caret)}${value.slice(Math.max(lineEnd, selectionEnd))}`,
+      selectionStart: caret,
+      selectionEnd: caret
+    };
+  }
+
+  const continuation = `\n${match.continuationPrefix}`;
+  const caret = selectionStart + continuation.length;
+  return {
+    value: `${value.slice(0, selectionStart)}${continuation}${value.slice(selectionEnd)}`,
+    selectionStart: caret,
+    selectionEnd: caret
+  };
+}
+
+function applyChatComposerListEdit(
+  textarea: HTMLTextAreaElement,
+  edit: ChatComposerListEdit,
+  onInputChange: (value: string) => void
+): void {
+  const originalValue = textarea.value;
+  let replaceStart = 0;
+  while (
+    replaceStart < originalValue.length &&
+    replaceStart < edit.value.length &&
+    originalValue[replaceStart] === edit.value[replaceStart]
+  ) {
+    replaceStart += 1;
+  }
+
+  let originalEnd = originalValue.length;
+  let editEnd = edit.value.length;
+  while (
+    originalEnd > replaceStart &&
+    editEnd > replaceStart &&
+    originalValue[originalEnd - 1] === edit.value[editEnd - 1]
+  ) {
+    originalEnd -= 1;
+    editEnd -= 1;
+  }
+
+  textarea.setSelectionRange(replaceStart, originalEnd);
+  const replacement = edit.value.slice(replaceStart, editEnd);
+  const appliedWithUndo = document.execCommand?.("insertText", false, replacement) ?? false;
+  if (!appliedWithUndo) {
+    textarea.setRangeText(replacement, replaceStart, originalEnd, "end");
+  }
+  onInputChange(edit.value);
+
+  requestAnimationFrame(() => {
+    if (textarea.isConnected && document.activeElement === textarea) {
+      textarea.setSelectionRange(edit.selectionStart, edit.selectionEnd);
+    }
+  });
+}
+
+function continueListForTextarea(
+  event: React.SyntheticEvent<HTMLTextAreaElement>,
+  onInputChange: (value: string) => void
+): boolean {
+  const textarea = event.currentTarget;
+  const edit = chatComposerListEdit(textarea.value, textarea.selectionStart, textarea.selectionEnd);
+  if (!edit) return false;
+
+  event.preventDefault();
+  applyChatComposerListEdit(textarea, edit, onInputChange);
+  return true;
+}
+
+export function continueChatComposerList(
+  event: React.KeyboardEvent<HTMLTextAreaElement>,
+  onInputChange: (value: string) => void
+): boolean {
+  if (event.key !== "Enter" || event.nativeEvent.isComposing) return false;
+  return continueListForTextarea(event, onInputChange);
+}
+
+export function continueChatComposerListBeforeInput(
+  event: React.FormEvent<HTMLTextAreaElement>,
+  onInputChange: (value: string) => void
+): boolean {
+  const inputEvent = event.nativeEvent as InputEvent;
+  if (
+    inputEvent.isComposing ||
+    (inputEvent.inputType !== "insertLineBreak" && inputEvent.inputType !== "insertParagraph")
+  ) {
+    return false;
+  }
+
+  return continueListForTextarea(event, onInputChange);
+}


### PR DESCRIPTION
## Summary

- continue unordered, ordered, and task-list Markdown prefixes in Chat and Agent Mode
- preserve indentation, selection/caret behavior, native undo/redo, compact-layout newline input, and desktop send semantics
- exit empty list items and ignore fenced code, horizontal rules, escaped markers, malformed markers, paste, and IME composition

Closes #763.

## Validation

- `nix develop .#ci -c ./scripts/ci/frontend.sh` — 635 tests, 2,034 assertions; format, lint, and typecheck passed (13 existing warnings, 0 errors)
- `MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh`
- `VITE_FORCE_FEATURE_FLAGS=agent_mode nix develop -c just desktop-build-debug-overlay`
- `./bin/ows smoke maple-list-763` — OpenSecret, migrations, Continuum/Tinfoil, and billing passed
- exact packaged app at `ae9f0e82`: Chat and Agent Mode unordered/ordered/task continuation, caret placement, empty-item exit, expanded composer, and one-step undo/redo

Not manually exercised on physical mobile soft keyboards or with an active IME composition session.