### PR TITLE
feat(agent): steer a queued follow-up into the current turn

### DIFF
--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -125,7 +125,7 @@ The refactor exposes a transport-neutral Maple service around the existing embed
 - ensure the account-scoped runtime exists;
 - create and delete a Maple task;
 - send and cancel a run;
-- stage a Desktop follow-up onto Maple's per-task FIFO and promote it with a later sequential `Agent::reply` on the same outer run; Stop cancels only the live Goose turn and leaves staged chips; X drops a chip; pencil edits a chip in place; an open edit holds leftover promotion until save or discard; Discard leaves that chip unchanged; a later Send flushes leftover chips plus any composer draft;
+- stage a Desktop follow-up onto Maple's per-task FIFO and promote it with a later sequential `Agent::reply` on the same outer run; Stop cancels only the live Goose turn and leaves staged chips; X drops a chip; pencil edits a chip in place; an open edit holds leftover promotion until save or discard; Discard leaves that chip unchanged; a chip up-arrow or Command/Control-Enter steers one follow-up into the current Goose turn; a later Send flushes leftover chips plus any composer draft;
 - keep Desktop Stop from racing a follow-up send: in-flight composer sends are cancelled, and Send stays locked until the cancelled run settles;
 - consume an isolated, bounded event stream for one exact run;
 - receive typed permission requests and resolve them through an opaque responder bound to that exact account, task, and run;

--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -125,7 +125,7 @@ The refactor exposes a transport-neutral Maple service around the existing embed
 - ensure the account-scoped runtime exists;
 - create and delete a Maple task;
 - send and cancel a run;
-- stage a Desktop follow-up onto Maple's per-task FIFO and promote it with a later sequential `Agent::reply` on the same outer run; Stop cancels only the live Goose turn and leaves staged chips; X drops a chip; pencil edits a chip in place; an open edit holds leftover promotion until save or discard; Discard leaves that chip unchanged; a chip up-arrow or Command/Control-Enter steers one follow-up into the current Goose turn; a later Send flushes leftover chips plus any composer draft;
+- stage a Desktop follow-up onto Maple's per-task FIFO and promote it with a later sequential `Agent::reply` on the same outer run; Stop cancels only the live Goose turn and leaves staged chips; X drops a chip; pencil edits a chip in place; an open edit holds leftover promotion until save or discard; Discard leaves that chip unchanged; a chip up-arrow steers that one follow-up into the current Goose turn; Command/Control-Enter steers a composer draft, or the whole leftover chip stack when the composer is empty; a later Send flushes leftover chips plus any composer draft;
 - keep Desktop Stop from racing a follow-up send: in-flight composer sends are cancelled, and Send stays locked until the cancelled run settles;
 - consume an isolated, bounded event stream for one exact run;
 - receive typed permission requests and resolve them through an opaque responder bound to that exact account, task, and run;

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -3739,6 +3739,17 @@ impl AgentRuntimeHandle {
             // agent_cancel_run. Whichever side acquires it first owns the terminal
             // result, so Stop cannot succeed against an already-settled run.
             task_accepting_queue.store(false, Ordering::Release);
+            // Stop already ran this pair (mem::take makes a second persist a
+            // no-op). Natural completion and provider errors must do the same
+            // so a steer Goose never drained is not dropped or leaked into
+            // the next reply on this pooled session agent.
+            persist_unacked_steers(
+                task_session_manager.as_ref(),
+                &session_id,
+                &task_steered_unacked,
+            )
+            .await;
+            task_agent.discard_pending_steers(&session_id).await;
             let run_was_cancelled = !should_run || task_cancel_token.is_cancelled();
             let terminal_permissions = cancel_pending_permissions_for_runs(
                 &task_pending_permissions,
@@ -4087,13 +4098,7 @@ impl AgentRuntimeHandle {
         let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
         self.verify_generation().await?;
         let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-        begin_desktop_queue_edit(
-            state,
-            account_scope,
-            &request.session_id,
-            &request.queue_id,
-        )
-        .await
+        begin_desktop_queue_edit(state, account_scope, &request.session_id, &request.queue_id).await
     }
 
     pub(crate) async fn end_queued_message_edit(
@@ -4105,13 +4110,7 @@ impl AgentRuntimeHandle {
         let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
         self.verify_generation().await?;
         let _session_lifecycle_guard = state.session_lifecycle.lock().await;
-        end_desktop_queue_edit(
-            state,
-            account_scope,
-            &request.session_id,
-            &request.queue_id,
-        )
-        .await
+        end_desktop_queue_edit(state, account_scope, &request.session_id, &request.queue_id).await
     }
 
     pub(crate) async fn cancel_desktop_run(&self, run_id: String) -> Result<(), String> {
@@ -7729,12 +7728,16 @@ async fn take_desktop_steer_plan(
             update_desktop_queue_item(state, account_scope, &request.session_id, queue_id, text)
                 .await?;
         }
-        let (removed, snapshot) =
-            remove_desktop_queue_item(state, account_scope, &request.session_id, queue_id).await?;
+        let snapshot = snapshot_desktop_queue(state, account_scope, &request.session_id).await;
+        let selected = snapshot
+            .items
+            .iter()
+            .find(|item| item.queue_id == queue_id)
+            .ok_or_else(|| "Queued Agent message has already been sent".to_string())?;
         return Ok(DesktopSendPlan::Start {
-            launch_messages: vec![queued_user_message(&removed)],
+            launch_messages: vec![queued_user_message(selected)],
+            consume_queue_ids: vec![queue_id.to_string()],
             queue: snapshot,
-            consume_queue_ids: Vec::new(),
         });
     }
 
@@ -7772,10 +7775,7 @@ async fn steer_into_desktop_run(
     };
     agent.steer(session_id, message.clone()).await;
     steered_unacked.lock().await.push(message.clone());
-    if let Some(mut item) = message_to_timeline_items(message, false)
-        .into_iter()
-        .next()
-    {
+    if let Some(mut item) = message_to_timeline_items(message, false).into_iter().next() {
         // Keep the pending-assistant loader off until Goose starts the next
         // turn. This row is already in the live loop but not yet picked up.
         item.status = Some("steered".to_string());
@@ -7810,7 +7810,37 @@ async fn persist_unacked_steers(
         let mut steered_unacked = steered_unacked.lock().await;
         std::mem::take(&mut *steered_unacked)
     };
+    if pending.is_empty() {
+        return;
+    }
+    let already_persisted: HashSet<String> =
+        match session_manager.get_session(session_id, true).await {
+            Ok(session) => session
+                .conversation
+                .as_ref()
+                .map(|conversation| {
+                    conversation
+                        .messages()
+                        .iter()
+                        .filter_map(|message| message.id.clone())
+                        .collect()
+                })
+                .unwrap_or_default(),
+            Err(error) => {
+                log::warn!(
+                    "Failed to inspect session before persisting steered Agent messages: {error}"
+                );
+                HashSet::new()
+            }
+        };
     for message in pending {
+        if message
+            .id
+            .as_deref()
+            .is_some_and(|message_id| already_persisted.contains(message_id))
+        {
+            continue;
+        }
         if let Err(error) = session_manager.add_message(session_id, &message).await {
             log::warn!("Failed to persist steered Agent message: {error}");
         }
@@ -8910,10 +8940,7 @@ mod tests {
                 .iter()
                 .map(|message| message.as_concat_text())
                 .collect::<Vec<_>>(),
-            vec![
-                "keep me queued".to_string(),
-                "draft after stop".to_string()
-            ]
+            vec!["keep me queued".to_string(), "draft after stop".to_string()]
         );
         assert_eq!(
             launch
@@ -9241,7 +9268,7 @@ mod tests {
                 mode: None,
                 vision_capable: false,
                 steer: true,
-                queue_id: Some(first_id),
+                queue_id: Some(first_id.clone()),
             },
             "",
         )
@@ -9260,18 +9287,71 @@ mod tests {
                         .collect::<Vec<_>>(),
                     vec!["first".to_string()]
                 );
-                assert!(consume_queue_ids.is_empty());
+                assert_eq!(consume_queue_ids, vec![first_id]);
                 assert_eq!(
                     queue
                         .items
                         .iter()
                         .map(|item| item.text.as_str())
                         .collect::<Vec<_>>(),
-                    vec!["second"]
+                    vec!["first", "second"]
                 );
             }
             _ => panic!("idle chip steer should start a single-message run"),
         }
+
+        let _ = fs::remove_dir_all(test_root);
+    }
+
+    #[tokio::test]
+    async fn persist_unacked_steers_skips_messages_already_in_history() {
+        let sink = Arc::new(RecordingAgentEventSink::default());
+        let (test_root, paths, _state) =
+            agent_service_test_context("persist-unacked-steers-skip", sink);
+        let user_id = "persist-unacked-steers-skip-user";
+        let project_root = test_root.join("project");
+        fs::create_dir_all(&project_root).unwrap();
+        let session_manager = account_session_manager(&paths, user_id).unwrap();
+        let session = session_manager
+            .create_session(
+                project_root,
+                "Steer persist skip".to_string(),
+                SessionType::User,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let already = Message::user()
+            .with_text("already persisted")
+            .with_id("steer-already");
+        let fresh = Message::user()
+            .with_text("fresh steer")
+            .with_id("steer-fresh");
+        session_manager
+            .add_message(&session.id, &already)
+            .await
+            .unwrap();
+        persist_unacked_steers(
+            session_manager.as_ref(),
+            &session.id,
+            &Mutex::new(vec![already.clone(), fresh.clone()]),
+        )
+        .await;
+        let loaded = session_manager
+            .get_session(&session.id, true)
+            .await
+            .unwrap();
+        let ids = loaded
+            .conversation
+            .expect("session conversation")
+            .messages()
+            .iter()
+            .filter_map(|message| message.id.clone())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            ids,
+            vec!["steer-already".to_string(), "steer-fresh".to_string()]
+        );
 
         let _ = fs::remove_dir_all(test_root);
     }

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -7637,7 +7637,7 @@ async fn take_desktop_steer_plan(
     if let Some(run_id) =
         desktop_run_id_for_session(state, account_scope, &request.session_id).await?
     {
-        let (message, snapshot) = if let Some(queue_id) = request.queue_id.as_deref() {
+        if let Some(queue_id) = request.queue_id.as_deref() {
             if !text.is_empty() {
                 update_desktop_queue_item(
                     state,
@@ -7658,20 +7658,66 @@ async fn take_desktop_steer_plan(
                 snapshot.clone(),
             )
             .await;
-            (queued_user_message(&removed), snapshot)
-        } else {
-            if text.is_empty() {
-                return Err("Prompt cannot be empty".to_string());
-            }
-            if text.len() > MAX_DESKTOP_QUEUE_TEXT_BYTES {
-                return Err("Queued Agent message is too large".to_string());
-            }
-            (
-                user_message_from_prompt(text),
-                snapshot_desktop_queue(state, account_scope, &request.session_id).await,
+            steer_into_desktop_run(
+                state,
+                account_scope,
+                &request.session_id,
+                &queued_user_message(&removed),
             )
-        };
-        steer_into_desktop_run(state, account_scope, &request.session_id, &message).await?;
+            .await?;
+            return Ok(DesktopSendPlan::Steered {
+                run_id,
+                queue: snapshot,
+            });
+        }
+        if text.is_empty() {
+            let Some((items, snapshot)) = take_all_desktop_queue_items_from_map(
+                &state.desktop_queues,
+                account_scope,
+                &request.session_id,
+            )
+            .await
+            else {
+                let leftover =
+                    snapshot_desktop_queue(state, account_scope, &request.session_id).await;
+                return Err(if leftover.items.is_empty() {
+                    "Prompt cannot be empty".to_string()
+                } else {
+                    "Queued messages cannot be steered while one is being edited".to_string()
+                });
+            };
+            publish_desktop_queue_changed(
+                state,
+                account_scope,
+                &request.session_id,
+                snapshot.clone(),
+            )
+            .await;
+            for item in &items {
+                steer_into_desktop_run(
+                    state,
+                    account_scope,
+                    &request.session_id,
+                    &queued_user_message(item),
+                )
+                .await?;
+            }
+            return Ok(DesktopSendPlan::Steered {
+                run_id,
+                queue: snapshot,
+            });
+        }
+        if text.len() > MAX_DESKTOP_QUEUE_TEXT_BYTES {
+            return Err("Queued Agent message is too large".to_string());
+        }
+        let snapshot = snapshot_desktop_queue(state, account_scope, &request.session_id).await;
+        steer_into_desktop_run(
+            state,
+            account_scope,
+            &request.session_id,
+            &user_message_from_prompt(text),
+        )
+        .await?;
         return Ok(DesktopSendPlan::Steered {
             run_id,
             queue: snapshot,
@@ -9226,6 +9272,191 @@ mod tests {
             }
             _ => panic!("idle chip steer should start a single-message run"),
         }
+
+        let _ = fs::remove_dir_all(test_root);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn desktop_empty_steer_sends_the_whole_leftover_stack() {
+        let sink = Arc::new(RecordingAgentEventSink::default());
+        let (test_root, paths, state) =
+            agent_service_test_context("desktop-steer-empty-stack", sink.clone());
+        let user_id = "desktop-steer-empty-stack-user";
+        let account_scope = account_scope(user_id).unwrap();
+        let project_root = test_root.join("project");
+        fs::create_dir_all(&project_root).unwrap();
+        let session_manager = Arc::new(account_session_manager(&paths, user_id).unwrap());
+        let permission_manager = Arc::new(PermissionManager::new(test_root.join("permissions")));
+        let session = session_manager
+            .create_session(
+                project_root.clone(),
+                "Steer stack task".to_string(),
+                SessionType::User,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let agent = Arc::new(Agent::with_config(GooseAgentConfig::new(
+            Arc::clone(&session_manager),
+            Arc::clone(&permission_manager),
+            None,
+            GooseMode::SmartApprove,
+            true,
+            GoosePlatform::GooseDesktop,
+        )));
+        let agent_manager = Arc::new(
+            AgentManager::new(
+                GooseAgentConfig::new(
+                    Arc::clone(&session_manager),
+                    permission_manager,
+                    None,
+                    GooseMode::SmartApprove,
+                    true,
+                    GoosePlatform::GooseDesktop,
+                ),
+                Some(2),
+            )
+            .await
+            .unwrap(),
+        );
+        let (run_events, _run_events_rx) = AgentRunEventPublisher::new(
+            AgentEventDispatcher::new(sink.clone()),
+            session.id.clone(),
+            "desktop-steer-empty-stack-run".to_string(),
+            AgentHostEventPolicy::Suppress,
+        );
+        let steered_unacked = Arc::new(Mutex::new(Vec::new()));
+        *state.inner.lock().await = Some(AgentRuntime {
+            agent_manager,
+            session_manager: Arc::clone(&session_manager),
+            maple_api_session: crate::maple_api::test_maple_api_session(user_id),
+            active_runs: HashMap::from([(
+                "desktop-steer-empty-stack-run".to_string(),
+                ActiveAgentRun {
+                    agent,
+                    permission_routing: AgentPermissionRouting::Desktop,
+                    token: CancellationToken::new(),
+                    tool_context: SharedAgentToolContext::new(AgentToolContextSpec::default()),
+                    session_id: session.id.clone(),
+                    events: run_events,
+                    cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
+                    accepting_queue: Arc::new(AtomicBool::new(true)),
+                    steered_unacked: Arc::clone(&steered_unacked),
+                    task_handle: tokio::spawn(async {}),
+                },
+            )]),
+            session_title_tasks: HashMap::new(),
+            session_tool_contexts: HashMap::new(),
+            permission_modes: Arc::new(Mutex::new(HashMap::new())),
+            web_tool_state: Arc::new(WebToolState::default()),
+            project_root,
+            model: DEFAULT_AGENT_MODEL.to_string(),
+            mode: DEFAULT_GOOSE_MODE.to_string(),
+            account_scope: account_scope.clone(),
+        });
+
+        let handle = state.handle_for_user(user_id).await.unwrap();
+        let empty_error = match handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: String::new(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: true,
+                queue_id: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("empty steer without chips should fail"),
+            Err(error) => error,
+        };
+        assert_eq!(empty_error, "Prompt cannot be empty");
+
+        handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: "first leftover".to_string(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: false,
+                queue_id: None,
+            })
+            .await
+            .unwrap();
+        handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: "second leftover".to_string(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: false,
+                queue_id: None,
+            })
+            .await
+            .unwrap();
+        let first_id = snapshot_desktop_queue(&state, &account_scope, &session.id)
+            .await
+            .items[0]
+            .queue_id
+            .clone();
+        begin_desktop_queue_edit(&state, &account_scope, &session.id, &first_id)
+            .await
+            .unwrap();
+        let held_error = match handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: String::new(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: true,
+                queue_id: None,
+            })
+            .await
+        {
+            Ok(_) => panic!("empty steer should hold while a chip is being edited"),
+            Err(error) => error,
+        };
+        assert_eq!(
+            held_error,
+            "Queued messages cannot be steered while one is being edited"
+        );
+        end_desktop_queue_edit(&state, &account_scope, &session.id, &first_id)
+            .await
+            .unwrap();
+
+        let steered = handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: String::new(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: true,
+                queue_id: None,
+            })
+            .await
+            .unwrap();
+        assert_eq!(steered.run_id, "desktop-steer-empty-stack-run");
+        assert!(steered.queued.is_none());
+        assert!(steered.queue.items.is_empty());
+        assert_eq!(
+            steered_unacked
+                .lock()
+                .await
+                .iter()
+                .map(|message| message.as_concat_text())
+                .collect::<Vec<_>>(),
+            vec!["first leftover".to_string(), "second leftover".to_string()]
+        );
 
         let _ = fs::remove_dir_all(test_root);
     }

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -308,6 +308,10 @@ pub struct AgentSendMessageRequest {
     pub mode: Option<String>,
     #[serde(default)]
     pub vision_capable: bool,
+    #[serde(default)]
+    pub steer: bool,
+    #[serde(default)]
+    pub queue_id: Option<String>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -655,6 +659,7 @@ struct ActiveAgentRun {
     events: AgentRunEventPublisher,
     cancelled_permission_ids: CancelledPermissionIds,
     accepting_queue: Arc<AtomicBool>,
+    steered_unacked: Arc<Mutex<Vec<Message>>>,
     task_handle: tokio::task::JoinHandle<()>,
 }
 
@@ -3225,6 +3230,9 @@ impl AgentRuntimeHandle {
                     } => {
                         return Ok(staged_run_handle(run_id, queued, queue));
                     }
+                    DesktopSendPlan::Steered { run_id, queue } => {
+                        return Ok(steered_run_handle(run_id, queue));
+                    }
                     DesktopSendPlan::Start {
                         launch_messages,
                         queue,
@@ -3507,6 +3515,8 @@ impl AgentRuntimeHandle {
         let cancelled_permission_ids = Arc::new(Mutex::new(HashSet::new()));
         let task_cancelled_permission_ids = Arc::clone(&cancelled_permission_ids);
         let accepting_queue = Arc::new(AtomicBool::new(true));
+        let steered_unacked = Arc::new(Mutex::new(Vec::new()));
+        let task_steered_unacked = Arc::clone(&steered_unacked);
         let task_accepting_queue = Arc::clone(&accepting_queue);
         let task_desktop_queues = Arc::clone(&state.desktop_queues);
         let task_account_scope = account_scope.to_string();
@@ -3638,6 +3648,7 @@ impl AgentRuntimeHandle {
                             cancelled_permission_ids: Arc::clone(&task_cancelled_permission_ids),
                             run_id: task_run_id.clone(),
                             permission_routing,
+                            steered_unacked: Arc::clone(&task_steered_unacked),
                         }),
                     )
                     .await;
@@ -3849,6 +3860,7 @@ impl AgentRuntimeHandle {
                                 events: run_events.clone(),
                                 cancelled_permission_ids: Arc::clone(&cancelled_permission_ids),
                                 accepting_queue: Arc::clone(&accepting_queue),
+                                steered_unacked: Arc::clone(&steered_unacked),
                                 task_handle: task.take().expect("task handle must be available"),
                             },
                         );
@@ -3977,6 +3989,9 @@ impl AgentRuntimeHandle {
         let account_scope = self.account_scope.as_ref();
         reject_foreign_surface_session(state, account_scope, &request.session_id).await?;
         let text = request.text.trim();
+        if request.steer {
+            return take_desktop_steer_plan(state, account_scope, request, text).await;
+        }
         if let Some(run_id) =
             desktop_run_id_for_session(state, account_scope, &request.session_id).await?
         {
@@ -4120,6 +4135,9 @@ impl AgentRuntimeHandle {
         let _session_lifecycle_guard = state.session_lifecycle.lock().await;
         let (
             agent,
+            session_id,
+            session_manager,
+            steered_unacked,
             cancel_token,
             tool_context,
             run_events,
@@ -4142,6 +4160,9 @@ impl AgentRuntimeHandle {
             )?;
             (
                 Arc::clone(&active_run.agent),
+                active_run.session_id.clone(),
+                Arc::clone(&current.session_manager),
+                Arc::clone(&active_run.steered_unacked),
                 active_run.token.clone(),
                 active_run.tool_context.clone(),
                 active_run.events.clone(),
@@ -4149,6 +4170,8 @@ impl AgentRuntimeHandle {
                 Arc::clone(&active_run.accepting_queue),
             )
         };
+        persist_unacked_steers(session_manager.as_ref(), &session_id, &steered_unacked).await;
+        agent.discard_pending_steers(&session_id).await;
         accepting_queue.store(false, Ordering::Release);
         tool_context.cancel_run(&cancel_token);
         let run_id = run_id.to_string();
@@ -4566,6 +4589,7 @@ struct AgentPromptRun {
     cancelled_permission_ids: CancelledPermissionIds,
     run_id: String,
     permission_routing: AgentPermissionRouting,
+    steered_unacked: Arc<Mutex<Vec<Message>>>,
 }
 
 #[derive(Default)]
@@ -4989,6 +5013,7 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
         cancelled_permission_ids,
         run_id,
         permission_routing,
+        steered_unacked,
     } = run;
     let mut terminal_message = None;
     let session_config = SessionConfig {
@@ -5068,6 +5093,9 @@ async fn run_agent_prompt(run: AgentPromptRun) -> Result<AgentPromptOutcome, Str
                 }
                 // Steered user rows are emitted when queued. Goose later yields
                 // the same complete message; replace it instead of appending.
+                if message_role(&message) == "user" {
+                    ack_steered_message(&steered_unacked, &message).await;
+                }
                 let live = message_role(&message) != "user";
                 let mut items = message_to_timeline_items(&message, live);
                 items.retain(|item| {
@@ -7584,6 +7612,10 @@ enum DesktopSendPlan {
         queued: AgentQueuedMessage,
         queue: AgentDesktopQueueSnapshot,
     },
+    Steered {
+        run_id: String,
+        queue: AgentDesktopQueueSnapshot,
+    },
     Start {
         launch_messages: Vec<Message>,
         queue: AgentDesktopQueueSnapshot,
@@ -7593,6 +7625,165 @@ enum DesktopSendPlan {
 
 fn user_message_from_prompt(text: &str) -> Message {
     Message::user().with_text(text).with_generated_id()
+}
+
+async fn take_desktop_steer_plan(
+    state: &MapleAgentService,
+    account_scope: &str,
+    request: &AgentSendMessageRequest,
+    text: &str,
+) -> Result<DesktopSendPlan, String> {
+    reject_foreign_surface_session(state, account_scope, &request.session_id).await?;
+    if let Some(run_id) =
+        desktop_run_id_for_session(state, account_scope, &request.session_id).await?
+    {
+        let (message, snapshot) = if let Some(queue_id) = request.queue_id.as_deref() {
+            if !text.is_empty() {
+                update_desktop_queue_item(
+                    state,
+                    account_scope,
+                    &request.session_id,
+                    queue_id,
+                    text,
+                )
+                .await?;
+            }
+            let (removed, snapshot) =
+                remove_desktop_queue_item(state, account_scope, &request.session_id, queue_id)
+                    .await?;
+            publish_desktop_queue_changed(
+                state,
+                account_scope,
+                &request.session_id,
+                snapshot.clone(),
+            )
+            .await;
+            (queued_user_message(&removed), snapshot)
+        } else {
+            if text.is_empty() {
+                return Err("Prompt cannot be empty".to_string());
+            }
+            if text.len() > MAX_DESKTOP_QUEUE_TEXT_BYTES {
+                return Err("Queued Agent message is too large".to_string());
+            }
+            (
+                user_message_from_prompt(text),
+                snapshot_desktop_queue(state, account_scope, &request.session_id).await,
+            )
+        };
+        steer_into_desktop_run(state, account_scope, &request.session_id, &message).await?;
+        return Ok(DesktopSendPlan::Steered {
+            run_id,
+            queue: snapshot,
+        });
+    }
+
+    if let Some(queue_id) = request.queue_id.as_deref() {
+        if !text.is_empty() {
+            update_desktop_queue_item(state, account_scope, &request.session_id, queue_id, text)
+                .await?;
+        }
+        let (removed, snapshot) =
+            remove_desktop_queue_item(state, account_scope, &request.session_id, queue_id).await?;
+        return Ok(DesktopSendPlan::Start {
+            launch_messages: vec![queued_user_message(&removed)],
+            queue: snapshot,
+            consume_queue_ids: Vec::new(),
+        });
+    }
+
+    let launch = prepare_desktop_launch(state, account_scope, &request.session_id, text).await?;
+    Ok(DesktopSendPlan::Start {
+        launch_messages: launch.launch_messages,
+        queue: launch.queue,
+        consume_queue_ids: launch.consume_queue_ids,
+    })
+}
+
+async fn steer_into_desktop_run(
+    state: &MapleAgentService,
+    account_scope: &str,
+    session_id: &str,
+    message: &Message,
+) -> Result<(), String> {
+    let (agent, events, permission_routing, steered_unacked) = {
+        let runtime = state.inner.lock().await;
+        let current = runtime
+            .as_ref()
+            .ok_or_else(|| "Agent runtime is not running".to_string())?;
+        ensure_runtime_account(current, account_scope)?;
+        let active_run = current
+            .active_runs
+            .values()
+            .find(|run| run.session_id == session_id && desktop_run_is_stageable(run))
+            .ok_or_else(|| "No active Agent run to steer".to_string())?;
+        (
+            Arc::clone(&active_run.agent),
+            active_run.events.clone(),
+            active_run.permission_routing,
+            Arc::clone(&active_run.steered_unacked),
+        )
+    };
+    agent.steer(session_id, message.clone()).await;
+    steered_unacked.lock().await.push(message.clone());
+    if let Some(mut item) = message_to_timeline_items(message, false)
+        .into_iter()
+        .next()
+    {
+        // Keep the pending-assistant loader off until Goose starts the next
+        // turn. This row is already in the live loop but not yet picked up.
+        item.status = Some("steered".to_string());
+        record_and_emit_timeline_item(
+            &events,
+            &state.live_timelines,
+            session_id,
+            permission_routing,
+            item,
+        )
+        .await;
+    }
+    Ok(())
+}
+
+async fn ack_steered_message(steered_unacked: &Mutex<Vec<Message>>, message: &Message) {
+    let Some(message_id) = message.id.as_deref() else {
+        return;
+    };
+    steered_unacked
+        .lock()
+        .await
+        .retain(|pending| pending.id.as_deref() != Some(message_id));
+}
+
+async fn persist_unacked_steers(
+    session_manager: &SessionManager,
+    session_id: &str,
+    steered_unacked: &Mutex<Vec<Message>>,
+) {
+    let pending = {
+        let mut steered_unacked = steered_unacked.lock().await;
+        std::mem::take(&mut *steered_unacked)
+    };
+    for message in pending {
+        if let Err(error) = session_manager.add_message(session_id, &message).await {
+            log::warn!("Failed to persist steered Agent message: {error}");
+        }
+    }
+}
+
+fn steered_run_handle(run_id: String, queue: AgentDesktopQueueSnapshot) -> AgentRunHandle {
+    let (_events_tx, events) = mpsc::channel(1);
+    let (_terminal_tx, terminal) = watch::channel(None);
+    AgentRunHandle {
+        run_id,
+        events,
+        terminal,
+        event_overflowed: Arc::new(AtomicBool::new(false)),
+        permission_responder: None,
+        cancellation: None,
+        queued: None,
+        queue,
+    }
 }
 
 fn staged_run_handle(
@@ -8485,6 +8676,7 @@ mod tests {
                     events: run_events,
                     cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
                     accepting_queue: Arc::new(AtomicBool::new(true)),
+                    steered_unacked: Arc::new(Mutex::new(Vec::new())),
                     task_handle: tokio::spawn(async {}),
                 },
             )]),
@@ -8519,6 +8711,8 @@ mod tests {
                 context_limit: None,
                 mode: None,
                 vision_capable: false,
+                steer: false,
+                queue_id: None,
             }),
         )
         .await
@@ -8532,6 +8726,8 @@ mod tests {
                 context_limit: None,
                 mode: None,
                 vision_capable: false,
+                steer: false,
+                queue_id: None,
             })
             .await
             .unwrap();
@@ -8595,12 +8791,52 @@ mod tests {
                 context_limit: None,
                 mode: None,
                 vision_capable: false,
+                steer: false,
+                queue_id: None,
             })
             .await
             .unwrap();
         assert_eq!(
             restaged.queued.as_ref().map(|item| item.text.as_str()),
             Some("retry after edit")
+        );
+        let later = handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: "keep me queued".to_string(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: false,
+                queue_id: None,
+            })
+            .await
+            .unwrap();
+        let first_chip = later.queue.items[0].queue_id.clone();
+        let steered = handle
+            .send_message(AgentSendMessageRequest {
+                session_id: session.id.clone(),
+                text: String::new(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: true,
+                queue_id: Some(first_chip),
+            })
+            .await
+            .unwrap();
+        assert_eq!(steered.run_id, "desktop-steer-run");
+        assert!(steered.queued.is_none());
+        assert_eq!(
+            steered
+                .queue
+                .items
+                .iter()
+                .map(|item| item.text.as_str())
+                .collect::<Vec<_>>(),
+            vec!["keep me queued"]
         );
         handle
             .cancel_desktop_run("desktop-steer-run".to_string())
@@ -8614,7 +8850,7 @@ mod tests {
                 .iter()
                 .map(|item| item.text.as_str())
                 .collect::<Vec<_>>(),
-            vec!["retry after edit"],
+            vec!["keep me queued"],
             "Stop must leave staged chips so the user can edit, drop, or send them"
         );
 
@@ -8629,7 +8865,7 @@ mod tests {
                 .map(|message| message.as_concat_text())
                 .collect::<Vec<_>>(),
             vec![
-                "retry after edit".to_string(),
+                "keep me queued".to_string(),
                 "draft after stop".to_string()
             ]
         );
@@ -8640,7 +8876,7 @@ mod tests {
                 .iter()
                 .map(|item| item.text.as_str())
                 .collect::<Vec<_>>(),
-            vec!["retry after edit", "draft after stop"]
+            vec!["keep me queued", "draft after stop"]
         );
         assert_eq!(
             launch.consume_queue_ids,
@@ -8730,6 +8966,7 @@ mod tests {
                     events: run_events,
                     cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
                     accepting_queue: Arc::new(AtomicBool::new(true)),
+                    steered_unacked: Arc::new(Mutex::new(Vec::new())),
                     task_handle: tokio::spawn(async {}),
                 },
             )]),
@@ -8752,6 +8989,8 @@ mod tests {
                 context_limit: None,
                 mode: None,
                 vision_capable: false,
+                steer: false,
+                queue_id: None,
             })
             .await
         {
@@ -8923,6 +9162,70 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec!["kept revised", "also"]
         );
+
+        let _ = fs::remove_dir_all(test_root);
+    }
+
+    #[tokio::test]
+    async fn desktop_steer_of_one_idle_chip_leaves_the_rest_queued() {
+        let sink = Arc::new(RecordingAgentEventSink::default());
+        let (test_root, _paths, state) =
+            agent_service_test_context("desktop-steer-one-idle-chip", sink);
+        let account_scope = account_scope("desktop-steer-one-idle-user").unwrap();
+        let session_id = "session-steer-one-idle";
+        enqueue_desktop_queue_item(&state, &account_scope, session_id, "first")
+            .await
+            .unwrap();
+        enqueue_desktop_queue_item(&state, &account_scope, session_id, "second")
+            .await
+            .unwrap();
+        let first_id = snapshot_desktop_queue(&state, &account_scope, session_id)
+            .await
+            .items[0]
+            .queue_id
+            .clone();
+        let plan = take_desktop_steer_plan(
+            &state,
+            &account_scope,
+            &AgentSendMessageRequest {
+                session_id: session_id.to_string(),
+                text: String::new(),
+                model: None,
+                context_limit: None,
+                mode: None,
+                vision_capable: false,
+                steer: true,
+                queue_id: Some(first_id),
+            },
+            "",
+        )
+        .await
+        .unwrap();
+        match plan {
+            DesktopSendPlan::Start {
+                launch_messages,
+                queue,
+                consume_queue_ids,
+            } => {
+                assert_eq!(
+                    launch_messages
+                        .iter()
+                        .map(|message| message.as_concat_text())
+                        .collect::<Vec<_>>(),
+                    vec!["first".to_string()]
+                );
+                assert!(consume_queue_ids.is_empty());
+                assert_eq!(
+                    queue
+                        .items
+                        .iter()
+                        .map(|item| item.text.as_str())
+                        .collect::<Vec<_>>(),
+                    vec!["second"]
+                );
+            }
+            _ => panic!("idle chip steer should start a single-message run"),
+        }
 
         let _ = fs::remove_dir_all(test_root);
     }
@@ -13359,6 +13662,7 @@ mod tests {
                 cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
                 run_id: "fast-reply-run".to_string(),
                 permission_routing: AgentPermissionRouting::Desktop,
+                steered_unacked: Arc::new(Mutex::new(Vec::new())),
             }),
         )
         .await
@@ -13484,6 +13788,7 @@ mod tests {
             cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
             run_id: "rename-during-run-summary".to_string(),
             permission_routing: AgentPermissionRouting::Desktop,
+            steered_unacked: Arc::new(Mutex::new(Vec::new())),
         }));
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
@@ -13624,6 +13929,7 @@ mod tests {
             cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
             run_id: "reply-poll-session-isolation".to_string(),
             permission_routing: AgentPermissionRouting::Desktop,
+            steered_unacked: Arc::new(Mutex::new(Vec::new())),
         }));
 
         let outcome = tokio::time::timeout(std::time::Duration::from_secs(1), prompt_task)
@@ -13706,6 +14012,7 @@ mod tests {
                     events: run_events,
                     cancelled_permission_ids: Arc::new(Mutex::new(HashSet::new())),
                     accepting_queue: Arc::new(AtomicBool::new(true)),
+                    steered_unacked: Arc::new(Mutex::new(Vec::new())),
                     task_handle: tokio::spawn(async {}),
                 },
             )]),

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -693,6 +693,8 @@ impl AcpConnectionContext {
                     context_limit: None,
                     mode: Some(config.permission_mode.maple_mode().to_string()),
                     vision_capable: false,
+                    steer: false,
+                    queue_id: None,
                 },
                 tool_context_access,
                 prompt_lifetime.clone(),

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -156,6 +156,7 @@ import {
   agentComposerShowsStop,
   canSubmitAgentComposerMessage,
   isAgentComposerSendLocked,
+  isAgentComposerSteerHotkey,
   planAgentComposerStop,
   shouldClearStoppingSendLock
 } from "@/services/agentComposerSend";
@@ -181,7 +182,7 @@ import {
   groupAgentTimelineItems,
   hasAgentUserMessage,
   isRenderableAgentTimelineItem,
-  shouldShowAgentAssistantLoader,
+  agentPendingAssistantLoader,
   type AgentThoughtPhase
 } from "@/services/agentTimeline";
 import {
@@ -2324,11 +2325,13 @@ export function AgentMode({ userId }: { userId: string }) {
   ]);
 
   const sendMessage = useCallback(
-    async (restoreComposerFocus = false) => {
+    async (restoreComposerFocus = false, steerNow = false, steerQueueId?: string) => {
       let text = input.trim();
       const requestedSessionId = activeSessionIdRef.current;
       let pendingSessionKey = requestedSessionId || NEW_SESSION_PENDING_KEY;
+      const canSteerExistingChip = Boolean(steerQueueId);
       if (
+        !canSteerExistingChip &&
         !canSubmitAgentComposerMessage({
           text,
           isSendLocked: isAgentSendLocked,
@@ -2340,6 +2343,9 @@ export function AgentMode({ userId }: { userId: string }) {
       ) {
         return;
       }
+      if (isAgentSendLocked || pendingSessionSelectionIdRef.current !== null) {
+        return;
+      }
 
       const activeEdit =
         queueEditRef.current &&
@@ -2347,8 +2353,16 @@ export function AgentMode({ userId }: { userId: string }) {
         queueEditRef.current.sessionId === requestedSessionId
           ? queueEditRef.current
           : null;
-      if (activeEdit && requestedSessionId) {
-        const stashedDraft = discardQueuedMessageEdit(activeEdit);
+      const editingSteeredChip =
+        steerNow && activeEdit && (!steerQueueId || activeEdit.queueId === steerQueueId)
+          ? activeEdit
+          : null;
+      const stashedDraft = editingSteeredChip
+        ? discardQueuedMessageEdit(editingSteeredChip)
+        : activeEdit && !steerNow
+          ? discardQueuedMessageEdit(activeEdit)
+          : "";
+      if (activeEdit && requestedSessionId && !steerNow) {
         setQueueEdit(null);
         try {
           const snapshot = await agentRuntimeService.updateQueuedMessage(userId, {
@@ -2370,6 +2384,9 @@ export function AgentMode({ userId }: { userId: string }) {
         }
         text = stashedDraft.trim();
       }
+      if (editingSteeredChip) {
+        setQueueEdit(null);
+      }
 
       const selectionGeneration = sessionSelectionGenerationRef.current;
       const interactionGeneration = interactionGenerationRef.current;
@@ -2385,9 +2402,13 @@ export function AgentMode({ userId }: { userId: string }) {
       }
       markPendingSend(pendingSessionKey, sendToken);
 
+      const keepComposerDraft = Boolean(steerQueueId) && !editingSteeredChip;
+      const requestText = keepComposerDraft ? "" : text;
       setError(null);
       resetPromptHistoryNavigation();
-      setInput("");
+      if (!keepComposerDraft) {
+        setInput(editingSteeredChip ? stashedDraft : "");
+      }
       shouldAutoScrollRef.current = true;
       requestAnimationFrame(() => scrollTimelineToBottom("smooth"));
       try {
@@ -2413,7 +2434,7 @@ export function AgentMode({ userId }: { userId: string }) {
           }
           const response = await agentRuntimeService.sendMessage(userId, {
             sessionId,
-            text,
+            text: requestText,
             model: requestModel,
             contextLimit: contextLimitForModel(requestModel),
             mode: selectedModeRef.current,
@@ -2421,7 +2442,9 @@ export function AgentMode({ userId }: { userId: string }) {
               requestModel,
               availableModels,
               modelAliases
-            )
+            ),
+            steer: steerNow,
+            queueId: steerQueueId ?? editingSteeredChip?.queueId
           });
           if (cancelledPendingSendTokensRef.current.has(sendToken)) {
             // The native command may have crossed the start boundary while the
@@ -2429,7 +2452,7 @@ export function AgentMode({ userId }: { userId: string }) {
             await agentRuntimeService.cancelRun(userId, response.runId);
             return;
           }
-          if (shouldPrepareThoughtAfterAgentSend(response.queued)) {
+          if (!steerNow && shouldPrepareThoughtAfterAgentSend(response.queued)) {
             thoughtPhaseTrackerRef.current.prepareUserRequest(sessionId, text);
           }
           if (response.queue) {
@@ -2664,6 +2687,11 @@ export function AgentMode({ userId }: { userId: string }) {
       if (event.key === "Escape" && queueEditRef.current) {
         event.preventDefault();
         discardQueueEdit();
+        return;
+      }
+      if (isAgentComposerSteerHotkey(event)) {
+        event.preventDefault();
+        void sendMessage(true, true);
         return;
       }
       const direction = agentPromptHistoryDirection(
@@ -3213,6 +3241,12 @@ export function AgentMode({ userId }: { userId: string }) {
   const handleSendMessage = useCallback(() => {
     void sendMessage();
   }, [sendMessage]);
+  const handleSteerQueuedMessage = useCallback(
+    (queueId: string) => {
+      void sendMessage(false, true, queueId);
+    },
+    [sendMessage]
+  );
   const handleToggleAgentFullscreen = useCallback(() => {
     setIsAgentFullscreen((current) => !current);
   }, []);
@@ -3495,6 +3529,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   editingQueueId={editingQueueId}
                   onCancelQueuedMessage={cancelQueuedMessage}
                   onEditQueuedMessage={editQueuedMessage}
+                  onSteerQueuedMessage={handleSteerQueuedMessage}
                   onDiscardQueuedMessageEdit={discardQueueEdit}
                 />
               ) : (
@@ -3545,6 +3580,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   editingQueueId={editingQueueId}
                   onCancelQueuedMessage={cancelQueuedMessage}
                   onEditQueuedMessage={editQueuedMessage}
+                  onSteerQueuedMessage={handleSteerQueuedMessage}
                   onDiscardQueuedMessageEdit={discardQueueEdit}
                 />
                 <p className="mb-2 mt-1 text-center text-[10px] text-muted-foreground/50 landscape-short:mb-1">
@@ -4703,6 +4739,7 @@ interface AgentComposerProps {
   editingQueueId?: string | null;
   onCancelQueuedMessage?: (queueId: string) => void;
   onEditQueuedMessage?: (queueId: string) => void;
+  onSteerQueuedMessage?: (queueId: string) => void;
   onDiscardQueuedMessageEdit?: () => void;
 }
 
@@ -4740,6 +4777,7 @@ function AgentComposer({
   editingQueueId = null,
   onCancelQueuedMessage,
   onEditQueuedMessage,
+  onSteerQueuedMessage,
   onDiscardQueuedMessageEdit
 }: AgentComposerProps) {
   const rootOptions = recentRoots;
@@ -4795,6 +4833,18 @@ function AgentComposer({
                   aria-label="Edit queued message"
                 >
                   <FilePenLine className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
+              {onSteerQueuedMessage ? (
+                <button
+                  type="button"
+                  className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground disabled:pointer-events-none disabled:opacity-40"
+                  onClick={() => onSteerQueuedMessage(item.queueId)}
+                  disabled={isSendDisabled}
+                  title="Send into the current turn"
+                  aria-label="Send queued message into the current turn"
+                >
+                  <ArrowUp className="h-3.5 w-3.5" />
                 </button>
               ) : null}
               {onCancelQueuedMessage ? (
@@ -5329,10 +5379,9 @@ function AgentTimeline({
   const visibleItems = coalesceAdjacentThinkingItems(items).filter(isRenderableAgentTimelineItem);
   const turns = groupAgentTimelineItems(visibleItems);
   const activeThinkingItemId = activeAgentThinkingItemId(visibleItems, isRunActive);
-  const showAssistantLoader = shouldShowAgentAssistantLoader(turns, isResponsePending);
-  const trailingTurn = turns[turns.length - 1];
-  const pendingIndicatorTurnId =
-    showAssistantLoader && trailingTurn?.type === "assistant" ? trailingTurn.id : null;
+  const pendingLoader = agentPendingAssistantLoader(turns, isResponsePending);
+  const pendingIndicatorTurnId = pendingLoader.type === "inAssistant" ? pendingLoader.turnId : null;
+  const pendingAfterUserTurnId = pendingLoader.type === "afterUser" ? pendingLoader.turnId : null;
 
   return (
     <div className="space-y-1">
@@ -5341,12 +5390,12 @@ function AgentTimeline({
 
         if (turn.type === "user") {
           return (
-            <ChatUserTurn
-              key={turn.id}
-              actions={copyText ? <ChatCopyButton text={copyText} /> : undefined}
-            >
-              <Markdown content={turn.item.text || ""} />
-            </ChatUserTurn>
+            <div key={turn.id} className="space-y-1">
+              <ChatUserTurn actions={copyText ? <ChatCopyButton text={copyText} /> : undefined}>
+                <Markdown content={turn.item.text || ""} />
+              </ChatUserTurn>
+              {pendingAfterUserTurnId === turn.id ? <ChatAssistantPendingTurn /> : null}
+            </div>
           );
         }
 
@@ -5383,7 +5432,6 @@ function AgentTimeline({
           </ChatAssistantTurn>
         );
       })}
-      {showAssistantLoader && pendingIndicatorTurnId === null ? <ChatAssistantPendingTurn /> : null}
     </div>
   );
 }
@@ -5648,6 +5696,7 @@ function mergeTimelineItem(
     ...previous,
     ...incoming,
     title: incoming.title ?? previous.title,
+    status: incoming.status ?? previous.status,
     input: incoming.input ?? previous.input,
     output: incoming.output ?? previous.output,
     text: appendText

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -2344,7 +2344,11 @@ export function AgentMode({ userId }: { userId: string }) {
       ) {
         return;
       }
-      if (isAgentSendLocked || pendingSessionSelectionIdRef.current !== null) {
+      if (
+        isAgentSendLocked ||
+        pendingSessionSelectionIdRef.current !== null ||
+        pendingSendTokensRef.current.has(pendingSessionKey)
+      ) {
         return;
       }
 

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -2338,7 +2338,8 @@ export function AgentMode({ userId }: { userId: string }) {
           isSessionSelectionPending: pendingSessionSelectionIdRef.current !== null,
           hasInFlightSend: pendingSendTokensRef.current.has(pendingSessionKey),
           hasQueuedMessages: queuedMessages.length > 0,
-          hasActiveRun: Boolean(activeRunId)
+          hasActiveRun: Boolean(activeRunId),
+          steerNow
         })
       ) {
         return;

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -4826,6 +4826,16 @@ function AgentComposer({
               <span className="min-w-0 flex-1 truncate" title={item.text}>
                 {item.text}
               </span>
+              {onCancelQueuedMessage ? (
+                <button
+                  type="button"
+                  className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
+                  onClick={() => onCancelQueuedMessage(item.queueId)}
+                  aria-label="Remove queued message"
+                >
+                  <Trash className="h-3.5 w-3.5" />
+                </button>
+              ) : null}
               {onEditQueuedMessage ? (
                 <button
                   type="button"
@@ -4846,16 +4856,6 @@ function AgentComposer({
                   aria-label="Send queued message into the current turn"
                 >
                   <ArrowUp className="h-3.5 w-3.5" />
-                </button>
-              ) : null}
-              {onCancelQueuedMessage ? (
-                <button
-                  type="button"
-                  className="rounded-md p-1 text-muted-foreground transition-colors hover:bg-background hover:text-foreground"
-                  onClick={() => onCancelQueuedMessage(item.queueId)}
-                  aria-label="Remove queued message"
-                >
-                  <X className="h-3.5 w-3.5" />
                 </button>
               ) : null}
             </div>

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -5390,9 +5390,20 @@ function AgentTimeline({
         const copyText = getAgentTurnCopyText(turn);
 
         if (turn.type === "user") {
+          const previousTurn = turnIndex > 0 ? turns[turnIndex - 1] : undefined;
+          const nextTurn = turns[turnIndex + 1];
+          const previousShowsPending =
+            previousTurn?.type === "user" && pendingAfterUserTurnId === previousTurn.id;
+          const stackedTop = previousTurn?.type === "user" && !previousShowsPending;
+          const stackedBottom = nextTurn?.type === "user" && pendingAfterUserTurnId !== turn.id;
+
           return (
             <div key={turn.id} className="space-y-1">
-              <ChatUserTurn actions={copyText ? <ChatCopyButton text={copyText} /> : undefined}>
+              <ChatUserTurn
+                stackedTop={stackedTop}
+                stackedBottom={stackedBottom}
+                actions={copyText ? <ChatCopyButton text={copyText} /> : undefined}
+              >
                 <Markdown content={turn.item.text || ""} />
               </ChatUserTurn>
               {pendingAfterUserTurnId === turn.id ? <ChatAssistantPendingTurn /> : null}

--- a/frontend/src/components/UnifiedChat.tsx
+++ b/frontend/src/components/UnifiedChat.tsx
@@ -1480,17 +1480,21 @@ const MessageList = memo(
 
     return (
       <>
-        {groupedMessages.map((group) => {
+        {groupedMessages.map((group, groupIndex) => {
           if (group.type === "user") {
             const message = group.message;
             if (!message.content || message.content.length === 0) return null;
 
             const userText = getUserMessageText(message);
+            const stackedTop = groupedMessages[groupIndex - 1]?.type === "user";
+            const stackedBottom = groupedMessages[groupIndex + 1]?.type === "user";
 
             return (
               <ChatUserTurn
                 key={group.id}
                 historyAnchorIds={message.id}
+                stackedTop={stackedTop}
+                stackedBottom={stackedBottom}
                 actions={userText ? <ChatCopyButton text={userText} /> : undefined}
               >
                 {message.content.map((part, partIdx) => {

--- a/frontend/src/components/chat/ChatTurn.test.tsx
+++ b/frontend/src/components/chat/ChatTurn.test.tsx
@@ -12,6 +12,23 @@ describe("shared chat typography scope", () => {
 
     expect(markup).toContain("chat-typography");
     expect(markup).toContain("User message");
+    expect(markup).toContain("pt-4");
+    expect(markup).toContain("pb-4");
+    expect(markup).not.toContain("data-stacked-user");
+  });
+
+  test("tightens consecutive user turns without reserving a copy row", () => {
+    const markup = renderToStaticMarkup(
+      <ChatUserTurn stackedTop stackedBottom actions={<button type="button">Copy</button>}>
+        <p>Follow-up</p>
+      </ChatUserTurn>
+    );
+
+    expect(markup).toContain("data-stacked-user");
+    expect(markup).toContain("pt-1 -mt-1");
+    expect(markup).toContain("pb-0");
+    expect(markup).toContain("right-full");
+    expect(markup).toContain("Copy");
   });
 
   test("applies the typography scope to assistant, reasoning, and tool content", () => {

--- a/frontend/src/components/chat/ChatTurn.tsx
+++ b/frontend/src/components/chat/ChatTurn.tsx
@@ -9,6 +9,8 @@ type ChatTurnProps = {
   containerRef?: Ref<HTMLDivElement>;
   className?: string;
   historyAnchorIds?: string;
+  stackedTop?: boolean;
+  stackedBottom?: boolean;
 };
 
 function MapleChatAvatar() {
@@ -29,27 +31,34 @@ export function ChatUserTurn({
   actions,
   containerRef,
   className,
-  historyAnchorIds
+  historyAnchorIds,
+  stackedTop = false,
+  stackedBottom = false
 }: ChatTurnProps) {
   return (
     <div
       ref={containerRef}
       data-history-anchor-ids={historyAnchorIds}
+      data-stacked-user={stackedTop || stackedBottom ? "true" : undefined}
       className={cn(
-        "chat-typography group/user flex flex-col items-end py-4 landscape-short:py-1.5",
+        "chat-typography group/user relative flex flex-col items-end",
+        stackedTop ? "pt-1 -mt-1 landscape-short:pt-0.5" : "pt-4 landscape-short:pt-1.5",
+        stackedBottom ? "pb-0" : "pb-4 landscape-short:pb-1.5",
         className
       )}
     >
-      <div className="max-w-[min(100%,42rem)] rounded-2xl border border-border bg-muted px-4 py-3 dark:bg-card landscape-short:px-3 landscape-short:py-2">
-        <div className="prose prose-sm max-w-none text-left dark:prose-invert">
-          <div className="space-y-3">{children}</div>
+      <div className="relative max-w-[min(100%,42rem)]">
+        <div className="rounded-2xl border border-border bg-muted px-4 py-3 dark:bg-card landscape-short:px-3 landscape-short:py-2">
+          <div className="prose prose-sm max-w-none text-left dark:prose-invert">
+            <div className="space-y-3">{children}</div>
+          </div>
         </div>
+        {actions ? (
+          <div className="absolute bottom-0 right-full mr-0.5 flex justify-end opacity-100 transition-opacity md:opacity-0 md:group-hover/user:opacity-100 md:group-focus-within/user:opacity-100 landscape-short:opacity-100">
+            {actions}
+          </div>
+        ) : null}
       </div>
-      {actions ? (
-        <div className="flex justify-end pr-1 pt-1 opacity-100 transition-opacity md:opacity-0 md:group-hover/user:opacity-100 md:group-focus-within/user:opacity-100 landscape-short:opacity-100">
-          {actions}
-        </div>
-      ) : null}
     </div>
   );
 }

--- a/frontend/src/services/agentComposerSend.test.ts
+++ b/frontend/src/services/agentComposerSend.test.ts
@@ -109,6 +109,28 @@ describe("agent composer send policy", () => {
         isSendLocked: false,
         isSessionSelectionPending: false,
         hasInFlightSend: false,
+        hasQueuedMessages: true,
+        hasActiveRun: true,
+        steerNow: true
+      })
+    ).toBe(true);
+    expect(
+      canSubmitAgentComposerMessage({
+        text: "",
+        isSendLocked: false,
+        isSessionSelectionPending: false,
+        hasInFlightSend: false,
+        hasQueuedMessages: false,
+        hasActiveRun: true,
+        steerNow: true
+      })
+    ).toBe(false);
+    expect(
+      canSubmitAgentComposerMessage({
+        text: "",
+        isSendLocked: false,
+        isSessionSelectionPending: false,
+        hasInFlightSend: false,
         hasQueuedMessages: false
       })
     ).toBe(false);

--- a/frontend/src/services/agentComposerSend.test.ts
+++ b/frontend/src/services/agentComposerSend.test.ts
@@ -4,11 +4,42 @@ import {
   agentComposerShowsStop,
   canSubmitAgentComposerMessage,
   isAgentComposerSendLocked,
+  isAgentComposerSteerHotkey,
   planAgentComposerStop,
   shouldClearStoppingSendLock
 } from "./agentComposerSend";
 
 describe("agent composer send policy", () => {
+  test("treats Command or Control Enter as a steer bypass", () => {
+    expect(
+      isAgentComposerSteerHotkey({
+        key: "Enter",
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false
+      })
+    ).toBe(true);
+    expect(
+      isAgentComposerSteerHotkey({
+        key: "Enter",
+        metaKey: false,
+        ctrlKey: true,
+        altKey: false,
+        shiftKey: false
+      })
+    ).toBe(true);
+    expect(
+      isAgentComposerSteerHotkey({
+        key: "Enter",
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false
+      })
+    ).toBe(false);
+  });
+
   test("accepts a mid-run submit so the native runtime can stage a follow-up", () => {
     expect(
       canSubmitAgentComposerMessage({

--- a/frontend/src/services/agentComposerSend.ts
+++ b/frontend/src/services/agentComposerSend.ts
@@ -16,7 +16,8 @@ export function canSubmitAgentComposerMessage({
   isSessionSelectionPending,
   hasInFlightSend,
   hasQueuedMessages = false,
-  hasActiveRun = false
+  hasActiveRun = false,
+  steerNow = false
 }: {
   text: string;
   isSendLocked: boolean;
@@ -24,11 +25,13 @@ export function canSubmitAgentComposerMessage({
   hasInFlightSend: boolean;
   hasQueuedMessages?: boolean;
   hasActiveRun?: boolean;
+  steerNow?: boolean;
 }): boolean {
   const hasSendableText = Boolean(text.trim());
   const canFlushQueuedOnly = hasQueuedMessages && !hasActiveRun;
+  const canSteerQueuedStack = steerNow && hasQueuedMessages && !hasSendableText;
   return (
-    (hasSendableText || canFlushQueuedOnly) &&
+    (hasSendableText || canFlushQueuedOnly || canSteerQueuedStack) &&
     !isSendLocked &&
     !isSessionSelectionPending &&
     !hasInFlightSend

--- a/frontend/src/services/agentComposerSend.ts
+++ b/frontend/src/services/agentComposerSend.ts
@@ -1,3 +1,15 @@
+export function isAgentComposerSteerHotkey(event: {
+  key: string;
+  metaKey: boolean;
+  ctrlKey: boolean;
+  altKey: boolean;
+  shiftKey: boolean;
+}): boolean {
+  return (
+    event.key === "Enter" && (event.metaKey || event.ctrlKey) && !event.altKey && !event.shiftKey
+  );
+}
+
 export function canSubmitAgentComposerMessage({
   text,
   isSendLocked,

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -167,6 +167,8 @@ export interface AgentSendMessageRequest {
   contextLimit?: number | null;
   mode?: string | null;
   visionCapable: boolean;
+  steer?: boolean;
+  queueId?: string | null;
 }
 
 export interface AgentRunResponse {

--- a/frontend/src/services/agentTimeline.test.ts
+++ b/frontend/src/services/agentTimeline.test.ts
@@ -10,6 +10,7 @@ import {
   groupAgentTimelineItems,
   hasAgentUserMessage,
   hasRenderableThinkingText,
+  agentPendingAssistantLoader,
   shouldShowAgentAssistantLoader
 } from "./agentTimeline";
 
@@ -531,6 +532,48 @@ describe("shouldShowAgentAssistantLoader", () => {
 
   test("shows while a sent user turn is waiting for its first assistant activity", () => {
     expect(shouldShowAgentAssistantLoader([userTurn], true)).toBe(true);
+  });
+
+  test("hides under a steered follow-up until Goose starts that turn", () => {
+    expect(
+      shouldShowAgentAssistantLoader(
+        [
+          userTurn,
+          assistantTurn,
+          {
+            ...userTurn,
+            id: "steered",
+            item: { ...userTurn.item, id: "steered", status: "steered" }
+          }
+        ],
+        true
+      )
+    ).toBe(false);
+  });
+
+  test("keeps the first-send pending indicator above a fast steer", () => {
+    const steered = {
+      ...userTurn,
+      id: "steered",
+      item: { ...userTurn.item, id: "steered", status: "steered" }
+    };
+    expect(agentPendingAssistantLoader([userTurn, steered], true)).toEqual({
+      type: "afterUser",
+      turnId: "user"
+    });
+    expect(shouldShowAgentAssistantLoader([userTurn, steered], true)).toBe(true);
+  });
+
+  test("keeps a post-tool pending indicator above a later steer", () => {
+    const steered = {
+      ...userTurn,
+      id: "steered",
+      item: { ...userTurn.item, id: "steered", status: "steered" }
+    };
+    expect(agentPendingAssistantLoader([userTurn, toolTurn("completed"), steered], true)).toEqual({
+      type: "inAssistant",
+      turnId: "assistant-after-user"
+    });
   });
 
   test("hides when the response is no longer pending or assistant activity has arrived", () => {

--- a/frontend/src/services/agentTimeline.ts
+++ b/frontend/src/services/agentTimeline.ts
@@ -355,15 +355,16 @@ export function groupAgentTimelineItems(items: AgentTimelineItem[]): AgentTimeli
   return turns;
 }
 
-export function shouldShowAgentAssistantLoader(
-  turns: AgentTimelineTurn[],
-  isResponsePending: boolean
-): boolean {
-  if (!isResponsePending) return false;
+export type AgentPendingAssistantLoader =
+  | { type: "none" }
+  | { type: "afterUser"; turnId: string }
+  | { type: "inAssistant"; turnId: string };
 
+function assistantTurnNeedsPendingLoader(turns: AgentTimelineTurn[]): boolean {
   const trailingTurn = turns[turns.length - 1];
-  if (trailingTurn?.type === "user") return true;
-  if (trailingTurn?.type !== "assistant" || turns[turns.length - 2]?.type !== "user") return false;
+  if (trailingTurn?.type !== "assistant" || turns[turns.length - 2]?.type !== "user") {
+    return false;
+  }
 
   let trailingItemIndex = trailingTurn.items.length - 1;
   while (trailingItemIndex >= 0) {
@@ -378,4 +379,36 @@ export function shouldShowAgentAssistantLoader(
     trailingItem?.itemType === "tool" &&
     ["completed", "failed", "error"].includes(trailingItem.status ?? "")
   );
+}
+
+export function agentPendingAssistantLoader(
+  turns: AgentTimelineTurn[],
+  isResponsePending: boolean
+): AgentPendingAssistantLoader {
+  if (!isResponsePending) return { type: "none" };
+
+  let lastLiveIndex = turns.length - 1;
+  while (lastLiveIndex >= 0) {
+    const turn = turns[lastLiveIndex];
+    if (turn.type !== "user" || turn.item.status !== "steered") break;
+    lastLiveIndex -= 1;
+  }
+  if (lastLiveIndex < 0) return { type: "none" };
+
+  const liveTurns = turns.slice(0, lastLiveIndex + 1);
+  const liveTrailing = liveTurns[liveTurns.length - 1];
+  if (liveTrailing.type === "user") {
+    return { type: "afterUser", turnId: liveTrailing.id };
+  }
+  if (assistantTurnNeedsPendingLoader(liveTurns)) {
+    return { type: "inAssistant", turnId: liveTrailing.id };
+  }
+  return { type: "none" };
+}
+
+export function shouldShowAgentAssistantLoader(
+  turns: AgentTimelineTurn[],
+  isResponsePending: boolean
+): boolean {
+  return agentPendingAssistantLoader(turns, isResponsePending).type !== "none";
 }


### PR DESCRIPTION
## Summary

Maple Agent still **queues** on Send. This adds an explicit **steer** path so a follow-up can join the live turn instead of waiting for the whole agentic loop.

- Chip **↑** hands that one chip to Goose `Agent::steer` as soon as the current model + tool batch finishes. Other leftover chips stay queued.
- **Cmd/Ctrl+Enter** with a typed draft steers that draft (no chip).
- **Cmd/Ctrl+Enter** with an empty composer steers the **whole leftover chip stack** in FIFO order. Regular Enter / Send still only queues.
- Idle ↑ on a leftover chip starts a run with **only** that message; remaining chips stay staged.
- Stop still cancels Goose only. Already-steered text stays on the timeline like a normal sent user message (Maple persists it, then discards Goose's in-memory pending steers so they are not re-injected on the next reply).
- Pending `...` stays **between** the original first-send user row and a fast steer. It does not vanish, and it does not move under the steered row.

Queue remains the default. ACP is unchanged and still rejects a second prompt.

Relates to #792.

## Test plan

- [ ] Mid-run Send still creates a chip; leftover chips flush after the current reply finishes.
- [ ] Chip ↑ removes that chip, shows the steered user row, and the current run continues (no second reply).
- [ ] Fast steer after first Send: `...` stays between the first user message and the steered message.
- [ ] No extra `...` under a steered row while the previous assistant is still streaming / steer is waiting for Goose.
- [ ] Cmd/Ctrl+Enter with a typed draft steers that draft without creating a chip.
- [ ] Mid-run: queue one or more chips, leave the composer empty, Cmd/Ctrl+Enter — every leftover chip is steered in order and the chip row clears.
- [ ] Empty Cmd/Ctrl+Enter does nothing when there are no leftover chips.
- [ ] Empty Cmd/Ctrl+Enter does not fire while a chip is being edited.
- [ ] Stop after a steer: steered text remains; leftover chips remain; next Send does not re-inject the steered text as a new user message.
- [ ] Idle leftover chip ↑ starts only that message; other chips stay.
- [ ] Pencil / Discard / X on leftover chips still work after a steer.