### PR TITLE
chore: bump version to 3.3.4

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.3",
+  "version": "3.3.4",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4618,7 +4618,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.3"
+version = "3.3.4"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.3"
+version = "3.3.4"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.3</string>
+	<string>3.3.4</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.3</string>
+	<string>3.3.4</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.3
-        CFBundleVersion: 3.3.3
+        CFBundleShortVersionString: 3.3.4
+        CFBundleVersion: 3.3.4
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.3",
+  "version": "3.3.4",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -97,7 +97,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028014
+      "versionCode": 2000028015
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- bump Maple from 3.3.3 to 3.3.4 for post-release development
- advance Android versionCode to 2000028015

## Validation
- `/nix/var/nix/profiles/default/bin/nix develop .#ci -c just bump-patch`
- `/nix/var/nix/profiles/default/bin/nix develop .#ci -c ./scripts/ci/frontend.sh`
- `/nix/var/nix/profiles/default/bin/nix develop .#ci -c ./scripts/ci/rust.sh`
- `cargo fmt --check` and release-version parity check in the pinned Nix shell

No tag, release, deployment, or store action is included.