### PR TITLE
fix(agent): retry transient inference failures for ~3 minutes

### DIFF
--- a/frontend/src-tauri/src/agent/provider.rs
+++ b/frontend/src-tauri/src/agent/provider.rs
@@ -11,7 +11,10 @@ use goose_providers::http_status::is_context_length_exceeded_message;
 use goose_providers::images::ImageFormat;
 use goose_providers::model::ModelConfig;
 use goose_providers::request_log::{start_log, LoggerHandleExt};
-use goose_providers::retry::{should_retry, RetryConfig};
+use goose_providers::retry::{
+    should_retry, RetryConfig, DEFAULT_BACKOFF_MULTIPLIER, DEFAULT_INITIAL_RETRY_INTERVAL_MS,
+    DEFAULT_MAX_RETRY_INTERVAL_MS,
+};
 use opensecret::{InferenceRequest, InferenceResponse, OpenSecretClient, OpenSecretResponseBody};
 use rmcp::model::Tool;
 use serde_json::{json, Value};
@@ -24,6 +27,9 @@ use tokio_util::sync::CancellationToken;
 
 const CHAT_COMPLETIONS_PATH: &str = "/v1/chat/completions";
 pub(super) const MAPLE_PROVIDER_NAME: &str = "maple";
+/// Extra transient inference attempts after the first failure. Goose's 1s × 2^n
+/// backoff, capped at 30s, then covers roughly three minutes of provider blips.
+const TRANSIENT_MAX_RETRIES: usize = 10;
 const KIMI_K3_MODEL_ID: &str = "kimi-k3";
 // Agent Mode forwards the selected catalog ID unchanged for direct model
 // selections. Keep Gemma's provider-specific opt-in scoped to that explicit
@@ -450,7 +456,13 @@ impl Provider for MapleProvider {
         // Retrying deterministic client failures can repeat side effects and
         // causes the SDK to repeat its own stale-session recovery for a 400. One
         // shared transient budget covers both setup and pre-first-item failures.
-        RetryConfig::default().transient_only()
+        RetryConfig::new(
+            TRANSIENT_MAX_RETRIES,
+            DEFAULT_INITIAL_RETRY_INTERVAL_MS,
+            DEFAULT_BACKOFF_MULTIPLIER,
+            DEFAULT_MAX_RETRY_INTERVAL_MS,
+        )
+        .transient_only()
     }
 
     async fn stream(
@@ -1582,20 +1594,20 @@ mod tests {
 
     #[tokio::test]
     async fn shares_one_retry_budget_across_status_and_first_item_failures() {
-        let transport = Arc::new(FakeTransport::queued(vec![
-            response(
-                503,
-                vec![br#"{"error":{"message":"temporarily unavailable"}}"#.to_vec()],
-                None,
-            ),
-            malformed_response("invalid-stream-1"),
-            malformed_response("invalid-stream-2"),
-            malformed_response("invalid-stream-3"),
-            fragmented_success_response(),
-        ]));
+        let mut responses = vec![response(
+            503,
+            vec![br#"{"error":{"message":"temporarily unavailable"}}"#.to_vec()],
+            None,
+        )];
+        responses.extend(
+            (0..TRANSIENT_MAX_RETRIES)
+                .map(|index| malformed_response(&format!("invalid-stream-{index}"))),
+        );
+        responses.push(fragmented_success_response());
+        let transport = Arc::new(FakeTransport::queued(responses));
         let provider = MapleProvider::new(Arc::clone(&transport));
         let default_max_retries = Provider::retry_config(&provider).max_retries();
-        assert_eq!(default_max_retries, 3);
+        assert_eq!(default_max_retries, TRANSIENT_MAX_RETRIES);
         let provider = provider.with_test_retry_config(fast_retry_config(default_max_retries));
 
         let result = provider
@@ -1615,7 +1627,7 @@ mod tests {
             error,
             ProviderError::NetworkError("Maple's response stream was invalid".to_string())
         );
-        assert_eq!(transport.request_count(), 4);
+        assert_eq!(transport.request_count(), TRANSIENT_MAX_RETRIES + 1);
         assert_eq!(transport.remaining_response_count(), 1);
     }
 


### PR DESCRIPTION
## Summary

- raise Maple Agent Mode's transient inference retry budget from Goose's default **3** extra attempts (~7s) to **10** (~3 minutes)
- keep the existing 1s × 2 backoff, 30s cap, `transient_only` policy, and Cancel-interrupts-backoff behavior
- do not retry deterministic 4xx / client failures, and do not retry after the first successful streamed item

A glm-5-2 500 from OpenSecret/Tinfoil already exhausted the old 4-call / ~7s budget as four immediate `http_status_500` lines, then surfaced `Server error: Maple's server returned status 500`. Long autonomous Agent runs should survive a short provider brownout. No UI attempt counter in this PR; Cancel remains the escape hatch.

## Behavior and scope

- change is confined to `MapleProvider::retry_config()` and the shared-budget unit test
- no Goose fork, no Goose pin bump, no frontend or permission changes
- after this lands, a 500 before the first streamed item can take up to ~3 minutes of silent retry while the run stays active and Cancel stays available

## Validation

- `cargo test --locked "agent::provider::tests::"`: 30 passed
- pre-commit hook ran Prettier, the frontend production build, TypeScript, and the locked Rust suite: **313 passed**, 0 failed, 2 ignored
- not run: native desktop smoke of a live 3-minute 500 streak (we have not reproduced one since local OpenSecret logging was fixed)