### PR TITLE
Guard native OAuth callbacks

### DIFF
--- a/frontend/src/components/DeepLinkHandler.test.tsx
+++ b/frontend/src/components/DeepLinkHandler.test.tsx
@@ -1,0 +1,186 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestRenderer } from "react-test-renderer";
+import { beginNativeOAuthAttempt } from "@/services/nativeOAuthAttempt";
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+interface DeepLinkEvent {
+  payload: string;
+}
+
+let deepLinkListener: ((event: DeepLinkEvent) => void) | undefined;
+let currentUser: { id: string } | undefined;
+const unlisten = mock(() => {});
+
+mock.module("@opensecret/react", () => ({
+  useOpenSecret: () => ({ auth: { user: currentUser } })
+}));
+
+mock.module("@/utils/platform", () => ({
+  isTauri: () => true
+}));
+
+mock.module("@tauri-apps/api/event", () => ({
+  listen: async (_eventName: string, listener: (event: DeepLinkEvent) => void) => {
+    deepLinkListener = listener;
+    return unlisten;
+  }
+}));
+
+const { DeepLinkHandler } = await import("./DeepLinkHandler");
+
+const originalGlobals = {
+  localStorage: Object.getOwnPropertyDescriptor(globalThis, "localStorage"),
+  window: Object.getOwnPropertyDescriptor(globalThis, "window")
+};
+
+function restoreGlobal(name: string, descriptor: PropertyDescriptor | undefined): void {
+  if (descriptor) {
+    Object.defineProperty(globalThis, name, descriptor);
+  } else {
+    Reflect.deleteProperty(globalThis, name);
+  }
+}
+
+describe("DeepLinkHandler native auth callbacks", () => {
+  let location: { href: string };
+  let renderer: ReactTestRenderer | null;
+  let storage: MemoryStorage;
+  let originalConsoleError: typeof console.error;
+  let originalConsoleLog: typeof console.log;
+  let originalConsoleWarn: typeof console.warn;
+
+  beforeEach(async () => {
+    deepLinkListener = undefined;
+    currentUser = undefined;
+    renderer = null;
+    storage = new MemoryStorage();
+    location = { href: "tauri://localhost/" };
+
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+      writable: true
+    });
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { localStorage: storage, location },
+      writable: true
+    });
+
+    originalConsoleError = console.error;
+    originalConsoleLog = console.log;
+    originalConsoleWarn = console.warn;
+    console.error = mock(() => {});
+    console.log = mock(() => {});
+    console.warn = mock(() => {});
+
+    await act(async () => {
+      renderer = create(<DeepLinkHandler />);
+      await Promise.resolve();
+    });
+    if (!deepLinkListener) throw new Error("Deep-link listener was not registered");
+  });
+
+  afterEach(() => {
+    if (renderer) {
+      act(() => renderer?.unmount());
+    }
+    restoreGlobal("localStorage", originalGlobals.localStorage);
+    restoreGlobal("window", originalGlobals.window);
+    console.error = originalConsoleError;
+    console.log = originalConsoleLog;
+    console.warn = originalConsoleWarn;
+  });
+
+  function emitAuthLink(accessToken = "incoming-access", refreshToken = "incoming-refresh"): void {
+    const query = new URLSearchParams({
+      access_token: accessToken,
+      refresh_token: refreshToken,
+      next: "/settings"
+    });
+    deepLinkListener?.({ payload: `cloud.opensecret.maple://auth?${query}` });
+  }
+
+  test("preserves an authenticated session and consumes any pending marker", () => {
+    beginNativeOAuthAttempt();
+    storage.setItem("access_token", "current-access");
+    storage.setItem("refresh_token", "current-refresh");
+    currentUser = { id: "current-user" };
+    act(() => renderer?.update(<DeepLinkHandler />));
+
+    emitAuthLink();
+
+    expect(storage.getItem("access_token")).toBe("current-access");
+    expect(storage.getItem("refresh_token")).toBe("current-refresh");
+    expect(location.href).toBe("tauri://localhost/");
+
+    storage.removeItem("access_token");
+    storage.removeItem("refresh_token");
+    emitAuthLink();
+    expect(storage.getItem("access_token")).toBeNull();
+  });
+
+  test("rejects an unsolicited auth callback without a pending marker", () => {
+    emitAuthLink();
+
+    expect(storage.getItem("access_token")).toBeNull();
+    expect(storage.getItem("refresh_token")).toBeNull();
+    expect(location.href).toBe("tauri://localhost/");
+  });
+
+  test("accepts a pending auth callback once and preserves its safe redirect", () => {
+    beginNativeOAuthAttempt();
+    storage.setItem("access_token", "stale-access");
+    storage.setItem("refresh_token", "stale-refresh");
+
+    emitAuthLink();
+
+    expect(storage.getItem("access_token")).toBe("incoming-access");
+    expect(storage.getItem("refresh_token")).toBe("incoming-refresh");
+    expect(location.href).toBe("/settings");
+
+    storage.removeItem("access_token");
+    storage.removeItem("refresh_token");
+    emitAuthLink("replayed-access", "replayed-refresh");
+    expect(storage.getItem("access_token")).toBeNull();
+  });
+
+  test("does not consume the pending marker for a callback missing required tokens", () => {
+    beginNativeOAuthAttempt();
+    deepLinkListener?.({
+      payload: "cloud.opensecret.maple://auth?access_token=incomplete"
+    });
+
+    emitAuthLink();
+
+    expect(storage.getItem("access_token")).toBe("incoming-access");
+    expect(storage.getItem("refresh_token")).toBe("incoming-refresh");
+  });
+});

--- a/frontend/src/components/DeepLinkHandler.tsx
+++ b/frontend/src/components/DeepLinkHandler.tsx
@@ -1,13 +1,19 @@
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
+import { useOpenSecret } from "@opensecret/react";
 import { isTauri } from "@/utils/platform";
 import { listen } from "@tauri-apps/api/event";
 import { getSafeInternalRedirect } from "@/utils/internalRedirect";
+import { authorizeNativeOAuthCallback } from "@/services/nativeOAuthAttempt";
 
 // For direct deep link handling, we'll listen to our custom event
 // If we had the types installed, we would use:
 // import { onOpenUrl } from '@tauri-apps/plugin-deep-link';
 
 export function DeepLinkHandler() {
+  const os = useOpenSecret();
+  const isAuthenticatedRef = useRef(false);
+  isAuthenticatedRef.current = Boolean(os.auth.user);
+
   useEffect(() => {
     let unlisten: (() => void) | undefined;
 
@@ -37,6 +43,16 @@ export function DeepLinkHandler() {
                 const safeNext = getSafeInternalRedirect(next) ?? "/";
 
                 if (accessToken && refreshToken) {
+                  const authorization = authorizeNativeOAuthCallback(isAuthenticatedRef.current);
+                  if (authorization === "already_authenticated") {
+                    console.warn("[Deep Link] Ignoring auth callback for an existing session");
+                    return;
+                  }
+                  if (authorization === "missing_or_expired_attempt") {
+                    console.warn("[Deep Link] Ignoring unsolicited or expired auth callback");
+                    return;
+                  }
+
                   console.log("[Deep Link] Auth tokens received");
 
                   // Store the tokens in localStorage with consistent naming

--- a/frontend/src/routes/login.tsx
+++ b/frontend/src/routes/login.tsx
@@ -20,6 +20,7 @@ import { isIOS, isTauri } from "@/utils/platform";
 import { appUrl } from "@/config/domains";
 import { useRouteMeta } from "@/utils/routeMeta";
 import { getSafeInternalRedirect, navigateToSafeInternalRedirect } from "@/utils/internalRedirect";
+import { beginNativeOAuthAttempt, cancelNativeOAuthAttempt } from "@/services/nativeOAuthAttempt";
 
 type LoginSearchParams = {
   next?: string;
@@ -145,7 +146,9 @@ function LoginPage() {
         // Use the opener plugin by directly invoking the command
         // This works for both desktop and mobile (iOS/Android)
         console.log("[OAuth] Opening URL in external browser:", desktopAuthUrl);
+        const nativeOAuthAttemptId = beginNativeOAuthAttempt();
         invoke("plugin:opener|open_url", { url: desktopAuthUrl }).catch((error: Error) => {
+          cancelNativeOAuthAttempt(nativeOAuthAttemptId);
           console.error("[OAuth] Failed to open external browser:", error);
           setError("Failed to open authentication page in browser");
         });
@@ -196,7 +199,9 @@ function LoginPage() {
         // Use the opener plugin by directly invoking the command
         // This works for both desktop and mobile (iOS/Android)
         console.log("[OAuth] Opening URL in external browser:", desktopAuthUrl);
+        const nativeOAuthAttemptId = beginNativeOAuthAttempt();
         invoke("plugin:opener|open_url", { url: desktopAuthUrl }).catch((error: Error) => {
+          cancelNativeOAuthAttempt(nativeOAuthAttemptId);
           console.error("[OAuth] Failed to open external browser:", error);
           setError("Failed to open authentication page in browser");
         });
@@ -373,7 +378,9 @@ function LoginPage() {
 
         // Use the opener plugin by directly invoking the command
         console.log("[OAuth] Opening URL in external browser:", desktopAuthUrl);
+        const nativeOAuthAttemptId = beginNativeOAuthAttempt();
         invoke("plugin:opener|open_url", { url: desktopAuthUrl }).catch((error: Error) => {
+          cancelNativeOAuthAttempt(nativeOAuthAttemptId);
           console.error("[OAuth] Failed to open external browser:", error);
           setError("Failed to open authentication page in browser");
         });

--- a/frontend/src/routes/signup.tsx
+++ b/frontend/src/routes/signup.tsx
@@ -24,6 +24,7 @@ import { appUrl } from "@/config/domains";
 import { useRouteMeta } from "@/utils/routeMeta";
 import { getSafeInternalRedirect, navigateToSafeInternalRedirect } from "@/utils/internalRedirect";
 import { shouldRedirectAuthenticatedSignup } from "@/utils/signupRedirect";
+import { beginNativeOAuthAttempt, cancelNativeOAuthAttempt } from "@/services/nativeOAuthAttempt";
 
 type SignupSearchParams = {
   next?: string;
@@ -175,7 +176,9 @@ function SignupPage() {
         // Use the opener plugin by directly invoking the command
         // This works for both desktop and mobile (iOS/Android)
         console.log("[OAuth] Opening URL in external browser:", desktopAuthUrl);
+        const nativeOAuthAttemptId = beginNativeOAuthAttempt();
         invoke("plugin:opener|open_url", { url: desktopAuthUrl }).catch((error: Error) => {
+          cancelNativeOAuthAttempt(nativeOAuthAttemptId);
           console.error("[OAuth] Failed to open external browser:", error);
           setError("Failed to open authentication page in browser");
         });
@@ -226,7 +229,9 @@ function SignupPage() {
         // Use the opener plugin by directly invoking the command
         // This works for both desktop and mobile (iOS/Android)
         console.log("[OAuth] Opening URL in external browser:", desktopAuthUrl);
+        const nativeOAuthAttemptId = beginNativeOAuthAttempt();
         invoke("plugin:opener|open_url", { url: desktopAuthUrl }).catch((error: Error) => {
+          cancelNativeOAuthAttempt(nativeOAuthAttemptId);
           console.error("[OAuth] Failed to open external browser:", error);
           setError("Failed to open authentication page in browser");
         });
@@ -406,7 +411,9 @@ function SignupPage() {
 
         // Use the opener plugin by directly invoking the command
         console.log("[OAuth] Opening URL in external browser:", desktopAuthUrl);
+        const nativeOAuthAttemptId = beginNativeOAuthAttempt();
         invoke("plugin:opener|open_url", { url: desktopAuthUrl }).catch((error: Error) => {
+          cancelNativeOAuthAttempt(nativeOAuthAttemptId);
           console.error("[OAuth] Failed to open external browser:", error);
           setError("Failed to open authentication page in browser");
         });

--- a/frontend/src/services/nativeOAuthAttempt.test.ts
+++ b/frontend/src/services/nativeOAuthAttempt.test.ts
@@ -1,0 +1,112 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  authorizeNativeOAuthCallback,
+  beginNativeOAuthAttempt,
+  cancelNativeOAuthAttempt,
+  PENDING_NATIVE_OAUTH_ATTEMPT_TTL_MS
+} from "./nativeOAuthAttempt";
+
+class MemoryStorage implements Storage {
+  private readonly values = new Map<string, string>();
+
+  get length(): number {
+    return this.values.size;
+  }
+
+  clear(): void {
+    this.values.clear();
+  }
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null;
+  }
+
+  key(index: number): string | null {
+    return [...this.values.keys()][index] ?? null;
+  }
+
+  removeItem(key: string): void {
+    this.values.delete(key);
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value);
+  }
+}
+
+const originalLocalStorage = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+
+function restoreLocalStorage(): void {
+  if (originalLocalStorage) {
+    Object.defineProperty(globalThis, "localStorage", originalLocalStorage);
+  } else {
+    Reflect.deleteProperty(globalThis, "localStorage");
+  }
+}
+
+describe("native OAuth attempt authorization", () => {
+  let storage: MemoryStorage;
+
+  beforeEach(() => {
+    storage = new MemoryStorage();
+    Object.defineProperty(globalThis, "localStorage", {
+      configurable: true,
+      value: storage,
+      writable: true
+    });
+  });
+
+  afterEach(() => {
+    restoreLocalStorage();
+  });
+
+  test("a retry replaces the marker and an older failed attempt cannot cancel it", () => {
+    const firstAttemptId = beginNativeOAuthAttempt(1_000);
+    const secondAttemptId = beginNativeOAuthAttempt(2_000);
+
+    expect(secondAttemptId).not.toBe(firstAttemptId);
+    cancelNativeOAuthAttempt(firstAttemptId);
+    expect(authorizeNativeOAuthCallback(false, 2_001)).toBe("accepted");
+    expect(authorizeNativeOAuthCallback(false, 2_001)).toBe("missing_or_expired_attempt");
+  });
+
+  test("canceling the current browser-open attempt removes its marker", () => {
+    const attemptId = beginNativeOAuthAttempt(1_000);
+
+    cancelNativeOAuthAttempt(attemptId);
+
+    expect(authorizeNativeOAuthCallback(false, 1_001)).toBe("missing_or_expired_attempt");
+  });
+
+  test("rejects and clears an expired or future-dated marker", () => {
+    beginNativeOAuthAttempt(1_000);
+    expect(
+      authorizeNativeOAuthCallback(false, 1_000 + PENDING_NATIVE_OAUTH_ATTEMPT_TTL_MS + 1)
+    ).toBe("missing_or_expired_attempt");
+
+    beginNativeOAuthAttempt(2_000);
+    expect(authorizeNativeOAuthCallback(false, 1_999)).toBe("missing_or_expired_attempt");
+    expect(authorizeNativeOAuthCallback(false, 2_001)).toBe("missing_or_expired_attempt");
+  });
+
+  test("rejects a callback for an authenticated user and clears the marker", () => {
+    beginNativeOAuthAttempt(1_000);
+
+    expect(authorizeNativeOAuthCallback(true, 1_001)).toBe("already_authenticated");
+    expect(authorizeNativeOAuthCallback(false, 1_001)).toBe("missing_or_expired_attempt");
+  });
+
+  test("rejects an unsolicited callback without a marker", () => {
+    expect(authorizeNativeOAuthCallback(false, 1_000)).toBe("missing_or_expired_attempt");
+  });
+
+  test("rejects and removes malformed marker data", () => {
+    beginNativeOAuthAttempt(1_000);
+    const markerKey = storage.key(0);
+    if (!markerKey) throw new Error("Expected the pending marker to be stored");
+    storage.setItem(markerKey, "not-json");
+
+    expect(authorizeNativeOAuthCallback(false, 1_001)).toBe("missing_or_expired_attempt");
+    expect(storage.getItem(markerKey)).toBeNull();
+  });
+});

--- a/frontend/src/services/nativeOAuthAttempt.ts
+++ b/frontend/src/services/nativeOAuthAttempt.ts
@@ -1,0 +1,100 @@
+import { v4 as uuidv4 } from "uuid";
+
+const PENDING_NATIVE_OAUTH_ATTEMPT_KEY = "maple_pending_native_oauth_attempt_v1";
+export const PENDING_NATIVE_OAUTH_ATTEMPT_TTL_MS = 15 * 60 * 1000;
+
+// This is a local freshness marker, not provider OAuth state and not a secret.
+interface PendingNativeOAuthAttempt {
+  attemptId: string;
+  startedAt: number;
+}
+
+export type NativeOAuthCallbackAuthorization =
+  | "accepted"
+  | "already_authenticated"
+  | "missing_or_expired_attempt";
+
+function readPendingNativeOAuthAttempt(): PendingNativeOAuthAttempt | null {
+  let encoded: string | null;
+  try {
+    encoded = localStorage.getItem(PENDING_NATIVE_OAUTH_ATTEMPT_KEY);
+  } catch {
+    return null;
+  }
+
+  if (!encoded) return null;
+
+  try {
+    const attempt = JSON.parse(encoded) as Partial<PendingNativeOAuthAttempt>;
+    if (
+      typeof attempt.attemptId !== "string" ||
+      !attempt.attemptId ||
+      typeof attempt.startedAt !== "number" ||
+      !Number.isSafeInteger(attempt.startedAt) ||
+      attempt.startedAt < 0
+    ) {
+      throw new Error("Invalid pending native OAuth attempt");
+    }
+    return attempt as PendingNativeOAuthAttempt;
+  } catch {
+    try {
+      localStorage.removeItem(PENDING_NATIVE_OAUTH_ATTEMPT_KEY);
+    } catch {
+      // A later authorization check will continue to fail closed.
+    }
+    return null;
+  }
+}
+
+function removePendingNativeOAuthAttempt(attemptId?: string): boolean {
+  try {
+    if (attemptId) {
+      const currentAttempt = readPendingNativeOAuthAttempt();
+      if (currentAttempt?.attemptId !== attemptId) return false;
+    }
+    localStorage.removeItem(PENDING_NATIVE_OAUTH_ATTEMPT_KEY);
+    return localStorage.getItem(PENDING_NATIVE_OAUTH_ATTEMPT_KEY) === null;
+  } catch {
+    return false;
+  }
+}
+
+export function beginNativeOAuthAttempt(now = Date.now()): string {
+  if (!Number.isSafeInteger(now) || now < 0) {
+    throw new Error("Cannot start native OAuth with an invalid timestamp");
+  }
+
+  const attemptId = uuidv4();
+  const attempt: PendingNativeOAuthAttempt = { attemptId, startedAt: now };
+  localStorage.setItem(PENDING_NATIVE_OAUTH_ATTEMPT_KEY, JSON.stringify(attempt));
+  return attemptId;
+}
+
+export function cancelNativeOAuthAttempt(attemptId: string): void {
+  removePendingNativeOAuthAttempt(attemptId);
+}
+
+export function authorizeNativeOAuthCallback(
+  isAuthenticated: boolean,
+  now = Date.now()
+): NativeOAuthCallbackAuthorization {
+  if (isAuthenticated) {
+    removePendingNativeOAuthAttempt();
+    return "already_authenticated";
+  }
+
+  const attempt = readPendingNativeOAuthAttempt();
+  if (!attempt) return "missing_or_expired_attempt";
+
+  const age = now - attempt.startedAt;
+  if (!Number.isSafeInteger(now) || age < 0 || age > PENDING_NATIVE_OAUTH_ATTEMPT_TTL_MS) {
+    removePendingNativeOAuthAttempt(attempt.attemptId);
+    return "missing_or_expired_attempt";
+  }
+
+  if (!removePendingNativeOAuthAttempt(attempt.attemptId)) {
+    return "missing_or_expired_attempt";
+  }
+
+  return "accepted";
+}


### PR DESCRIPTION
## Summary

- keep active sessions unchanged when a native auth callback arrives
- require a recent native sign-in attempt before applying a callback
- refresh and expire attempt markers so retries continue to work

## Testing

- `./scripts/ci/frontend.sh`
- `MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh`
- `nix develop .#ci -c ./scripts/ci/desktop-pr.sh`