### PR TITLE
fix: bind enclave trust roots to build environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ present.
 `frontend/.env.example` documents Maple's public configuration surface:
 
 - `VITE_OPEN_SECRET_API_URL` selects the required OpenSecret backend.
+- `VITE_OPEN_SECRET_PCR_ENVIRONMENT` selects the matching PCR0 trust roots;
+  it defaults to `production`, so hosted development enclaves must set
+  `development` explicitly.
 - `VITE_CLIENT_ID` overrides Maple's public project ID when developing against
   another OpenSecret project.
 - `VITE_OS_FLAGS_BASE_URL` selects an optional feature-flags API.

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,6 +1,8 @@
 # Public OpenSecret project id. Optional; the app uses this value by default.
 VITE_CLIENT_ID=ba5a14b5-d915-47b1-b7b1-afda52bc5fc6
 VITE_OPEN_SECRET_API_URL=http://127.0.0.1:3000
+# Defaults to production. Set development explicitly for a hosted development enclave.
+#VITE_OPEN_SECRET_PCR_ENVIRONMENT=development
 #VITE_OS_FLAGS_BASE_URL=https://flags-dev.opensecret.cloud
 # Comma-separated local preview flags. Agent connections supports macOS/Linux desktop only.
 #VITE_FORCE_FEATURE_FLAGS=agent_connections

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,7 +5,7 @@
     "": {
       "name": "maple",
       "dependencies": {
-        "@opensecret/react": "3.3.1",
+        "@opensecret/react": "3.4.0",
         "@radix-ui/react-alert-dialog": "^1.1.15",
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -237,7 +237,7 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
-    "@opensecret/react": ["@opensecret/react@3.3.1", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-jNdG+ulrRVug8+627ELxrXALUGY1tQBqnmsQwTnQBIX7sFPZUQSTHUnZ4cJ+VevQRBNfli65xxy1YOpr2oWTrw=="],
+    "@opensecret/react": ["@opensecret/react@3.4.0", "", { "dependencies": { "@peculiar/x509": "^1.12.2", "@stablelib/base64": "^2.0.0", "@stablelib/chacha20poly1305": "^2.0.0", "@stablelib/random": "^2.0.0", "cbor2": "^1.7.0", "tweetnacl": "^1.0.3", "zod": "^3.23.8" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0" } }, "sha512-3s4kSdqCt72l53Qj7QMnr725gKL2R3c/XkE/UjDPrHZ57OWJhrdOMtQEvxID9TwSQ5UlnBgKEO8e+gBGtYTrxQ=="],
 
     "@peculiar/asn1-cms": ["@peculiar/asn1-cms@2.3.15", "", { "dependencies": { "@peculiar/asn1-schema": "^2.3.15", "@peculiar/asn1-x509": "^2.3.15", "@peculiar/asn1-x509-attr": "^2.3.15", "asn1js": "^3.0.5", "tslib": "^2.8.1" } }, "sha512-B+DoudF+TCrxoJSTjjcY8Mmu+lbv8e7pXGWrhNp2/EGJp9EEcpzjBCar7puU57sGifyzaRVM03oD5L7t7PghQg=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,7 +36,7 @@
     "yaml": "^2.8.3"
   },
   "dependencies": {
-    "@opensecret/react": "3.3.1",
+    "@opensecret/react": "3.4.0",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4674,9 +4674,9 @@ dependencies = [
 
 [[package]]
 name = "maple-proxy"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1167df860d322880d1bacf48f57505244f4d805b3fa492e57e8a4a355d93cf"
+checksum = "6179a035d6e3cece433894eeec239e33298ef7076f4f27c667fdb76a930f94f2"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -5519,9 +5519,9 @@ dependencies = [
 
 [[package]]
 name = "opensecret"
-version = "3.5.0"
+version = "3.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3079b068b873507012e3a2c41af6ee527a84ae83dbf79f6e55f684cf9039b51f"
+checksum = "f870bc0826a7091062aba70eeb82590691bcec630f35b7c2b60792f982fc66d8"
 dependencies = [
  "aes-gcm",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -36,7 +36,7 @@ tauri-plugin-os = "2.3.2"
 tauri-plugin-sign-in-with-apple = "1.0.2"
 tokio = { version = "1.0", features = ["io-std", "io-util", "net", "process", "sync", "rt-multi-thread", "macros", "time"] }
 once_cell = "1.18.0"
-maple-proxy = "0.2.0"
+maple-proxy = "0.3.0"
 tauri-plugin-fs = "2.5.1"
 anyhow = "1.0"
 axum = "0.8"
@@ -59,7 +59,7 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["std", "
 # history.
 goose = { git = "https://github.com/aaif-goose/goose.git", rev = "064244e6bddf641876676f054a006b7da1da5182", package = "goose", default-features = false }
 goose-providers = { git = "https://github.com/aaif-goose/goose.git", rev = "064244e6bddf641876676f054a006b7da1da5182", package = "goose-providers", default-features = false }
-opensecret = "3.5.0"
+opensecret = "3.6.0"
 rand = "0.8.6"
 async-trait = "0.1"
 rmcp = { version = "=3.1.2", default-features = false }

--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -1,4 +1,6 @@
 fn main() {
+    println!("cargo:rerun-if-env-changed=VITE_OPEN_SECRET_PCR_ENVIRONMENT");
+
     let target_os = std::env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
     if target_os == "ios" {
         println!("cargo:rustc-link-lib=c++");

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -14,6 +14,7 @@ mod legacy_tts_cleanup;
 #[cfg(desktop)]
 mod maple_api;
 mod onnxruntime;
+mod open_secret_config;
 mod pdf_extractor;
 mod pdf_ocr;
 mod proxy;

--- a/frontend/src-tauri/src/maple_api.rs
+++ b/frontend/src-tauri/src/maple_api.rs
@@ -1,3 +1,4 @@
+use crate::open_secret_config::configured_pcr0_environment;
 use opensecret::{
     InferenceRequest, InferenceResponse, OpenSecretClient, WebExtractRequest, WebExtractResponse,
     WebSearchRequest, WebSearchResponse,
@@ -453,7 +454,11 @@ fn build_client(
         return Err("Maple API access token is missing".to_string());
     }
     let refresh_token = refresh_token.filter(|token| !token.trim().is_empty());
-    let client = OpenSecretClient::new(api_url.to_string()).map_err(map_sdk_error)?;
+    let client = OpenSecretClient::new_with_pcr0_environment(
+        api_url.to_string(),
+        configured_pcr0_environment()?,
+    )
+    .map_err(map_sdk_error)?;
     client
         .set_tokens(access_token, refresh_token)
         .map_err(map_sdk_error)?;

--- a/frontend/src-tauri/src/open_secret_config.rs
+++ b/frontend/src-tauri/src/open_secret_config.rs
@@ -1,0 +1,39 @@
+use maple_proxy::Pcr0Environment;
+
+pub(crate) fn parse_pcr0_environment(value: Option<&str>) -> Result<Pcr0Environment, String> {
+    match value {
+        None | Some("production") => Ok(Pcr0Environment::Production),
+        Some("development") => Ok(Pcr0Environment::Development),
+        Some(_) => Err(
+            "VITE_OPEN_SECRET_PCR_ENVIRONMENT must be either production or development".to_string(),
+        ),
+    }
+}
+
+pub(crate) fn configured_pcr0_environment() -> Result<Pcr0Environment, String> {
+    parse_pcr0_environment(option_env!("VITE_OPEN_SECRET_PCR_ENVIRONMENT"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pcr_environment_defaults_to_production_and_requires_an_exact_override() {
+        assert_eq!(
+            parse_pcr0_environment(None).unwrap(),
+            Pcr0Environment::Production
+        );
+        assert_eq!(
+            parse_pcr0_environment(Some("production")).unwrap(),
+            Pcr0Environment::Production
+        );
+        assert_eq!(
+            parse_pcr0_environment(Some("development")).unwrap(),
+            Pcr0Environment::Development
+        );
+        for invalid in ["", "dev", "prod", "Development", "staging"] {
+            assert!(parse_pcr0_environment(Some(invalid)).is_err());
+        }
+    }
+}

--- a/frontend/src-tauri/src/proxy.rs
+++ b/frontend/src-tauri/src/proxy.rs
@@ -1,3 +1,4 @@
+use crate::open_secret_config::configured_pcr0_environment;
 use anyhow::{anyhow, Result};
 use axum::{
     body::Body,
@@ -206,7 +207,7 @@ async fn start_proxy_inner(
         .clone()
         .unwrap_or_else(|| "https://enclave.trymaple.ai".to_string());
 
-    let proxy_config = build_proxy_server_config(&config, backend_url);
+    let proxy_config = build_proxy_server_config(&config, backend_url)?;
 
     // Try to bind to the address first to check if port is available
     let addr = proxy_config
@@ -258,8 +259,9 @@ async fn start_proxy_inner(
     })
 }
 
-fn build_proxy_server_config(config: &ProxyConfig, backend_url: String) -> Config {
+fn build_proxy_server_config(config: &ProxyConfig, backend_url: String) -> Result<Config, String> {
     let proxy_config = Config::new(config.host.clone(), config.port, backend_url)
+        .with_pcr0_environment(configured_pcr0_environment()?)
         .with_debug(false)
         // Maple owns the browser boundary below so it can both list the
         // non-wildcard Authorization header and reject browser origins when
@@ -270,9 +272,9 @@ fn build_proxy_server_config(config: &ProxyConfig, backend_url: String) -> Confi
     // combine that reachability with Maple's saved credential: browser-enabled
     // clients must provide their own Authorization header on every request.
     if config.enable_cors {
-        proxy_config
+        Ok(proxy_config)
     } else {
-        proxy_config.with_api_key(config.api_key.clone())
+        Ok(proxy_config.with_api_key(config.api_key.clone()))
     }
 }
 
@@ -458,10 +460,14 @@ mod tests {
         };
 
         let server_config =
-            build_proxy_server_config(&config, "https://example.invalid".to_string());
+            build_proxy_server_config(&config, "https://example.invalid".to_string()).unwrap();
 
         assert!(!server_config.enable_cors);
         assert!(server_config.default_api_key.is_none());
+        assert_eq!(
+            server_config.pcr0_environment,
+            configured_pcr0_environment().unwrap()
+        );
     }
 
     #[test]
@@ -472,7 +478,7 @@ mod tests {
         };
 
         let server_config =
-            build_proxy_server_config(&config, "https://example.invalid".to_string());
+            build_proxy_server_config(&config, "https://example.invalid".to_string()).unwrap();
 
         assert!(!server_config.enable_cors);
         assert_eq!(server_config.default_api_key.as_deref(), Some("saved-key"));
@@ -492,7 +498,7 @@ mod tests {
             ..ProxyConfig::default()
         };
         let server_config =
-            build_proxy_server_config(&config, "https://example.invalid".to_string());
+            build_proxy_server_config(&config, "https://example.invalid".to_string()).unwrap();
         let app = apply_proxy_access_policy(server_config, config.enable_cors);
         let (base_url, server) = serve_test_app(app).await;
 
@@ -516,7 +522,7 @@ mod tests {
             ..ProxyConfig::default()
         };
         let server_config =
-            build_proxy_server_config(&config, "https://example.invalid".to_string());
+            build_proxy_server_config(&config, "https://example.invalid".to_string()).unwrap();
         let app = apply_proxy_access_policy(server_config, config.enable_cors);
         let (base_url, server) = serve_test_app(app).await;
 
@@ -539,7 +545,7 @@ mod tests {
             ..ProxyConfig::default()
         };
         let server_config =
-            build_proxy_server_config(&config, "https://example.invalid".to_string());
+            build_proxy_server_config(&config, "https://example.invalid".to_string()).unwrap();
         let app = apply_proxy_access_policy(server_config, config.enable_cors);
         let (base_url, server) = serve_test_app(app).await;
 

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -17,6 +17,7 @@ import { ThemeProvider } from "./contexts/ThemeContext";
 import { ProxyEventListener } from "./components/ProxyEventListener";
 import { UpdateEventListener } from "./components/UpdateEventListener";
 import { TTSProvider } from "./services/tts/TTSContext";
+import { openSecretPcrEnvironment } from "./config/openSecretPcrEnvironment";
 
 const DEFAULT_OPEN_SECRET_CLIENT_ID = "ba5a14b5-d915-47b1-b7b1-afda52bc5fc6";
 
@@ -61,6 +62,7 @@ export default function App() {
           apiUrl={import.meta.env.VITE_OPEN_SECRET_API_URL}
           clientId={import.meta.env.VITE_CLIENT_ID || DEFAULT_OPEN_SECRET_CLIENT_ID}
           pcrConfig={{
+            environment: openSecretPcrEnvironment(),
             pcr0Values: [
               "ed9109c16f30a470cf0ea2251816789b4ffa510c990118323ce94a2364b9bf05bdb8777959cbac86f5cabc4852e0da71",
               "4f2bcdf16c38842e1a45defd944d24ea58bb5bcb76491843223022acfe9eb6f1ff79b2cb9a6b2a9219daf9c7bf40fa37",

--- a/frontend/src/config/openSecretPcrEnvironment.test.ts
+++ b/frontend/src/config/openSecretPcrEnvironment.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from "bun:test";
+import { parseOpenSecretPcrEnvironment } from "./openSecretPcrEnvironment";
+
+describe("OpenSecret PCR environment", () => {
+  test("defaults to production", () => {
+    expect(parseOpenSecretPcrEnvironment(undefined)).toBe("production");
+  });
+
+  test("accepts the explicit production and development values", () => {
+    expect(parseOpenSecretPcrEnvironment("production")).toBe("production");
+    expect(parseOpenSecretPcrEnvironment("development")).toBe("development");
+  });
+
+  test("rejects unknown values", () => {
+    for (const value of ["", "dev", "prod", "Development", "staging"]) {
+      expect(() => parseOpenSecretPcrEnvironment(value)).toThrow(
+        /VITE_OPEN_SECRET_PCR_ENVIRONMENT/
+      );
+    }
+  });
+});

--- a/frontend/src/config/openSecretPcrEnvironment.ts
+++ b/frontend/src/config/openSecretPcrEnvironment.ts
@@ -1,0 +1,11 @@
+import type { PcrEnvironment } from "@opensecret/react";
+
+export function parseOpenSecretPcrEnvironment(value: string | undefined): PcrEnvironment {
+  if (value === undefined || value === "production") return "production";
+  if (value === "development") return "development";
+  throw new Error('VITE_OPEN_SECRET_PCR_ENVIRONMENT must be either "production" or "development"');
+}
+
+export function openSecretPcrEnvironment(): PcrEnvironment {
+  return parseOpenSecretPcrEnvironment(import.meta.env.VITE_OPEN_SECRET_PCR_ENVIRONMENT);
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_OPEN_SECRET_API_URL: string;
+  readonly VITE_OPEN_SECRET_PCR_ENVIRONMENT?: "production" | "development";
   readonly VITE_OS_FLAGS_BASE_URL?: string;
   readonly VITE_FORCE_FEATURE_FLAGS?: string;
   readonly VITE_CLIENT_ID?: string;

--- a/scripts/ci/_common.sh
+++ b/scripts/ci/_common.sh
@@ -142,6 +142,7 @@ use_pr_environment() {
   done < <(env)
 
   export VITE_OPEN_SECRET_API_URL="https://enclave.secretgpt.ai"
+  export VITE_OPEN_SECRET_PCR_ENVIRONMENT="development"
   export VITE_OS_FLAGS_BASE_URL="https://flags-dev.opensecret.cloud"
   export VITE_MAPLE_BILLING_API_URL="https://billing-dev.opensecret.cloud"
   export VITE_CLIENT_ID="ba5a14b5-d915-47b1-b7b1-afda52bc5fc6"
@@ -158,6 +159,7 @@ use_release_environment() {
   done < <(env)
 
   export VITE_OPEN_SECRET_API_URL="https://enclave.trymaple.ai"
+  export VITE_OPEN_SECRET_PCR_ENVIRONMENT="production"
   export VITE_OS_FLAGS_BASE_URL="https://flags.opensecret.cloud"
   export VITE_MAPLE_BILLING_API_URL="https://billing.opensecret.cloud"
   export VITE_CLIENT_ID="ba5a14b5-d915-47b1-b7b1-afda52bc5fc6"


### PR DESCRIPTION
## Summary

- upgrade to published @opensecret/react 3.4.0, opensecret 3.6.0, and maple-proxy 0.3.0 from their registries
- make PCR0 trust selection a strict build setting that defaults to production and requires an explicit development override
- pass the same selection through the React provider, native Agent Mode client, and embedded maple-proxy without changing REST or Tauri IPC contracts
- map PR builds explicitly to development and release builds explicitly to production
- retain static PCR allowlists plus the SDK signed GitHub PCR history fallback, so trusted backend rotations do not require a Maple release

## Security behavior

A development backend without the development selector now fails closed against production trust roots. The SDKs enforce the selected PCR0 policy before key exchange. Invalid build values fail instead of silently falling back.

## Validation

- nix develop .#ci -c ./scripts/ci/frontend.sh: formatting, ESLint, TypeScript, and 650 Bun tests passed
- nix develop .#ci -c ./scripts/ci/rust.sh: 304 passed, 0 failed, 2 ignored
- nix develop .#ci -c just rust-lint: formatting and Clippy with warnings denied passed
- MAPLE_WEB_ENVIRONMENT=pr nix develop .#ci -c ./scripts/ci/web.sh: development artifact passed
- MAPLE_WEB_ENVIRONMENT=release nix develop .#ci -c ./scripts/ci/web.sh: production artifact passed
- focused post-fix Rust checks: PCR parser 1/1 and proxy 12/12 passed
- hosted development TypeScript smoke: explicit development loaded and validated signed pcrDevHistory.json before key exchange; production default loaded pcrProdHistory.json and rejected the development enclave without requesting key exchange
- hosted development native smoke: the registry Rust client constructed with the Maple development selector completed attestation and session establishment
- static iOS and Android dependency audit: both resolve maple-proxy 0.3.0 and its public PCR environment re-export through a single opensecret 3.6.0 instance

A packaged GUI smoke and full mobile package build were not run. No mobile-specific code was added.