### PR TITLE
feat: add Agent prompt history navigation

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -93,12 +93,19 @@ import { RenameAgentTaskDialog } from "@/components/RenameAgentTaskDialog";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { AgentMcpMenu, AgentMcpServersDialog } from "@/components/agent/AgentMcpControls";
 import { AgentSidebarInfoCard } from "@/components/agent/AgentSidebarInfoCard";
+import {
+  isDeliberateAgentComposerFocusTarget,
+  settleAgentComposerFocusRequest,
+  type AgentComposerFocusRequest
+} from "@/components/agent/agentComposerFocus";
 import { handleAgentModeThoughtRunFinished } from "@/components/agent/agentModeThoughtRun";
 import {
   agentPromptHistory,
   agentPromptHistoryDirection,
+  AgentPromptHistoryReplacementTracker,
   navigateAgentPromptHistory,
-  type AgentPromptHistoryNavigation
+  type AgentPromptHistoryNavigation,
+  type AgentPromptHistoryReplacementAttempt
 } from "@/components/agent/agentPromptHistory";
 import {
   agentRuntimeService,
@@ -441,7 +448,9 @@ export function AgentMode({ userId }: { userId: string }) {
   const promptHistoryEntriesRef = useRef<readonly string[]>(promptHistoryEntries);
   const promptHistoryNavigationRef = useRef<AgentPromptHistoryNavigation | null>(null);
   const promptHistoryGenerationRef = useRef(0);
-  const promptHistoryReplacementSessionRef = useRef<string | null>(null);
+  const promptHistoryReplacementTrackerRef = useLazyRef(
+    () => new AgentPromptHistoryReplacementTracker()
+  );
   const [isAgentFullscreen, setIsAgentFullscreen] = useState(
     () => localStorage.getItem("agentFullscreen") === "true"
   );
@@ -466,6 +475,8 @@ export function AgentMode({ userId }: { userId: string }) {
     () => new Set()
   );
   const chatContainerRef = useRef<HTMLDivElement>(null);
+  const agentComposerTextareaRef = useRef<HTMLTextAreaElement>(null);
+  const agentComposerFocusRequestRef = useRef<AgentComposerFocusRequest | null>(null);
   const activeSessionIdRef = useRef(activeSessionId);
   const deletedSessionIdsRef = useLazyRef(() => new Set<string>());
   const markSessionSummaryChanged = useCallback((sessionId: string) => {
@@ -532,11 +543,11 @@ export function AgentMode({ userId }: { userId: string }) {
   useLayoutEffect(() => {
     if (
       activeSessionId === null ||
-      promptHistoryReplacementSessionRef.current !== activeSessionId
+      !promptHistoryReplacementTrackerRef.current.isReplacing(activeSessionId)
     ) {
       promptHistoryEntriesRef.current = promptHistoryEntries;
     }
-  }, [activeSessionId, promptHistoryEntries]);
+  }, [activeSessionId, promptHistoryEntries, promptHistoryReplacementTrackerRef]);
 
   const resetPromptHistoryNavigation = useCallback(() => {
     promptHistoryNavigationRef.current = null;
@@ -544,8 +555,9 @@ export function AgentMode({ userId }: { userId: string }) {
   }, []);
 
   useLayoutEffect(() => {
+    promptHistoryReplacementTrackerRef.current.abandonInactive(activeSessionId);
     resetPromptHistoryNavigation();
-  }, [activeSessionId, resetPromptHistoryNavigation, userId]);
+  }, [activeSessionId, promptHistoryReplacementTrackerRef, resetPromptHistoryNavigation, userId]);
 
   const handleAgentInputChange = useCallback(
     (value: string) => {
@@ -554,6 +566,41 @@ export function AgentMode({ userId }: { userId: string }) {
     },
     [resetPromptHistoryNavigation]
   );
+
+  useEffect(() => {
+    const cancelFocusRequestForPointer = (event: PointerEvent) => {
+      if (
+        agentComposerFocusRequestRef.current &&
+        event.target !== agentComposerTextareaRef.current
+      ) {
+        agentComposerFocusRequestRef.current = null;
+      }
+    };
+    const cancelFocusRequestForWindowBlur = () => {
+      agentComposerFocusRequestRef.current = null;
+    };
+    const cancelFocusRequestForFocus = (event: FocusEvent) => {
+      if (
+        agentComposerFocusRequestRef.current &&
+        isDeliberateAgentComposerFocusTarget(
+          event.target,
+          agentComposerTextareaRef.current,
+          document.body,
+          document
+        )
+      ) {
+        agentComposerFocusRequestRef.current = null;
+      }
+    };
+    window.addEventListener("pointerdown", cancelFocusRequestForPointer, true);
+    window.addEventListener("focusin", cancelFocusRequestForFocus, true);
+    window.addEventListener("blur", cancelFocusRequestForWindowBlur);
+    return () => {
+      window.removeEventListener("pointerdown", cancelFocusRequestForPointer, true);
+      window.removeEventListener("focusin", cancelFocusRequestForFocus, true);
+      window.removeEventListener("blur", cancelFocusRequestForWindowBlur);
+    };
+  }, []);
 
   const restoreNewTaskModel = useCallback(() => {
     const nextModel = newTaskAgentModel(agentModelPreferenceRef.current);
@@ -905,6 +952,22 @@ export function AgentMode({ userId }: { userId: string }) {
   const isAgentModelSelectionDisabled = areAgentSettingsLocked || isAgentModelLocked;
   const isAgentSendLocked = areAgentSettingsLocked;
   const isSending = Boolean(activeRunId) || isSubmitting;
+  useLayoutEffect(() => {
+    const request = agentComposerFocusRequestRef.current;
+    if (!request) return;
+    const settled = settleAgentComposerFocusRequest(request, {
+      currentInteractionGeneration: interactionGenerationRef.current,
+      isSubmitting,
+      hasTimeline: timelineItems.length > 0,
+      textarea: agentComposerTextareaRef.current,
+      activeElement: document.activeElement,
+      documentBody: document.body,
+      documentRoot: document
+    });
+    if (settled && agentComposerFocusRequestRef.current === request) {
+      agentComposerFocusRequestRef.current = null;
+    }
+  });
   const selectedNewChatMcpServerNames = useMemo(
     () =>
       mcpServers
@@ -1098,9 +1161,7 @@ export function AgentMode({ userId }: { userId: string }) {
         return false;
       }
       bumpTimelineRevision(sessionId);
-      if (promptHistoryReplacementSessionRef.current === sessionId) {
-        promptHistoryReplacementSessionRef.current = null;
-      }
+      promptHistoryReplacementTrackerRef.current.authoritativeReplace(sessionId);
       if (activeSessionIdRef.current === sessionId) {
         // Routine reconciliation (including runFinished) refreshes entries for
         // the next navigation session without disturbing the active snapshot.
@@ -1110,7 +1171,7 @@ export function AgentMode({ userId }: { userId: string }) {
       }
       return true;
     },
-    [bumpTimelineRevision, timelineRevisionBySessionRef]
+    [bumpTimelineRevision, promptHistoryReplacementTrackerRef, timelineRevisionBySessionRef]
   );
 
   const mergeSessionTimelineItem = useCallback(
@@ -2052,6 +2113,8 @@ export function AgentMode({ userId }: { userId: string }) {
         // Commit the selected session and all of its settings together. Until
         // this point the previous chat remains active and its composer is gated.
         shouldAutoScrollRef.current = true;
+        promptHistoryReplacementTrackerRef.current.abandonInactive(detail.session.id);
+        promptHistoryEntriesRef.current = agentPromptHistory(detail.timeline);
         activeSessionIdRef.current = detail.session.id;
         clearCompletedUnreadSession(detail.session.id);
         setActiveSessionId(detail.session.id);
@@ -2117,6 +2180,7 @@ export function AgentMode({ userId }: { userId: string }) {
       observeActiveThoughtPhase,
       pendingSendTokensRef,
       persistSelectedProjectRoot,
+      promptHistoryReplacementTrackerRef,
       replaceSessionTimeline,
       thoughtPhaseTrackerRef,
       timelineRevisionBySessionRef,
@@ -2150,131 +2214,146 @@ export function AgentMode({ userId }: { userId: string }) {
     userId
   ]);
 
-  const sendMessage = useCallback(async () => {
-    const text = input.trim();
-    const requestedSessionId = activeSessionIdRef.current;
-    let pendingSessionKey = requestedSessionId || NEW_SESSION_PENDING_KEY;
-    if (
-      !text ||
-      isAgentSendLocked ||
-      pendingSessionSelectionIdRef.current !== null ||
-      pendingSendTokensRef.current.has(pendingSessionKey) ||
-      (requestedSessionId && activeRunsBySession[requestedSessionId])
-    ) {
-      return;
-    }
-
-    const selectionGeneration = sessionSelectionGenerationRef.current;
-    const interactionGeneration = interactionGenerationRef.current;
-    const sendToken = nextSendTokenRef.current + 1;
-    nextSendTokenRef.current = sendToken;
-    let targetSessionId = requestedSessionId;
-    markPendingSend(pendingSessionKey, sendToken);
-
-    setError(null);
-    resetPromptHistoryNavigation();
-    setInput("");
-    shouldAutoScrollRef.current = true;
-    requestAnimationFrame(() => scrollTimelineToBottom("smooth"));
-    try {
-      await trackAgentWorkflow(async () => {
-        const { sessionId, requestModel } = await ensureRuntimeAndSession(
-          selectionGeneration,
-          interactionGeneration,
-          requestedSessionId
-        );
-        targetSessionId = sessionId;
-        if (pendingSessionKey !== sessionId) {
-          movePendingSend(pendingSessionKey, sessionId, sendToken);
-          pendingSessionKey = sessionId;
-        }
-        if (cancelledPendingSendTokensRef.current.has(sendToken)) {
-          throw new PendingAgentSendCancelledError();
-        }
-        // The selector reflects only committed policy. Wait for any in-flight
-        // update so this send cannot replay a stale mode snapshot afterward.
-        await permissionModeUpdateRef.current;
-        if (cancelledPendingSendTokensRef.current.has(sendToken)) {
-          throw new PendingAgentSendCancelledError();
-        }
-        thoughtPhaseTrackerRef.current.prepareUserRequest(sessionId, text);
-        const response = await agentRuntimeService.sendMessage(userId, {
-          sessionId,
-          text,
-          model: requestModel,
-          contextLimit: contextLimitForModel(requestModel),
-          mode: selectedModeRef.current,
-          visionCapable: resolveAgentModelVisionCapability(
-            requestModel,
-            availableModels,
-            modelAliases
-          )
-        });
-        if (cancelledPendingSendTokensRef.current.has(sendToken)) {
-          // The native command may have crossed the start boundary while the
-          // user clicked Cancel. Cancel the concrete run before returning.
-          await agentRuntimeService.cancelRun(userId, response.runId);
-          return;
-        }
-        if (!terminalRunIdsRef.current.has(response.runId)) {
-          recordActiveRun(sessionId, response.runId);
-        }
-      });
-    } catch (sendError) {
-      if (sendError instanceof PendingAgentSendCancelledError) {
-        setInput((current) => (current ? current : text));
+  const sendMessage = useCallback(
+    async (restoreComposerFocus = false) => {
+      const text = input.trim();
+      const requestedSessionId = activeSessionIdRef.current;
+      let pendingSessionKey = requestedSessionId || NEW_SESSION_PENDING_KEY;
+      if (
+        !text ||
+        isAgentSendLocked ||
+        pendingSessionSelectionIdRef.current !== null ||
+        pendingSendTokensRef.current.has(pendingSessionKey) ||
+        (requestedSessionId && activeRunsBySession[requestedSessionId])
+      ) {
         return;
       }
-      const message = errorMessage(sendError);
-      if (
-        (targetSessionId && activeSessionIdRef.current === targetSessionId) ||
-        (!targetSessionId &&
-          activeSessionIdRef.current === null &&
-          sessionSelectionGenerationRef.current === selectionGeneration &&
-          interactionGenerationRef.current === interactionGeneration)
-      ) {
-        setError(message);
+
+      const selectionGeneration = sessionSelectionGenerationRef.current;
+      const interactionGeneration = interactionGenerationRef.current;
+      const sendToken = nextSendTokenRef.current + 1;
+      nextSendTokenRef.current = sendToken;
+      let targetSessionId = requestedSessionId;
+      if (restoreComposerFocus) {
+        agentComposerFocusRequestRef.current = {
+          sendToken,
+          interactionGeneration,
+          waitForTimeline: timelineItems.length === 0
+        };
       }
-      if (targetSessionId && !deletedSessionIdsRef.current.has(targetSessionId)) {
-        mergeSessionTimelineItem(targetSessionId, {
-          id: `error-${Date.now()}-${sendToken}`,
-          itemType: "error",
-          role: "system",
-          title: "Agent error",
-          text: message,
-          status: "failed",
-          createdMs: Date.now(),
-          merge: "replace"
+      markPendingSend(pendingSessionKey, sendToken);
+
+      setError(null);
+      resetPromptHistoryNavigation();
+      setInput("");
+      shouldAutoScrollRef.current = true;
+      requestAnimationFrame(() => scrollTimelineToBottom("smooth"));
+      try {
+        await trackAgentWorkflow(async () => {
+          const { sessionId, requestModel } = await ensureRuntimeAndSession(
+            selectionGeneration,
+            interactionGeneration,
+            requestedSessionId
+          );
+          targetSessionId = sessionId;
+          if (pendingSessionKey !== sessionId) {
+            movePendingSend(pendingSessionKey, sessionId, sendToken);
+            pendingSessionKey = sessionId;
+          }
+          if (cancelledPendingSendTokensRef.current.has(sendToken)) {
+            throw new PendingAgentSendCancelledError();
+          }
+          // The selector reflects only committed policy. Wait for any in-flight
+          // update so this send cannot replay a stale mode snapshot afterward.
+          await permissionModeUpdateRef.current;
+          if (cancelledPendingSendTokensRef.current.has(sendToken)) {
+            throw new PendingAgentSendCancelledError();
+          }
+          thoughtPhaseTrackerRef.current.prepareUserRequest(sessionId, text);
+          const response = await agentRuntimeService.sendMessage(userId, {
+            sessionId,
+            text,
+            model: requestModel,
+            contextLimit: contextLimitForModel(requestModel),
+            mode: selectedModeRef.current,
+            visionCapable: resolveAgentModelVisionCapability(
+              requestModel,
+              availableModels,
+              modelAliases
+            )
+          });
+          if (cancelledPendingSendTokensRef.current.has(sendToken)) {
+            // The native command may have crossed the start boundary while the
+            // user clicked Cancel. Cancel the concrete run before returning.
+            await agentRuntimeService.cancelRun(userId, response.runId);
+            return;
+          }
+          if (!terminalRunIdsRef.current.has(response.runId)) {
+            recordActiveRun(sessionId, response.runId);
+          }
         });
+      } catch (sendError) {
+        const focusRequest = agentComposerFocusRequestRef.current;
+        if (focusRequest?.sendToken === sendToken) {
+          focusRequest.waitForTimeline = false;
+        }
+        if (sendError instanceof PendingAgentSendCancelledError) {
+          setInput((current) => (current ? current : text));
+          return;
+        }
+        const message = errorMessage(sendError);
+        if (
+          (targetSessionId && activeSessionIdRef.current === targetSessionId) ||
+          (!targetSessionId &&
+            activeSessionIdRef.current === null &&
+            sessionSelectionGenerationRef.current === selectionGeneration &&
+            interactionGenerationRef.current === interactionGeneration)
+        ) {
+          setError(message);
+        }
+        if (targetSessionId && !deletedSessionIdsRef.current.has(targetSessionId)) {
+          mergeSessionTimelineItem(targetSessionId, {
+            id: `error-${Date.now()}-${sendToken}`,
+            itemType: "error",
+            role: "system",
+            title: "Agent error",
+            text: message,
+            status: "failed",
+            createdMs: Date.now(),
+            merge: "replace"
+          });
+        }
+      } finally {
+        cancelledPendingSendTokensRef.current.delete(sendToken);
+        clearPendingSend(pendingSessionKey, sendToken);
       }
-    } finally {
-      cancelledPendingSendTokensRef.current.delete(sendToken);
-      clearPendingSend(pendingSessionKey, sendToken);
-    }
-  }, [
-    activeRunsBySession,
-    availableModels,
-    cancelledPendingSendTokensRef,
-    clearPendingSend,
-    contextLimitForModel,
-    deletedSessionIdsRef,
-    ensureRuntimeAndSession,
-    input,
-    isAgentSendLocked,
-    markPendingSend,
-    mergeSessionTimelineItem,
-    modelAliases,
-    movePendingSend,
-    pendingSendTokensRef,
-    permissionModeUpdateRef,
-    recordActiveRun,
-    resetPromptHistoryNavigation,
-    scrollTimelineToBottom,
-    terminalRunIdsRef,
-    thoughtPhaseTrackerRef,
-    trackAgentWorkflow,
-    userId
-  ]);
+    },
+    [
+      activeRunsBySession,
+      availableModels,
+      cancelledPendingSendTokensRef,
+      clearPendingSend,
+      contextLimitForModel,
+      deletedSessionIdsRef,
+      ensureRuntimeAndSession,
+      input,
+      isAgentSendLocked,
+      markPendingSend,
+      mergeSessionTimelineItem,
+      modelAliases,
+      movePendingSend,
+      pendingSendTokensRef,
+      permissionModeUpdateRef,
+      recordActiveRun,
+      resetPromptHistoryNavigation,
+      scrollTimelineToBottom,
+      terminalRunIdsRef,
+      timelineItems.length,
+      thoughtPhaseTrackerRef,
+      trackAgentWorkflow,
+      userId
+    ]
+  );
 
   const cancelPrompt = useCallback(async () => {
     const sessionId = activeSessionIdRef.current;
@@ -2355,7 +2434,8 @@ export function AgentMode({ userId }: { userId: string }) {
               textarea.isConnected &&
               document.activeElement === textarea
             ) {
-              textarea.setSelectionRange(step.value.length, step.value.length);
+              const caret = textarea.value.length;
+              textarea.setSelectionRange(caret, caret);
             }
           });
           return;
@@ -2369,7 +2449,7 @@ export function AgentMode({ userId }: { userId: string }) {
       }
       if (event.key === "Enter" && !event.shiftKey && !isCompactLayout) {
         event.preventDefault();
-        void sendMessage();
+        void sendMessage(true);
       }
     },
     [handleAgentInputChange, isCompactLayout, sendMessage]
@@ -2666,9 +2746,23 @@ export function AgentMode({ userId }: { userId: string }) {
           void (async () => {
             const id = event.sessionId || activeSessionIdRef.current;
             if (!id) return;
+            let replacementAttempt: AgentPromptHistoryReplacementAttempt | null = null;
+            const recoverPromptHistory = (activeId: string | null) => {
+              if (!replacementAttempt) return;
+              const fallback = promptHistoryReplacementTrackerRef.current.recover(
+                replacementAttempt,
+                activeId
+              );
+              if (fallback !== null) {
+                promptHistoryEntriesRef.current = fallback;
+              }
+            };
             if (activeSessionIdRef.current === id) {
               resetPromptHistoryNavigation();
-              promptHistoryReplacementSessionRef.current = id;
+              replacementAttempt = promptHistoryReplacementTrackerRef.current.begin(
+                id,
+                promptHistoryEntriesRef.current
+              );
               promptHistoryEntriesRef.current = [];
             }
             const invalidatedTurnId = thoughtPhaseTrackerRef.current.resetForHistoryReplacement(id);
@@ -2688,14 +2782,19 @@ export function AgentMode({ userId }: { userId: string }) {
                 userIdRef.current !== userId ||
                 deletedSessionIdsRef.current.has(id)
               ) {
+                recoverPromptHistory(null);
                 return;
               }
               const replaced = replaceSessionTimeline(id, detail.timeline, historyTimelineRevision);
+              if (!replaced) {
+                recoverPromptHistory(activeSessionIdRef.current);
+              }
               if (replaced && activeRunsBySessionRef.current[id]) {
                 thoughtPhaseTrackerRef.current.seedActiveTimeline(id, detail.timeline);
                 observeActiveThoughtPhase(id);
               }
             } catch (historyError) {
+              recoverPromptHistory(activeSessionIdRef.current);
               if (
                 isAgentModeMountedRef.current &&
                 userIdRef.current === userId &&
@@ -2721,6 +2820,7 @@ export function AgentMode({ userId }: { userId: string }) {
       mergeSessionTimelineItem,
       observeLiveThoughtItem,
       observeActiveThoughtPhase,
+      promptHistoryReplacementTrackerRef,
       refreshSessionList,
       recordActiveRun,
       refreshSessionMcpServers,
@@ -3098,6 +3198,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   projectRoot={projectRoot}
                   recentRoots={displayProjectRoots}
                   isExpanded={isAgentFullscreen}
+                  textareaRef={agentComposerTextareaRef}
                   onCancelPrompt={cancelPrompt}
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={handleAgentInputChange}
@@ -3143,6 +3244,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   model={model}
                   projectRoot={projectRoot}
                   recentRoots={displayProjectRoots}
+                  textareaRef={agentComposerTextareaRef}
                   onCancelPrompt={cancelPrompt}
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={handleAgentInputChange}
@@ -4294,6 +4396,7 @@ interface AgentComposerProps {
   projectRoot: string;
   recentRoots: AgentProjectRootView[];
   isExpanded?: boolean;
+  textareaRef: React.RefObject<HTMLTextAreaElement>;
   onCancelPrompt: () => void;
   onChooseProjectRoot: () => void;
   onInputChange: (value: string) => void;
@@ -4325,6 +4428,7 @@ function AgentComposer({
   projectRoot,
   recentRoots,
   isExpanded = false,
+  textareaRef,
   onCancelPrompt,
   onChooseProjectRoot,
   onInputChange,
@@ -4339,7 +4443,6 @@ function AgentComposer({
   onSendMessage,
   onToggleExpanded
 }: AgentComposerProps) {
-  const textareaRef = useRef<HTMLTextAreaElement>(null);
   const rootOptions = recentRoots;
 
   useLayoutEffect(() => {
@@ -4353,7 +4456,7 @@ function AgentComposer({
 
     textarea.style.height = "auto";
     textarea.style.height = `${Math.min(textarea.scrollHeight, 200)}px`;
-  }, [input, isExpanded]);
+  }, [input, isExpanded, textareaRef]);
 
   return (
     <ChatComposerSurface

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -95,6 +95,12 @@ import { AgentMcpMenu, AgentMcpServersDialog } from "@/components/agent/AgentMcp
 import { AgentSidebarInfoCard } from "@/components/agent/AgentSidebarInfoCard";
 import { handleAgentModeThoughtRunFinished } from "@/components/agent/agentModeThoughtRun";
 import {
+  agentPromptHistory,
+  agentPromptHistoryDirection,
+  navigateAgentPromptHistory,
+  type AgentPromptHistoryNavigation
+} from "@/components/agent/agentPromptHistory";
+import {
   agentRuntimeService,
   awaitAgentAuthUser,
   type AgentConfig,
@@ -431,6 +437,11 @@ export function AgentMode({ userId }: { userId: string }) {
   const [isSessionMcpServersLoading, setIsSessionMcpServersLoading] = useState(false);
   const [isMcpServerTogglePending, setIsMcpServerTogglePending] = useState(false);
   const [input, setInput] = useState("");
+  const promptHistoryEntries = useMemo(() => agentPromptHistory(timelineItems), [timelineItems]);
+  const promptHistoryEntriesRef = useRef<readonly string[]>(promptHistoryEntries);
+  const promptHistoryNavigationRef = useRef<AgentPromptHistoryNavigation | null>(null);
+  const promptHistoryGenerationRef = useRef(0);
+  const promptHistoryReplacementSessionRef = useRef<string | null>(null);
   const [isAgentFullscreen, setIsAgentFullscreen] = useState(
     () => localStorage.getItem("agentFullscreen") === "true"
   );
@@ -517,6 +528,32 @@ export function AgentMode({ userId }: { userId: string }) {
     };
     userIdRef.current = userId;
   }, [model, openai, os, setAvailableModels, setHasWhisperModel, setModelAliases, userId]);
+
+  useLayoutEffect(() => {
+    if (
+      activeSessionId === null ||
+      promptHistoryReplacementSessionRef.current !== activeSessionId
+    ) {
+      promptHistoryEntriesRef.current = promptHistoryEntries;
+    }
+  }, [activeSessionId, promptHistoryEntries]);
+
+  const resetPromptHistoryNavigation = useCallback(() => {
+    promptHistoryNavigationRef.current = null;
+    promptHistoryGenerationRef.current += 1;
+  }, []);
+
+  useLayoutEffect(() => {
+    resetPromptHistoryNavigation();
+  }, [activeSessionId, resetPromptHistoryNavigation, userId]);
+
+  const handleAgentInputChange = useCallback(
+    (value: string) => {
+      resetPromptHistoryNavigation();
+      setInput(value);
+    },
+    [resetPromptHistoryNavigation]
+  );
 
   const restoreNewTaskModel = useCallback(() => {
     const nextModel = newTaskAgentModel(agentModelPreferenceRef.current);
@@ -1061,12 +1098,17 @@ export function AgentMode({ userId }: { userId: string }) {
         return false;
       }
       bumpTimelineRevision(sessionId);
+      if (promptHistoryReplacementSessionRef.current === sessionId) {
+        promptHistoryReplacementSessionRef.current = null;
+      }
       if (activeSessionIdRef.current === sessionId) {
+        resetPromptHistoryNavigation();
+        promptHistoryEntriesRef.current = agentPromptHistory(items);
         setTimelineItems(items);
       }
       return true;
     },
-    [bumpTimelineRevision, timelineRevisionBySessionRef]
+    [bumpTimelineRevision, resetPromptHistoryNavigation, timelineRevisionBySessionRef]
   );
 
   const mergeSessionTimelineItem = useCallback(
@@ -2128,6 +2170,7 @@ export function AgentMode({ userId }: { userId: string }) {
     markPendingSend(pendingSessionKey, sendToken);
 
     setError(null);
+    resetPromptHistoryNavigation();
     setInput("");
     shouldAutoScrollRef.current = true;
     requestAnimationFrame(() => scrollTimelineToBottom("smooth"));
@@ -2223,6 +2266,7 @@ export function AgentMode({ userId }: { userId: string }) {
     pendingSendTokensRef,
     permissionModeUpdateRef,
     recordActiveRun,
+    resetPromptHistoryNavigation,
     scrollTimelineToBottom,
     terminalRunIdsRef,
     thoughtPhaseTrackerRef,
@@ -2276,7 +2320,49 @@ export function AgentMode({ userId }: { userId: string }) {
   const handleKeyDown = useCallback(
     (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (event.nativeEvent.isComposing) return;
-      if ((event.shiftKey || isCompactLayout) && continueChatComposerList(event, setInput)) {
+      const direction = agentPromptHistoryDirection(
+        {
+          key: event.key,
+          value: event.currentTarget.value,
+          selectionStart: event.currentTarget.selectionStart,
+          selectionEnd: event.currentTarget.selectionEnd,
+          altKey: event.altKey,
+          ctrlKey: event.ctrlKey,
+          metaKey: event.metaKey,
+          shiftKey: event.shiftKey,
+          isComposing: event.nativeEvent.isComposing
+        },
+        promptHistoryNavigationRef.current
+      );
+      if (direction) {
+        const step = navigateAgentPromptHistory(
+          promptHistoryNavigationRef.current,
+          promptHistoryEntriesRef.current,
+          direction
+        );
+        if (step) {
+          event.preventDefault();
+          promptHistoryNavigationRef.current = step.navigation;
+          promptHistoryGenerationRef.current += 1;
+          const promptHistoryGeneration = promptHistoryGenerationRef.current;
+          setInput(step.value);
+          const textarea = event.currentTarget;
+          requestAnimationFrame(() => {
+            if (
+              promptHistoryGenerationRef.current === promptHistoryGeneration &&
+              textarea.isConnected &&
+              document.activeElement === textarea
+            ) {
+              textarea.setSelectionRange(step.value.length, step.value.length);
+            }
+          });
+          return;
+        }
+      }
+      if (
+        (event.shiftKey || isCompactLayout) &&
+        continueChatComposerList(event, handleAgentInputChange)
+      ) {
         return;
       }
       if (event.key === "Enter" && !event.shiftKey && !isCompactLayout) {
@@ -2284,12 +2370,15 @@ export function AgentMode({ userId }: { userId: string }) {
         void sendMessage();
       }
     },
-    [isCompactLayout, sendMessage]
+    [handleAgentInputChange, isCompactLayout, sendMessage]
   );
 
-  const handleBeforeInput = useCallback((event: React.FormEvent<HTMLTextAreaElement>) => {
-    continueChatComposerListBeforeInput(event, setInput);
-  }, []);
+  const handleBeforeInput = useCallback(
+    (event: React.FormEvent<HTMLTextAreaElement>) => {
+      continueChatComposerListBeforeInput(event, handleAgentInputChange);
+    },
+    [handleAgentInputChange]
+  );
 
   const removeSessionFromState = useCallback(
     (sessionId: string) => {
@@ -2575,6 +2664,11 @@ export function AgentMode({ userId }: { userId: string }) {
           void (async () => {
             const id = event.sessionId || activeSessionIdRef.current;
             if (!id) return;
+            if (activeSessionIdRef.current === id) {
+              resetPromptHistoryNavigation();
+              promptHistoryReplacementSessionRef.current = id;
+              promptHistoryEntriesRef.current = [];
+            }
             const invalidatedTurnId = thoughtPhaseTrackerRef.current.resetForHistoryReplacement(id);
             if (invalidatedTurnId) {
               invalidateThoughtLabelsForTurn(id, invalidatedTurnId);
@@ -2629,6 +2723,7 @@ export function AgentMode({ userId }: { userId: string }) {
       recordActiveRun,
       refreshSessionMcpServers,
       replaceSessionTimeline,
+      resetPromptHistoryNavigation,
       terminalRunIdsRef,
       thoughtPhaseSeededRunIdsRef,
       thoughtPhaseTrackerRef,
@@ -3003,7 +3098,8 @@ export function AgentMode({ userId }: { userId: string }) {
                   isExpanded={isAgentFullscreen}
                   onCancelPrompt={cancelPrompt}
                   onChooseProjectRoot={chooseProjectRoot}
-                  onInputChange={setInput}
+                  onInputChange={handleAgentInputChange}
+                  onInputPointerDown={resetPromptHistoryNavigation}
                   onKeyDown={handleKeyDown}
                   onBeforeInput={handleBeforeInput}
                   onManageMcpServers={handleManageMcpServers}
@@ -3047,7 +3143,8 @@ export function AgentMode({ userId }: { userId: string }) {
                   recentRoots={displayProjectRoots}
                   onCancelPrompt={cancelPrompt}
                   onChooseProjectRoot={chooseProjectRoot}
-                  onInputChange={setInput}
+                  onInputChange={handleAgentInputChange}
+                  onInputPointerDown={resetPromptHistoryNavigation}
                   onKeyDown={handleKeyDown}
                   onBeforeInput={handleBeforeInput}
                   onManageMcpServers={handleManageMcpServers}
@@ -4198,6 +4295,7 @@ interface AgentComposerProps {
   onCancelPrompt: () => void;
   onChooseProjectRoot: () => void;
   onInputChange: (value: string) => void;
+  onInputPointerDown: () => void;
   onBeforeInput: (event: React.FormEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onManageMcpServers: () => void;
@@ -4228,6 +4326,7 @@ function AgentComposer({
   onCancelPrompt,
   onChooseProjectRoot,
   onInputChange,
+  onInputPointerDown,
   onBeforeInput,
   onKeyDown,
   onManageMcpServers,
@@ -4276,6 +4375,7 @@ function AgentComposer({
         id="agent-message"
         value={input}
         onChange={(event) => onInputChange(event.target.value)}
+        onPointerDown={onInputPointerDown}
         onBeforeInput={onBeforeInput}
         onKeyDown={onKeyDown}
         disabled={isSendDisabled}

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -1102,13 +1102,15 @@ export function AgentMode({ userId }: { userId: string }) {
         promptHistoryReplacementSessionRef.current = null;
       }
       if (activeSessionIdRef.current === sessionId) {
-        resetPromptHistoryNavigation();
+        // Routine reconciliation (including runFinished) refreshes entries for
+        // the next navigation session without disturbing the active snapshot.
+        // Edit, send, pointer, task/account, and historyReplaced paths own exits.
         promptHistoryEntriesRef.current = agentPromptHistory(items);
         setTimelineItems(items);
       }
       return true;
     },
-    [bumpTimelineRevision, resetPromptHistoryNavigation, timelineRevisionBySessionRef]
+    [bumpTimelineRevision, timelineRevisionBySessionRef]
   );
 
   const mergeSessionTimelineItem = useCallback(

--- a/frontend/src/components/agent/agentComposerFocus.test.ts
+++ b/frontend/src/components/agent/agentComposerFocus.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, test } from "bun:test";
+import {
+  isDeliberateAgentComposerFocusTarget,
+  settleAgentComposerFocusRequest,
+  type AgentComposerFocusContext,
+  type AgentComposerFocusRequest,
+  type AgentComposerFocusTarget
+} from "./agentComposerFocus";
+
+function focusHarness(overrides: Partial<AgentComposerFocusContext> = {}) {
+  const body = {};
+  const calls: Array<FocusOptions | undefined> = [];
+  const textarea: AgentComposerFocusTarget = {
+    disabled: false,
+    focus: (options) => calls.push(options)
+  };
+  const context: AgentComposerFocusContext = {
+    currentInteractionGeneration: 3,
+    isSubmitting: false,
+    hasTimeline: true,
+    textarea,
+    activeElement: body,
+    documentBody: body,
+    documentRoot: {},
+    ...overrides
+  };
+  const request: AgentComposerFocusRequest = {
+    sendToken: 7,
+    interactionGeneration: 3,
+    waitForTimeline: false
+  };
+  return { body, calls, context, request, textarea };
+}
+
+describe("settleAgentComposerFocusRequest", () => {
+  test("waits for submit unlock and the first accepted timeline row", () => {
+    const { calls, context, request } = focusHarness({
+      isSubmitting: true,
+      hasTimeline: false
+    });
+    request.waitForTimeline = true;
+
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(false);
+    context.isSubmitting = false;
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(false);
+    context.hasTimeline = true;
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(true);
+    expect(calls).toEqual([{ preventScroll: true }]);
+  });
+
+  test("waits while the current composer is absent or disabled", () => {
+    const { context, request, textarea } = focusHarness({ textarea: null });
+
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(false);
+    context.textarea = textarea;
+    textarea.disabled = true;
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(false);
+  });
+
+  test("does not focus again when the composer already owns focus", () => {
+    const { calls, context, request, textarea } = focusHarness();
+    context.activeElement = textarea;
+
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(true);
+    expect(calls).toEqual([]);
+  });
+
+  test("cancels after a task interaction or deliberate focus change", () => {
+    const changedTask = focusHarness({ currentInteractionGeneration: 4 });
+    expect(settleAgentComposerFocusRequest(changedTask.request, changedTask.context)).toBe(true);
+    expect(changedTask.calls).toEqual([]);
+
+    const changedFocus = focusHarness({ activeElement: {} });
+    expect(settleAgentComposerFocusRequest(changedFocus.request, changedFocus.context)).toBe(true);
+    expect(changedFocus.calls).toEqual([]);
+  });
+
+  test("retains a deliberate keyboard focus move after its control disappears", () => {
+    const { body, calls, context, request, textarea } = focusHarness();
+    const documentRoot = context.documentRoot;
+    const otherControl = {};
+
+    const cancelled = isDeliberateAgentComposerFocusTarget(
+      otherControl,
+      textarea,
+      body,
+      documentRoot
+    );
+    expect(cancelled).toBe(true);
+    expect(isDeliberateAgentComposerFocusTarget(body, textarea, body, documentRoot)).toBe(false);
+    expect(isDeliberateAgentComposerFocusTarget(documentRoot, textarea, body, documentRoot)).toBe(
+      false
+    );
+
+    const currentRequest = cancelled ? null : request;
+    context.activeElement = body;
+    if (currentRequest) {
+      settleAgentComposerFocusRequest(currentRequest, context);
+    }
+    expect(calls).toEqual([]);
+  });
+
+  test("a failed first send can release the timeline wait and refocus the empty composer", () => {
+    const { calls, context, request } = focusHarness({ hasTimeline: false });
+    request.waitForTimeline = true;
+
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(false);
+    request.waitForTimeline = false;
+    expect(settleAgentComposerFocusRequest(request, context)).toBe(true);
+    expect(calls).toEqual([{ preventScroll: true }]);
+  });
+});

--- a/frontend/src/components/agent/agentComposerFocus.ts
+++ b/frontend/src/components/agent/agentComposerFocus.ts
@@ -1,0 +1,66 @@
+export interface AgentComposerFocusRequest {
+  readonly sendToken: number;
+  readonly interactionGeneration: number;
+  waitForTimeline: boolean;
+}
+
+export interface AgentComposerFocusTarget {
+  disabled: boolean;
+  focus(options?: FocusOptions): void;
+}
+
+export interface AgentComposerFocusContext {
+  currentInteractionGeneration: number;
+  isSubmitting: boolean;
+  hasTimeline: boolean;
+  textarea: AgentComposerFocusTarget | null;
+  activeElement: unknown;
+  documentBody: unknown;
+  documentRoot: unknown;
+}
+
+export function isDeliberateAgentComposerFocusTarget(
+  target: unknown,
+  textarea: AgentComposerFocusTarget | null,
+  documentBody: unknown,
+  documentRoot: unknown
+): boolean {
+  return (
+    target !== null && target !== textarea && target !== documentBody && target !== documentRoot
+  );
+}
+
+/** Returns true when the request has either been fulfilled or invalidated. */
+export function settleAgentComposerFocusRequest(
+  request: AgentComposerFocusRequest,
+  context: AgentComposerFocusContext
+): boolean {
+  if (request.interactionGeneration !== context.currentInteractionGeneration) {
+    return true;
+  }
+
+  if (
+    isDeliberateAgentComposerFocusTarget(
+      context.activeElement,
+      context.textarea,
+      context.documentBody,
+      context.documentRoot
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    context.isSubmitting ||
+    (request.waitForTimeline && !context.hasTimeline) ||
+    !context.textarea ||
+    context.textarea.disabled
+  ) {
+    return false;
+  }
+
+  if (context.activeElement !== context.textarea) {
+    context.textarea.focus({ preventScroll: true });
+  }
+  return true;
+}

--- a/frontend/src/components/agent/agentPromptHistory.test.ts
+++ b/frontend/src/components/agent/agentPromptHistory.test.ts
@@ -3,6 +3,7 @@ import type { AgentTimelineItem } from "@/services/agentRuntimeService";
 import {
   agentPromptHistory,
   agentPromptHistoryDirection,
+  AgentPromptHistoryReplacementTracker,
   navigateAgentPromptHistory,
   type AgentPromptHistoryKeyState,
   type AgentPromptHistoryNavigation
@@ -152,8 +153,120 @@ describe("agentPromptHistory", () => {
     ).toBeNull();
   });
 
+  test("matches the textarea's LF value to recalled CRLF and bare CR entries", () => {
+    const crlfNavigation = navigateAgentPromptHistory(
+      null,
+      ["first", "line one\r\nline two"],
+      "older"
+    )!.navigation;
+    expect(
+      agentPromptHistoryDirection(
+        keyState({ key: "ArrowUp", value: "line one\nline two" }),
+        crlfNavigation
+      )
+    ).toBe("older");
+
+    const crNavigation = navigateAgentPromptHistory(
+      null,
+      ["first", "line one\rline two"],
+      "older"
+    )!.navigation;
+    expect(
+      agentPromptHistoryDirection(
+        keyState({ key: "ArrowDown", value: "line one\nline two" }),
+        crNavigation
+      )
+    ).toBe("newer");
+  });
+
+  test("preserves canonical line endings in the navigation snapshot", () => {
+    const history = ["older\rentry", "newer\r\nentry"];
+    let step = navigateAgentPromptHistory(null, history, "older")!;
+
+    expect(step.value).toBe("newer\r\nentry");
+    expect(step.navigation?.entries).toEqual(history);
+
+    step = navigateAgentPromptHistory(step.navigation, history, "older")!;
+    expect(step.value).toBe("older\rentry");
+    expect(step.navigation?.entries).toEqual(history);
+  });
+
+  test("does not mistake real edits for textarea newline normalization", () => {
+    const navigation = navigateAgentPromptHistory(
+      null,
+      ["first", "line one\r\nline two"],
+      "older"
+    )!.navigation;
+
+    expect(
+      agentPromptHistoryDirection(
+        keyState({ value: "line one\nline two edited", selectionStart: 24, selectionEnd: 24 }),
+        navigation
+      )
+    ).toBeNull();
+  });
+
   test("does not start without history or move newer outside navigation", () => {
     expect(navigateAgentPromptHistory(null, [], "older")).toBeNull();
     expect(navigateAgentPromptHistory(null, ["A"], "newer")).toBeNull();
+  });
+});
+
+describe("AgentPromptHistoryReplacementTracker", () => {
+  test("restores the current attempt fallback after a failed or raced replacement", () => {
+    const tracker = new AgentPromptHistoryReplacementTracker();
+    const attempt = tracker.begin("task-a", ["A", "B"]);
+
+    expect(tracker.isReplacing("task-a")).toBe(true);
+    expect(tracker.recover(attempt, "task-a")).toEqual(["A", "B"]);
+    expect(tracker.isReplacing("task-a")).toBe(false);
+  });
+
+  test("an older same-task attempt cannot release or empty a newer replacement", () => {
+    const tracker = new AgentPromptHistoryReplacementTracker();
+    const older = tracker.begin("task-a", ["A", "B"]);
+    const newer = tracker.begin("task-a", []);
+
+    expect(tracker.recover(older, "task-a")).toBeNull();
+    expect(tracker.isReplacing("task-a")).toBe(true);
+    expect(tracker.recover(newer, "task-a")).toEqual(["A", "B"]);
+    expect(tracker.isReplacing("task-a")).toBe(false);
+  });
+
+  test("does not restore an old task over the newly active task", () => {
+    const tracker = new AgentPromptHistoryReplacementTracker();
+    const taskA = tracker.begin("task-a", ["A"]);
+
+    expect(tracker.recover(taskA, "task-b")).toBeNull();
+    expect(tracker.isReplacing("task-a")).toBe(false);
+
+    const taskB = tracker.begin("task-b", ["B"]);
+    expect(tracker.recover(taskA, "task-b")).toBeNull();
+    expect(tracker.isReplacing("task-b")).toBe(true);
+    expect(tracker.recover(taskB, "task-b")).toEqual(["B"]);
+  });
+
+  test("abandons prompt-bearing fallback state when another task becomes active", () => {
+    const tracker = new AgentPromptHistoryReplacementTracker();
+    const taskA = tracker.begin("task-a", ["A"]);
+
+    tracker.abandonInactive("task-a");
+    expect(tracker.isReplacing("task-a")).toBe(true);
+
+    tracker.abandonInactive("task-b");
+    expect(tracker.isReplacing("task-a")).toBe(false);
+    expect(tracker.recover(taskA, "task-a")).toBeNull();
+  });
+
+  test("only an authoritative replacement for the tracked task clears it", () => {
+    const tracker = new AgentPromptHistoryReplacementTracker();
+    const attempt = tracker.begin("task-a", ["A"]);
+
+    tracker.authoritativeReplace("task-b");
+    expect(tracker.isReplacing("task-a")).toBe(true);
+
+    tracker.authoritativeReplace("task-a");
+    expect(tracker.isReplacing("task-a")).toBe(false);
+    expect(tracker.recover(attempt, "task-a")).toBeNull();
   });
 });

--- a/frontend/src/components/agent/agentPromptHistory.test.ts
+++ b/frontend/src/components/agent/agentPromptHistory.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, test } from "bun:test";
+import type { AgentTimelineItem } from "@/services/agentRuntimeService";
+import {
+  agentPromptHistory,
+  agentPromptHistoryDirection,
+  navigateAgentPromptHistory,
+  type AgentPromptHistoryKeyState,
+  type AgentPromptHistoryNavigation
+} from "./agentPromptHistory";
+
+function item(
+  id: string,
+  text: string | null,
+  itemType: AgentTimelineItem["itemType"] = "message",
+  role: AgentTimelineItem["role"] = "user"
+): AgentTimelineItem {
+  return { id, itemType, role, text, createdMs: 0, merge: "replace" };
+}
+
+function keyState(overrides: Partial<AgentPromptHistoryKeyState> = {}): AgentPromptHistoryKeyState {
+  return {
+    key: "ArrowUp",
+    value: "",
+    selectionStart: 0,
+    selectionEnd: 0,
+    altKey: false,
+    ctrlKey: false,
+    metaKey: false,
+    shiftKey: false,
+    isComposing: false,
+    ...overrides
+  };
+}
+
+describe("agentPromptHistory", () => {
+  test("derives only non-empty canonical user messages in chronological order", () => {
+    expect(
+      agentPromptHistory([
+        item("assistant", "answer", "message", "assistant"),
+        item("thinking", "reasoning", "thinking", "thought"),
+        item("tool-user", "tool payload", "tool", "user"),
+        item("permission-user", "permission payload", "permission", "user"),
+        item("system-user", "system payload", "system", "user"),
+        item("error-user", "error payload", "error", "user"),
+        item("empty", ""),
+        item("missing", null),
+        item("first", "  first\nline  "),
+        item("failed", "accepted before failure"),
+        item("failure", "later failure", "error", "system"),
+        item("cancelled", "accepted before cancellation"),
+        item("cancellation", "later cancellation", "system", "system"),
+        item("duplicate-a", "重複 👩‍💻"),
+        item("duplicate-b", "重複 👩‍💻")
+      ])
+    ).toEqual([
+      "  first\nline  ",
+      "accepted before failure",
+      "accepted before cancellation",
+      "重複 👩‍💻",
+      "重複 👩‍💻"
+    ]);
+  });
+
+  test("navigates without wrapping and restores the empty composer", () => {
+    let navigation: AgentPromptHistoryNavigation | null = null;
+
+    let step = navigateAgentPromptHistory(navigation, ["A", "B"], "older")!;
+    navigation = step.navigation;
+    expect(step.value).toBe("B");
+
+    step = navigateAgentPromptHistory(navigation, ["A", "B"], "older")!;
+    navigation = step.navigation;
+    expect(step.value).toBe("A");
+
+    step = navigateAgentPromptHistory(navigation, ["A", "B"], "older")!;
+    navigation = step.navigation;
+    expect(step.value).toBe("A");
+
+    step = navigateAgentPromptHistory(navigation, ["A", "B"], "newer")!;
+    navigation = step.navigation;
+    expect(step.value).toBe("B");
+
+    step = navigateAgentPromptHistory(navigation, ["A", "B"], "newer")!;
+    expect(step).toEqual({ navigation: null, value: "" });
+  });
+
+  test("snapshots duplicate entries so live timeline updates cannot shift navigation", () => {
+    let step = navigateAgentPromptHistory(null, ["same", "same"], "older")!;
+    expect(step.navigation?.index).toBe(1);
+
+    step = navigateAgentPromptHistory(step.navigation, ["same", "same", "new"], "older")!;
+    expect(step.navigation?.index).toBe(0);
+    expect(step.value).toBe("same");
+
+    step = navigateAgentPromptHistory(step.navigation, ["same", "same", "new"], "newer")!;
+    expect(step.navigation?.index).toBe(1);
+
+    step = navigateAgentPromptHistory(step.navigation, ["same", "same", "new"], "newer")!;
+    expect(step).toEqual({ navigation: null, value: "" });
+
+    step = navigateAgentPromptHistory(step.navigation, ["same", "same", "new"], "older")!;
+    expect(step.value).toBe("new");
+  });
+
+  test("starts only with unmodified Up in an empty unselected composer", () => {
+    expect(agentPromptHistoryDirection(keyState(), null)).toBe("older");
+    expect(agentPromptHistoryDirection(keyState({ key: "ArrowDown" }), null)).toBeNull();
+    expect(agentPromptHistoryDirection(keyState({ value: "draft" }), null)).toBeNull();
+    expect(agentPromptHistoryDirection(keyState({ selectionEnd: 1 }), null)).toBeNull();
+
+    for (const modifier of ["altKey", "ctrlKey", "metaKey", "shiftKey"] as const) {
+      expect(agentPromptHistoryDirection(keyState({ [modifier]: true }), null)).toBeNull();
+    }
+
+    expect(agentPromptHistoryDirection(keyState({ isComposing: true }), null)).toBeNull();
+  });
+
+  test("navigates directly from an untouched recalled multiline prompt", () => {
+    const navigation = navigateAgentPromptHistory(
+      null,
+      ["first", "line one\nline two"],
+      "older"
+    )!.navigation;
+
+    expect(
+      agentPromptHistoryDirection(
+        keyState({
+          key: "ArrowUp",
+          value: "line one\nline two",
+          selectionStart: 4,
+          selectionEnd: 4
+        }),
+        navigation
+      )
+    ).toBe("older");
+    expect(
+      agentPromptHistoryDirection(
+        keyState({
+          key: "ArrowDown",
+          value: "line one\nline two",
+          selectionStart: 4,
+          selectionEnd: 4
+        }),
+        navigation
+      )
+    ).toBe("newer");
+    expect(
+      agentPromptHistoryDirection(
+        keyState({ value: "line one\nline two edited", selectionStart: 24, selectionEnd: 24 }),
+        navigation
+      )
+    ).toBeNull();
+  });
+
+  test("does not start without history or move newer outside navigation", () => {
+    expect(navigateAgentPromptHistory(null, [], "older")).toBeNull();
+    expect(navigateAgentPromptHistory(null, ["A"], "newer")).toBeNull();
+  });
+});

--- a/frontend/src/components/agent/agentPromptHistory.ts
+++ b/frontend/src/components/agent/agentPromptHistory.ts
@@ -1,0 +1,95 @@
+import type { AgentTimelineItem } from "@/services/agentRuntimeService";
+
+export type AgentPromptHistoryDirection = "older" | "newer";
+
+export interface AgentPromptHistoryNavigation {
+  entries: readonly string[];
+  index: number;
+}
+
+export interface AgentPromptHistoryKeyState {
+  key: string;
+  value: string;
+  selectionStart: number | null;
+  selectionEnd: number | null;
+  altKey: boolean;
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  isComposing: boolean;
+}
+
+export interface AgentPromptHistoryStep {
+  navigation: AgentPromptHistoryNavigation | null;
+  value: string;
+}
+
+export function agentPromptHistory(items: readonly AgentTimelineItem[]): string[] {
+  return items.flatMap((item) => {
+    const text = item.text;
+    return item.itemType === "message" &&
+      item.role === "user" &&
+      typeof text === "string" &&
+      text.length > 0
+      ? [text]
+      : [];
+  });
+}
+
+export function agentPromptHistoryDirection(
+  keyState: AgentPromptHistoryKeyState,
+  navigation: AgentPromptHistoryNavigation | null
+): AgentPromptHistoryDirection | null {
+  if (
+    keyState.isComposing ||
+    keyState.altKey ||
+    keyState.ctrlKey ||
+    keyState.metaKey ||
+    keyState.shiftKey ||
+    keyState.selectionStart === null ||
+    keyState.selectionEnd === null ||
+    keyState.selectionStart !== keyState.selectionEnd
+  ) {
+    return null;
+  }
+
+  if (keyState.key !== "ArrowUp" && keyState.key !== "ArrowDown") return null;
+
+  if (navigation) {
+    if (keyState.value !== navigation.entries[navigation.index]) return null;
+    return keyState.key === "ArrowUp" ? "older" : "newer";
+  }
+
+  return keyState.key === "ArrowUp" && keyState.value === "" ? "older" : null;
+}
+
+export function navigateAgentPromptHistory(
+  navigation: AgentPromptHistoryNavigation | null,
+  history: readonly string[],
+  direction: AgentPromptHistoryDirection
+): AgentPromptHistoryStep | null {
+  if (!navigation) {
+    if (direction === "newer" || history.length === 0) return null;
+    const entries = [...history];
+    const index = entries.length - 1;
+    return { navigation: { entries, index }, value: entries[index] };
+  }
+
+  if (direction === "older") {
+    const index = Math.max(0, navigation.index - 1);
+    return {
+      navigation: { entries: navigation.entries, index },
+      value: navigation.entries[index]
+    };
+  }
+
+  if (navigation.index === navigation.entries.length - 1) {
+    return { navigation: null, value: "" };
+  }
+
+  const index = navigation.index + 1;
+  return {
+    navigation: { entries: navigation.entries, index },
+    value: navigation.entries[index]
+  };
+}

--- a/frontend/src/components/agent/agentPromptHistory.ts
+++ b/frontend/src/components/agent/agentPromptHistory.ts
@@ -24,6 +24,65 @@ export interface AgentPromptHistoryStep {
   value: string;
 }
 
+export interface AgentPromptHistoryReplacementAttempt {
+  readonly sessionId: string;
+  readonly fallbackEntries: readonly string[];
+}
+
+export class AgentPromptHistoryReplacementTracker {
+  private current: AgentPromptHistoryReplacementAttempt | null = null;
+
+  isReplacing(sessionId: string): boolean {
+    return this.current?.sessionId === sessionId;
+  }
+
+  begin(
+    sessionId: string,
+    fallbackEntries: readonly string[]
+  ): AgentPromptHistoryReplacementAttempt {
+    const attempt = {
+      sessionId,
+      fallbackEntries:
+        this.current?.sessionId === sessionId ? this.current.fallbackEntries : [...fallbackEntries]
+    };
+    this.current = attempt;
+    return attempt;
+  }
+
+  authoritativeReplace(sessionId: string): void {
+    if (this.current?.sessionId === sessionId) {
+      this.current = null;
+    }
+  }
+
+  abandonInactive(activeSessionId: string | null): void {
+    if (this.current && this.current.sessionId !== activeSessionId) {
+      this.current = null;
+    }
+  }
+
+  recover(
+    attempt: AgentPromptHistoryReplacementAttempt,
+    activeSessionId: string | null
+  ): readonly string[] | null {
+    if (this.current !== attempt) return null;
+    this.current = null;
+    return activeSessionId === attempt.sessionId ? attempt.fallbackEntries : null;
+  }
+}
+
+// The textarea API exposes CRLF and bare CR line breaks as LF.
+function normalizeTextareaNewlines(value: string): string {
+  return value.replace(/\r\n?/g, "\n");
+}
+
+function matchesTextareaValue(value: string, historyEntry: string): boolean {
+  return (
+    value === historyEntry ||
+    normalizeTextareaNewlines(value) === normalizeTextareaNewlines(historyEntry)
+  );
+}
+
 export function agentPromptHistory(items: readonly AgentTimelineItem[]): string[] {
   return items.flatMap((item) => {
     const text = item.text;
@@ -56,7 +115,7 @@ export function agentPromptHistoryDirection(
   if (keyState.key !== "ArrowUp" && keyState.key !== "ArrowDown") return null;
 
   if (navigation) {
-    if (keyState.value !== navigation.entries[navigation.index]) return null;
+    if (!matchesTextareaValue(keyState.value, navigation.entries[navigation.index])) return null;
     return keyState.key === "ArrowUp" ? "older" : "newer";
   }
 


### PR DESCRIPTION
## Summary

- Add Terminal-style Arrow Up/Arrow Down prompt recall to both Agent Mode composer placements.
- Derive recall entries from the selected task's canonical user-message timeline, preserving order, duplicates, multiline text, and Unicode without creating a second history store.
- Anchor active navigation against live timeline updates and reset it on edits, pointer movement, sends, scope changes, and authoritative history replacement.
- Keep Chat Mode unchanged.

## Why

Agent users often reuse an earlier instruction with small edits. The prompts already exist in the account- and task-scoped Agent timeline, but the composer had no navigation state for recalling them.

## Validation

- `nix develop .#ci -c ./scripts/ci/frontend.sh` — passed formatting, TypeScript, and all 666 tests; ESLint completed with 0 errors and 13 existing warnings.
- Pre-commit production frontend build passed and the hook reran all 666 tests successfully.
- Focused Agent prompt-history tests cover filtering, failed/cancelled runs, duplicates, no-wrap navigation, modifier/selection/IME guards, multiline recall, and stable snapshots.
- Unsigned macOS QA app build and exact-bundle launch succeeded using the managed workspace overlay.

Closes #782
