### PR TITLE
docs: add CUA targeting for macOS Open/Save panels

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -192,7 +192,7 @@ the changed boundary and classify it by behavior, not file path:
 For changes requiring full lifecycle coverage, continue through the remaining
 baseline:
 
-4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task.
+4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task. CUA only: the folder picker is not a Maple window — see `$validate-maple` **CUA only: macOS Open/Save**.
 5. Send: `Read README.md using the read tool. Reply only with the exact marker. Do not use shell.` Confirm the visible user row, tool activity, exact marker result, final answer, and completed terminal state.
 6. Send: `Create agent-smoke-output.txt containing exactly <marker> using the write tool. Do not use shell.` Confirm a single pending permission card. Choose `Deny once`; verify the card settles as denied, the run terminates coherently, and the file does not exist.
 7. Repeat the write request and choose `Allow once`. Verify one settled permission card, exact on-disk contents, a visible tool result, final answer, and completed state. Do not use `Allow all` merely to make the smoke easier.

--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -192,7 +192,7 @@ the changed boundary and classify it by behavior, not file path:
 For changes requiring full lifecycle coverage, continue through the remaining
 baseline:
 
-4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task. CUA only: the folder picker is not a Maple window — see `$validate-maple` **CUA only: macOS Open/Save**.
+4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task. CUA only: the native picker is not a Maple window — see `$validate-maple` **CUA only: macOS Open/Save**.
 5. Send: `Read README.md using the read tool. Reply only with the exact marker. Do not use shell.` Confirm the visible user row, tool activity, exact marker result, final answer, and completed terminal state.
 6. Send: `Create agent-smoke-output.txt containing exactly <marker> using the write tool. Do not use shell.` Confirm a single pending permission card. Choose `Deny once`; verify the card settles as denied, the run terminates coherently, and the file does not exist.
 7. Repeat the write request and choose `Allow once`. Verify one settled permission card, exact on-disk contents, a visible tool result, final answer, and completed state. Do not use `Allow all` merely to make the smoke easier.

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -305,6 +305,29 @@ Choose only scenarios relevant to the change, but cross every changed boundary.
 - Verify cold start and already-running behavior where relevant.
 - Exercise real dialogs, filesystem access, keyring, updater, microphone, and packaged resources on each affected platform.
 
+### CUA only: macOS Open/Save
+
+Skip unless you drive the GUI with cua-driver (pid + `window_id`). Codex
+computer use and other full-desktop screenshot drivers should ignore this.
+
+On macOS, Maple's Open/Save sheet is hosted by **Open and Save Panel
+Service** (`com.apple.appkit.xpc.openAndSavePanelService`), not Maple and
+not Finder. After the picker appears, `list_windows` with no pid filter
+and take the panel-service window whose title is `Open` or `Save` and
+whose bounds match Maple's new stub.
+
+Do not act on Maple's `Open`/`Save` window: its AX is empty, background
+pixels fail `off_space_or_ax_unresolved`, and Maple-pid clicks (including
+a correct foreground crosshair) do not change the sheet. Sheet AX on the
+Maple parent is observation-only; presses return
+`element_outside_target_window`.
+
+Act on the panel-service pid/`window_id` (`foreground` pixels). That
+window may be `is_on_screen: false` and screenshot black. Confirm on
+Maple (`Where:`, then Trust/PROJECTS). Do not escalate the CUA session to
+desktop because Maple's stub refused input. After Open, Trust and the
+rest of the UI are Maple AX again.
+
 ## Report evidence without inflation
 
 Write the handoff in five buckets:

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -310,11 +310,13 @@ Choose only scenarios relevant to the change, but cross every changed boundary.
 Skip unless you drive the GUI with cua-driver (pid + `window_id`). Codex
 computer use and other full-desktop screenshot drivers should ignore this.
 
-On macOS, Maple's Open/Save sheet is hosted by **Open and Save Panel
-Service** (`com.apple.appkit.xpc.openAndSavePanelService`), not Maple and
-not Finder. After the picker appears, `list_windows` with no pid filter
-and take the panel-service window whose title is `Open` or `Save` and
-whose bounds match Maple's new stub.
+On macOS every Maple native file or folder picker — Agent project folder,
+chat photo/document upload, Save, and any other Tauri `dialog` — is hosted
+by **Open and Save Panel Service**
+(`com.apple.appkit.xpc.openAndSavePanelService`), not Maple and not Finder.
+After the picker appears, `list_windows` with no pid filter and take the
+panel-service window whose title is `Open` or `Save` and whose bounds
+match Maple's new stub.
 
 Do not act on Maple's `Open`/`Save` window: its AX is empty, background
 pixels fail `off_space_or_ax_unresolved`, and Maple-pid clicks (including
@@ -324,9 +326,10 @@ Maple parent is observation-only; presses return
 
 Act on the panel-service pid/`window_id` (`foreground` pixels). That
 window may be `is_on_screen: false` and screenshot black. Confirm on
-Maple (`Where:`, then Trust/PROJECTS). Do not escalate the CUA session to
-desktop because Maple's stub refused input. After Open, Trust and the
-rest of the UI are Maple AX again.
+Maple (`Where:` / selected name, then the product result: Trust/PROJECTS
+for an Agent folder, or the composer attachment for an upload). Do not
+escalate the CUA session to desktop because Maple's stub refused input.
+After the panel closes, Maple web AX is the target again.
 
 ## Report evidence without inflation
 


### PR DESCRIPTION
## Summary

Adds a skippable **CUA only** note so cua-driver agents can complete Maple native folder/file pickers. No new skill.

Codex computer use and other full-desktop screenshot drivers should ignore the subsection. CUA is pid/window-scoped, so Maple's `Open`/`Save` stub is the wrong target.

## What CUA agents need

On macOS the sheet is hosted by **Open and Save Panel Service**, not Maple and not Finder. Act on that pid/window (`foreground` pixels), even if it reports off-screen or screenshots black. Confirm on Maple (`Where:`, Trust, PROJECTS). Do not escalate the CUA session to desktop because Maple's stub refused input.

`$change-maple-agent-mode` step 4 points at the same subsection for project-folder selection.

## Test plan

- [ ] Docs-only. No product behavior change.
- [ ] CUA agent: open Add project folder, select a folder via the panel-service window, see Trust/PROJECTS update.
- [ ] Non-CUA / Codex computer-use readers can skip the new heading.