### PR TITLE
Polish compact Settings layout and usage controls

### DIFF
--- a/frontend/src/components/AccountMenu.test.tsx
+++ b/frontend/src/components/AccountMenu.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, mock, test } from "bun:test";
+import type { ComponentPropsWithoutRef, ReactNode } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+const billingStatus = {
+  product_name: "Pro",
+  total_tokens: 100,
+  used_tokens: 25,
+  api_credit_balance: 50,
+  usage_reset_date: null
+};
+
+mock.module("@tanstack/react-query", () => ({
+  useQuery: () => ({ data: undefined })
+}));
+
+mock.module("@tanstack/react-router", () => ({
+  Link: ({
+    to,
+    state,
+    children,
+    ...props
+  }: Omit<ComponentPropsWithoutRef<"a">, "href"> & {
+    to: string;
+    state?: unknown;
+    children: ReactNode;
+  }) => {
+    void state;
+    return (
+      <a href={to} {...props}>
+        {children}
+      </a>
+    );
+  }
+}));
+
+mock.module("@opensecret/react", () => ({
+  useOpenSecret: () => ({ auth: { user: { user: { id: "user-1" } } } })
+}));
+
+mock.module("@/billing/billingService", () => ({
+  getBillingService: () => ({
+    getBillingStatus: async () => billingStatus,
+    getTeamStatus: async () => null
+  })
+}));
+
+mock.module("@/components/settings/useCompactSettingsLayout", () => ({
+  useCompactSettingsLayout: () => true
+}));
+
+mock.module("@/state/useLocalState", () => ({
+  useBillingState: () => ({ billingStatus, setBillingStatus: () => {} })
+}));
+
+const { AccountMenu } = await import("./AccountMenu");
+
+describe("AccountMenu", () => {
+  test("keeps Settings and Usage together by default", () => {
+    const markup = renderToStaticMarkup(<AccountMenu pagePresentation />);
+
+    expect(markup).toContain('href="/settings"');
+    expect(markup).toContain('href="/pricing"');
+    expect(markup).toContain('aria-label="Open settings"');
+    expect(markup).toContain("h-11 w-11");
+  });
+
+  test("renders the shared 44px Settings control without Usage for a page header", () => {
+    const markup = renderToStaticMarkup(<AccountMenu pagePresentation showCreditUsage={false} />);
+
+    expect(markup).toContain('href="/settings"');
+    expect(markup).toContain('aria-label="Open settings"');
+    expect(markup).toContain("h-11 w-11");
+    expect(markup).toContain("w-auto");
+    expect(markup).not.toContain('href="/pricing"');
+    expect(markup.match(/<a /g)).toHaveLength(1);
+  });
+});

--- a/frontend/src/components/AccountMenu.tsx
+++ b/frontend/src/components/AccountMenu.tsx
@@ -11,7 +11,13 @@ import { SETTINGS_HOME_PARENT_STATE_KEY } from "@/utils/settingsNavigation";
 import { getTeamSeatMismatch } from "@/utils/teamSeats";
 import { cn } from "@/utils/utils";
 
-export function AccountMenu({ pagePresentation = false }: { pagePresentation?: boolean }) {
+export function AccountMenu({
+  pagePresentation = false,
+  showCreditUsage = true
+}: {
+  pagePresentation?: boolean;
+  showCreditUsage?: boolean;
+}) {
   const os = useOpenSecret();
   const { billingStatus, setBillingStatus } = useBillingState();
   const isCompactSettingsLayout = useCompactSettingsLayout();
@@ -44,7 +50,7 @@ export function AccountMenu({ pagePresentation = false }: { pagePresentation?: b
       : undefined;
 
   return (
-    <div className="flex w-full max-w-full items-end gap-2">
+    <div className={cn("flex max-w-full items-end gap-2", showCreditUsage ? "w-full" : "w-auto")}>
       <Link
         to={isCompactSettingsLayout ? "/settings" : "/settings/account"}
         state={
@@ -68,16 +74,18 @@ export function AccountMenu({ pagePresentation = false }: { pagePresentation?: b
           />
         )}
       </Link>
-      <Link
-        to="/pricing"
-        className={cn(
-          "group/credit-link min-w-0 flex-1 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
-          pagePresentation && "flex min-h-11"
-        )}
-        aria-label={billingStatus ? `${billingStatus.product_name} plan` : "Billing status"}
-      >
-        <CreditUsage pagePresentation={pagePresentation} />
-      </Link>
+      {showCreditUsage && (
+        <Link
+          to="/pricing"
+          className={cn(
+            "group/credit-link min-w-0 flex-1 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+            pagePresentation && "flex min-h-11"
+          )}
+          aria-label={billingStatus ? `${billingStatus.product_name} plan` : "Billing status"}
+        >
+          <CreditUsage pagePresentation={pagePresentation} />
+        </Link>
+      )}
     </div>
   );
 }

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -248,8 +248,7 @@ export function MainMenu({
   const isMobile = useIsMobile();
   const isLandscapeMobile = useIsLandscapeMobile();
   const isCompactLayout = isMobile || isLandscapeMobile;
-  const chatHistoryContainerRef =
-    isPagePresentation && isLandscapeMobile ? sidebarRef : historyContainerRef;
+  const chatHistoryContainerRef = historyContainerRef;
   const agentModeAvailable = isTauriDesktop();
   const [agentModeFlag, setAgentModeFlag] = useState<{
     userId: string;
@@ -369,7 +368,7 @@ export function MainMenu({
               "fixed md:static landscape-short:fixed z-10 h-full overflow-x-hidden overflow-y-hidden",
               isOpen ? `block ${SIDEBAR_WIDTH_CLASS}` : "hidden"
             ]
-          : "relative z-0 h-full min-h-0 w-full overflow-x-hidden overflow-y-hidden landscape-short:overflow-y-auto"
+          : "relative z-0 h-full min-h-0 w-full overflow-x-hidden overflow-y-hidden"
       )}
     >
       <div
@@ -377,7 +376,7 @@ export function MainMenu({
           "flex h-full min-h-0 min-w-0 flex-col items-stretch overflow-x-hidden bg-muted dark:bg-[hsl(var(--sidebar))]",
           presentation === "sidebar"
             ? ["border-r border-border/20", SIDEBAR_WIDTH_CLASS, SIDEBAR_MAX_WIDTH_CLASS]
-            : "w-full max-w-none overflow-y-hidden backdrop-blur-lg landscape-short:h-auto landscape-short:min-h-full landscape-short:overflow-y-visible"
+            : "w-full max-w-none overflow-y-hidden backdrop-blur-lg"
         )}
       >
         {/* Header section */}
@@ -405,7 +404,9 @@ export function MainMenu({
               >
                 <PanelLeft className="h-4 w-4" />
               </button>
-            ) : null}
+            ) : (
+              <AccountMenu pagePresentation showCreditUsage={false} />
+            )}
           </div>
           {!isPagePresentation && (showAgentMode || isAgentMode) && (
             <div className="mb-2 px-8">
@@ -530,19 +531,12 @@ export function MainMenu({
             )}
           </div>
         )}
-        <div
-          className={cn(
-            "relative flex min-h-0 min-w-0 flex-1 flex-col",
-            isPagePresentation && "landscape-short:flex-none"
-          )}
-        >
+        <div className={cn("relative flex min-h-0 min-w-0 flex-1 flex-col")}>
           <nav
             ref={historyContainerRef}
             className={cn(
               "sidebar-scrollbar relative flex min-h-0 min-w-0 flex-1 flex-col overflow-y-auto overflow-x-clip pt-5",
-              isPagePresentation
-                ? "px-5 landscape-short:flex-none landscape-short:overflow-y-visible"
-                : "pl-4 pr-2 md:px-4"
+              isPagePresentation ? "px-5" : "pl-4 pr-2 md:px-4"
             )}
           >
             {navigationContent || (
@@ -569,8 +563,8 @@ export function MainMenu({
             <div
               aria-hidden
               className={cn(
-                "min-h-[7.5rem] shrink-0 bg-transparent",
-                isPagePresentation && "landscape-short:min-h-4"
+                "shrink-0 bg-transparent",
+                isPagePresentation ? "min-h-8" : "min-h-[7.5rem]"
               )}
             />
           </nav>
@@ -578,21 +572,15 @@ export function MainMenu({
           <div
             aria-hidden
             className={cn(
-              "pointer-events-none absolute bottom-0 left-0 z-[8] h-8 w-[calc(100%-10px)] max-w-full bg-gradient-to-b from-transparent to-muted/75 dark:to-[hsl(var(--sidebar)/0.75)]",
-              isPagePresentation && "landscape-short:hidden"
+              "pointer-events-none absolute bottom-0 left-0 z-[8] h-8 w-[calc(100%-10px)] max-w-full bg-gradient-to-b from-transparent to-muted/75 dark:to-[hsl(var(--sidebar)/0.75)]"
             )}
           />
         </div>
-        <div
-          className={cn(
-            "w-full border-t border-border/25 pt-2",
-            isPagePresentation
-              ? "maple-mobile-menu-footer shrink-0 px-5 pb-[max(1rem,env(safe-area-inset-bottom))]"
-              : "px-4 pb-4"
-          )}
-        >
-          <AccountMenu pagePresentation={isPagePresentation} />
-        </div>
+        {!isPagePresentation && (
+          <div className="w-full border-t border-border/25 px-4 pb-4 pt-2">
+            <AccountMenu />
+          </div>
+        )}
       </div>
       {!isPagePresentation ? (
         <UpgradePromptDialog

--- a/frontend/src/components/settings/SettingsLayout.tsx
+++ b/frontend/src/components/settings/SettingsLayout.tsx
@@ -24,6 +24,7 @@ import {
   type ComponentType
 } from "react";
 import { getBillingService } from "@/billing/billingService";
+import { CreditUsage } from "@/components/CreditUsage";
 import { MapleWordmark } from "@/components/MapleWordmark";
 import { SettingsNavigationLockProvider } from "@/components/settings/SettingsNavigationLockProvider";
 import { useCompactSettingsLayout } from "@/components/settings/useCompactSettingsLayout";
@@ -92,7 +93,7 @@ function browserHistoryEntryKey(state: unknown) {
   return typeof candidate.key === "string" ? candidate.key : null;
 }
 
-function SettingsNavLink({ item }: { item: SettingsNavItem }) {
+function SettingsNavLink({ item, compact }: { item: SettingsNavItem; compact: boolean }) {
   const Icon = item.icon;
   const isNavigationLocked = useSettingsNavigationLockState();
   const attentionLabel =
@@ -122,12 +123,15 @@ function SettingsNavLink({ item }: { item: SettingsNavItem }) {
         className: "text-muted-foreground hover:bg-background/70 hover:text-foreground"
       }}
       className={cn(
-        "group flex min-h-11 items-center justify-start gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors",
+        "group flex min-h-11 items-center justify-start font-medium transition-colors",
+        compact
+          ? "gap-2 rounded-2xl pr-1 text-base leading-6"
+          : "gap-3 rounded-lg px-3 py-2 text-sm",
         isNavigationLocked && "cursor-not-allowed opacity-50"
       )}
     >
       <span className="shrink-0">
-        <Icon className="h-4 w-4" />
+        <Icon className={compact ? "h-5 w-5" : "h-4 w-4"} />
       </span>
       <span className="min-w-0 flex-1 truncate">{item.label}</span>
       {item.badge && (
@@ -708,37 +712,72 @@ function SettingsLayoutContent() {
         )}
         style={isSettingsDetailSwipeActive ? settingsMenuSwipeStyle : undefined}
       >
-        <div className="flex h-16 shrink-0 items-center border-b border-border/30 px-3 sm:px-4">
+        <div
+          className={cn(
+            "flex h-16 shrink-0 items-center",
+            isCompactViewport ? "px-5 pb-2 pt-3" : "border-b border-border/30 px-3 sm:px-4"
+          )}
+        >
           <button
             ref={menuBackButtonRef}
             type="button"
             onClick={() => void closeSettings()}
             disabled={isNavigationLocked || isClosingSettings}
-            className="flex h-10 min-w-0 flex-1 items-center justify-start gap-2 rounded-lg px-2 text-foreground transition-colors hover:bg-background/70 disabled:cursor-not-allowed disabled:opacity-50"
+            className={cn(
+              "flex min-w-0 flex-1 items-center justify-start gap-2 rounded-lg text-foreground transition-colors hover:bg-background/70 disabled:cursor-not-allowed disabled:opacity-50",
+              isCompactViewport ? "min-h-11" : "h-10 px-2"
+            )}
             aria-label="Back to chats"
           >
-            <ArrowLeft className="h-4 w-4 shrink-0" />
-            <MapleWordmark className="h-4 min-w-0 w-auto" aria-hidden />
+            <ArrowLeft className={cn("shrink-0", isCompactViewport ? "h-5 w-5" : "h-4 w-4")} />
+            <MapleWordmark
+              className={cn("min-w-0 w-auto", isCompactViewport ? "h-5" : "h-4")}
+              aria-hidden
+            />
           </button>
         </div>
 
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-3 py-3">
-          <div className="mb-3 flex items-center gap-2 px-3">
-            <Settings className="h-4 w-4 text-muted-foreground" />
-            <p className="text-sm font-semibold">Settings</p>
+        <div
+          className={cn(
+            "flex min-h-0 flex-1 flex-col overflow-y-auto",
+            isCompactViewport ? "overscroll-y-contain px-5 pb-4 pt-5" : "px-3 py-3"
+          )}
+        >
+          <div
+            className={cn(
+              "flex items-center gap-2",
+              isCompactViewport ? "mb-5 min-h-11" : "mb-3 px-3"
+            )}
+          >
+            <Settings
+              className={cn("text-muted-foreground", isCompactViewport ? "h-5 w-5" : "h-4 w-4")}
+            />
+            <p className={cn("font-semibold", isCompactViewport ? "text-base" : "text-sm")}>
+              Settings
+            </p>
           </div>
 
-          <nav className="space-y-4" aria-label="Settings categories">
+          <nav
+            className={isCompactViewport ? "space-y-5" : "space-y-4"}
+            aria-label="Settings categories"
+          >
             {sections
               .filter((section) => section.items.length > 0)
               .map((section) => (
-                <div key={section.label}>
-                  <p className="mb-1 px-3 text-[10px] font-semibold uppercase tracking-[0.12em] text-muted-foreground/80">
+                <div key={section.label} className={isCompactViewport ? "space-y-2" : undefined}>
+                  <p
+                    className={cn(
+                      "uppercase text-muted-foreground",
+                      isCompactViewport
+                        ? "pb-1.5 text-xs font-medium tracking-wider"
+                        : "mb-1 px-3 text-[10px] font-semibold tracking-[0.12em] text-muted-foreground/80"
+                    )}
+                  >
                     {section.label}
                   </p>
-                  <div className="space-y-0.5">
+                  <div className={isCompactViewport ? "space-y-2" : "space-y-0.5"}>
                     {section.items.map((item) => (
-                      <SettingsNavLink key={item.to} item={item} />
+                      <SettingsNavLink key={item.to} item={item} compact={isCompactViewport} />
                     ))}
                   </div>
                 </div>
@@ -746,19 +785,42 @@ function SettingsLayoutContent() {
           </nav>
         </div>
 
-        <div className="shrink-0 border-t border-border/30 p-3">
-          <div className="mb-2 min-w-0 px-3">
-            <p className="truncate text-xs font-medium">
+        <div
+          className={cn(
+            "shrink-0 border-t border-border/30",
+            isCompactViewport
+              ? "maple-mobile-settings-account-footer px-5 pb-[max(1rem,env(safe-area-inset-bottom))] pt-2"
+              : "p-3"
+          )}
+        >
+          <div className={cn("mb-2 min-w-0", !isCompactViewport && "px-3")}>
+            <p
+              className={cn(
+                "truncate font-medium",
+                isCompactViewport ? "text-base leading-6" : "text-xs"
+              )}
+            >
               {os.auth.user.user.email || "Maple user"}
             </p>
-            <p className="truncate text-[11px] text-muted-foreground">
+            <p
+              className={cn(
+                "truncate text-muted-foreground",
+                isCompactViewport ? "text-xs leading-5" : "text-[11px]"
+              )}
+            >
               {resolvedBillingStatus?.product_name
                 ? `${resolvedBillingStatus.product_name} Plan`
                 : "Loading plan..."}
             </p>
           </div>
           {signOutError && (
-            <p role="alert" className="mb-2 px-3 text-xs leading-relaxed text-destructive">
+            <p
+              role="alert"
+              className={cn(
+                "mb-2 leading-relaxed text-destructive",
+                isCompactViewport ? "text-sm" : "px-3 text-xs"
+              )}
+            >
               {signOutError}
             </p>
           )}
@@ -768,11 +830,29 @@ function SettingsLayoutContent() {
             onClick={signOut}
             disabled={isNavigationLocked || isSigningOut}
             title="Log out"
-            className="h-10 w-full justify-start px-3 text-muted-foreground hover:text-foreground"
+            className={cn(
+              "w-full justify-start text-muted-foreground hover:text-foreground",
+              isCompactViewport ? "h-11 px-0 text-base" : "h-10 px-3"
+            )}
           >
-            <LogOut className="mr-3 h-4 w-4 shrink-0" />
+            <LogOut
+              className={cn("shrink-0", isCompactViewport ? "mr-2 h-5 w-5" : "mr-3 h-4 w-4")}
+            />
             <span>{isSigningOut ? "Logging out..." : "Log out"}</span>
           </Button>
+          {isCompactViewport && (
+            <Link
+              to="/pricing"
+              className="group/credit-link mt-2 flex min-h-11 min-w-0 rounded-xl outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+              aria-label={
+                resolvedBillingStatus
+                  ? `${resolvedBillingStatus.product_name} plan`
+                  : "Billing status"
+              }
+            >
+              <CreditUsage pagePresentation />
+            </Link>
+          )}
         </div>
       </aside>
 
@@ -792,18 +872,18 @@ function SettingsLayoutContent() {
         style={isSettingsDetailSwipeActive ? settingsDetailSwipeStyle : undefined}
       >
         {isCompactViewport && (
-          <div className="maple-mobile-settings-sticky-header sticky top-0 z-30 flex h-14 items-center gap-3 border-b border-border/50 bg-background/95 px-3 backdrop-blur supports-[backdrop-filter]:bg-background/80">
+          <div className="maple-mobile-settings-sticky-header sticky top-0 z-30 flex h-16 items-center gap-2 border-b border-border/50 bg-background/95 px-5 backdrop-blur supports-[backdrop-filter]:bg-background/80">
             <button
               ref={detailBackButtonRef}
               type="button"
               onClick={() => void showSettingsMenu()}
               disabled={isNavigationLocked || isPopping || isSettingsDetailSwipeActive}
-              className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              className="flex h-11 w-11 shrink-0 items-center justify-center rounded-lg text-foreground transition-colors hover:bg-muted disabled:cursor-not-allowed disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
               aria-label="Back to settings"
             >
               <ArrowLeft className="h-5 w-5" />
             </button>
-            <p className="text-sm font-semibold">Settings</p>
+            <p className="text-base font-semibold">Settings</p>
           </div>
         )}
         <Outlet />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -406,7 +406,7 @@
     height: 100%;
   }
 
-  html.maple-native-ios-compact-viewport .maple-mobile-menu-footer {
+  html.maple-native-ios-compact-viewport .maple-mobile-settings-account-footer {
     padding-bottom: 1rem;
   }
 


### PR DESCRIPTION
## Summary

- move the compact main-menu Settings control into the header and let chat history own the remaining scrollable height
- align compact Settings typography, spacing, touch targets, and header chrome with the shared mobile menu while leaving desktop presentation unchanged
- move the shared Usage meter below Log out in the compact Settings account area, preserving safe-area clearance and independent option-list scrolling

## Validation

- nix develop .#ci -c ./scripts/ci/frontend.sh — passed: formatting, typecheck, lint (0 errors; 13 existing warnings), and 726 tests across 83 files
- nix develop .#ci -c ./scripts/ci/web.sh — passed
- pre-commit checks — passed: formatting, build, and 726 tests
- git diff --check — passed

Authenticated browser layout and physical iPhone safe-area/gesture smoke remain before this draft is ready for review; the frontend-only workspace has no fixture backend/account.

Depends on #618
Closes #783