### PR TITLE
chore: disable Tauri file watcher on local justfile dev

### DIFF
--- a/justfile
+++ b/justfile
@@ -23,17 +23,17 @@ format:
 lint:
     cd frontend && bun run lint
 
-# Run Tauri iOS development build (default simulator)
+# Run Tauri iOS development build (default simulator) without the Rust file watcher
 ios-dev:
-    cd frontend && bun run tauri ios dev
+    cd frontend && bun run tauri ios dev --no-watch
 
 # Run Tauri iOS development build on specific simulator (e.g., "iPhone 16 Pro iOS 26")
 ios-dev-sim simulator:
-    cd frontend && bun run tauri ios dev '{{simulator}}'
+    cd frontend && bun run tauri ios dev --no-watch '{{simulator}}'
 
 # Run Tauri iOS development build on physical device (e.g., "Your iPhone")
 ios-dev-device device:
-    cd frontend && bun run tauri ios dev --device '{{device}}'
+    cd frontend && bun run tauri ios dev --no-watch --device '{{device}}'
 
 # Build and verify ONNX Runtime for iOS (device + simulator) - used by PDF OCR
 ios-build-onnxruntime:
@@ -64,9 +64,9 @@ android-build:
 desktop-build:
     cd frontend && src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri build
 
-# Run Tauri desktop development build, using workspace-local config when available
+# Run Tauri desktop development build without the Rust file watcher, using workspace-local config when available
 desktop-dev:
-    cd frontend && if [ -f ../.local/tauri-workspace.json ]; then src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri dev --config ../.local/tauri-workspace.json; else src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri dev; fi
+    cd frontend && if [ -f ../.local/tauri-workspace.json ]; then src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri dev --no-watch --config ../.local/tauri-workspace.json; else src-tauri/scripts/run-with-desktop-onnxruntime.sh bun tauri dev --no-watch; fi
 
 # Build Tauri desktop debug
 desktop-build-debug:


### PR DESCRIPTION
## Summary
Local `just desktop-dev` / `just ios-dev*` recipes now pass `--no-watch` to Tauri.

`tauri dev` watches `src-tauri` and rebuilds the native process on every save. That rebuild often runs `cargo` outside the Nix PATH and kills the desktop-dev session. We do not want that watcher on local debug builds.

Vite HMR is unchanged (`beforeDevCommand` is still `bun dev`). Restart `just desktop-dev` to pick up a Rust change.

## Test plan
- [x] `just --list` still parses the recipes
- [x] `@tauri-apps/cli` 2.11 accepts `--no-watch` on both `tauri dev` and `tauri ios dev`
- [ ] `just desktop-dev` starts and no longer restarts on a `src-tauri` save