### PR TITLE
feat(agent): expand ACP support for Paseo

### DIFF
--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -76,7 +76,7 @@ Use the active authenticated Paseo daemon for end-to-end testing:
 1. Launch the exact Maple build that Paseo will invoke and sign in.
 2. Ensure Maple Agent Mode is running.
 3. Enable the `agent_connections` feature and open **Settings -> Agent connections** in Maple.
-4. Leave **ACP client decides** selected, save the policy if needed, and start the ACP service.
+4. Leave **ACP client decides** selected, save the policy if needed, and start the ACP service once.
 5. In Paseo Desktop, add or edit a Generic ACP provider. Set Command to the exact Maple executable and add `acp` as its one separate argument.
 6. Enable MCP-server support for that provider. Do not add a Maple API key or copy Maple credentials into Paseo.
 7. Let Paseo discover Maple's authenticated model list and interactive mode. A static model list is unnecessary.
@@ -92,7 +92,7 @@ VITE_FORCE_FEATURE_FLAGS=agent_connections
 
 Restart the frontend development process after changing the flag. On macOS, use the executable belonging to the exact development app being tested; do not point Paseo at an installed release while validating a development build.
 
-The settings surface is available only in macOS and Linux Tauri Desktop builds and is disabled by default. Web, mobile, and Windows builds do not expose it. The feature flag controls discovery of the settings page, not service activation. ACP must be started manually after each Maple launch.
+The settings surface is available only in macOS and Linux Tauri Desktop builds and is disabled by default. Web, mobile, and Windows builds do not expose it. The feature flag controls discovery of the settings page, not service activation. After the user starts ACP once, Maple persists that enabled choice and restores the listener after a later authenticated Desktop launch. **Stop service** persists the disabled choice and prevents that restoration.
 
 The default maximum is eight simultaneous ACP connections. The current settings UI exposes neither that limit nor the allowed-project-root list. Its saved default has an empty root list, which accepts any absolute working directory Maple can access. The backend configuration still validates both fields, and changes require **Stop -> Save -> Start**, but the preview UI must not be described as a root-policy editor.
 

--- a/docs/agent-mode-acp.md
+++ b/docs/agent-mode-acp.md
@@ -1,289 +1,333 @@
-# Agent Mode ACP harness preview
+# Maple Agent Mode ACP adapter
 
-This document describes Maple's experimental Agent Client Protocol (ACP) surface. The first tested consumer is [Buzz](https://github.com/block/buzz), but the architectural boundary is Maple-owned: external harnesses adapt into Maple's existing Agent Mode runtime rather than starting a second Goose runtime.
+Maple exposes an experimental [Agent Client Protocol (ACP)](https://agentclientprotocol.com/) edge adapter so a local client such as Paseo can control the signed-in Maple Agent. ACP is not Maple Agent Mode's internal abstraction: normal Desktop Agent Mode continues to call Maple's embedded Goose runtime directly.
 
-ACP is not Maple Agent's primary internal abstraction. Maple continues to embed Goose directly. The preview exists to answer a narrower question: can another local application control the real, signed-in Maple Agent through a standard agent protocol?
+This document describes the implementation in the current source tree. It does not by itself claim that a released Maple build includes the feature. The Paseo and native-Desktop checks in the validation matrix remain the release evidence.
 
-## Architecture
+## Architecture and ownership
 
 ```mermaid
 flowchart LR
-    Buzz["Buzz Desktop"]
-    Harness["Buzz ACP harness"]
-    Connector["maple acp\nstdio connector"]
-    Socket["owner-only\nUnix socket"]
-    Adapter["Maple ACP adapter"]
-    Runtime["MapleAgentService\nAgentRuntimeHandle"]
-    Goose["embedded Goose AgentManager"]
-    Provider["MapleProvider + MapleApiSession"]
-    Tools["Maple developer, web, and skills clients"]
-    BuzzCli["Buzz CLI"]
-
-    Buzz --> Harness
-    Harness -->|"ACP v1 over stdio"| Connector
-    Connector --> Socket
-    Socket --> Adapter
-    Adapter --> Runtime
-    Runtime --> Goose
-    Goose --> Provider
-    Goose --> Tools
-    Tools -->|"session-scoped BUZZ_* environment"| BuzzCli
-    BuzzCli --> Buzz
+    Desktop["Maple Desktop Agent Mode"] --> Tauri["Tauri adapter"]
+    Paseo["Paseo daemon"] --> Connector["maple acp\nstdio connector"]
+    Buzz["Buzz harness"] --> Connector
+    Connector -->|"owner-only Unix socket"| ACP["Maple ACP adapter"]
+    Tauri --> Runtime["MapleAgentService\naccount-scoped runtime"]
+    ACP --> Runtime
+    Runtime --> Goose["embedded Goose AgentManager"]
+    Goose --> Provider["MapleProvider + authenticated MapleApiSession"]
+    Goose --> Developer["MapleDeveloperClient"]
+    Developer --> Native["Maple native tools"]
+    Developer --> Wrapper["static ask-before external_mcp tool"]
+    Wrapper --> Router["lease-scoped transient HTTP MCP router"]
 ```
 
-The packaged executable has two entry paths:
+The executable has separate entry paths:
 
 - Normal invocation launches Maple Desktop.
-- `maple acp` connects standard input/output to the already-running desktop process.
+- `maple acp` connects ACP stdio to the already-running Maple Desktop process.
+- `maple --version` and `maple -V` print the version and exit without launching the GUI. Paseo uses this path for provider diagnostics.
 
-Buzz owns the subprocess and supplies its relay context there. Maple Desktop owns authentication, the account-scoped provider, Goose managers, tasks, tools, automatic permission classification, runs, and UI events. The surface that starts a run owns any unresolved interactive permission decision: Tauri for a Desktop run and the connected ACP client for an ACP run. The connector sends no inference request itself and does not initialize a second agent runtime.
+The connector does not authenticate to Maple's API or create another Goose runtime. The running Desktop process owns the authenticated provider, account-scoped session manager, tools, permission policy, model catalog, and task history. The connector only bridges local stdio to that process.
 
-The executable path is part of the socket name. This keeps an installed Maple build and independent development builds from accidentally sharing an ACP endpoint.
+The executable path is included in the local socket identity. An installed Maple build and an independent development build therefore do not accidentally share an ACP endpoint.
 
-## Why Goose ACP is not used directly
+### Why Maple does not launch Goose ACP directly
 
-Goose already implements a much broader ACP server, including a reusable byte-stream transport. At Maple's pinned Goose revision, however, `GooseAcpAgent::new` creates and owns fresh session, permission, and agent managers and reads Goose's global configuration. Its public construction path cannot attach the ACP projection to Maple's existing managers.
+At Maple's pinned Goose revision, the public Goose ACP construction path creates its own session, agent, permission, and configuration managers. It cannot attach its projection to Maple's existing account-scoped managers and caller-owned provider.
 
-Starting `goose acp`, enabling `goose serve`, or constructing a `GooseAcpAgent` after Maple initializes would therefore create a second runtime:
+Launching `goose acp`, enabling `goose serve`, or creating a second `GooseAcpAgent` would split ownership:
 
 ```mermaid
 flowchart TB
-    subgraph Separate["Standalone Goose ACP path"]
-        ClientA["ACP client"] --> GooseAcp["new GooseAcpAgent"]
-        GooseAcp --> ManagersA["new managers, config, tools, and permissions"]
+    subgraph Wrong["Separate standalone Goose runtime"]
+        ClientA["ACP client"] --> GooseACP["new GooseAcpAgent"]
+        GooseACP --> ManagersA["new managers, config, provider, and tools"]
     end
 
-    subgraph MaplePath["Required Maple path"]
-        ClientB["ACP client"] --> MapleAcp["Maple ACP adapter"]
-        MapleAcp --> ManagersB["existing account-scoped Maple runtime"]
+    subgraph Required["Maple-owned runtime"]
+        ClientB["ACP client"] --> MapleACP["Maple ACP adapter"]
+        MapleACP --> ManagersB["existing account-scoped Maple runtime"]
         ManagersB --> Auth["in-memory authenticated Maple provider"]
-        ManagersB --> MapleTools["Maple tools, policy, tasks, and UI events"]
+        ManagersB --> MapleTools["Maple tools, policy, tasks, and events"]
     end
 ```
 
-A provider factory alone is insufficient. Maple also needs to preserve:
+Sharing a data directory would not make two in-memory managers one runtime. Maple instead keeps ACP protocol types in the edge adapter and exposes transport-neutral operations from `MapleAgentService`.
 
-- its authenticated `MapleApiSession` and caller-owned `MapleProvider`;
-- account-scoped session storage and lifecycle fencing;
-- model locking and session restoration behavior;
-- `MapleDeveloperClient`, Maple web tools, and trust-filtered skills;
-- Maple-local permission classification and surface-scoped approval routing;
-- run cancellation, retained terminal state, and desktop timeline events; and
-- ephemeral per-session tool context supplied by the external harness.
+The service owns:
 
-Sharing a data directory between two managers would not make them one runtime and would introduce conflicting in-memory ownership. The preview therefore uses the standard `agent-client-protocol` crate for a deliberately narrow mapping into Maple-owned operations.
+- account and shutdown admission fencing;
+- creation, attachment, listing, and deletion of Maple tasks;
+- one active run per task, cancellation, and retained terminal state;
+- bounded per-run events and exact-run permission responders;
+- model locking and task restoration;
+- leased external tool context; and
+- transient HTTP MCP setup, routing, revocation, and cleanup.
 
-## Current protocol surface
+Tauri and ACP are sibling callers. Neither adapter calls through the other, and ACP changes must not make Desktop Agent Mode depend on ACP.
 
-`No` means "not implemented by this preview," not "fundamentally impossible." Effort is relative to the current branch:
+Maple Desktop's send-while-running behavior also remains Desktop-owned. It stages follow-ups in a per-task FIFO and advances them through sequential `Agent::reply` runs, with its own chip editing, steer, and Stop/Send fencing. ACP still permits only one active prompt per task and does not expose Goose's unstable steer method; Buzz continues to use its cancel-and-merge fallback.
 
-- **Low** is primarily ACP dispatch or projection over an existing Maple operation.
-- **Medium** adds an account-scoped Maple runtime-facade operation, richer event contract, or lifecycle tests.
-- **High** changes a security/product boundary or needs a broader structured-content/runtime abstraction. High does not necessarily imply a Buzz or Goose fork.
+## Setup with Paseo
 
-Goose already implements many of these semantics, but at Maple's pinned revision its history replayer, response builders, tool converters, permission mapping, usage mapping, and handlers are private or `pub(crate)` and operate on concrete `GooseAcpAgent` state. Maple can port that behavior, or Goose could extract it, but Maple cannot currently plug its host-owned runtime into those handlers.
+Use the active authenticated Paseo daemon for end-to-end testing:
 
-| ACP operation or capability                | Preview support | Remaining effort                  | Feasibility and limiting layer                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| ------------------------------------------ | --------------- | --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `initialize`                               | Yes             | Implemented                       | Negotiates ACP v1 and deliberately advertises only the narrow implemented capability set. New capabilities should be advertised only with their handlers and wire tests.                                                                                                                                                                                                                                                                                                                                                                                    |
-| `session/new`                              | Yes             | Implemented                       | Requires an absolute `cwd` and creates a real Maple task. Optional additional workspace directories and generic ACP-provided MCP servers are graded separately below.                                                                                                                                                                                                                                                                                                                                                                                       |
-| Additional workspace directories           | No              | Medium                            | Supportable, but Maple currently has a single-root task and Skills-trust model. Correct support needs canonical admission against the configured roots, an explicit per-session root set, tool and Skills semantics for those roots, and consistent persistence/reporting across list, load, resume, and fork. This is a Maple workspace-model change, not a Goose loop limitation.                                                                                                                                                                         |
-| `session/prompt` text                      | Yes             | Implemented                       | Accepts text blocks and permits one active prompt per session. Text annotations are not currently preserved.                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-| `session/update` text and thought          | Partial         | Low–Medium                        | Assistant text and thought chunks are projected. Maple could incrementally add actual ACP variants such as user chunks, plans, available commands, modes/config, and session info. Full Goose fidelity is the sum of the richer tool, usage, and media rows below; Goose's mature projector cannot currently be called independently of `GooseAcpAgent`.                                                                                                                                                                                                    |
-| `session/cancel`                           | Yes             | Implemented                       | Cancels Maple's underlying run and retains its terminal state.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
-| `session/list`                             | No              | Low                               | Supportable without rearchitecture. Maple already lists account-scoped persisted tasks and can filter by `cwd`. The adapter needs ACP field mapping and pagination plus a policy decision: may a same-user ACP client enumerate all Desktop tasks, or only ACP-created tasks? Restricting by origin would first require durable provenance because preview tasks are ordinary Maple user tasks.                                                                                                                                                             |
-| `session/resume`                           | No              | Medium                            | Supportable. Attach an existing same-account task without replay, validate its `cwd`, allowed roots, and active-run state, preserve its persisted model, and restore Maple provider/tool/permission state plus the current connection's transient environment. A service-global session lease is needed so two ACP clients cannot overwrite one task's credentials or tool context. This is a Maple lifecycle seam, not an agent-loop redesign.                                                                                                             |
-| `session/load`                             | No              | Medium–High                       | Supportable. This is resume plus the protocol-required ordered replay before responding. Maple already loads a normalized timeline; faithful replay needs a separate ACP history projection for user/assistant/thought/tool rows, stable tool correlation, bounded content, and explicit treatment of media that Maple's UI timeline omits. Goose's existing replayer is useful upstream code to extract, but its activation path owns concrete Goose managers.                                                                                             |
-| `session/close`                            | No              | Low–Medium                        | Supportable. Cancel active work, revoke connection-scoped credentials, release ACP ownership, and detach/unload only what ACP owns while preserving the persisted Maple task. The main work is race-safe cleanup without disrupting the same task if Maple Desktop is using it.                                                                                                                                                                                                                                                                             |
-| `session/delete`                           | No              | Low code; high policy             | Maple already has a deletion operation, so the handler is straightforward. The product decision is consequential: whether ACP may destroy Desktop history, whether deletion is limited to ACP-created tasks, and whether an explicit opt-in is required.                                                                                                                                                                                                                                                                                                    |
-| `session/fork`                             | No              | Medium                            | Goose's underlying `SessionManager` already has copy primitives, and its ACP implementation shows copy, optional truncation, and activation. Maple needs an account-scoped wrapper, root/policy validation, fresh transient context, activation, and rollback for partial failures. ACP fork is still unstable, so enabling it also accepts an unstable wire commitment; no Goose fork is otherwise required.                                                                                                                                               |
-| Session mode                               | No              | Medium                            | Maple already changes per-session permission mode. ACP support needs advertised mode state, a handler, update projection, and an explicit rule about whether a client may select unattended approval. This is principally a Maple trust-policy decision.                                                                                                                                                                                                                                                                                                    |
-| Model selection and other config           | No              | Medium–High                       | A Maple model option is feasible before the first prompt using Maple's authenticated catalog. Maple intentionally locks a task's model once it has history, so arbitrary mid-session switching should be rejected or treated as a product change. The native ACP path also needs authoritative vision/context metadata. Goose's config builder cannot be reused because it assumes Goose's global provider inventory rather than Maple's caller-owned `MapleProvider`; provider switching should remain out of scope.                                       |
-| ACP permission requests                    | Yes             | Implemented                       | Maple automatically resolves operations covered by its own policy, then emits a typed, run-scoped request for anything unresolved. ACP offers only `allow_once` and `reject_once`; cancellation, disconnect, transport failure, an unknown option, duplicate response, or reused request ID fails closed. The ACP caller is the sole interactive broker for that run, and Maple Desktop receives no actionable live card. Buzz currently chooses `allow_once` automatically. Maple has no separate non-overridable dangerous-deny policy yet. |
-| Basic structured tool calls and results    | Partial         | Low–Medium                        | A permission request includes a pending ACP `ToolCallUpdate` with stable ID, title, kind, prompt, and raw input. General tool starts, progress, outputs, and results are not yet projected. Maple's timeline already carries most ordinary card fields, so this is mainly projection work, but lifecycle correlation and bounded rich output still need wire tests.                                                                                                                                                                                           |
-| Rich tool/resource/location/MCP projection | No              | Medium–High                       | Rich image/resource content, file locations, progressive MCP notifications, and faithful replay need data below Maple's deliberately summarized UI timeline. A public transport-neutral Goose `AcpEventProjector` would avoid maintaining this nuanced mapping twice.                                                                                                                                                                                                                                                                                       |
-| Terminal and diff parity                   | No              | Medium–High; architectural choice | Goose's terminal handles and diff updates are not projection alone: its ACP filesystem layer replaces/delegates developer operations through ACP-client filesystem and terminal RPCs. Maple currently executes its own local tools. Maple would need either to synthesize bounded metadata from those results or delegate execution to the client, which would change its tool and permission architecture; an event projector by itself is insufficient.                                                                                                   |
-| Usage and context updates                  | No              | Medium                            | Supportable. Goose emits and persists usage, but Maple currently discards ephemeral usage notifications before its public event stream. Maple must retain a protocol-neutral usage event or query post-turn totals, pair usage with the persisted context limit, and define cumulative semantics. ACP cost is optional and should remain absent until it matches Maple billing semantics. Buzz can display standard usage for observability, but its durable turn-accounting path currently consumes a Goose-private cumulative-usage notification instead. |
-| Prompt images                              | No              | Medium                            | The embedded Goose message model and `MapleProvider` already carry images. Maple's non-UI send facade is text-only and ACP forces `vision_capable: false`; support needs structured prompt input, MIME/base64/size limits, native model-capability resolution, and replay/UI policy. This is mainly a Maple facade change.                                                                                                                                                                                                                                  |
-| Prompt audio                               | No              | High                              | Native audio is not a small adapter change. Pinned Goose has no audio message variant and its ACP conversion ignores audio. Maple could define a transcription-to-text pipeline, but native multimodal audio requires a Goose/provider/message abstraction change. This is the clearest current Goose-level content limitation.                                                                                                                                                                                                                             |
-| Embedded text resources                    | No              | Low–Medium                        | Supportable by flattening bounded content into a clearly labeled, untrusted prompt block while preserving URI/provenance metadata.                                                                                                                                                                                                                                                                                                                                                                                                                          |
-| Embedded binary resources                  | No              | Medium–High                       | Known image or document types could use explicit Maple ingestion paths. Arbitrary blobs have no generic model-facing representation and need type, decoding, size, staging, persistence, and rejection rules.                                                                                                                                                                                                                                                                                                                                               |
-| Resource links                             | No              | Medium–High                       | Supportable with policy work, and currently a baseline ACP v1 gap because resource links have no opt-out capability. Local and remote links need separate scheme, root, symlink, size, encoding, permission, and provenance rules so prompt ingress cannot bypass Maple's filesystem/web controls. Goose's private helper only performs an unbounded local `file://` text read, which Maple should not copy literally.                                                                                                                                      |
-| Arbitrary ACP-provided MCP servers         | No              | High                              | Technically supportable, but production-safe support expands a code-execution and secret boundary. Maple must validate client-supplied commands, URLs, headers, and environments; define authorization and name-collision rules; attach them transiently without persisting secrets; and guarantee per-session process cleanup across close, disconnect, crash, and Flatpak constraints. Generic stdio MCP is an ACP v1 baseline, so the current Buzz-only adaptation is a real conformance gap.                                                            |
-| Goose/Buzz native steering                 | No              | Medium code; high coupling        | Supportable but intentionally non-standard. Buzz uses `_goose/unstable/session/steer`, not an ACP v1 method. Maple Desktop owns a staged FIFO and sequential `Agent::reply` pump for send-while-running; it does not call Goose `steer`. ACP still rejects a second prompt and relies on Buzz's cancel-and-merge fallback; adding the unstable wire method would couple the adapter to a Goose-specific extension.                                                                                                                    |
+1. Launch the exact Maple build that Paseo will invoke and sign in.
+2. Ensure Maple Agent Mode is running.
+3. Enable the `agent_connections` feature and open **Settings -> Agent connections** in Maple.
+4. Leave **ACP client decides** selected, save the policy if needed, and start the ACP service.
+5. In Paseo Desktop, add or edit a Generic ACP provider. Set Command to the exact Maple executable and add `acp` as its one separate argument.
+6. Enable MCP-server support for that provider. Do not add a Maple API key or copy Maple credentials into Paseo.
+7. Let Paseo discover Maple's authenticated model list and interactive mode. A static model list is unnecessary.
+8. Keep both Desktop applications running while using the provider.
 
-This is parity for the tested Maple task path, not parity with Goose's complete ACP implementation.
+Keep the daemon's existing lifecycle intact. If provider configuration changes, reload or restart the same daemon instance that Paseo Desktop is connected to, then verify the Desktop reconnects before testing. Do not accidentally start a second daemon with a different lifecycle or state directory.
 
-Two ACP v1 baseline caveats are worth making explicit: agents must accept `ResourceLink` prompt blocks and stdio MCP definitions. The preview handles neither generically. The tested Buzz custom-harness path uses text prompts and does not depend on arbitrary MCP definitions; Maple also contains one exact Buzz compatibility adaptation. Image, audio, and embedded-resource capabilities are correctly advertised as unavailable.
-
-None of the `No` rows blocks the tested Buzz harness. That Buzz build does not call list/load/resume/fork/close, tolerates absent model/config options by using the agent default, and falls back from native steering to cancel-and-merge. General tool lifecycle notifications would improve Buzz Desktop visibility and reset its idle watchdog during long tools. Standard usage would improve observability, while durable turn metrics currently rely on a Goose-private notification. Its signed channel reply remains a separate tool/CLI path.
-
-## Maple-owned runtime service
-
-The refactor exposes a transport-neutral Maple service around the existing embedded runtime:
-
-- ensure the account-scoped runtime exists;
-- create and delete a Maple task;
-- send and cancel a run;
-- stage a Desktop follow-up onto Maple's per-task FIFO and promote it with a later sequential `Agent::reply` on the same outer run; Stop cancels only the live Goose turn and leaves staged chips; X drops a chip; pencil edits a chip in place; an open edit holds leftover promotion until save or discard; Discard leaves that chip unchanged; a chip up-arrow steers that one follow-up into the current Goose turn; Command/Control-Enter steers a composer draft, or the whole leftover chip stack when the composer is empty; a later Send flushes leftover chips plus any composer draft;
-- keep Desktop Stop from racing a follow-up send: in-flight composer sends are cancelled, and Send stays locked until the cancelled run settles;
-- consume an isolated, bounded event stream for one exact run;
-- receive typed permission requests and resolve them through an opaque responder bound to that exact account, task, and run;
-- observe a retained terminal result when a run stream closes normally; and
-- install and revoke per-session tool environments.
-
-These are useful host capabilities independent of ACP. Protocol types remain in the ACP adapter rather than becoming Maple Agent domain types. The service owns account and shutdown admission fences, atomic session creation plus transient tool context, one active run per session, cancellation, cleanup, typed warnings/errors, and an ordered per-run event stream with a retained terminal result.
-
-```mermaid
-flowchart LR
-    UI["Maple UI"] --> Tauri["Tauri command and event projector"]
-    ACP["ACP clients"] --> Adapter["ACP adapter and Buzz compatibility"]
-    Tauri --> Service["MapleAgentService\ntyped operations, leases, and per-run events"]
-    Adapter --> Service
-    Service --> Goose["embedded Goose runtime"]
-```
-
-Tauri remains a thin projection of the Desktop contract: the original command names, arguments, and `agent-event` envelopes are unchanged. Stop and restart now return a small host-lifecycle outcome containing the authoritative runtime status plus any ACP cleanup warning; the frontend unwraps it without changing normal Agent Mode behavior. ACP independently projects the same service operations and run events into ACP requests, notifications, and stop reasons. Socket ownership, protocol negotiation, connection leases, and `BUZZ_*` parsing remain adapter concerns.
-
-This keeps Maple's domain model a useful superset instead of forcing Maple, Tauri, and ACP into exact wire parity. Neither adapter calls through the other, and the core service imports no Tauri or ACP types.
-
-## Lifecycle and desktop configuration
-
-The Agent connections settings surface is fail-closed and hidden by default. On macOS and Linux Tauri Desktop it can be enabled for a user by the remote `agent_connections` feature flag. For local development, set the Vite override in `frontend/.env.local` (or the build environment) and restart the frontend dev server:
+For local Maple development, expose the settings surface with:
 
 ```dotenv
 VITE_FORCE_FEATURE_FLAGS=agent_connections
 ```
 
-The local override takes precedence; otherwise Maple checks the user-scoped remote flag. Web, mobile, and Windows builds keep both the navigation item and direct route unavailable even when either flag is enabled. This gate controls discovery of the preview settings surface only: it does not start the ACP service, which remains a manual action after every app launch.
+Restart the frontend development process after changing the flag. On macOS, use the executable belonging to the exact development app being tested; do not point Paseo at an installed release while validating a development build.
 
-Before remote rollout, create `agent_connections` with a default value of `false` in each OS Flags environment. An absent key is treated as disabled. Flag changes are resolved when the settings tree mounts, successful values may remain cached for up to ten minutes, and the flag is not a live kill switch for an already running ACP service.
+The settings surface is available only in macOS and Linux Tauri Desktop builds and is disabled by default. Web, mobile, and Windows builds do not expose it. The feature flag controls discovery of the settings page, not service activation. ACP must be started manually after each Maple launch.
 
-The macOS/Linux desktop settings page is intentionally manual. It can:
+The default maximum is eight simultaneous ACP connections. The current settings UI exposes neither that limit nor the allowed-project-root list. Its saved default has an empty root list, which accepts any absolute working directory Maple can access. The backend configuration still validates both fields, and changes require **Stop -> Save -> Start**, but the preview UI must not be described as a root-policy editor.
 
-- start and stop the local service;
-- show that unresolved approvals belong to the connected ACP client;
-- show connected client, session, and active-run counts;
-- copy the exact packaged executable path and `acp` argument;
-- copy a Buzz custom-harness definition;
-- show protocol, endpoint, and Buzz credential diagnostics; and
-- warn that Buzz's default parallelism must be reduced to Maple's current default of one connection.
+## Supported protocol surface
 
-Maple's composite host lifecycle attempts ACP shutdown before Agent-runtime stop or restart, and it always attempts the core runtime operation even if ACP cleanup reports an error. Desktop receives both the authoritative runtime result and any ACP cleanup warning, so it can resynchronize successful runtime changes while logout and credential cleanup still fail closed. Local Agent-data/history clearing remains stricter: it proceeds only after ACP has stopped successfully. Application update restart and exit also report failure if either surface cannot shut down. A saved `enabled` value does not auto-start ACP on the next launch; the user must explicitly start it again.
+| ACP operation or behavior            | Support       | Notes                                                                                                              |
+| ------------------------------------ | ------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `initialize`                         | Yes           | ACP v1; advertises load, list, close, HTTP MCP, text prompts, models, and one mode.                                |
+| `session/new`                        | Yes           | Requires one admitted absolute `cwd`; additional directories are rejected.                                         |
+| `session/prompt` text                | Yes           | One active prompt per task.                                                                                        |
+| Prompt resource links                | URI text only | Maple adds the resource name and URI to the prompt; it does not fetch the resource or treat it as trusted content. |
+| Prompt images                        | No            | Advertised as unsupported and rejected; Paseo's current attachment path does not supply a compatible ACP prompt.   |
+| Prompt audio and embedded resources  | No            | Rejected rather than silently dropped.                                                                             |
+| `session/update` text and thought    | Yes           | Bounded streaming notifications with stable message IDs.                                                           |
+| Ordinary tool lifecycle              | Yes           | Stable tool IDs, start/update status, bounded input/output, and absolute file locations when available.            |
+| Permission requests                  | Yes           | The ACP caller owns every unresolved decision for that run.                                                        |
+| `session/cancel`                     | Yes           | Cancels the exact Maple run and retains terminal state.                                                            |
+| `session/list`                       | Yes           | Same-account Read only/SmartApprove tasks, filtered by admitted root, in pages of at most 100.                     |
+| `session/load`                       | Yes           | Loads only Read only/SmartApprove tasks, then acquires a lease and replays ordered visible history.                |
+| `session/close`                      | Yes           | Uses one five-second deadline, revokes state on timeout, and deletes only a confirmed untouched provisional task.  |
+| Session mode                         | Yes           | One caller-mediated `interactive` mode; no unattended Maple Auto mapping.                                          |
+| Dynamic model catalog                | Yes           | Uses the authenticated Maple catalog and advertises an ACP model config option.                                    |
+| End-of-turn token usage              | Yes           | Per-prompt-turn input/output/total and cache-token counts. No cost is invented.                                    |
+| Streamable HTTP MCP                  | Loopback only | Plain HTTP through a direct lease-scoped `rmcp` client; no proxy, redirect, OAuth, registry, or persistence.       |
+| Generic stdio MCP                    | No            | Rejected because it would execute caller-supplied native code without a Maple approval boundary.                   |
+| Exact historical Buzz stdio bridge   | Yes           | Recognized only as a credential/context adaptation; Maple does not launch it as a generic transient server.        |
+| SSE MCP                              | No            | Rejected. Streamable HTTP may itself carry protocol SSE events.                                                    |
+| Goose/Buzz native steering           | No            | Desktop's staged queue and steer controls are not exposed as ACP methods; Buzz uses cancel-and-merge.              |
+| `session/resume`, fork, and delete   | No            | Load covers Paseo import. ACP deletion remains a separate product-policy decision.                                 |
+| Client-delegated terminal/filesystem | No            | Maple continues to execute its own local tools.                                                                    |
 
-Allowed-root and maximum-connection changes require Stop, then change and save, then Start. This prevents a new session from racing a policy update and retaining the previous policy.
+This is Paseo compatibility over Maple's real task path, not parity with every Goose ACP feature or unstable ACP extension.
+
+## Provisional sessions and probe hygiene
+
+Every task created by an external surface starts as Goose `SessionType::Acp`. It is a real persisted task so model configuration, tools, and the first prompt use the same Maple runtime path as any later turn, but it remains provisional while it has no admitted user message.
+
+Zero-message ACP tasks are hidden from `session/list`. If `session/close` or connection cleanup sees a task that this connection created and never prompted, Maple deletes it only after the same-session operation has drained and core confirms that the durable row is still untouched. If that proof cannot complete within the cleanup bound, Maple revokes the lease but preserves the row rather than risking admitted work. Runtime startup sweeps an ACP-typed, zero-message task with no user rename or conversation that a crash or timed-out cleanup may have stranded. Renamed tasks, tasks with conversation content, and tasks with an admitted message survive. Once the first prompt is admitted, disconnect preserves the task for `session/list`, `session/load`, and Maple Desktop. A task loaded from existing history is never considered connection-created and is preserved even if the new connection never prompts it.
+
+This rule is uniform for every admitted project directory. Maple does not special-case `$HOME`, Paseo's discovery directory, or any other path. Repeated Paseo model probes therefore do not require a HOME bypass and never appear in `session/list`; normal cleanup deletes them, while a crash or cleanup timeout is handled by the next runtime-start sweep.
+
+Setup and teardown are race-aware:
+
+- new/load, prompt, close, disconnect, runtime stop, and account change share lifecycle fences;
+- a task cannot be attached by two external connections or attached while it has an active run;
+- close gives cancellation, the same-session operation barrier, and lease cleanup one shared five-second deadline; if any phase misses it, Maple revokes the lease and retains a closing tombstone until connection teardown so late work cannot republish ownership; and
+- disconnect revokes every capability synchronously before bounded asynchronous cleanup.
+
+## Persisted tasks, load, and connection leases
+
+Maple task history remains Maple-owned and account-scoped. Paseo uses ordinary Maple storage rather than a separate ACP database.
+
+`session/list` optionally filters by an exact canonical `cwd`, rechecks every result against the saved allowed-root policy, sorts newest first, and returns a numeric cursor with at most 100 tasks per page. It exposes only tasks whose saved mode is Read only (`GooseMode::SmartApprove`). Desktop Auto tasks are omitted without being modified.
+
+`session/load`:
+
+1. verifies the task belongs to the active account;
+2. requires the request `cwd` to match the task's canonical persisted root;
+3. requires the task's saved mode to be Read only/SmartApprove, leaving Auto tasks unchanged for Maple Desktop;
+4. rejects additional directories, an active run, another external lease, or a persisted model that has retired from the authenticated catalog;
+5. connects the current request's transient HTTP MCP before committing ownership;
+6. reconstructs the task using its persisted model and Maple tools; and
+7. emits ordered visible user, assistant, thought, and tool history before returning the load response.
+
+A connection lease is an opaque exact-match capability tied to one account, task, installation, and external surface. It prevents two ACP connections from overwriting one task's transient credentials or tool clients. Desktop can still view persisted history, but it does not receive an actionable permission card for a live ACP run.
+
+For a durable task, `session/close` is not deletion. A clean close cancels the active ACP run, fails pending permissions closed, releases the lease, destroys the transient router and headers, unloads the cached agent, and leaves the task available to Desktop and a later `session/load`. If cancellation, the operation barrier, or exact-match lease cleanup exceeds the shared five-second deadline, Maple revokes the capability synchronously and returns without waiting indefinitely. It retains that session's operation registration and closing tombstone until connection teardown so a late load or prompt cannot republish ownership; dropped lease cleanup retries asynchronously. Deletion on close is limited to the connection's own still-unprompted provisional task after its operation barrier has drained and the durable row is confirmed untouched.
+
+Runtime stop, logout, account change, application exit, and update restart also attempt ACP shutdown before tearing down the core Agent runtime.
+
+## Models, modes, and usage
+
+The model list comes from the authenticated `MapleApiSession`, not Goose's process-global provider inventory and not a static Paseo list. Non-chat entries such as embedding, transcription, speech, reranking, and image-generation models are filtered out. Maple's runtime default is always first and remains available if catalog refresh fails. Each ACP discovery attempt is cancellation-aware and has one 30-second total bound. The account generation and provider instance are rechecked after the network catalog request so a response from a signed-out account cannot be published into a replacement runtime.
+
+Each session advertises a model config option in ACP's `model` category. Selection is allowed before the first message. Maple intentionally locks the model after a task has history; a mid-history change to a different model fails. When a persisted model is present, loading restores it exactly. If that locked model has retired from the current authenticated catalog, ACP rejects the load and leaves the task available in Maple Desktop rather than silently substituting the current default.
+
+Maple does not expose a separate ACP thought-level control and does not invent one.
+
+The adapter advertises one `interactive` mode in both ACP's mode state and config options. New ACP tasks use Maple's Read only/SmartApprove policy. Paseo may itself auto-select `allow_once` when it receives a permission request, but it cannot switch Maple into unattended Auto mode. Existing Desktop Auto tasks remain Auto and cannot be listed or loaded through ACP.
+
+Core computes the token delta for each exact run from the persisted session's before/after usage. ACP returns that prompt turn's input, output, total, cache-read, and cache-write counts on the corresponding prompt response. It does not accumulate earlier turns into later responses, because Paseo records each response as `currentTurnUsage` and would otherwise double-count the session. Cost remains absent.
+
+## Lease-scoped HTTP MCP
+
+Paseo injects a Streamable HTTP MCP endpoint for per-agent controls and may include a connection-specific authorization header. Those values are credentials even when they are intended only for loopback.
+
+Maple does not add this server to Goose's `ExtensionManager`. Instead:
+
+1. the ACP adapter validates the definitions and creates a `SharedAgentToolContext` for the external lease;
+2. a direct `rmcp` client connects and discovers a frozen tool catalog;
+3. a lease-scoped router is installed in that shared context;
+4. `MapleDeveloperClient` exposes one fixed `external_mcp` tool with a broadly compatible flat schema: a required exact tool ID enum plus a required arguments object; the wrapper description retains each frozen tool's sanitized description and argument contract;
+5. an `external_mcp` call selects one exact ID, and `MapleDeveloperClient` routes it directly without registering the server's raw tools with Goose; and
+6. lease revocation cancels requests, drops the router and headers, and unloads the cached Agent.
+
+This path never enters Goose's extension registry, OAuth flow, credential store, configuration, or session-extension persistence. Transient names and secrets are not persisted even briefly.
+
+The network and catalog boundary is deliberately narrow:
+
+- at most 16 transient servers are accepted;
+- URLs must use plain `http` with `localhost` or an explicit loopback IP; HTTPS and non-loopback hosts are rejected;
+- URL credentials and fragments are rejected;
+- the HTTP client disables ambient proxies and redirects;
+- duplicate, malformed, newline-bearing, null-bearing, and oversized headers are rejected;
+- the complete multi-server connection and catalog setup has one 30-second deadline;
+- catalogs have page, tool-count, name, per-tool, and aggregate byte limits;
+- exact router IDs are frozen as `<normalized-server>__<original-tool>` and appear only in the static wrapper's tool enum and catalog description; and
+- expired MCP sessions are not reinitialized by replaying an in-flight tool request.
+
+Sanitized tool descriptions and input schemas remain available in the static wrapper's frozen catalog description, but the raw transient tools are not added to Goose's model-facing catalog. The wrapper's actual input schema stays flat instead of using conditional JSON Schema branches that some OpenAI-compatible providers do not encode reliably. Server-supplied tool annotations, `_meta`, and icons are stripped. Result-level and content-level presentation metadata and annotations are also stripped. This prevents a transient server from using permission hints or host-active metadata to enter Maple's durable policy or UI state.
+
+Tool calls have request and cancellation timeouts, protocol SSE events are capped, and the sanitized result is rejected if its serialized size exceeds 4 MiB. There is one known lower-layer gap: `rmcp` does not currently expose a pre-deserialization byte cap for an ordinary JSON response. Maple can enforce its semantic result limit only after that response has already been read and decoded. The loopback-only network boundary, 30-second request timeout, no-proxy client, and no-redirect policy reduce exposure but do not remove that allocation risk.
+
+Generic stdio MCP is rejected before setup because starting an arbitrary command would be native code execution selected by the caller, before Maple could place the resulting tool use behind its approval boundary. The historical exact `buzz-dev-mcp` shape remains a special adaptation: Maple validates its absolute executable path, imports only the approved Buzz environment, and does not launch it as a transient server. Legacy SSE and every other MCP transport are rejected.
 
 ## Permissions are policy, not confinement
 
-`read_only` is the retained serialized name for caller-mediated `smart_approve`; it is not a literal read-only sandbox. Maple automatically approves operations covered by its own classifier and sends every unresolved tool decision to the ACP client. That client may prompt, reject, or approve automatically. Buzz currently selects `allow_once`, so guarded writes can still run unattended.
+`read_only` is the retained serialized name for caller-mediated `smart_approve`; it is not a literal read-only sandbox. The legacy `allow_all` value is normalized to the same policy. Maple's user-facing task policy therefore remains caller-mediated and is persisted separately from internal Goose routing.
 
-The exploratory `allow_all` value previously bypassed the caller through Maple's Auto mode. Current configuration normalization migrates it to `read_only`, and both variants resolve to caller-mediated policy in the native adapter. This preserves old files without retaining a second Maple-owned approval path.
+Maple keeps Goose in `SmartApprove`; it does not switch the live agent to Goose `Approve` or persist a lease-only mode. Maple's owned permission file marks the one static `external_mcp` tool as ask-before, so every external MCP call reaches Maple's `ActionRequired` handler regardless of server-supplied metadata. Maple can still resolve native operations covered by its own classifier; every unresolved native operation, and every `external_mcp` operation, is routed to the ACP caller.
 
 ```mermaid
 flowchart LR
     Tool["Goose tool request"] --> Policy["Maple automatic policy"]
-    Policy -->|"covered locally"| Goose["Exact running Goose Agent"]
-    Policy -->|"unresolved ACP run"| Request["Run-scoped ACP permission request"]
-    Request --> Caller["Connected ACP client"]
-    Caller -->|"allow_once or reject_once"| Responder["Opaque exact-run responder"]
+    Policy -->|"covered native operation"| Goose["Exact running Goose Agent"]
+    Policy -->|"unresolved native operation"| Request["Run-scoped ACP permission request"]
+    Tool -->|"static external_mcp is always ask-before"| Request
+    Request --> Client["Connected ACP client"]
+    Client -->|"allow_once or reject_once"| Responder["Opaque exact-run responder"]
     Responder --> Goose
-    Caller -->|"cancel, disconnect, invalid response"| Deny["Fail closed and cancel"]
+    Client -->|"cancel, disconnect, invalid or reused response"| Deny["Fail closed and cancel"]
     Deny --> Goose
 ```
 
-Neither mode is an operating-system sandbox.
+The ACP caller is the sole interactive broker for that run. Maple Desktop receives no actionable live approval card. Cancellation, disconnect, an unknown choice, duplicate response, reused request ID, or transport failure fails closed.
 
-Native configuration supports a list of allowed project roots, but the preview UI does not expose it. An empty list accepts any absolute session working directory available to the Maple process. Even a configured root checks session admission, not every path later accessed by a read, edit, or shell tool. Do not describe this as filesystem confinement.
+Allowed project roots are admission policy, not filesystem confinement. An empty list accepts any absolute session working directory available to the Maple process. A configured root controls which task roots may be opened; it does not enforce every path later accessed by a read, edit, shell, skill, or MCP tool. The current settings UI does not expose this list.
+
+## Prompt and event projection
+
+Text prompt blocks are concatenated with separation. An ACP resource link contributes only visible text in the form of its resource name and URI. Maple does not dereference it, copy its bytes, grant it filesystem authority, or preserve additional resource metadata. Image, audio, and embedded-resource blocks are rejected. Image capability is advertised as false because Paseo's current attachment behavior does not produce a compatible prompt block for this adapter; this is not a claim that Maple's underlying model path lacks vision.
+
+Live assistant text and thought chunks retain stable message IDs. The first row for a tool ID is projected as `tool_call`; later rows for that ID become `tool_call_update`, with status, bounded text, bounded raw input/output, inferred kind, and absolute file locations when Maple has one. Loading history uses the same projector and additionally includes visible user messages. For a coalesced completed, failed, or cancelled tool row, replay prefers the terminal `output.text` over the earlier request summary so Paseo displays the actual result while still receiving bounded raw input and output.
+
+Each run has an isolated bounded event queue. A dropped event is not silently reconstructed: Maple emits a terminal error and cancels the exact underlying run.
+
+Connection-wide admission permits at most 256 outstanding streamed updates and approximately 4 MiB of update/permission data. Notification credit returns only after the complete line is written to the local socket. Permission-request credit remains held until the caller responds or the connection closes. A stalled client therefore backpressures the adapter instead of accumulating unbounded frames.
+
+Inbound newline-delimited ACP frames are limited to 10 MiB. Individual projected tool input/output is limited to 64 KiB, and errors are bounded before crossing the protocol.
 
 ## Local trust and credentials
 
-The Unix socket is mode `0600`; the Linux runtime directory is owner-checked and mode `0700`. There is no second application-level client credential. While the service is enabled, any process running as the same OS user and able to reach that endpoint is inside the local trust boundary and can use the signed-in Maple Agent.
+On Unix, the ACP socket is mode `0600`; the Linux runtime directory is owner-checked and mode `0700`. There is no second Maple application credential. While the service is enabled, another process running as the same OS user and able to reach the endpoint is inside the local trust boundary and can control the signed-in Maple Agent.
 
-Maple and Buzz credentials follow different paths:
+Maple API credentials remain inside Maple Desktop's authenticated provider session. They are not copied into Paseo provider configuration, command arguments, or child environments.
 
-- Maple access credentials stay inside Maple Desktop's authenticated provider session. They are not written to the ACP harness, command arguments, or child environment.
-- Buzz relay credentials begin in the Buzz-owned connector process. The connector sends an internal `_maple/bridge/hello` notification over the local socket before normal ACP traffic.
-- The bridge filters to five `BUZZ_*` variables plus `PATH`, rejects null bytes, and rejects values over 16 KiB.
-- Filtered values remain in the ACP connection's in-memory context and are copied into per-session tool context. Session installation revalidates the six-key allowlist and enforces the 16-KiB-per-value and 32-KiB-total bounds.
-- The context is revoked during session and connection cleanup. Credential-bearing shells terminate their Unix process group or Windows Job Object immediately after each command to limit descendant retention. Forced async-task shutdown uses the same containment handle.
+Paseo's MCP authorization header lives only inside the leased HTTP client described above. It is cleared when the lease is revoked and never enters Maple or Goose configuration or task-extension storage.
 
-This design keeps Buzz credentials out of saved harness JSON, Maple configuration, argv, and Maple's process-global environment. It does **not** make the credentials invisible to the trusted agent or commands it runs. The shell needs the signing identity to publish a durable Buzz reply, and a command with that environment can inspect or transmit it. Because Buzz currently auto-selects `allow_once`, use this integration only with trusted clients, prompts, projects, and toolchains.
+Buzz relay credentials use a separate historical bridge:
 
-Unix process groups are not a complete sandbox: a command can deliberately call `setsid` or otherwise move a descendant into another process group before cleanup. Windows Job Objects provide stronger descendant containment. A hard Maple process crash or `SIGKILL` also bypasses Maple's in-process cleanup on both platforms, so a surviving descendant may retain an already copied credential. A portable hard credential boundary would require keeping the Buzz signing key out of arbitrary shell environments and exposing only a revocable Maple-owned broker or dedicated tool; that is outside this preview.
+- the Buzz-owned connector sends `_maple/bridge/hello` before normal ACP traffic;
+- Maple accepts only five `BUZZ_*` values plus `PATH` with per-value and total bounds;
+- values stay in the ACP connection's in-memory tool context; and
+- session/connection cleanup revokes the context and terminates credential-bearing shells using the available process-containment primitive.
 
-Credential-bearing Buzz shell execution fails closed inside Flatpak. Host-executable Linux packaging and socket behavior still require end-to-end validation.
+These controls limit accidental persistence and descendant retention; they are not a full sandbox. A trusted command can inspect credentials intentionally provided to its process, a Unix child can attempt to escape its process group, and a hard Maple crash can bypass in-process cleanup.
 
-## Buzz compatibility behavior
+## Buzz compatibility history
 
-The wire surface is standard ACP v1, but this first adapter includes explicit Buzz compatibility:
+Buzz was the first tested ACP consumer and remains a compatibility path, not the architecture's center. The implementation retains:
 
-- the private bridge hello for subprocess environment transfer;
-- the Buzz relay variable allowlist;
-- recognition of a narrowly shaped absolute `buzz-dev-mcp` stdio definition: matching server name and executable basename, no arguments, and an existing executable file;
-- adaptation of that environment into Maple's existing developer shell instead of launching a second general-purpose shell server;
-- a `Buzz ACP` Maple task title;
-- custom-harness JSON and parallelism guidance in settings.
+- the private bridge hello and Buzz relay-variable allowlist;
+- exact recognition of `buzz-dev-mcp` and adaptation into Maple's developer shell;
+- custom-harness fields and parallelism guidance in the settings UI; and
+- post-start error settlement chosen to avoid Buzz retrying potentially non-idempotent work.
 
-If this integration is maintained, these concerns should move behind an explicit Buzz adapter rather than expanding Maple's protocol-neutral runtime facade.
+Historical manual validation used a packaged arm64 macOS Maple development app and Buzz commit `3a4bf513df0e0c258587bfcbed9463d63723b56b`. One task returned a deterministic marker; another read Maple's real `README.md`, used local tools, and posted a substantive reply. That is compatibility evidence only, not a conformance, security, load, billing, or performance result.
 
-## End-to-end proof
+Paseo support must preserve this exact compatibility behavior without broadening private Buzz methods or credentials into Maple's protocol-neutral service.
 
-The exploratory validation used:
+## Validation matrix
 
-- Maple with Goose pinned to `c3111c71cd682ed1d115741677f0ca9946c51499`;
-- Buzz commit `3a4bf513df0e0c258587bfcbed9463d63723b56b`;
-- a packaged arm64 macOS Maple development app;
-- ACP v1;
-- Buzz owner-only channel admission and parallelism `1`; and
-- Maple's then-current unattended `allow_all` policy (historical; current builds migrate this value to caller-mediated approval).
+The implementation is ready for review only when the applicable rows below have evidence.
 
-Two Buzz GUI tasks completed:
+| Layer                     | Required evidence                                                                                                                                                                                                                                                                                                                                                                                                                             |
+| ------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Focused Rust tests        | ACP dispatch and wire types; root admission; resource-link flattening; model lock and retired-model rejection; SmartApprove-only list/load; provisional-task hiding/sweeping/deletion; bounded close and resurrection fences; terminal-tool replay result precedence; permission ownership; per-turn usage; tool lifecycle; static `external_mcp` schema/routing; HTTP MCP validation, cancellation, metadata stripping, and non-persistence. |
+| Full Maple backend        | Nix-based checks and tests with the repository's Desktop ONNX runtime wrapper; no regression in existing Agent service, host lifecycle, developer client, or Tauri adapter tests.                                                                                                                                                                                                                                                             |
+| Exact macOS Maple app     | Build and run the exact development app identity; sign in; create a native Desktop Agent task; stream a response; run a local tool; resolve a guarded permission; reload history; restart Agent Mode successfully.                                                                                                                                                                                                                            |
+| Paseo Desktop diagnostics | The configured Maple executable returns promptly for `--version` without launching another GUI process.                                                                                                                                                                                                                                                                                                                                       |
+| Paseo Desktop discovery   | The active authenticated daemon discovers the chat-model list and interactive mode within the cancellation/30-second bound; repeated refresh never lists and does not strand zero-message Maple tasks.                                                                                                                                                                                                                                        |
+| Paseo basic task          | Create a task in an admitted project; select a model; receive text/thought; cancel one run; complete another; verify each response reports only that prompt turn's usage.                                                                                                                                                                                                                                                                     |
+| Paseo tool task           | Observe ordinary tool start/progress/result events and file locations; an unresolved tool decision is owned only by Paseo.                                                                                                                                                                                                                                                                                                                    |
+| Paseo persistence         | Close/disconnect preserves a prompted SmartApprove task; list/import finds it; load replays ordered history and terminal tool results before accepting a new prompt; Auto tasks stay Desktop-only; a retired locked model rejects load without fallback; closing the loaded session does not delete it; a stalled close returns within its bound without allowing late lease publication.                                                     |
+| Paseo HTTP MCP            | The injected plain-loopback HTTP MCP connects; Goose sees one `external_mcp` tool with a required exact-ID enum and required arguments object; each call asks Paseo; headers and raw transient tools are absent from Maple/Goose configuration and task extensions; close/disconnect revokes the router.                                                                                                                                      |
+| Negative security cases   | Reject relative/out-of-policy roots, additional directories, duplicate external leases, mid-history or retired model changes, images and other unsupported content, HTTPS/remote/redirecting MCP URLs, generic stdio/SSE, name collisions, malformed/oversized headers/catalogs/results, and disconnect during setup, calls, or permission.                                                                                                   |
+| Regression after ACP      | Close the Paseo agent and stop Maple ACP, then repeat a native Desktop Agent task against the same Maple build. Verify no transient Paseo MCP tool or header appears in Desktop state.                                                                                                                                                                                                                                                        |
 
-1. A deterministic mention returned exactly `MAPLE-GUI-OK`.
-2. A mention asked Maple to read the checkout's real `README.md` and explain the project. Maple used its local file tools and posted a substantive Buzz reply covering the Tauri/Bun architecture, platforms, TTS, PDF OCR, signing and updates, development prerequisites, and platform-specific setup notes.
+Use the same authenticated Paseo daemon for every row. If a provider refresh is required, reload that daemon through its configured lifecycle and verify Desktop reconnects before continuing.
 
-The second run took roughly two to three minutes and ended with zero active runs. That timing has not been profiled and should not be attributed to ACP. The result is manual compatibility evidence, not a performance, load, conformance, billing, or security test.
+The focused ACP test entry point on macOS is:
 
-## Known limitations
+```bash
+nix develop -c frontend/src-tauri/scripts/run-with-desktop-onnxruntime.sh \
+  cargo test --manifest-path frontend/src-tauri/Cargo.toml agent_acp --lib
+```
 
-- macOS is the only platform validated end to end.
-- Windows, mobile, and web are unsupported; non-Flatpak Linux remains unvalidated.
-- Service activation is manual after every Maple launch.
-- ACP runs keep transient events isolated from Maple Desktop. Unresolved permissions are sent only to the connected ACP caller, and Buzz currently auto-selects `allow_once`.
-- Each ACP run has an isolated bounded event queue. If any event is dropped, Maple emits an explicit terminal error message and cancels the underlying run. It settles the already-admitted ACP turn without a JSON-RPC error because Buzz treats post-start agent errors as retryable and could otherwise repeat non-idempotent work; missed chunks are not reconstructed.
-- Maple applies connection-wide admission to streamed `session/update` notifications and outbound permission requests: at most 256 admitted events and roughly 4 MiB may be in flight. Notification credit returns after the complete line is written to the real local socket; permission-request credit remains held until the caller responds or the connection closes, including after local turn cancellation. A stalled client therefore backpressures the adapter instead of accumulating permission frames or orphaned SDK correlations. A single oversized update or request is rejected and cancels that run. Ordinary JSON-RPC responses still use `agent-client-protocol` 1.0.1's internal outgoing path.
-- An idle same-user socket can occupy the default one-connection limit; there is no initialization or idle timeout yet.
-- Disconnecting keeps the Maple task, but ACP cannot reload it. Repeated connections can accumulate `Buzz ACP` tasks.
-- Root and maximum-connection policy changes are rejected while the listener is running.
-- The UI polls service status instead of subscribing to lifecycle events.
-- Permission mapping and ownership have focused unit coverage, but there is no checked-in full wire-level, socket-lifecycle, reconnect, or Buzz GUI integration fixture yet.
-- The adapter intentionally omits much of Goose's ACP event and capability surface.
+Use the managed OpenSecret workspace and its repository-native smoke commands for the supporting OpenSecret and billing services. Never substitute a different installed Maple app for the exact development app in the GUI rows.
 
-## Maintenance recommendation
+## Known limitations and non-goals
+
+- macOS is the only platform with historical end-to-end ACP evidence. Linux implementation paths have unit coverage but still require a real host-executable validation; Flatpak credential-bearing shell behavior fails closed.
+- Windows, mobile, and web do not expose the service.
+- Service activation is manual after each Maple launch.
+- The settings UI does not expose allowed roots or the connection limit. Defaults are any absolute accessible root and eight connections.
+- One active prompt is allowed per ACP task. An idle same-user client can consume one connection slot; there is no general initialization or idle timeout.
+- Resource links are URI text only. Images, audio, embedded resources, client-delegated terminals/filesystems, additional workspace roots, fork, resume, and delete are unsupported. Paseo's current attachment path is why ACP image capability remains disabled here.
+- Prompt usage is per turn and cost is absent.
+- Transient MCP ordinary JSON responses do not have a pre-deserialization byte cap in the pinned `rmcp` transport. Semantic and serialized-result caps apply afterward.
+- Maple intentionally projects a bounded subset of Goose's ACP behavior. Goose's complete projector remains coupled to its standalone runtime.
+- The settings UI polls status instead of subscribing to service lifecycle events.
+- A local owner-only socket and exact leases protect against cross-user and accidental cross-surface use; they do not protect the signed-in agent from a malicious process already running as the same OS user.
+
+## Maintenance direction
 
 Keep Maple's primary path direct:
 
 ```text
-Maple UI -> Maple runtime -> embedded Goose -> MapleProvider
+Maple UI -> Tauri adapter -> Maple runtime -> embedded Goose -> MapleProvider
 ```
 
 Keep ACP at the edge:
 
 ```text
-External harness -> ACP adapter -> Maple runtime facade
+Paseo, Buzz, or another local client -> ACP adapter -> Maple runtime facade
 ```
 
-Maintaining the bounded adapter is reasonable if Buzz or other external harnesses are strategically useful. Maple should not duplicate Goose's full ACP feature set speculatively, refactor primary Agent Mode around ACP, or fork Goose solely for this preview.
-
-Before broadening the local adapter, the preferred path is to pursue reusable Goose seams:
-
-1. construct ACP around existing `AgentManager`, `SessionManager`, and `PermissionManager` handles;
-2. use an injectable provider resolver for new, restored, and reconfigured sessions;
-3. add host session-admission, activation, prompt-preparation, and cleanup hooks;
-4. accept an invocation-scoped permission responder so the host can bind each run to exactly one calling surface;
-5. let a host preserve its installed developer/tool clients;
-6. support transient ACP-provided session context with explicit cleanup;
-7. extract the Goose-event-to-ACP projection for use without runtime ownership; and
-8. remove global configuration and path assumptions from the embedded path.
-
-Even with those changes, the small `maple acp` connector and local IPC boundary would remain: stdio and the Buzz-owned environment live in a spawned process, while Maple authentication lives in the running desktop process.
+Do not refactor native Agent Mode around ACP, start a second Goose runtime, or fork Goose merely to copy every ACP feature. Useful upstream Goose seams would be host-supplied managers and providers, invocation-scoped permission responders, transient session context with explicit cleanup, and a transport-neutral Goose-event-to-ACP projector. Even with those seams, Maple would retain its small `maple acp` connector because stdio belongs to the spawned client process while authentication belongs to the running Desktop process.

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4637,6 +4637,7 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "cfb 0.10.0",
+ "chrono",
  "ciborium",
  "futures-util",
  "goose",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -69,10 +69,11 @@ goose-providers = { git = "https://github.com/aaif-goose/goose.git", rev = "0642
 opensecret = "3.6.1"
 rand = "0.8.6"
 async-trait = "0.1"
-rmcp = { version = "=3.1.2", default-features = false }
+rmcp = { version = "=3.1.2", default-features = false, features = ["client", "transport-streamable-http-client-reqwest"] }
 tauri-plugin-dialog = "2.7.1"
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
-agent-client-protocol = { version = "=1.0.1", default-features = false }
+agent-client-protocol = { version = "=1.0.1", default-features = false, features = ["unstable_end_turn_token_usage"] }
+chrono = { version = "0.4", default-features = false, features = ["std"] }
 httpdate = "1"
 process-wrap = { version = "=9.1.0", default-features = false, features = ["tokio1", "creation-flags", "job-object", "process-group"] }
 pulldown-cmark = { version = "0.13", default-features = false }

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -5,11 +5,14 @@ pub(crate) mod provider;
 mod shell_permission;
 mod system_prompt;
 mod tool_context;
+mod transient_mcp;
 mod web_permission;
 mod web_tools;
 
 use crate::maple_api::{account_scope, MapleApiSession};
 use developer_tools::MapleDeveloperClient;
+#[cfg(test)]
+use developer_tools::EXTERNAL_MCP_TOOL_NAME;
 use futures_util::StreamExt;
 use goose::agents::extension::Envs;
 use goose::agents::{
@@ -51,6 +54,7 @@ use tokio::sync::{mpsc, oneshot, watch, Mutex};
 use tokio_util::sync::CancellationToken;
 pub(crate) use tool_context::AgentToolContextSpec;
 use tool_context::SharedAgentToolContext;
+use transient_mcp::{TransientMcpConfig, TransientMcpRouter};
 use web_permission::{
     web_search_request_id, OpenUrlPermissionRequest, WebPermissionClassifier, WebPermissionContext,
     WebPermissionOutcome,
@@ -63,7 +67,8 @@ const DEFAULT_GOOSE_MODE: &str = "smart_approve";
 // Keep Goose on its ActionRequired path so Maple can apply the currently selected
 // policy at every tool boundary, including when the user changes it mid-run.
 const GOOSE_PERMISSION_ROUTING_MODE: GooseMode = GooseMode::SmartApprove;
-const MAPLE_DEVELOPER_TOOLS: [&str; 7] = [
+#[cfg(test)]
+const MAPLE_DEVELOPER_TOOLS: [&str; 8] = [
     "read",
     "shell",
     "edit",
@@ -71,6 +76,7 @@ const MAPLE_DEVELOPER_TOOLS: [&str; 7] = [
     "read_image",
     "web_search",
     "open_url",
+    EXTERNAL_MCP_TOOL_NAME,
 ];
 const MAPLE_SKILLS_TOOLS: [&str; 1] = ["load_skill"];
 // Goose currently renders the runtime registration key as the model-facing
@@ -87,6 +93,7 @@ const MAPLE_GOOSE_PERMISSION_CONFIG: &str = r#"user:
   - read_image
   - web_search
   - open_url
+  - external_mcp
   never_allow: []
 "#;
 const RUN_SHUTDOWN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
@@ -158,6 +165,21 @@ fn default_agent_model() -> String {
     DEFAULT_AGENT_MODEL.to_string()
 }
 
+fn selectable_agent_model_id(model: &str) -> bool {
+    let model = model.to_ascii_lowercase();
+    ![
+        "whisper",
+        "embed",
+        "rerank",
+        "transcription",
+        "text-to-speech",
+        "tts",
+        "image-generation",
+    ]
+    .iter()
+    .any(|marker| model.contains(marker))
+}
+
 impl Default for AgentConfig {
     fn default() -> Self {
         Self {
@@ -220,6 +242,28 @@ pub struct AgentMcpServer {
     #[serde(default = "default_mcp_timeout_seconds")]
     pub timeout_seconds: u64,
     pub transport: AgentMcpTransport,
+}
+
+/// An MCP server supplied by an external Agent surface for one leased session.
+///
+/// Unlike [`AgentMcpServer`], this type is never serialized into Maple's user
+/// configuration or Goose session metadata. It may contain short-lived bearer
+/// headers owned by the calling surface, so the lease that installs it also
+/// owns its removal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AgentTransientMcpServer {
+    pub(crate) name: String,
+    pub(crate) description: String,
+    pub(crate) timeout_seconds: u64,
+    pub(crate) transport: AgentTransientMcpTransport,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum AgentTransientMcpTransport {
+    StreamableHttp {
+        url: String,
+        headers: Vec<AgentMcpKeyValue>,
+    },
 }
 
 fn default_mcp_timeout_seconds() -> u64 {
@@ -427,11 +471,65 @@ pub(crate) struct AgentRunHandle {
     pub run_id: String,
     pub events: mpsc::Receiver<AgentRunEvent>,
     pub terminal: watch::Receiver<Option<AgentRunTerminal>>,
+    pub usage: watch::Receiver<Option<AgentRunUsage>>,
     pub event_overflowed: Arc<AtomicBool>,
     pub permission_responder: Option<AgentRunPermissionResponder>,
     pub cancellation: Option<AgentRunCancellation>,
     pub queued: Option<AgentQueuedMessage>,
     pub queue: AgentDesktopQueueSnapshot,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct AgentRunUsage {
+    pub(crate) input_tokens: u64,
+    pub(crate) output_tokens: u64,
+    pub(crate) total_tokens: u64,
+    pub(crate) cached_read_tokens: u64,
+    pub(crate) cached_write_tokens: u64,
+}
+
+type AgentRunSetup = (
+    Arc<Agent>,
+    Vec<AgentMcpConnectionError>,
+    SharedAgentToolContext,
+    bool,
+    AgentRunUsage,
+);
+
+impl AgentRunUsage {
+    fn from_accumulated_session(session: &Session) -> Self {
+        Self {
+            input_tokens: nonnegative_tokens(session.accumulated_usage.input_tokens),
+            output_tokens: nonnegative_tokens(session.accumulated_usage.output_tokens),
+            total_tokens: nonnegative_tokens(session.accumulated_usage.total_tokens),
+            cached_read_tokens: nonnegative_tokens(
+                session.accumulated_usage.cache_read_input_tokens,
+            ),
+            cached_write_tokens: nonnegative_tokens(
+                session.accumulated_usage.cache_write_input_tokens,
+            ),
+        }
+    }
+
+    fn saturating_delta(self, before: Self) -> Self {
+        Self {
+            input_tokens: self.input_tokens.saturating_sub(before.input_tokens),
+            output_tokens: self.output_tokens.saturating_sub(before.output_tokens),
+            total_tokens: self.total_tokens.saturating_sub(before.total_tokens),
+            cached_read_tokens: self
+                .cached_read_tokens
+                .saturating_sub(before.cached_read_tokens),
+            cached_write_tokens: self
+                .cached_write_tokens
+                .saturating_sub(before.cached_write_tokens),
+        }
+    }
+}
+
+fn nonnegative_tokens(tokens: Option<i32>) -> u64 {
+    tokens
+        .and_then(|tokens| u64::try_from(tokens).ok())
+        .unwrap_or(0)
 }
 
 #[derive(Clone)]
@@ -516,6 +614,16 @@ impl AgentHostEventPolicy {
 pub(crate) struct AgentToolContextLease {
     service: MapleAgentService,
     access: AgentToolContextAccess,
+    created_cleanup: Option<CreatedAgentSessionCleanup>,
+    discard_created_on_drop: bool,
+    cleanup_started: bool,
+}
+
+#[derive(Clone)]
+struct CreatedAgentSessionCleanup {
+    agent_manager: Arc<AgentManager>,
+    session_manager: Arc<SessionManager>,
+    expected: Session,
 }
 
 #[derive(Clone)]
@@ -535,33 +643,206 @@ impl AgentToolContextLease {
         self.access.context.revoke();
     }
 
-    pub(crate) async fn release(self) {
-        self.revoke();
-        let _session_lifecycle = self.service.session_lifecycle.lock().await;
-        let removed = {
-            let mut runtime = self.service.inner.lock().await;
-            let Some(current) = runtime.as_mut() else {
-                return;
-            };
-            if current.account_scope != self.access.account_scope.as_ref() {
-                return;
-            }
-            take_matching_tool_context(
-                &mut current.session_tool_contexts,
-                self.access.session_id.as_ref(),
-                self.access.installation_id,
-                &self.access.context,
+    pub(crate) async fn release(mut self) {
+        // Stop credential-bearing calls synchronously before waiting for the
+        // session lifecycle fence and cached-Agent unload.
+        self.access.context.revoke();
+        release_tool_context_lease(self.service.clone(), self.access.clone()).await;
+        // Mark completion only after the awaited cleanup. If this future is
+        // cancelled while waiting for the lifecycle fence, Drop schedules an
+        // exact-match retry instead of stranding a revoked leased entry.
+        self.cleanup_started = true;
+    }
+
+    pub(crate) async fn discard_created_if_untouched(mut self) {
+        self.discard_created_on_drop = true;
+        self.access.context.revoke();
+        if let Some(cleanup) = self.created_cleanup.as_ref() {
+            cleanup_provisional_created_session(
+                self.service.clone(),
+                self.access.clone(),
+                Arc::clone(&cleanup.agent_manager),
+                Arc::clone(&cleanup.session_manager),
+                cleanup.expected.clone(),
             )
-        };
-        if let Some(installed) = removed {
-            installed.context.revoke();
+            .await;
+        } else {
+            release_tool_context_lease(self.service.clone(), self.access.clone()).await;
         }
+        self.cleanup_started = true;
+    }
+}
+
+async fn release_tool_context_lease(service: MapleAgentService, access: AgentToolContextAccess) {
+    // A revoked leased entry remains authoritative until this lifecycle
+    // section removes it. Desktop callers must never garbage-collect it and
+    // reuse the still-cached Agent while transient caller state is attached.
+    let _session_lifecycle = service.session_lifecycle.lock().await;
+    let (removed, agent_manager) = {
+        let mut runtime = service.inner.lock().await;
+        let Some(current) = runtime.as_mut() else {
+            return;
+        };
+        if current.account_scope != access.account_scope.as_ref() {
+            return;
+        }
+        let removed = take_matching_tool_context(
+            &mut current.session_tool_contexts,
+            access.session_id.as_ref(),
+            access.installation_id,
+            &access.context,
+        );
+        (removed, Arc::clone(&current.agent_manager))
+    };
+    if let Some(installed) = removed {
+        installed.context.revoke();
+        // Dropping the cached Agent is the fail-closed way to remove every
+        // transient MCP client (and any secret-bearing HTTP headers) without
+        // mutating the persisted extension set. A later Desktop or ACP use
+        // reconstructs the Agent from durable, non-transient metadata.
+        if let Err(error) = agent_manager
+            .remove_session_if_loaded(access.session_id.as_ref())
+            .await
+        {
+            log::warn!(
+                "Failed to unload Agent task {} after external lease release: {error}",
+                access.session_id
+            );
+        }
+    }
+}
+
+async fn cleanup_provisional_created_session(
+    service: MapleAgentService,
+    access: AgentToolContextAccess,
+    agent_manager: Arc<AgentManager>,
+    session_manager: Arc<SessionManager>,
+    expected: Session,
+) {
+    // Keep the task fenced until both the secret-bearing cached Agent and the
+    // untouched provisional row are gone. If the exact reservation no longer
+    // belongs to us, fail closed and leave the durable task alone.
+    let _session_lifecycle = service.session_lifecycle.lock().await;
+    let permission_modes = {
+        let mut runtime = service.inner.lock().await;
+        match runtime.as_mut() {
+            Some(current) if current.account_scope == access.account_scope.as_ref() => {
+                if has_active_session_run(&current.active_runs, access.session_id.as_ref()) {
+                    return;
+                }
+                if let Some(installed) = current
+                    .session_tool_contexts
+                    .get(access.session_id.as_ref())
+                {
+                    let exact = installed.installation_id == access.installation_id
+                        && installed.context.ptr_eq(&access.context);
+                    if !exact {
+                        // A replacement owner won the task. Never unload or
+                        // delete underneath it.
+                        return;
+                    }
+                }
+                if let Some(installed) = take_matching_tool_context(
+                    &mut current.session_tool_contexts,
+                    access.session_id.as_ref(),
+                    access.installation_id,
+                    &access.context,
+                ) {
+                    installed.context.revoke();
+                }
+                Some(Arc::clone(&current.permission_modes))
+            }
+            // Runtime stop/replacement drains the old registry. The captured
+            // account-scoped managers still let us remove only the untouched
+            // row that this setup created.
+            _ => None,
+        }
+    };
+    access.context.revoke();
+    if let Err(error) = agent_manager
+        .remove_session_if_loaded(access.session_id.as_ref())
+        .await
+    {
+        log::warn!(
+            "Failed to unload provisional Agent task {} after setup error: {error}",
+            access.session_id
+        );
+    }
+    if let Some(permission_modes) = permission_modes {
+        permission_modes
+            .lock()
+            .await
+            .remove(access.session_id.as_ref());
+    }
+
+    let current = match session_manager
+        .get_session(access.session_id.as_ref(), true)
+        .await
+    {
+        Ok(session) => session,
+        Err(_) => return,
+    };
+    let conversation_is_empty = current
+        .conversation
+        .as_ref()
+        .is_none_or(|conversation| conversation.messages().is_empty());
+    let untouched = current.id == expected.id
+        && current.created_at == expected.created_at
+        && current.working_dir == expected.working_dir
+        && current.session_type == expected.session_type
+        && current.name == expected.name
+        && !current.user_set_name
+        && current.message_count == 0
+        && conversation_is_empty
+        && current.archived_at == expected.archived_at;
+    if !untouched {
+        log::warn!(
+            "Preserving provisional Agent task {} after setup error because it changed while setup was pending",
+            access.session_id
+        );
+        return;
+    }
+    if let Err(error) = session_manager
+        .delete_session(access.session_id.as_ref())
+        .await
+    {
+        log::warn!(
+            "Failed to remove provisional Agent task {} after setup error: {error}",
+            access.session_id
+        );
     }
 }
 
 impl Drop for AgentToolContextLease {
     fn drop(&mut self) {
         self.access.context.revoke();
+        if self.cleanup_started {
+            return;
+        }
+        let service = self.service.clone();
+        let access = self.access.clone();
+        let created_cleanup = self.created_cleanup.clone();
+        let discard_created = self.discard_created_on_drop;
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                if discard_created {
+                    if let Some(cleanup) = created_cleanup {
+                        cleanup_provisional_created_session(
+                            service,
+                            access,
+                            cleanup.agent_manager,
+                            cleanup.session_manager,
+                            cleanup.expected,
+                        )
+                        .await;
+                    } else {
+                        release_tool_context_lease(service, access).await;
+                    }
+                } else {
+                    release_tool_context_lease(service, access).await;
+                }
+            });
+        }
     }
 }
 
@@ -737,15 +1018,52 @@ enum AgentToolContextOwner {
 
 struct PendingAgentToolContextInstallation {
     context: SharedAgentToolContext,
+    cleanup: Option<PendingAgentToolContextCleanup>,
     committed: bool,
+}
+
+enum PendingAgentToolContextCleanup {
+    Lease {
+        service: MapleAgentService,
+        access: AgentToolContextAccess,
+    },
+    Created {
+        service: MapleAgentService,
+        access: AgentToolContextAccess,
+        agent_manager: Arc<AgentManager>,
+        session_manager: Arc<SessionManager>,
+        expected: Box<Session>,
+    },
 }
 
 impl PendingAgentToolContextInstallation {
     fn new(context: SharedAgentToolContext) -> Self {
         Self {
             context,
+            cleanup: None,
             committed: false,
         }
+    }
+
+    fn arm_lease_cleanup(&mut self, service: MapleAgentService, access: AgentToolContextAccess) {
+        self.cleanup = Some(PendingAgentToolContextCleanup::Lease { service, access });
+    }
+
+    fn arm_created_cleanup(
+        &mut self,
+        service: MapleAgentService,
+        access: AgentToolContextAccess,
+        agent_manager: Arc<AgentManager>,
+        session_manager: Arc<SessionManager>,
+        expected: Session,
+    ) {
+        self.cleanup = Some(PendingAgentToolContextCleanup::Created {
+            service,
+            access,
+            agent_manager,
+            session_manager,
+            expected: Box::new(expected),
+        });
     }
 
     fn commit(&mut self) {
@@ -757,7 +1075,55 @@ impl Drop for PendingAgentToolContextInstallation {
     fn drop(&mut self) {
         if !self.committed {
             self.context.revoke();
+            let Some(cleanup) = self.cleanup.take() else {
+                return;
+            };
+            if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+                runtime.spawn(async move {
+                    match cleanup {
+                        PendingAgentToolContextCleanup::Lease { service, access } => {
+                            release_tool_context_lease(service, access).await;
+                        }
+                        PendingAgentToolContextCleanup::Created {
+                            service,
+                            access,
+                            agent_manager,
+                            session_manager,
+                            expected,
+                        } => {
+                            cleanup_provisional_created_session(
+                                service,
+                                access,
+                                agent_manager,
+                                session_manager,
+                                *expected,
+                            )
+                            .await;
+                        }
+                    }
+                });
+            }
         }
+    }
+}
+
+async fn run_external_surface_setup<T>(
+    setup_cancel: &CancellationToken,
+    tool_context: &SharedAgentToolContext,
+    cancellation_error: &'static str,
+    setup: impl std::future::Future<Output = Result<T, String>>,
+) -> Result<T, String> {
+    // The exact lease is installed before setup releases Maple's lifecycle
+    // fences. Make every later await cancellation-selectable, not just the MCP
+    // handshake, so a close/disconnect cannot strand an unpublished leased
+    // context while session reload or Agent configuration is stalled.
+    tokio::select! {
+        biased;
+        _ = setup_cancel.cancelled() => {
+            tool_context.revoke();
+            Err(cancellation_error.to_string())
+        }
+        result = setup => result,
     }
 }
 
@@ -775,6 +1141,61 @@ fn take_matching_tool_context(
             .remove(session_id)
             .expect("matching Agent tool context must still exist")
     })
+}
+
+fn matching_leased_tool_context(
+    contexts: &HashMap<String, InstalledAgentToolContext>,
+    session_id: &str,
+    installation_id: u64,
+    context: &SharedAgentToolContext,
+) -> bool {
+    contexts.get(session_id).is_some_and(|installed| {
+        installed.owner == AgentToolContextOwner::Leased
+            && installed.installation_id == installation_id
+            && installed.context.ptr_eq(context)
+            && !installed.context.is_revoked()
+    })
+}
+
+fn ensure_external_surface_loadable_session(session: &Session) -> Result<(), String> {
+    if session.goose_mode == GooseMode::SmartApprove {
+        Ok(())
+    } else {
+        Err(
+            "Maple ACP can load only Read only tasks; this task's saved approval mode was left unchanged"
+                .to_string(),
+        )
+    }
+}
+
+fn is_unprompted_acp_session(session: &Session) -> bool {
+    session.session_type == SessionType::Acp
+        && session.message_count == 0
+        && !session.user_set_name
+        && session
+            .conversation
+            .as_ref()
+            .is_none_or(|conversation| conversation.messages().is_empty())
+}
+
+async fn sweep_unprompted_acp_sessions(session_manager: &SessionManager) {
+    let sessions = match session_manager.list_all_sessions().await {
+        Ok(sessions) => sessions,
+        Err(error) => {
+            log::warn!("Failed to inspect stale provisional ACP tasks: {error}");
+            return;
+        }
+    };
+    for session in sessions {
+        if is_unprompted_acp_session(&session) {
+            if let Err(error) = session_manager.delete_session(&session.id).await {
+                log::warn!(
+                    "Failed to remove stale provisional ACP task {}: {error}",
+                    session.id
+                );
+            }
+        }
+    }
 }
 
 fn resolve_session_tool_context(
@@ -802,19 +1223,16 @@ fn resolve_session_tool_context(
         return Ok(installed.context.clone());
     }
 
-    if contexts
-        .get(session_id)
-        .is_some_and(|installed| installed.context.is_revoked())
-    {
-        contexts.remove(session_id);
-    }
     if let Some(installed) = contexts.get(session_id) {
         if installed.owner == AgentToolContextOwner::Leased {
             return Err("Agent task is controlled by another Agent surface".to_string());
         }
-        return Ok(installed.context.clone());
+        if installed.context.is_revoked() {
+            contexts.remove(session_id);
+        } else {
+            return Ok(installed.context.clone());
+        }
     }
-
     let context = SharedAgentToolContext::new(default_spec.clone());
     contexts.insert(
         session_id.to_string(),
@@ -1911,6 +2329,10 @@ async fn start_runtime_for_user(
         login_shell_search_paths,
     )?;
     let session_manager = Arc::new(SessionManager::new(goose_path_root.join("data")));
+    // A crash can strand a zero-message ACP probe before its connection-owned
+    // rollback runs. Such rows have never admitted user work; sweep them before
+    // the runtime becomes visible, while renamed or messaged tasks survive.
+    sweep_unprompted_acp_sessions(session_manager.as_ref()).await;
     let permission_manager = Arc::new(PermissionManager::new(goose_path_root.join("config")));
     let goose_config = GooseAgentConfig::new(
         Arc::clone(&session_manager),
@@ -2310,16 +2732,38 @@ impl AgentRuntimeHandle {
         tool_context: Option<AgentToolContextSpec>,
         host_events: AgentHostEventPolicy,
     ) -> Result<CreatedAgentSession, String> {
+        self.create_session_with_surface_context(
+            request,
+            tool_context,
+            Vec::new(),
+            CancellationToken::new(),
+            host_events,
+        )
+        .await
+    }
+
+    pub(crate) async fn create_session_with_surface_context(
+        &self,
+        request: Option<AgentCreateSessionRequest>,
+        tool_context: Option<AgentToolContextSpec>,
+        transient_mcp_servers: Vec<AgentTransientMcpServer>,
+        setup_cancel: CancellationToken,
+        host_events: AgentHostEventPolicy,
+    ) -> Result<CreatedAgentSession, String> {
         let state = &self.service;
         let user_id = self.user_id.as_ref();
         let account_scope = self.account_scope.as_ref();
         let has_external_tool_context = tool_context.is_some();
+        if !has_external_tool_context && !transient_mcp_servers.is_empty() {
+            return Err("Transient MCP servers require a leased Agent surface".to_string());
+        }
+        let transient_mcp_servers = normalize_transient_mcp_servers(transient_mcp_servers)?;
         let tool_context = SharedAgentToolContext::new(
             tool_context.unwrap_or_else(|| state.host.default_tool_context.clone()),
         );
         let mut tool_context_installation =
             PendingAgentToolContextInstallation::new(tool_context.clone());
-        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        let runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
         self.verify_generation().await?;
         self.ensure_accepting_new_work()?;
         let request = request.unwrap_or(AgentCreateSessionRequest {
@@ -2370,6 +2814,12 @@ impl AgentRuntimeHandle {
             .unwrap_or_else(|| DEFAULT_AGENT_SESSION_TITLE.to_string());
         let mode = request.mode.unwrap_or(runtime_mode);
         let permission_mode = parse_user_permission_mode(&mode)?;
+        if has_external_tool_context && permission_mode != GooseMode::SmartApprove {
+            return Err(
+                "External Agent surfaces require Maple's caller-mediated Read only mode"
+                    .to_string(),
+            );
+        }
         let model = request.model.unwrap_or(runtime_model);
         let configured_mcp = normalize_mcp_servers(config.mcp_servers)?;
         let selected_mcp =
@@ -2379,71 +2829,221 @@ impl AgentRuntimeHandle {
             .map(mcp_server_to_extension)
             .collect::<Result<Vec<_>, _>>()?;
         let selected_extension_keys = mcp_extension_keys(&selected_extensions);
+        ensure_extension_sets_do_not_conflict(&selected_extensions, &transient_mcp_servers)?;
+        let session_type = if has_external_tool_context {
+            SessionType::Acp
+        } else {
+            SessionType::User
+        };
         let session = session_manager
-            .create_session(root.clone(), title, SessionType::User, permission_mode)
+            .create_session(root.clone(), title, session_type, permission_mode)
             .await
             .map_err(|e| format!("Failed to create Agent task: {e}"))?;
-
+        let expected_provisional_session = session.clone();
         let installation_id = next_tool_context_installation_id();
-        let setup_result: Result<Vec<AgentMcpConnectionError>, String> = async {
-            let (agent, mut mcp_errors) = configure_session_agent(
-                AgentSkillsScope {
-                    paths: &state.host.paths,
-                    user_id,
-                },
-                &agent_manager,
-                &session_manager,
-                &maple_api_session,
-                SessionAgentConfiguration {
-                    web_tool_state: &web_tool_state,
-                    session: &session,
-                    model: &model,
-                    context_limit: request.context_limit,
-                    mode: &mode,
-                    primary_model_supports_vision: false,
-                    tool_context: &tool_context,
+        let tool_context_access = AgentToolContextAccess {
+            account_scope: Arc::clone(&self.account_scope),
+            session_id: Arc::from(session.id.as_str()),
+            installation_id,
+            context: tool_context.clone(),
+        };
+        // Fence the newly durable row before releasing Maple's lifecycle
+        // lock. Desktop operations now see an authoritative lease rather than
+        // a runnable/deletable task during the caller-controlled MCP handshake.
+        let reservation_error = {
+            let mut runtime = state.inner.lock().await;
+            match runtime.as_mut() {
+                Some(current) if current.account_scope == account_scope => {
+                    match current.session_tool_contexts.entry(session.id.clone()) {
+                        std::collections::hash_map::Entry::Vacant(entry) => {
+                            entry.insert(InstalledAgentToolContext {
+                                installation_id,
+                                context: tool_context.clone(),
+                                owner: AgentToolContextOwner::Leased,
+                            });
+                            None
+                        }
+                        std::collections::hash_map::Entry::Occupied(_) => {
+                            Some("Agent task context already existed during creation".to_string())
+                        }
+                    }
+                }
+                _ => Some("Agent runtime changed during session creation".to_string()),
+            }
+        };
+        if let Some(error) = reservation_error {
+            tool_context.revoke();
+            if let Err(cleanup_error) = session_manager.delete_session(&session.id).await {
+                log::warn!(
+                    "Failed to remove unreserved Agent task {} after setup error: {cleanup_error}",
+                    session.id
+                );
+            }
+            return Err(error);
+        }
+        tool_context_installation.arm_created_cleanup(
+            state.clone(),
+            tool_context_access.clone(),
+            Arc::clone(&agent_manager),
+            Arc::clone(&session_manager),
+            expected_provisional_session.clone(),
+        );
+        // A caller-controlled MCP endpoint must not hold Maple's global
+        // runtime lifecycle fence while it initializes.
+        drop(runtime_lifecycle_guard);
+
+        let setup_result: Result<(Session, Vec<AgentMcpConnectionError>), String> =
+            run_external_surface_setup(
+                &setup_cancel,
+                &tool_context,
+                "Agent surface closed during session setup",
+                async {
+                    install_transient_mcp_router(
+                        &tool_context,
+                        &session,
+                        transient_mcp_servers,
+                        &setup_cancel,
+                    )
+                    .await?;
+                    let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+                    self.verify_generation().await?;
+                    self.ensure_accepting_new_work()?;
+                    {
+                        let runtime = state.inner.lock().await;
+                        let current = runtime
+                            .as_ref()
+                            .ok_or_else(|| "Agent runtime is not running".to_string())?;
+                        ensure_runtime_account(current, account_scope)?;
+                        if !Arc::ptr_eq(&current.agent_manager, &agent_manager)
+                            || !Arc::ptr_eq(&current.session_manager, &session_manager)
+                            || !Arc::ptr_eq(&current.maple_api_session, &maple_api_session)
+                        {
+                            return Err("Agent runtime changed during session setup".to_string());
+                        }
+                        if has_active_session_run(&current.active_runs, &session.id)
+                            || !matching_leased_tool_context(
+                                &current.session_tool_contexts,
+                                &session.id,
+                                installation_id,
+                                &tool_context,
+                            )
+                        {
+                            return Err(
+                                "Agent task ownership changed during session setup".to_string()
+                            );
+                        }
+                    }
+                    let session = session_manager
+                        .get_session(&session.id, true)
+                        .await
+                        .map_err(|error| format!("Failed to reload Agent task: {error}"))?;
+                    if session.working_dir != root || session.session_type != session_type {
+                        return Err("Agent task changed during session setup".to_string());
+                    }
+                    let (agent, mut mcp_errors) = configure_session_agent(
+                        AgentSkillsScope {
+                            paths: &state.host.paths,
+                            user_id,
+                        },
+                        &agent_manager,
+                        &session_manager,
+                        &maple_api_session,
+                        SessionAgentConfiguration {
+                            web_tool_state: &web_tool_state,
+                            session: &session,
+                            model: &model,
+                            context_limit: request.context_limit,
+                            mode: &mode,
+                            primary_model_supports_vision: false,
+                            tool_context: &tool_context,
+                        },
+                    )
+                    .await?;
+                    if !selected_extensions.is_empty() {
+                        // Resolve every fallible part of restoring Maple's transient Skills client before
+                        // Goose persists the MCP mutation. Reattachment after this point is infallible.
+                        let skills_client = prepare_transient_skills_client(
+                            &state.host.paths,
+                            user_id,
+                            &agent,
+                            &session,
+                        )?;
+                        detach_transient_skills_client(&agent).await;
+                        let extension_result = agent
+                            .add_extensions_bulk(selected_extensions, &session.id)
+                            .await;
+                        attach_prepared_skills_client(&agent, skills_client).await;
+                        match extension_result {
+                            Ok(results) => mcp_errors
+                                .extend(mcp_connection_errors(results, &selected_extension_keys)),
+                            Err(error) => mcp_errors.push(AgentMcpConnectionError {
+                                name: "MCP servers".to_string(),
+                                error: error.to_string(),
+                            }),
+                        }
+                    }
+                    {
+                        let mut runtime = state.inner.lock().await;
+                        let current = runtime
+                            .as_mut()
+                            .ok_or_else(|| "Agent runtime is not running".to_string())?;
+                        ensure_runtime_account(current, account_scope)?;
+                        if has_active_session_run(&current.active_runs, &session.id)
+                            || !matching_leased_tool_context(
+                                &current.session_tool_contexts,
+                                &session.id,
+                                installation_id,
+                                &tool_context,
+                            )
+                        {
+                            return Err(
+                                "Agent task ownership changed during session setup".to_string()
+                            );
+                        }
+                        let mut modes = permission_modes.lock().await;
+                        current
+                            .session_tool_contexts
+                            .get_mut(&session.id)
+                            .expect("the exact provisional context was just verified")
+                            .owner = if has_external_tool_context {
+                            AgentToolContextOwner::Leased
+                        } else {
+                            AgentToolContextOwner::Maple
+                        };
+                        modes.insert(session.id.clone(), permission_mode);
+                    }
+                    let session = session_manager
+                        .get_session(&session.id, true)
+                        .await
+                        .map_err(|error| {
+                            format!("Failed to load configured Agent task: {error}")
+                        })?;
+                    if setup_cancel.is_cancelled() {
+                        return Err("Agent surface closed during session setup".to_string());
+                    }
+                    tool_context_installation.commit();
+                    Ok((session, mcp_errors))
                 },
             )
-            .await?;
-            if !selected_extensions.is_empty() {
-                // Resolve every fallible part of restoring Maple's transient Skills client before
-                // Goose persists the MCP mutation. Reattachment after this point is infallible.
-                let skills_client =
-                    prepare_transient_skills_client(&state.host.paths, user_id, &agent, &session)?;
-                detach_transient_skills_client(&agent).await;
-                let extension_result = agent
-                    .add_extensions_bulk(selected_extensions, &session.id)
-                    .await;
-                attach_prepared_skills_client(&agent, skills_client).await;
-                match extension_result {
-                    Ok(results) => {
-                        mcp_errors.extend(mcp_connection_errors(results, &selected_extension_keys))
-                    }
-                    Err(error) => mcp_errors.push(AgentMcpConnectionError {
-                        name: "MCP servers".to_string(),
-                        error: error.to_string(),
-                    }),
-                }
-            }
-            Ok(mcp_errors)
-        }
-        .await;
-        let mcp_errors = match setup_result {
-            Ok(mcp_errors) => mcp_errors,
+            .await;
+        let (session, mcp_errors) = match setup_result {
+            Ok(result) => result,
             Err(error) => {
-                if let Err(cleanup_error) = session_manager.delete_session(&session.id).await {
-                    log::warn!(
-                        "Failed to remove Agent task {} after setup error: {cleanup_error}",
-                        session.id
-                    );
-                }
-                if let Err(cleanup_error) =
-                    agent_manager.remove_session_if_loaded(&session.id).await
-                {
-                    log::warn!(
-                        "Failed to unload Agent task {} after setup error: {cleanup_error}",
-                        session.id
-                    );
+                tool_context.revoke();
+                let cleanup = cleanup_provisional_created_session(
+                    state.clone(),
+                    tool_context_access.clone(),
+                    Arc::clone(&agent_manager),
+                    Arc::clone(&session_manager),
+                    expected_provisional_session,
+                );
+                let cleaned = tokio::select! {
+                    biased;
+                    _ = setup_cancel.cancelled() => false,
+                    _ = cleanup => true,
+                };
+                if cleaned {
+                    tool_context_installation.commit();
                 }
                 return Err(error);
             }
@@ -2459,41 +3059,18 @@ impl AgentRuntimeHandle {
         };
         let tool_context_lease = has_external_tool_context.then(|| AgentToolContextLease {
             service: state.clone(),
-            access: AgentToolContextAccess {
-                account_scope: Arc::clone(&self.account_scope),
-                session_id: Arc::from(detail.session.id.as_str()),
-                installation_id,
-                context: tool_context.clone(),
-            },
+            access: tool_context_access,
+            created_cleanup: Some(CreatedAgentSessionCleanup {
+                agent_manager: Arc::clone(&agent_manager),
+                session_manager: Arc::clone(&session_manager),
+                expected: expected_provisional_session.clone(),
+            }),
+            discard_created_on_drop: false,
+            cleanup_started: false,
         });
 
-        // Publish the configured context only after every fallible setup await.
-        // Once inserted, the lease is committed and returned without yielding,
-        // so cancellation cannot strand a secret-bearing registry entry.
-        {
-            let mut runtime = state.inner.lock().await;
-            let current = runtime
-                .as_mut()
-                .ok_or_else(|| "Agent runtime is not running".to_string())?;
-            ensure_runtime_account(current, account_scope)?;
-            let mut modes = permission_modes.lock().await;
-            if let Some(replaced) = current.session_tool_contexts.insert(
-                session.id.clone(),
-                InstalledAgentToolContext {
-                    installation_id,
-                    context: tool_context,
-                    owner: if has_external_tool_context {
-                        AgentToolContextOwner::Leased
-                    } else {
-                        AgentToolContextOwner::Maple
-                    },
-                },
-            ) {
-                replaced.context.revoke();
-            }
-            modes.insert(session.id.clone(), permission_mode);
-        }
-        tool_context_installation.commit();
+        // The context was published only after every fallible setup await and
+        // committed without yielding while the lifecycle fence was held.
         if host_events.publishes() {
             emit_agent_event(
                 &state.host.events,
@@ -2503,6 +3080,293 @@ impl AgentRuntimeHandle {
         Ok(CreatedAgentSession {
             detail,
             tool_context_lease,
+        })
+    }
+
+    /// Attach an external Agent surface to an existing durable task.
+    ///
+    /// This is intentionally distinct from the Desktop-facing `load_session`:
+    /// it atomically acquires the task's external tool/MCP lease, rejects live
+    /// or already-leased tasks, and returns persisted history without Desktop
+    /// overlays or actionable permission routing.
+    pub(crate) async fn attach_session_with_surface_context(
+        &self,
+        session_id: String,
+        project_root: String,
+        tool_context: AgentToolContextSpec,
+        transient_mcp_servers: Vec<AgentTransientMcpServer>,
+        setup_cancel: CancellationToken,
+    ) -> Result<CreatedAgentSession, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let account_scope = self.account_scope.as_ref();
+        let session_id = session_id.trim().to_string();
+        if session_id.is_empty() {
+            return Err("Agent task ID cannot be empty".to_string());
+        }
+        let tool_context = SharedAgentToolContext::new(tool_context);
+        let mut tool_context_installation =
+            PendingAgentToolContextInstallation::new(tool_context.clone());
+        let transient_mcp_servers = normalize_transient_mcp_servers(transient_mcp_servers)?;
+        let runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        self.ensure_accepting_new_work()?;
+        let root = normalize_project_root(Path::new(&project_root))?;
+        let config = load_agent_config_inner(&state.host.paths, user_id)
+            .map_err(|error| error.to_string())?;
+        ensure_session_project_root_is_visible(&root, &config.removed_project_roots)?;
+        let session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let (
+            agent_manager,
+            session_manager,
+            maple_api_session,
+            permission_modes,
+            web_tool_state,
+            runtime_model,
+        ) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            if has_active_session_run(&current.active_runs, &session_id) {
+                return Err("This Agent task is already running".to_string());
+            }
+            if current
+                .session_tool_contexts
+                .get(&session_id)
+                .is_some_and(|installed| installed.owner == AgentToolContextOwner::Leased)
+            {
+                return Err("This Agent task is controlled by another Agent surface".to_string());
+            }
+            (
+                Arc::clone(&current.agent_manager),
+                Arc::clone(&current.session_manager),
+                Arc::clone(&current.maple_api_session),
+                Arc::clone(&current.permission_modes),
+                Arc::clone(&current.web_tool_state),
+                current.model.clone(),
+            )
+        };
+        let session = session_manager
+            .get_session(session_id.trim(), true)
+            .await
+            .map_err(|error| format!("Failed to load Agent task: {error}"))?;
+        if session.working_dir != root {
+            return Err("ACP session cwd does not match the persisted Agent task".to_string());
+        }
+        ensure_external_surface_loadable_session(&session)?;
+        let transient_keys = transient_mcp_servers
+            .iter()
+            .map(|server| goose::config::extensions::name_to_key(&server.name))
+            .collect::<HashSet<_>>();
+        if let Some(conflict) = session_mcp_extension_keys(&session)
+            .into_iter()
+            .find(|key| transient_keys.contains(key))
+        {
+            return Err(format!(
+                "Transient MCP server '{conflict}' conflicts with this task's persisted MCP configuration"
+            ));
+        }
+        let installation_id = next_tool_context_installation_id();
+        let tool_context_access = AgentToolContextAccess {
+            account_scope: Arc::clone(&self.account_scope),
+            session_id: Arc::from(session_id.as_str()),
+            installation_id,
+            context: tool_context.clone(),
+        };
+        {
+            let mut runtime = state.inner.lock().await;
+            let current = runtime
+                .as_mut()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, account_scope)?;
+            if has_active_session_run(&current.active_runs, &session_id)
+                || current
+                    .session_tool_contexts
+                    .get(&session_id)
+                    .is_some_and(|installed| installed.owner == AgentToolContextOwner::Leased)
+            {
+                return Err("This Agent task became active while ACP was attaching".to_string());
+            }
+            if let Some(replaced) = current.session_tool_contexts.insert(
+                session_id.clone(),
+                InstalledAgentToolContext {
+                    installation_id,
+                    context: tool_context.clone(),
+                    owner: AgentToolContextOwner::Leased,
+                },
+            ) {
+                replaced.context.revoke();
+            }
+        }
+        tool_context_installation.arm_lease_cleanup(state.clone(), tool_context_access.clone());
+        // The endpoint can be caller-controlled. Release both global fences
+        // while its bounded, cancellation-linked MCP handshake runs. The
+        // exact provisional lease remains authoritative for Desktop callers.
+        drop(session_lifecycle_guard);
+        drop(runtime_lifecycle_guard);
+        let setup_result: Result<AgentSessionDetail, String> = run_external_surface_setup(
+            &setup_cancel,
+            &tool_context,
+            "ACP session closed while attaching",
+            async {
+                install_transient_mcp_router(
+                    &tool_context,
+                    &session,
+                    transient_mcp_servers,
+                    &setup_cancel,
+                )
+                .await?;
+                let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+                self.verify_generation().await?;
+                self.ensure_accepting_new_work()?;
+                let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+                {
+                    let runtime = state.inner.lock().await;
+                    let current = runtime
+                        .as_ref()
+                        .ok_or_else(|| "Agent runtime is not running".to_string())?;
+                    ensure_runtime_account(current, account_scope)?;
+                    if !Arc::ptr_eq(&current.agent_manager, &agent_manager)
+                        || !Arc::ptr_eq(&current.session_manager, &session_manager)
+                        || !Arc::ptr_eq(&current.maple_api_session, &maple_api_session)
+                    {
+                        return Err("Agent runtime changed while ACP was attaching".to_string());
+                    }
+                    if has_active_session_run(&current.active_runs, &session_id)
+                        || !matching_leased_tool_context(
+                            &current.session_tool_contexts,
+                            &session_id,
+                            installation_id,
+                            &tool_context,
+                        )
+                    {
+                        return Err(
+                            "Agent task ownership changed while ACP was attaching".to_string()
+                        );
+                    }
+                }
+                let session = session_manager
+                    .get_session(&session_id, true)
+                    .await
+                    .map_err(|error| format!("Failed to reload Agent task: {error}"))?;
+                if session.working_dir != root {
+                    return Err(
+                        "ACP session cwd does not match the persisted Agent task".to_string()
+                    );
+                }
+                ensure_external_surface_loadable_session(&session)?;
+                if let Some(conflict) = session_mcp_extension_keys(&session)
+                    .into_iter()
+                    .find(|key| transient_keys.contains(key))
+                {
+                    return Err(format!(
+                        "Transient MCP server '{conflict}' conflicts with this task's persisted MCP configuration"
+                    ));
+                }
+                let model = session
+                    .model_config
+                    .as_ref()
+                    .map(|model| model.model_name.clone())
+                    .unwrap_or(runtime_model);
+                let mode = session.goose_mode.to_string();
+                let (agent, mcp_errors) = configure_session_agent(
+                    AgentSkillsScope {
+                        paths: &state.host.paths,
+                        user_id,
+                    },
+                    &agent_manager,
+                    &session_manager,
+                    &maple_api_session,
+                    SessionAgentConfiguration {
+                        web_tool_state: &web_tool_state,
+                        session: &session,
+                        model: &model,
+                        context_limit: session
+                            .model_config
+                            .as_ref()
+                            .and_then(|model| model.context_limit),
+                        mode: &mode,
+                        primary_model_supports_vision: false,
+                        tool_context: &tool_context,
+                    },
+                )
+                .await?;
+                drop(agent);
+
+                let session = session_manager
+                    .get_session(&session_id, true)
+                    .await
+                    .map_err(|error| format!("Failed to load configured Agent task: {error}"))?;
+                let detail = AgentSessionDetail {
+                    session: session_summary(&session),
+                    timeline: session
+                        .conversation
+                        .as_ref()
+                        .map(conversation_to_timeline_items)
+                        .unwrap_or_default(),
+                    mcp_errors,
+                    queue: empty_desktop_queue_snapshot(),
+                };
+                {
+                    let mut runtime = state.inner.lock().await;
+                    let current = runtime
+                        .as_mut()
+                        .ok_or_else(|| "Agent runtime is not running".to_string())?;
+                    ensure_runtime_account(current, account_scope)?;
+                    if has_active_session_run(&current.active_runs, &detail.session.id)
+                        || !matching_leased_tool_context(
+                            &current.session_tool_contexts,
+                            &detail.session.id,
+                            installation_id,
+                            &tool_context,
+                        )
+                    {
+                        return Err(
+                            "Agent task ownership changed while ACP was attaching".to_string()
+                        );
+                    }
+                    permission_modes
+                        .lock()
+                        .await
+                        .insert(detail.session.id.clone(), session.goose_mode);
+                }
+                if setup_cancel.is_cancelled() {
+                    return Err("ACP session closed while attaching".to_string());
+                }
+                tool_context_installation.commit();
+                Ok(detail)
+            },
+        )
+        .await;
+        let detail = match setup_result {
+            Ok(detail) => detail,
+            Err(error) => {
+                tool_context.revoke();
+                let cleanup =
+                    release_tool_context_lease(state.clone(), tool_context_access.clone());
+                let cleaned = tokio::select! {
+                    biased;
+                    _ = setup_cancel.cancelled() => false,
+                    _ = cleanup => true,
+                };
+                if cleaned {
+                    tool_context_installation.commit();
+                }
+                return Err(error);
+            }
+        };
+        let lease = AgentToolContextLease {
+            service: state.clone(),
+            access: tool_context_access,
+            created_cleanup: None,
+            discard_created_on_drop: false,
+            cleanup_started: false,
+        };
+        Ok(CreatedAgentSession {
+            detail,
+            tool_context_lease: Some(lease),
         })
     }
 
@@ -2538,16 +3402,65 @@ impl AgentRuntimeHandle {
             .map_err(|e| format!("Failed to list Agent tasks: {e}"))?
             .into_iter()
             .filter(|session| {
-                if let Some(root) = filter_root.as_ref() {
-                    session.working_dir == *root
-                } else {
-                    true
-                }
+                !is_unprompted_acp_session(session)
+                    && if let Some(root) = filter_root.as_ref() {
+                        session.working_dir == *root
+                    } else {
+                        true
+                    }
             })
             .map(|session| session_summary(&session))
             .collect::<Vec<_>>();
         sort_sessions_newest_first(&mut sessions);
         Ok(sessions)
+    }
+
+    pub(crate) async fn available_model_ids(&self) -> Result<Vec<String>, String> {
+        let state = &self.service;
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let (maple_api_session, default_model) = {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, self.account_scope.as_ref())?;
+            (
+                Arc::clone(&current.maple_api_session),
+                current.model.clone(),
+            )
+        };
+        drop(_runtime_lifecycle_guard);
+
+        let mut models = match maple_api_session.model_ids().await {
+            Ok(models) => models,
+            Err(error) => {
+                log::warn!("Failed to refresh Maple Agent model catalog: {error}");
+                Vec::new()
+            }
+        };
+        // A catalog request can outlive logout or runtime replacement. Recheck
+        // the exact account generation and transport before publishing a
+        // response that may have come from the former signed-in account.
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        {
+            let runtime = state.inner.lock().await;
+            let current = runtime
+                .as_ref()
+                .ok_or_else(|| "Agent runtime is not running".to_string())?;
+            ensure_runtime_account(current, self.account_scope.as_ref())?;
+            if !Arc::ptr_eq(&current.maple_api_session, &maple_api_session) {
+                return Err("Agent runtime changed while refreshing models".to_string());
+            }
+        }
+        models.retain(|model| selectable_agent_model_id(model));
+        models.retain(|model| !model.trim().is_empty());
+        let mut seen = HashSet::new();
+        models.retain(|model| seen.insert(model.clone()));
+        models.retain(|model| model != &default_model);
+        models.insert(0, default_model.clone());
+        Ok(models)
     }
 
     pub(crate) async fn load_session(
@@ -2747,6 +3660,15 @@ impl AgentRuntimeHandle {
             if has_active_session_run(&current.active_runs, &session_id) {
                 return Err("Stop the running agent before changing MCP servers".to_string());
             }
+            if current
+                .session_tool_contexts
+                .get(&session_id)
+                .is_some_and(|installed| installed.owner == AgentToolContextOwner::Leased)
+            {
+                return Err(
+                    "Disconnect the external Agent surface before changing MCP servers".to_string(),
+                );
+            }
             (
                 Arc::clone(&current.agent_manager),
                 Arc::clone(&current.session_manager),
@@ -2847,15 +3769,6 @@ impl AgentRuntimeHandle {
         self.delete_session_inner(session_id, true).await
     }
 
-    /// Remove a session that an adapter failed to publish. This cleanup path is
-    /// intentionally available while the service is draining.
-    pub(crate) async fn discard_session_during_cleanup(
-        &self,
-        session_id: String,
-    ) -> Result<(), String> {
-        self.delete_session_inner(session_id, false).await
-    }
-
     async fn delete_session_inner(
         &self,
         session_id: String,
@@ -2882,6 +3795,16 @@ impl AgentRuntimeHandle {
                     ensure_runtime_account(current, account_scope)?;
                     if has_active_session_run(&current.active_runs, &session_id) {
                         return Err("Stop the running agent before deleting this task".to_string());
+                    }
+                    if current
+                        .session_tool_contexts
+                        .get(&session_id)
+                        .is_some_and(|installed| installed.owner == AgentToolContextOwner::Leased)
+                    {
+                        return Err(
+                            "Disconnect the external Agent surface before deleting this task"
+                                .to_string(),
+                        );
                     }
                     (
                         Some(Arc::clone(&current.agent_manager)),
@@ -3307,6 +4230,14 @@ impl AgentRuntimeHandle {
             )
         };
         let requested_permission_mode = parse_user_permission_mode(&mode)?;
+        if permission_routing == AgentPermissionRouting::CallingSurface
+            && requested_permission_mode != GooseMode::SmartApprove
+        {
+            return Err(
+                "External Agent surfaces require Maple's caller-mediated Read only mode"
+                    .to_string(),
+            );
+        }
 
         if message_to_timeline_items(&user_message, false)
             .into_iter()
@@ -3339,19 +4270,11 @@ impl AgentRuntimeHandle {
         let effective_mode = permission_mode.to_string();
 
         let mut fallback_title_applied = false;
-        let setup_result: Result<
-            (
-                Arc<Agent>,
-                Vec<AgentMcpConnectionError>,
-                SharedAgentToolContext,
-                bool,
-            ),
-            String,
-        > = async {
+        let setup_result: Result<AgentRunSetup, String> = async {
             // External surfaces present an opaque exact-match capability. Check
             // it before any persisted-session work so deletion that won the
             // session lifecycle race is reported as an expired surface task.
-            let external_tool_context = if tool_context_access.is_some() {
+            let external_tool_context = if let Some(access) = tool_context_access.as_ref() {
                 let mut runtime = state.inner.lock().await;
                 let current = runtime
                     .as_mut()
@@ -3361,7 +4284,7 @@ impl AgentRuntimeHandle {
                     &mut current.session_tool_contexts,
                     account_scope,
                     &request.session_id,
-                    tool_context_access.as_ref(),
+                    Some(access),
                     &state.host.default_tool_context,
                 )?)
             } else {
@@ -3371,6 +4294,7 @@ impl AgentRuntimeHandle {
                 .get_session(&request.session_id, true)
                 .await
                 .map_err(|e| format!("Failed to load Agent task: {e}"))?;
+            let usage_before = AgentRunUsage::from_accumulated_session(&session);
             validate_session_model_lock(
                 session.message_count,
                 session
@@ -3432,38 +4356,45 @@ impl AgentRuntimeHandle {
                 },
             )
             .await?;
-            Ok((agent, mcp_errors, tool_context, should_name_from_prompt))
+            Ok((
+                agent,
+                mcp_errors,
+                tool_context,
+                should_name_from_prompt,
+                usage_before,
+            ))
         }
         .await;
-        let (agent, mcp_errors, tool_context, generate_session_title) = match setup_result {
-            Ok(setup) => setup,
-            Err(error) => {
-                if fallback_title_applied {
-                    match restore_unused_agent_session_fallback_under_lifecycle(
-                        session_manager.as_ref(),
-                        &request.session_id,
-                        &prompt_title,
-                    )
-                    .await
-                    {
-                        Ok(Some(session)) => {
-                            run_events
-                                .publish(AgentRunEvent::SessionUpdated(session))
-                                .await;
+        let (agent, mcp_errors, tool_context, generate_session_title, usage_before) =
+            match setup_result {
+                Ok(setup) => setup,
+                Err(error) => {
+                    if fallback_title_applied {
+                        match restore_unused_agent_session_fallback_under_lifecycle(
+                            session_manager.as_ref(),
+                            &request.session_id,
+                            &prompt_title,
+                        )
+                        .await
+                        {
+                            Ok(Some(session)) => {
+                                run_events
+                                    .publish(AgentRunEvent::SessionUpdated(session))
+                                    .await;
+                            }
+                            Ok(None) => {}
+                            Err(restore_error) => log::warn!("{restore_error}"),
                         }
-                        Ok(None) => {}
-                        Err(restore_error) => log::warn!("{restore_error}"),
                     }
+                    if seeded_permission_mode {
+                        permission_modes.lock().await.remove(&request.session_id);
+                    }
+                    agent_manager
+                        .unregister_cancel_token(&request.session_id)
+                        .await;
+                    return Err(error);
                 }
-                if seeded_permission_mode {
-                    permission_modes.lock().await.remove(&request.session_id);
-                }
-                agent_manager
-                    .unregister_cancel_token(&request.session_id)
-                    .await;
-                return Err(error);
-            }
-        };
+            };
         if !mcp_errors.is_empty() {
             run_events
                 .publish(AgentRunEvent::SetupWarning(format_mcp_connection_errors(
@@ -3593,6 +4524,7 @@ impl AgentRuntimeHandle {
         };
         let (start_tx, start_rx) = oneshot::channel();
         let (terminal_tx, terminal_rx) = watch::channel(None);
+        let (usage_tx, usage_rx) = watch::channel(None);
         let task = tokio::spawn(async move {
             let should_run = tokio::select! {
                 biased;
@@ -3832,6 +4764,14 @@ impl AgentRuntimeHandle {
                 "failed" => AgentRunTerminal::Failed,
                 _ => AgentRunTerminal::Completed,
             };
+            let usage = task_session_manager
+                .get_session(&session_id, false)
+                .await
+                .map(|session| {
+                    AgentRunUsage::from_accumulated_session(&session).saturating_delta(usage_before)
+                })
+                .unwrap_or_default();
+            let _ = usage_tx.send(Some(usage));
             task_events.publish(AgentRunEvent::Finished(terminal)).await;
             let _ = terminal_tx.send(Some(terminal));
             // Remove the stored JoinHandle only after the final externally visible
@@ -3984,6 +4924,7 @@ impl AgentRuntimeHandle {
             run_id,
             events: run_events_rx,
             terminal: terminal_rx,
+            usage: usage_rx,
             event_overflowed: run_events.overflow_flag(),
             permission_responder,
             cancellation,
@@ -5625,6 +6566,10 @@ async fn configure_session_agent(
         prepare_transient_skills_client(skills_scope.paths, skills_scope.user_id, &agent, session)?;
     let mcp_errors = mcp_connection_errors(manager_result.extension_results, &session_mcp_keys);
     install_maple_provider(&agent, maple_api_session, session, model, context_limit).await?;
+    // All transient MCP operations are hidden behind Maple's one static
+    // `external_mcp` tool, which is permanently ask-before in Maple's owned
+    // permission file. Keeping Goose in SmartApprove preserves native behavior
+    // without persisting caller-controlled tool names or a lease-only mode.
     agent
         .update_goose_mode(GOOSE_PERMISSION_ROUTING_MODE, &session.id)
         .await
@@ -5635,10 +6580,10 @@ async fn configure_session_agent(
         display_name: Some("Developer".to_string()),
         timeout: Some(DEFAULT_EXTENSION_TIMEOUT),
         bundled: Some(true),
-        available_tools: MAPLE_DEVELOPER_TOOLS
-            .iter()
-            .map(|tool| tool.to_string())
-            .collect(),
+        // MapleDeveloperClient owns the exact native catalog and may add a
+        // frozen lease-scoped MCP catalog. Persisting dynamic tool names would
+        // either hide those tools or leak transient session state.
+        available_tools: Vec::new(),
     };
     let mut developer_context = agent.extension_manager.get_context().clone();
     if !primary_model_supports_vision {
@@ -5670,7 +6615,6 @@ async fn configure_session_agent(
     let persist_result = agent.persist_extension_state(&session.id).await;
     attach_prepared_skills_client(&agent, skills_client).await;
     persist_result.map_err(|e| format!("Failed to persist Maple built-in tools: {e}"))?;
-    // Goose's live mode remains SmartApprove so every sensitive call reaches Maple.
     // Persist the user-facing policy separately for session restoration and display.
     session_manager
         .update(&session.id)
@@ -7021,6 +7965,210 @@ fn mcp_server_to_extension(server: &AgentMcpServer) -> Result<ExtensionConfig, S
     }
 }
 
+fn normalize_transient_mcp_servers(
+    servers: Vec<AgentTransientMcpServer>,
+) -> Result<Vec<AgentTransientMcpServer>, String> {
+    const MAX_TRANSIENT_MCP_SERVERS: usize = 16;
+    const MAX_TRANSIENT_MCP_TOTAL_BYTES: usize = 64 * 1024;
+    const MAX_TRANSIENT_MCP_DESCRIPTION_BYTES: usize = 1024;
+    const MAX_TRANSIENT_MCP_REQUEST_TIMEOUT_SECONDS: u64 = 30;
+
+    if servers.len() > MAX_TRANSIENT_MCP_SERVERS {
+        return Err(format!(
+            "An Agent surface may provide at most {MAX_TRANSIENT_MCP_SERVERS} transient MCP servers"
+        ));
+    }
+
+    let mut keys = HashSet::new();
+    let mut normalized = Vec::with_capacity(servers.len());
+    for mut server in servers {
+        server.name = server.name.trim().to_string();
+        server.description = server.description.trim().to_string();
+        if server.name.is_empty() || server.name.chars().count() > MAX_MCP_SERVER_NAME_CHARS {
+            return Err(
+                "Transient MCP server names must be between 1 and 64 characters".to_string(),
+            );
+        }
+        let key = goose::config::extensions::name_to_key(&server.name);
+        if key.is_empty() || maple_reserved_extension_key(&key) {
+            return Err(format!(
+                "The transient MCP server name '{}' is invalid or reserved by Maple",
+                server.name
+            ));
+        }
+        if !keys.insert(key) {
+            return Err(format!(
+                "Transient MCP server '{}' conflicts with another supplied server",
+                server.name
+            ));
+        }
+        if server.timeout_seconds == 0 {
+            return Err(format!(
+                "Transient MCP server '{}' must have a timeout greater than zero",
+                server.name
+            ));
+        }
+        if server.description.len() > MAX_TRANSIENT_MCP_DESCRIPTION_BYTES {
+            return Err(format!(
+                "Transient MCP server '{}' description exceeds the {MAX_TRANSIENT_MCP_DESCRIPTION_BYTES} byte limit",
+                server.name
+            ));
+        }
+        server.timeout_seconds = server
+            .timeout_seconds
+            .min(MAX_TRANSIENT_MCP_REQUEST_TIMEOUT_SECONDS);
+
+        let AgentTransientMcpTransport::StreamableHttp { url, headers } = &mut server.transport;
+        *url = url.trim().to_string();
+        validate_transient_mcp_url(url, &server.name)?;
+        validate_transient_mcp_key_values(
+            headers,
+            &server.name,
+            "HTTP header",
+            true,
+            MAX_TRANSIENT_MCP_TOTAL_BYTES,
+        )?;
+        normalized.push(server);
+    }
+    Ok(normalized)
+}
+
+fn validate_transient_mcp_key_values(
+    entries: &mut [AgentMcpKeyValue],
+    server_name: &str,
+    label: &str,
+    case_insensitive: bool,
+    max_total_bytes: usize,
+) -> Result<(), String> {
+    let mut keys = HashSet::new();
+    let mut total_bytes = 0usize;
+    for entry in entries {
+        entry.key = entry.key.trim().to_string();
+        let comparison_key = if case_insensitive {
+            entry.key.to_ascii_lowercase()
+        } else {
+            entry.key.clone()
+        };
+        if entry.key.is_empty()
+            || entry.key.contains(['\0', '='])
+            || (label == "HTTP header"
+                && (entry.key.chars().any(char::is_whitespace)
+                    || entry.value.contains(['\r', '\n'])))
+            || entry.value.contains('\0')
+            || entry.value.len() > 16 * 1024
+            || !keys.insert(comparison_key)
+        {
+            return Err(format!(
+                "Transient MCP server '{server_name}' has an invalid or duplicate {label}"
+            ));
+        }
+        total_bytes = total_bytes
+            .checked_add(entry.key.len())
+            .and_then(|total| total.checked_add(entry.value.len()))
+            .ok_or_else(|| format!("Transient MCP server '{server_name}' metadata is too large"))?;
+        if total_bytes > max_total_bytes {
+            return Err(format!(
+                "Transient MCP server '{server_name}' metadata exceeds the {max_total_bytes} byte limit"
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_transient_mcp_url(url: &str, server_name: &str) -> Result<(), String> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|_| format!("Transient MCP server '{server_name}' has an invalid URL"))?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| format!("Transient MCP server '{server_name}' URL requires a host"))?;
+    let loopback = host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback());
+    if !loopback || parsed.scheme() != "http" {
+        return Err(format!(
+            "Transient MCP server '{server_name}' must use loopback HTTP"
+        ));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() || parsed.fragment().is_some() {
+        return Err(format!(
+            "Transient MCP server '{server_name}' URL cannot contain credentials or a fragment"
+        ));
+    }
+    Ok(())
+}
+
+fn ensure_extension_sets_do_not_conflict(
+    persisted: &[ExtensionConfig],
+    transient: &[AgentTransientMcpServer],
+) -> Result<(), String> {
+    let persisted = persisted
+        .iter()
+        .map(ExtensionConfig::key)
+        .collect::<HashSet<_>>();
+    if let Some(conflict) = transient
+        .iter()
+        .find(|server| persisted.contains(&goose::config::extensions::name_to_key(&server.name)))
+    {
+        return Err(format!(
+            "Transient MCP server '{}' conflicts with this task's persisted MCP configuration",
+            conflict.name
+        ));
+    }
+    Ok(())
+}
+
+async fn install_transient_mcp_router(
+    tool_context: &SharedAgentToolContext,
+    session: &Session,
+    servers: Vec<AgentTransientMcpServer>,
+    setup_cancel: &CancellationToken,
+) -> Result<(), String> {
+    if servers.is_empty() {
+        return Ok(());
+    }
+
+    let configs = servers
+        .into_iter()
+        .map(|server| {
+            let AgentTransientMcpTransport::StreamableHttp { url, headers } = server.transport;
+            TransientMcpConfig {
+                name: server.name,
+                session_id: session.id.clone(),
+                request_timeout: std::time::Duration::from_secs(server.timeout_seconds),
+                url,
+                headers: headers
+                    .into_iter()
+                    .map(|entry| (entry.key, entry.value))
+                    .collect(),
+            }
+        })
+        .collect();
+    let lease_cancel = tool_context.lifetime_token();
+    let connect = TransientMcpRouter::connect(configs, lease_cancel.clone());
+    tokio::pin!(connect);
+    let router = tokio::select! {
+        biased;
+        _ = setup_cancel.cancelled() => {
+            tool_context.revoke();
+            return Err("Transient MCP setup was cancelled".to_string());
+        }
+        _ = lease_cancel.cancelled() => {
+            return Err("Agent tool context was revoked during MCP setup".to_string());
+        }
+        result = &mut connect => result.map_err(|error| format!("Failed to connect transient MCP: {error}"))?,
+        _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => {
+            tool_context.revoke();
+            return Err("Transient MCP setup timed out".to_string());
+        }
+    };
+    if let Err(error) = tool_context.install_transient_mcp(router.clone()) {
+        router.shutdown().await;
+        return Err(error);
+    }
+    Ok(())
+}
+
 fn select_mcp_servers(
     configured: &[AgentMcpServer],
     requested_names: Option<&[String]>,
@@ -7850,10 +8998,12 @@ async fn persist_unacked_steers(
 fn steered_run_handle(run_id: String, queue: AgentDesktopQueueSnapshot) -> AgentRunHandle {
     let (_events_tx, events) = mpsc::channel(1);
     let (_terminal_tx, terminal) = watch::channel(None);
+    let (_usage_tx, usage) = watch::channel(None);
     AgentRunHandle {
         run_id,
         events,
         terminal,
+        usage,
         event_overflowed: Arc::new(AtomicBool::new(false)),
         permission_responder: None,
         cancellation: None,
@@ -7869,10 +9019,12 @@ fn staged_run_handle(
 ) -> AgentRunHandle {
     let (_events_tx, events) = mpsc::channel(1);
     let (_terminal_tx, terminal) = watch::channel(None);
+    let (_usage_tx, usage) = watch::channel(None);
     AgentRunHandle {
         run_id,
         events,
         terminal,
+        usage,
         event_overflowed: Arc::new(AtomicBool::new(false)),
         permission_responder: None,
         cancellation: None,
@@ -8352,6 +9504,7 @@ fn path_string(path: &Path) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::response::IntoResponse;
     use goose_providers::base::{stream_from_single_message, MessageStream, Provider};
     use goose_providers::conversation::token_usage::{ProviderUsage, Usage};
     use goose_providers::errors::ProviderError;
@@ -8359,6 +9512,109 @@ mod tests {
     use rmcp::model::{Annotations, Role as McpRole, TextContent};
     use std::collections::{BTreeMap, BTreeSet};
     use std::sync::atomic::AtomicUsize;
+
+    struct BlockingMcpCatalogServer {
+        url: String,
+        catalog_entered: Arc<tokio::sync::Notify>,
+        catalog_release: Arc<tokio::sync::Notify>,
+        task: tokio::task::JoinHandle<()>,
+    }
+
+    impl Drop for BlockingMcpCatalogServer {
+        fn drop(&mut self) {
+            self.task.abort();
+        }
+    }
+
+    async fn blocking_mcp_catalog_server() -> BlockingMcpCatalogServer {
+        let catalog_entered = Arc::new(tokio::sync::Notify::new());
+        let catalog_release = Arc::new(tokio::sync::Notify::new());
+        let handler_entered = Arc::clone(&catalog_entered);
+        let handler_release = Arc::clone(&catalog_release);
+        let app = axum::Router::new().route(
+            "/mcp",
+            axum::routing::post(move |axum::Json(payload): axum::Json<Value>| {
+                let handler_entered = Arc::clone(&handler_entered);
+                let handler_release = Arc::clone(&handler_release);
+                async move {
+                    let method = payload["method"].as_str().unwrap_or_default();
+                    if method == "notifications/initialized" {
+                        return axum::http::StatusCode::ACCEPTED.into_response();
+                    }
+
+                    let id = payload["id"].clone();
+                    let result = match method {
+                        "initialize" => json!({
+                            "protocolVersion": payload["params"]["protocolVersion"],
+                            "capabilities": { "tools": {} },
+                            "serverInfo": {
+                                "name": "blocking-maple-setup-test",
+                                "version": "1.0.0"
+                            }
+                        }),
+                        "tools/list" => {
+                            handler_entered.notify_one();
+                            handler_release.notified().await;
+                            json!({
+                                "tools": [{
+                                    "name": "lookup",
+                                    "description": "Exercise post-install setup cancellation",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {}
+                                    }
+                                }]
+                            })
+                        }
+                        _ => {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::Json(json!({ "error": "unexpected method" })),
+                            )
+                                .into_response();
+                        }
+                    };
+                    axum::Json(json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        BlockingMcpCatalogServer {
+            url: format!("http://{address}/mcp"),
+            catalog_entered,
+            catalog_release,
+            task,
+        }
+    }
+
+    fn blocking_transient_mcp(server: &BlockingMcpCatalogServer) -> AgentTransientMcpServer {
+        AgentTransientMcpServer {
+            name: "paseo-test".to_string(),
+            description: "Deterministic setup cancellation fixture".to_string(),
+            timeout_seconds: 2,
+            transport: AgentTransientMcpTransport::StreamableHttp {
+                url: server.url.clone(),
+                headers: Vec::new(),
+            },
+        }
+    }
+
+    fn leased_test_tool_context() -> AgentToolContextSpec {
+        AgentToolContextSpec::try_new(
+            BTreeMap::from([("TOKEN".to_string(), "lease-secret".to_string())]),
+            BTreeSet::from(["TOKEN".to_string()]),
+            true,
+        )
+        .unwrap()
+    }
 
     struct NoopAgentEventSink;
 
@@ -8610,6 +9866,60 @@ mod tests {
             AgentToolContextSpec::default(),
         ));
         (test_root, paths, service)
+    }
+
+    async fn tool_context_cleanup_test_context(
+        label: &str,
+    ) -> (
+        PathBuf,
+        MapleAgentService,
+        Arc<SessionManager>,
+        PathBuf,
+        Arc<str>,
+    ) {
+        let (test_root, _paths, service) =
+            agent_service_test_context(label, Arc::new(NoopAgentEventSink));
+        let project_root = test_root.join("project");
+        fs::create_dir_all(&project_root).expect("project directory should be created");
+        let session_manager = Arc::new(SessionManager::new(test_root.join("sessions")));
+        let permission_manager = Arc::new(PermissionManager::new(test_root.join("permissions")));
+        let goose_config = GooseAgentConfig::new(
+            Arc::clone(&session_manager),
+            permission_manager,
+            None,
+            GooseMode::SmartApprove,
+            true,
+            GoosePlatform::GooseDesktop,
+        );
+        let agent_manager = Arc::new(
+            AgentManager::new(goose_config, None)
+                .await
+                .expect("test Agent manager should start"),
+        );
+        let user_id = format!("{label}-user");
+        let account_scope: Arc<str> = Arc::from(account_scope(&user_id).unwrap());
+        let runtime = AgentRuntime {
+            agent_manager,
+            session_manager: Arc::clone(&session_manager),
+            maple_api_session: crate::maple_api::test_maple_api_session(&user_id),
+            active_runs: HashMap::new(),
+            session_title_tasks: HashMap::new(),
+            session_tool_contexts: HashMap::new(),
+            permission_modes: Arc::new(Mutex::new(HashMap::new())),
+            web_tool_state: Arc::new(WebToolState::default()),
+            project_root: project_root.clone(),
+            model: DEFAULT_AGENT_MODEL.to_string(),
+            mode: DEFAULT_GOOSE_MODE.to_string(),
+            account_scope: account_scope.to_string(),
+        };
+        *service.inner.lock().await = Some(runtime);
+        (
+            test_root,
+            service,
+            session_manager,
+            project_root,
+            account_scope,
+        )
     }
 
     fn persisted_session_except_title(session: &Session) -> Value {
@@ -11206,7 +12516,7 @@ mod tests {
         let path = root.join("permission.yaml");
         fs::write(
             &path,
-            "user:\n  always_allow:\n  - shell\n  ask_before: []\n  never_allow: []\n",
+            "user:\n  always_allow:\n  - shell\n  - external_mcp\n  ask_before: []\n  never_allow: []\n",
         )
         .unwrap();
 
@@ -13339,16 +14649,19 @@ mod tests {
         .ptr_eq(&leased));
 
         leased.revoke();
-        let local = resolve_session_tool_context(
+        let error = match resolve_session_tool_context(
             &mut contexts,
             "account-1",
             "session-1",
             None,
             &AgentToolContextSpec::default(),
-        )
-        .expect("a revoked external context should be recoverable as a local task");
-        assert!(!local.ptr_eq(&leased));
-        assert_eq!(contexts["session-1"].owner, AgentToolContextOwner::Maple);
+        ) {
+            Err(error) => error,
+            Ok(_) => panic!("a revoked lease must remain authoritative until explicit release"),
+        };
+        assert!(error.contains("controlled by another Agent surface"));
+        assert!(contexts["session-1"].context.ptr_eq(&leased));
+        assert_eq!(contexts["session-1"].owner, AgentToolContextOwner::Leased);
     }
 
     #[test]
@@ -13366,6 +14679,455 @@ mod tests {
         }
         assert!(context.is_revoked());
         assert!(context.snapshot().values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn external_surface_setup_cancellation_interrupts_later_awaits() {
+        let context = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "secret".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+        let cancellation = CancellationToken::new();
+        let entered = Arc::new(tokio::sync::Notify::new());
+        let blocker = Arc::new(tokio::sync::Notify::new());
+        let task_context = context.clone();
+        let task_cancellation = cancellation.clone();
+        let task_entered = Arc::clone(&entered);
+        let task_blocker = Arc::clone(&blocker);
+        let setup = tokio::spawn(async move {
+            run_external_surface_setup(
+                &task_cancellation,
+                &task_context,
+                "surface closed",
+                async move {
+                    task_entered.notify_one();
+                    task_blocker.notified().await;
+                    Ok::<_, String>(())
+                },
+            )
+            .await
+        });
+
+        entered.notified().await;
+        cancellation.cancel();
+        let error = tokio::time::timeout(std::time::Duration::from_secs(1), setup)
+            .await
+            .expect("surface cancellation must not wait for a stalled setup phase")
+            .unwrap()
+            .unwrap_err();
+
+        assert_eq!(error, "surface closed");
+        assert!(context.is_revoked());
+        assert!(context.snapshot().values.is_empty());
+    }
+
+    #[tokio::test]
+    async fn cancelled_tool_context_release_retries_after_session_lifecycle_fence() {
+        let (test_root, service, session_manager, project_root, account_scope) =
+            tool_context_cleanup_test_context("cancelled-tool-context-release").await;
+        let session = session_manager
+            .create_session(
+                project_root,
+                "Cancelled lease release".to_string(),
+                SessionType::Acp,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let context = SharedAgentToolContext::new(
+            AgentToolContextSpec::try_new(
+                BTreeMap::from([("TOKEN".to_string(), "lease-secret".to_string())]),
+                BTreeSet::from(["TOKEN".to_string()]),
+                true,
+            )
+            .unwrap(),
+        );
+        let installation_id = next_tool_context_installation_id();
+        let access = AgentToolContextAccess {
+            account_scope,
+            session_id: Arc::from(session.id.as_str()),
+            installation_id,
+            context: context.clone(),
+        };
+        service
+            .inner
+            .lock()
+            .await
+            .as_mut()
+            .unwrap()
+            .session_tool_contexts
+            .insert(
+                session.id.clone(),
+                InstalledAgentToolContext {
+                    installation_id,
+                    context: context.clone(),
+                    owner: AgentToolContextOwner::Leased,
+                },
+            );
+        let lease = AgentToolContextLease {
+            service: service.clone(),
+            access: access.clone(),
+            created_cleanup: None,
+            discard_created_on_drop: false,
+            cleanup_started: false,
+        };
+
+        let session_lifecycle_guard = service.session_lifecycle.lock().await;
+        let release_task = tokio::spawn(lease.release());
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !context.is_revoked() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("lease release should revoke before waiting for the lifecycle fence");
+        release_task.abort();
+        assert!(release_task.await.unwrap_err().is_cancelled());
+
+        let exact_lease_remains_fenced = service
+            .inner
+            .lock()
+            .await
+            .as_ref()
+            .unwrap()
+            .session_tool_contexts
+            .get(&session.id)
+            .is_some_and(|installed| {
+                installed.installation_id == installation_id
+                    && installed.context.ptr_eq(&context)
+                    && installed.owner == AgentToolContextOwner::Leased
+            });
+        assert!(exact_lease_remains_fenced);
+
+        drop(session_lifecycle_guard);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let removed = service
+                    .inner
+                    .lock()
+                    .await
+                    .as_ref()
+                    .unwrap()
+                    .session_tool_contexts
+                    .get(&session.id)
+                    .is_none();
+                if removed {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("Drop should retry exact lease cleanup after cancellation");
+
+        drop(service);
+        drop(session_manager);
+        let _ = fs::remove_dir_all(test_root);
+    }
+
+    #[tokio::test]
+    async fn dropped_armed_pending_lease_cleans_registry_after_lifecycle_fence() {
+        let (test_root, service, session_manager, project_root, account_scope) =
+            tool_context_cleanup_test_context("dropped-pending-lease").await;
+        let session = session_manager
+            .create_session(
+                project_root,
+                "Pending attached lease".to_string(),
+                SessionType::User,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let context = SharedAgentToolContext::new(AgentToolContextSpec::default());
+        let installation_id = next_tool_context_installation_id();
+        let access = AgentToolContextAccess {
+            account_scope,
+            session_id: Arc::from(session.id.as_str()),
+            installation_id,
+            context: context.clone(),
+        };
+        service
+            .inner
+            .lock()
+            .await
+            .as_mut()
+            .unwrap()
+            .session_tool_contexts
+            .insert(
+                session.id.clone(),
+                InstalledAgentToolContext {
+                    installation_id,
+                    context: context.clone(),
+                    owner: AgentToolContextOwner::Leased,
+                },
+            );
+        let mut pending = PendingAgentToolContextInstallation::new(context.clone());
+        pending.arm_lease_cleanup(service.clone(), access);
+
+        let session_lifecycle_guard = service.session_lifecycle.lock().await;
+        drop(pending);
+        assert!(context.is_revoked());
+        assert!(service
+            .inner
+            .lock()
+            .await
+            .as_ref()
+            .unwrap()
+            .session_tool_contexts
+            .contains_key(&session.id));
+
+        drop(session_lifecycle_guard);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let removed = service
+                    .inner
+                    .lock()
+                    .await
+                    .as_ref()
+                    .unwrap()
+                    .session_tool_contexts
+                    .get(&session.id)
+                    .is_none();
+                if removed {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping an armed pending installation should clean its exact lease");
+        assert!(session_manager
+            .get_session(&session.id, false)
+            .await
+            .is_ok());
+
+        drop(service);
+        drop(session_manager);
+        let _ = fs::remove_dir_all(test_root);
+    }
+
+    #[tokio::test]
+    async fn dropped_pending_created_cleanup_deletes_only_untouched_provisional_session() {
+        let (test_root, service, session_manager, project_root, account_scope) =
+            tool_context_cleanup_test_context("dropped-pending-created").await;
+        let agent_manager = Arc::clone(&service.inner.lock().await.as_ref().unwrap().agent_manager);
+        let untouched = session_manager
+            .create_session(
+                project_root.clone(),
+                "Untouched provisional task".to_string(),
+                SessionType::Acp,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let modified = session_manager
+            .create_session(
+                project_root,
+                "Modified provisional task".to_string(),
+                SessionType::Acp,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        session_manager
+            .add_message(
+                &modified.id,
+                &Message::user()
+                    .with_text("Preserve this concurrent change")
+                    .with_generated_id(),
+            )
+            .await
+            .unwrap();
+
+        let untouched_context = SharedAgentToolContext::new(AgentToolContextSpec::default());
+        let untouched_installation_id = next_tool_context_installation_id();
+        let untouched_access = AgentToolContextAccess {
+            account_scope: Arc::clone(&account_scope),
+            session_id: Arc::from(untouched.id.as_str()),
+            installation_id: untouched_installation_id,
+            context: untouched_context.clone(),
+        };
+        let modified_context = SharedAgentToolContext::new(AgentToolContextSpec::default());
+        let modified_installation_id = next_tool_context_installation_id();
+        let modified_access = AgentToolContextAccess {
+            account_scope,
+            session_id: Arc::from(modified.id.as_str()),
+            installation_id: modified_installation_id,
+            context: modified_context.clone(),
+        };
+        {
+            let mut runtime = service.inner.lock().await;
+            let contexts = &mut runtime.as_mut().unwrap().session_tool_contexts;
+            contexts.insert(
+                untouched.id.clone(),
+                InstalledAgentToolContext {
+                    installation_id: untouched_installation_id,
+                    context: untouched_context.clone(),
+                    owner: AgentToolContextOwner::Leased,
+                },
+            );
+            contexts.insert(
+                modified.id.clone(),
+                InstalledAgentToolContext {
+                    installation_id: modified_installation_id,
+                    context: modified_context.clone(),
+                    owner: AgentToolContextOwner::Leased,
+                },
+            );
+        }
+        let mut untouched_pending =
+            PendingAgentToolContextInstallation::new(untouched_context.clone());
+        untouched_pending.arm_created_cleanup(
+            service.clone(),
+            untouched_access,
+            Arc::clone(&agent_manager),
+            Arc::clone(&session_manager),
+            untouched.clone(),
+        );
+        let mut modified_pending =
+            PendingAgentToolContextInstallation::new(modified_context.clone());
+        modified_pending.arm_created_cleanup(
+            service.clone(),
+            modified_access,
+            agent_manager,
+            Arc::clone(&session_manager),
+            modified.clone(),
+        );
+
+        let session_lifecycle_guard = service.session_lifecycle.lock().await;
+        drop(untouched_pending);
+        drop(modified_pending);
+        assert!(untouched_context.is_revoked());
+        assert!(modified_context.is_revoked());
+        assert_eq!(
+            service
+                .inner
+                .lock()
+                .await
+                .as_ref()
+                .unwrap()
+                .session_tool_contexts
+                .len(),
+            2
+        );
+
+        drop(session_lifecycle_guard);
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                let contexts_removed = service
+                    .inner
+                    .lock()
+                    .await
+                    .as_ref()
+                    .unwrap()
+                    .session_tool_contexts
+                    .is_empty();
+                let untouched_deleted = session_manager
+                    .get_session(&untouched.id, false)
+                    .await
+                    .is_err();
+                if contexts_removed && untouched_deleted {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("created cleanup should remove the untouched provisional task");
+
+        let preserved = session_manager
+            .get_session(&modified.id, true)
+            .await
+            .expect("cleanup must preserve a provisional task changed by another owner");
+        assert_eq!(preserved.message_count, 1);
+        assert!(preserved.conversation.is_some_and(|conversation| {
+            conversation
+                .messages()
+                .iter()
+                .any(|message| message.as_concat_text() == "Preserve this concurrent change")
+        }));
+
+        drop(service);
+        drop(session_manager);
+        let _ = fs::remove_dir_all(test_root);
+    }
+
+    #[tokio::test]
+    async fn dropped_pending_created_cleanup_survives_runtime_removal() {
+        let (test_root, service, session_manager, project_root, account_scope) =
+            tool_context_cleanup_test_context("dropped-pending-created-runtime-removal").await;
+        let agent_manager = Arc::clone(&service.inner.lock().await.as_ref().unwrap().agent_manager);
+        let provisional = session_manager
+            .create_session(
+                project_root,
+                "Runtime-stopped provisional task".to_string(),
+                SessionType::Acp,
+                GooseMode::SmartApprove,
+            )
+            .await
+            .unwrap();
+        let context = SharedAgentToolContext::new(AgentToolContextSpec::default());
+        let installation_id = next_tool_context_installation_id();
+        let access = AgentToolContextAccess {
+            account_scope,
+            session_id: Arc::from(provisional.id.as_str()),
+            installation_id,
+            context: context.clone(),
+        };
+        service
+            .inner
+            .lock()
+            .await
+            .as_mut()
+            .unwrap()
+            .session_tool_contexts
+            .insert(
+                provisional.id.clone(),
+                InstalledAgentToolContext {
+                    installation_id,
+                    context: context.clone(),
+                    owner: AgentToolContextOwner::Leased,
+                },
+            );
+        let mut pending = PendingAgentToolContextInstallation::new(context.clone());
+        pending.arm_created_cleanup(
+            service.clone(),
+            access,
+            agent_manager,
+            Arc::clone(&session_manager),
+            provisional.clone(),
+        );
+
+        // Runtime shutdown drains the in-memory registry before the abandoned
+        // handshake's Drop cleanup can run. The captured account-scoped
+        // managers must still remove only the untouched provisional row.
+        let removed_runtime = service.inner.lock().await.take();
+        drop(removed_runtime);
+        drop(pending);
+        assert!(context.is_revoked());
+
+        tokio::time::timeout(std::time::Duration::from_secs(2), async {
+            loop {
+                if session_manager
+                    .get_session(&provisional.id, false)
+                    .await
+                    .is_err()
+                {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("captured managers should clean the provisional row after runtime removal");
+
+        drop(service);
+        drop(session_manager);
+        let _ = fs::remove_dir_all(test_root);
     }
 
     #[test]

--- a/frontend/src-tauri/src/agent/developer_tools.rs
+++ b/frontend/src-tauri/src/agent/developer_tools.rs
@@ -62,6 +62,7 @@ const IMAGE_DESCRIPTION_MODEL: &str = "gemma4-31b";
 const IMAGE_DESCRIPTION_TEMPERATURE: f32 = 0.0;
 const IMAGE_DESCRIPTION_MAX_TOKENS: i32 = 2_048;
 const IMAGE_DESCRIPTION_CONTEXT_MAX_CHARS: usize = 12_000;
+pub(super) const EXTERNAL_MCP_TOOL_NAME: &str = "external_mcp";
 const IMAGE_DESCRIPTION_SYSTEM_PROMPT: &str = r#"You are the visual perception helper for a coding agent that cannot inspect images directly.
 
 Use the supplied task context only to determine which visual details are relevant. Do not continue
@@ -116,6 +117,13 @@ struct EditParams {
 struct WriteParams {
     path: String,
     content: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExternalMcpParams {
+    tool: String,
+    arguments: JsonObject,
 }
 
 fn deserialize_edits<'de, D>(deserializer: D) -> Result<Vec<Replacement>, D::Error>
@@ -393,6 +401,47 @@ impl MapleDeveloperClient {
         ))
     }
 
+    fn external_mcp_tool(tools: &[Tool]) -> Tool {
+        let tool_names = tools
+            .iter()
+            .map(|tool| tool.name.to_string())
+            .collect::<Vec<_>>();
+        let catalog = serde_json::Value::Array(
+            tools
+                .iter()
+                .map(|tool| {
+                    serde_json::json!({
+                        "tool": tool.name.as_ref(),
+                        "description": tool.description.as_ref(),
+                        "arguments": tool.input_schema.as_ref(),
+                    })
+                })
+                .collect(),
+        );
+        Tool::new(
+            EXTERNAL_MCP_TOOL_NAME.to_string(),
+            format!(
+                "Call one tool supplied by the current external ACP host. Select an exact tool ID and provide an arguments object matching its catalog contract. Calls are lease-scoped and require the host's permission policy.\n\nFrozen tool catalog:\n{catalog}"
+            ),
+            object!({
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                    "tool": {
+                        "type": "string",
+                        "enum": tool_names,
+                        "description": "Exact frozen external tool ID"
+                    },
+                    "arguments": {
+                        "type": "object",
+                        "description": "Arguments for the selected tool, matching its catalog contract"
+                    }
+                },
+                "required": ["tool", "arguments"],
+            }),
+        )
+    }
+
     fn parse_args<T: serde::de::DeserializeOwned>(
         arguments: Option<JsonObject>,
     ) -> Result<T, String> {
@@ -446,6 +495,17 @@ impl McpClientTrait for MapleDeveloperClient {
         }
         tools.push(web_search_tool());
         tools.push(open_url_tool());
+
+        if let Some(router) = self.tool_context.transient_mcp() {
+            if tools
+                .iter()
+                .any(|tool| tool.name.as_ref() == EXTERNAL_MCP_TOOL_NAME)
+            {
+                log::error!("Maple developer tools collided with the external MCP wrapper");
+                return Err(Error::UnexpectedResponse);
+            }
+            tools.push(Self::external_mcp_tool(router.tools()));
+        }
 
         Ok(ListToolsResult {
             tools,
@@ -558,6 +618,18 @@ impl McpClientTrait for MapleDeveloperClient {
                 }
                 Err(error) => error_result(bound_open_url_tool_error(error)),
             },
+            EXTERNAL_MCP_TOOL_NAME => {
+                let params = match Self::parse_args::<ExternalMcpParams>(arguments) {
+                    Ok(params) => params,
+                    Err(error) => return Ok(error_result(error)),
+                };
+                let Some(router) = self.tool_context.transient_mcp() else {
+                    return Ok(error_result("External MCP tools are no longer available"));
+                };
+                return router
+                    .call(&params.tool, ctx, Some(params.arguments), cancel_token)
+                    .await;
+            }
             _ => error_result(format!("Unknown tool: {name}")),
         };
         Ok(result)
@@ -2352,6 +2424,8 @@ fn mutation_key(path: &Path) -> PathBuf {
 mod tests {
     use super::*;
     use crate::agent::tool_context::AgentToolContextSpec;
+    use crate::agent::transient_mcp::{TransientMcpConfig, TransientMcpRouter};
+    use axum::response::IntoResponse;
     use goose::config::GooseMode;
     use goose::providers::base::{ProviderUsage, Usage};
     use goose::session::SessionManager;
@@ -2442,6 +2516,103 @@ mod tests {
         test_tool_context_snapshot(BTreeMap::new(), BTreeSet::new(), false)
     }
 
+    async fn install_test_transient_mcp(
+        tool_context: &SharedAgentToolContext,
+    ) -> (
+        TransientMcpRouter,
+        tokio::task::JoinHandle<()>,
+        Arc<AtomicU64>,
+    ) {
+        let call_count = Arc::new(AtomicU64::new(0));
+        let handler_call_count = Arc::clone(&call_count);
+        let app = axum::Router::new().route(
+            "/mcp",
+            axum::routing::post(move |axum::Json(payload): axum::Json<serde_json::Value>| {
+                let handler_call_count = Arc::clone(&handler_call_count);
+                async move {
+                    let method = payload["method"].as_str().unwrap_or_default();
+                    if method == "notifications/initialized" {
+                        return axum::http::StatusCode::ACCEPTED.into_response();
+                    }
+
+                    let id = payload["id"].clone();
+                    let result = match method {
+                        "initialize" => serde_json::json!({
+                            "protocolVersion": payload["params"]["protocolVersion"],
+                            "capabilities": { "tools": {} },
+                            "serverInfo": { "name": "test-transient-mcp", "version": "1.0.0" }
+                        }),
+                        "tools/list" => serde_json::json!({
+                            "tools": [
+                                {
+                                    "name": "lookup",
+                                    "description": "Look up an exact value",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "query": { "type": "string", "minLength": 2 }
+                                        },
+                                        "required": ["query"]
+                                    },
+                                    "annotations": { "readOnlyHint": true },
+                                    "_meta": { "untrusted": "catalog metadata" },
+                                    "icons": [{ "src": "https://example.com/untrusted.png" }]
+                                },
+                                {
+                                    "name": "mutate",
+                                    "description": "Mutate an exact value",
+                                    "inputSchema": {
+                                        "type": "object",
+                                        "additionalProperties": false,
+                                        "properties": {
+                                            "value": { "type": "integer", "minimum": 1 }
+                                        },
+                                        "required": ["value"]
+                                    }
+                                }
+                            ]
+                        }),
+                        "tools/call" => {
+                            handler_call_count.fetch_add(1, Ordering::Relaxed);
+                            serde_json::json!({ "content": [{ "type": "text", "text": "called" }] })
+                        }
+                        _ => {
+                            return (
+                                axum::http::StatusCode::BAD_REQUEST,
+                                axum::Json(serde_json::json!({ "error": "unexpected method" })),
+                            )
+                                .into_response();
+                        }
+                    };
+                    axum::Json(serde_json::json!({
+                        "jsonrpc": "2.0",
+                        "id": id,
+                        "result": result
+                    }))
+                    .into_response()
+                }
+            }),
+        );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+        let router = TransientMcpRouter::connect(
+            vec![TransientMcpConfig {
+                name: "paseo".to_string(),
+                session_id: "maple-test-session".to_string(),
+                request_timeout: Duration::from_secs(2),
+                url: format!("http://{address}/mcp"),
+                headers: Vec::new(),
+            }],
+            tool_context.lifetime_token(),
+        )
+        .await
+        .unwrap();
+        tool_context.install_transient_mcp(router.clone()).unwrap();
+        (router, server, call_count)
+    }
+
     struct TestDir(PathBuf);
 
     impl TestDir {
@@ -2528,6 +2699,7 @@ mod tests {
             ]
         );
         assert!(!names.contains(&"tree"));
+        assert!(!names.contains(&EXTERNAL_MCP_TOOL_NAME));
 
         let read = serde_json::to_value(&result.tools[0]).unwrap();
         assert_eq!(read["annotations"]["readOnlyHint"], false);
@@ -2569,6 +2741,116 @@ mod tests {
             .as_array()
             .unwrap()
             .contains(&serde_json::json!("purpose")));
+    }
+
+    #[tokio::test]
+    async fn transient_catalog_is_exposed_only_through_one_static_external_mcp_wrapper() {
+        let temp = TestDir::new();
+        let tool_context = test_tool_context(BTreeMap::new(), BTreeSet::new(), false);
+        let (router, server, call_count) = install_test_transient_mcp(&tool_context).await;
+        let client = MapleDeveloperClient::new(
+            test_context(temp.path().join("sessions")),
+            true,
+            Arc::new(TestWebTransport),
+            Arc::new(WebToolState::default()),
+            tool_context.clone(),
+        )
+        .unwrap();
+
+        let result = client
+            .list_tools("session", None, CancellationToken::new())
+            .await
+            .unwrap();
+        let names = result
+            .tools
+            .iter()
+            .map(|tool| tool.name.as_ref())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            names,
+            [
+                "read",
+                "shell",
+                "edit",
+                "write",
+                "read_image",
+                "web_search",
+                "open_url",
+                EXTERNAL_MCP_TOOL_NAME,
+            ]
+        );
+        assert!(!names.contains(&"paseo__lookup"));
+        assert!(!names.contains(&"paseo__mutate"));
+
+        let wrapper = result.tools.last().unwrap();
+        assert!(wrapper.annotations.is_none());
+        assert!(wrapper.meta.is_none());
+        assert!(wrapper.icons.is_none());
+        assert_eq!(wrapper.input_schema["type"], "object");
+        assert_eq!(wrapper.input_schema["additionalProperties"], false);
+        assert!(wrapper.input_schema.get("oneOf").is_none());
+        assert_eq!(
+            wrapper.input_schema["required"],
+            serde_json::json!(["tool", "arguments"])
+        );
+        let properties = wrapper.input_schema["properties"].as_object().unwrap();
+        assert_eq!(properties["tool"]["type"], "string");
+        assert_eq!(
+            properties["tool"]["enum"],
+            serde_json::json!(["paseo__lookup", "paseo__mutate"])
+        );
+        assert_eq!(properties["arguments"]["type"], "object");
+        assert!(properties["arguments"].get("oneOf").is_none());
+        assert!(properties["arguments"].get("properties").is_none());
+        let description = wrapper.description.as_deref().unwrap();
+        assert!(description.contains("Look up an exact value"));
+        assert!(description.contains("\"query\""));
+        assert!(description.contains("\"minLength\":2"));
+        assert!(description.contains("Mutate an exact value"));
+        assert!(description.contains("\"value\""));
+        assert!(description.contains("\"minimum\":1"));
+        let serialized = serde_json::to_string(wrapper).unwrap();
+        assert!(!serialized.contains("annotations"));
+        assert!(!serialized.contains("_meta"));
+        assert!(!serialized.contains("icons"));
+
+        let valid = client
+            .call_tool(
+                &ToolCallContext::new("session".to_string(), None, None),
+                EXTERNAL_MCP_TOOL_NAME,
+                Some(object!({
+                    "tool": "paseo__lookup",
+                    "arguments": { "query": "maple" }
+                })),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(!valid.is_error.unwrap_or(false));
+        assert_eq!(call_count.load(Ordering::Relaxed), 1);
+
+        let calls_before_unknown = call_count.load(Ordering::Relaxed);
+        let unknown = client
+            .call_tool(
+                &ToolCallContext::new("session".to_string(), None, None),
+                EXTERNAL_MCP_TOOL_NAME,
+                Some(object!({
+                    "tool": "paseo__missing",
+                    "arguments": {}
+                })),
+                CancellationToken::new(),
+            )
+            .await;
+        assert!(unknown.is_err());
+        assert_eq!(
+            call_count.load(Ordering::Relaxed),
+            calls_before_unknown,
+            "an unknown public tool ID must be rejected before any server call"
+        );
+
+        tool_context.revoke();
+        router.shutdown().await;
+        server.abort();
     }
 
     #[tokio::test]

--- a/frontend/src-tauri/src/agent/tool_context.rs
+++ b/frontend/src-tauri/src/agent/tool_context.rs
@@ -1,3 +1,4 @@
+use super::transient_mcp::TransientMcpRouter;
 use std::collections::{BTreeMap, BTreeSet};
 use std::sync::{Arc, Mutex, MutexGuard, RwLock};
 use tokio_util::sync::CancellationToken;
@@ -82,6 +83,7 @@ struct AgentToolContextState {
     values: BTreeMap<String, String>,
     scrub_from_parent: BTreeSet<String>,
     ephemeral: bool,
+    transient_mcp: Option<TransientMcpRouter>,
 }
 
 #[derive(Clone)]
@@ -98,6 +100,7 @@ impl SharedAgentToolContext {
                 values: spec.values,
                 scrub_from_parent: spec.scrub_from_parent,
                 ephemeral: spec.ephemeral,
+                transient_mcp: None,
             })),
             revoked: CancellationToken::new(),
             launch_gate: Arc::new(Mutex::new(())),
@@ -118,6 +121,35 @@ impl SharedAgentToolContext {
         }
     }
 
+    pub(crate) fn lifetime_token(&self) -> CancellationToken {
+        self.revoked.clone()
+    }
+
+    pub(crate) fn install_transient_mcp(&self, router: TransientMcpRouter) -> Result<(), String> {
+        let mut state = self
+            .state
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        if self.revoked.is_cancelled() {
+            return Err("Agent tool context was revoked during MCP setup".to_string());
+        }
+        if state.transient_mcp.is_some() {
+            return Err("Agent tool context already has transient MCP tools".to_string());
+        }
+        if !router.is_empty() {
+            state.transient_mcp = Some(router);
+        }
+        Ok(())
+    }
+
+    pub(crate) fn transient_mcp(&self) -> Option<TransientMcpRouter> {
+        self.state
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .transient_mcp
+            .clone()
+    }
+
     pub(crate) fn revoke(&self) {
         // Linearize revocation with command construction and spawn. Once this
         // method returns, no snapshot taken before revocation can launch a new
@@ -133,6 +165,7 @@ impl SharedAgentToolContext {
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         state.values.clear();
         state.ephemeral = false;
+        state.transient_mcp.take();
         // Retain inherited-key scrubbing after revocation. A removed explicit
         // credential must never reveal a same-named ambient process value.
     }

--- a/frontend/src-tauri/src/agent/transient_mcp.rs
+++ b/frontend/src-tauri/src/agent/transient_mcp.rs
@@ -1,0 +1,1037 @@
+//! Lease-scoped MCP clients supplied by an external Agent surface.
+//!
+//! These clients intentionally live outside Goose's `ExtensionManager`. In
+//! particular, they must never enter Goose's extension persistence,
+//! credential-store, or OAuth paths. The owning Agent-surface lease supplies a
+//! cancellation token; revoking it fails in-flight calls closed and tears down
+//! the transport.
+
+use goose::agents::mcp_client::{Error as McpError, McpClientTrait};
+use goose::agents::ToolCallContext;
+use goose::session_context::{SESSION_ID_HEADER, TOOL_CALL_REQUEST_ID_HEADER, WORKING_DIR_HEADER};
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, CancelledNotificationParam, ClientRequest, Extensions,
+    GetPromptRequestParams, GetPromptResult, InitializeResult, JsonObject, ListPromptsResult,
+    ListResourcesResult, ListToolsResult, MetaObject, Notification, PaginatedRequestParams,
+    ReadResourceRequestParams, ReadResourceResult, Request, RequestOptionalParam, ServerResult,
+    Tool,
+};
+use rmcp::service::{PeerRequestOptions, RoleClient, RunningService};
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::StreamableHttpClientTransport;
+use rmcp::{Peer, ServiceError, ServiceExt};
+use serde_json::Value;
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::{mpsc, Mutex};
+use tokio_util::sync::CancellationToken;
+
+const TRANSIENT_MCP_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+const TRANSIENT_MCP_CANCEL_SEND_TIMEOUT: Duration = Duration::from_secs(1);
+const TRANSIENT_MCP_MAX_SSE_EVENT_BYTES: usize = 4 * 1024 * 1024;
+const TRANSIENT_MCP_MAX_CATALOG_PAGES: usize = 16;
+const TRANSIENT_MCP_MAX_TOOLS_PER_SERVER: usize = 256;
+const TRANSIENT_MCP_MAX_TOOLS_TOTAL: usize = 1024;
+const TRANSIENT_MCP_MAX_TOOL_BYTES: usize = 256 * 1024;
+const TRANSIENT_MCP_MAX_CATALOG_BYTES: usize = 2 * 1024 * 1024;
+const TRANSIENT_MCP_MAX_PUBLIC_TOOL_NAME_BYTES: usize = 64;
+const TRANSIENT_MCP_MAX_TOOL_RESULT_BYTES: usize = 4 * 1024 * 1024;
+
+/// Complete, already-admitted configuration for one transient MCP server.
+///
+/// Validation at the ACP boundary remains authoritative. The checks here are
+/// defense in depth at the network authority boundary.
+pub(crate) struct TransientMcpConfig {
+    pub(crate) name: String,
+    pub(crate) session_id: String,
+    pub(crate) request_timeout: Duration,
+    pub(crate) url: String,
+    pub(crate) headers: Vec<(String, String)>,
+}
+
+/// A cloneable, secret-free descriptor used internally by the frozen router.
+///
+/// The credential-bearing HTTP client is reachable only through `client` and
+/// is dropped when the owning lease releases its final descriptor.
+#[derive(Clone)]
+struct TransientMcpDescriptor {
+    key: Arc<str>,
+    client: Arc<TransientMcpClient>,
+}
+
+impl fmt::Debug for TransientMcpDescriptor {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TransientMcpDescriptor")
+            .field("key", &self.key)
+            .finish_non_exhaustive()
+    }
+}
+
+impl TransientMcpDescriptor {
+    async fn connect(
+        mut config: TransientMcpConfig,
+        lease_cancel: CancellationToken,
+    ) -> Result<Self, TransientMcpConnectError> {
+        config.name = config.name.trim().to_owned();
+        config.session_id = config.session_id.trim().to_owned();
+        if config.name.is_empty() {
+            return Err(TransientMcpConnectError::InvalidConfiguration(
+                "MCP server name is empty",
+            ));
+        }
+        if config.request_timeout.is_zero() {
+            return Err(TransientMcpConnectError::InvalidConfiguration(
+                "MCP request timeout is zero",
+            ));
+        }
+        if config.session_id.is_empty() {
+            return Err(TransientMcpConnectError::InvalidConfiguration(
+                "MCP session ID is empty",
+            ));
+        }
+        let key = goose::config::extensions::name_to_key(&config.name);
+        if !valid_server_key(&key) {
+            return Err(TransientMcpConnectError::InvalidConfiguration(
+                "MCP server name has no usable key",
+            ));
+        }
+
+        let client = TransientMcpClient::connect_streamable_http(
+            config.url,
+            config.headers,
+            config.request_timeout,
+            lease_cancel,
+        )
+        .await?;
+
+        Ok(Self {
+            key: key.into(),
+            client,
+        })
+    }
+
+    fn key(&self) -> &str {
+        &self.key
+    }
+
+    async fn list_tools(
+        &self,
+        session_id: &str,
+        next_cursor: Option<String>,
+        cancel_token: CancellationToken,
+    ) -> Result<ListToolsResult, McpError> {
+        self.client
+            .list_tools(session_id, next_cursor, cancel_token)
+            .await
+    }
+
+    async fn call_tool(
+        &self,
+        context: &ToolCallContext,
+        name: &str,
+        arguments: Option<JsonObject>,
+        cancel_token: CancellationToken,
+    ) -> Result<CallToolResult, McpError> {
+        self.client
+            .call_tool(context, name, arguments, cancel_token)
+            .await
+    }
+
+    async fn shutdown(&self) {
+        self.client.shutdown().await;
+    }
+}
+
+#[derive(Clone)]
+struct TransientMcpRoute {
+    descriptor: TransientMcpDescriptor,
+    original_name: Arc<str>,
+}
+
+struct TransientMcpRouterInner {
+    tools: Arc<[Tool]>,
+    routes: HashMap<String, TransientMcpRoute>,
+    descriptors: Arc<[TransientMcpDescriptor]>,
+}
+
+/// Immutable, lease-scoped routing table for transient MCP tools.
+///
+/// Tool discovery happens exactly once while the router is constructed. A
+/// public tool name is always `<normalized-server-key>__<original-tool-name>`;
+/// later server catalog changes cannot retarget a model-visible name to a
+/// different client or operation.
+#[derive(Clone)]
+pub(crate) struct TransientMcpRouter {
+    inner: Arc<TransientMcpRouterInner>,
+}
+
+impl fmt::Debug for TransientMcpRouter {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TransientMcpRouter")
+            .field("servers", &self.inner.descriptors.len())
+            .field("tools", &self.inner.tools.len())
+            .finish()
+    }
+}
+
+impl TransientMcpRouter {
+    pub(crate) async fn connect(
+        configs: Vec<TransientMcpConfig>,
+        lease_cancel: CancellationToken,
+    ) -> Result<Self, TransientMcpConnectError> {
+        let mut server_keys = HashSet::with_capacity(configs.len());
+        for config in &configs {
+            let key = goose::config::extensions::name_to_key(config.name.trim());
+            if !valid_server_key(&key) {
+                return Err(TransientMcpConnectError::InvalidConfiguration(
+                    "MCP server name has no usable key",
+                ));
+            }
+            if !server_keys.insert(key) {
+                return Err(TransientMcpConnectError::DuplicateServer);
+            }
+        }
+
+        let mut descriptors = Vec::with_capacity(configs.len());
+        let mut routes = HashMap::new();
+        let mut public_tools = Vec::new();
+        let mut catalog_bytes = 0usize;
+        for config in configs {
+            let session_id = config.session_id.clone();
+            let descriptor =
+                match TransientMcpDescriptor::connect(config, lease_cancel.clone()).await {
+                    Ok(descriptor) => descriptor,
+                    Err(error) => {
+                        shutdown_descriptors(&descriptors).await;
+                        return Err(error);
+                    }
+                };
+            let discovered = match discover_tools(&descriptor, &session_id, &lease_cancel).await {
+                Ok(tools) => tools,
+                Err(error) => {
+                    descriptor.shutdown().await;
+                    shutdown_descriptors(&descriptors).await;
+                    return Err(error);
+                }
+            };
+
+            for (mut tool, original_name) in discovered {
+                if public_tools.len() >= TRANSIENT_MCP_MAX_TOOLS_TOTAL {
+                    descriptor.shutdown().await;
+                    shutdown_descriptors(&descriptors).await;
+                    return Err(TransientMcpConnectError::CatalogTooLarge);
+                }
+                let public_name = format!("{}__{}", descriptor.key(), original_name);
+                if !valid_public_tool_name(&public_name) {
+                    descriptor.shutdown().await;
+                    shutdown_descriptors(&descriptors).await;
+                    return Err(TransientMcpConnectError::InvalidCatalog);
+                }
+                if routes.contains_key(&public_name) {
+                    descriptor.shutdown().await;
+                    shutdown_descriptors(&descriptors).await;
+                    return Err(TransientMcpConnectError::DuplicateTool);
+                }
+
+                sanitize_catalog_tool(&mut tool, &public_name);
+                let tool_bytes = match serde_json::to_vec(&tool) {
+                    Ok(tool) => tool.len(),
+                    Err(_) => {
+                        descriptor.shutdown().await;
+                        shutdown_descriptors(&descriptors).await;
+                        return Err(TransientMcpConnectError::InvalidCatalog);
+                    }
+                };
+                if tool_bytes > TRANSIENT_MCP_MAX_TOOL_BYTES {
+                    descriptor.shutdown().await;
+                    shutdown_descriptors(&descriptors).await;
+                    return Err(TransientMcpConnectError::CatalogTooLarge);
+                }
+                catalog_bytes = match catalog_bytes.checked_add(tool_bytes) {
+                    Some(total) => total,
+                    None => {
+                        descriptor.shutdown().await;
+                        shutdown_descriptors(&descriptors).await;
+                        return Err(TransientMcpConnectError::CatalogTooLarge);
+                    }
+                };
+                if catalog_bytes > TRANSIENT_MCP_MAX_CATALOG_BYTES {
+                    descriptor.shutdown().await;
+                    shutdown_descriptors(&descriptors).await;
+                    return Err(TransientMcpConnectError::CatalogTooLarge);
+                }
+
+                routes.insert(
+                    public_name,
+                    TransientMcpRoute {
+                        descriptor: descriptor.clone(),
+                        original_name,
+                    },
+                );
+                public_tools.push(tool);
+            }
+            descriptors.push(descriptor);
+        }
+
+        Ok(Self {
+            inner: Arc::new(TransientMcpRouterInner {
+                tools: public_tools.into(),
+                routes,
+                descriptors: descriptors.into(),
+            }),
+        })
+    }
+
+    pub(crate) fn tools(&self) -> &[Tool] {
+        &self.inner.tools
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.inner.tools.is_empty()
+    }
+
+    pub(crate) async fn call(
+        &self,
+        public_name: &str,
+        context: &ToolCallContext,
+        arguments: Option<JsonObject>,
+        cancel_token: CancellationToken,
+    ) -> Result<CallToolResult, McpError> {
+        let route = self
+            .inner
+            .routes
+            .get(public_name)
+            .ok_or(ServiceError::UnexpectedResponse)?;
+        let mut result = route
+            .descriptor
+            .call_tool(context, &route.original_name, arguments, cancel_token)
+            .await
+            // Transport failures can contain a caller URL or malicious server
+            // response. Keep those details out of model-visible errors/logs.
+            .map_err(|_| ServiceError::UnexpectedResponse)?;
+        sanitize_tool_result(&mut result);
+        let result_bytes = serde_json::to_vec(&result)
+            .map_err(|_| ServiceError::UnexpectedResponse)?
+            .len();
+        if result_bytes > TRANSIENT_MCP_MAX_TOOL_RESULT_BYTES {
+            return Err(ServiceError::UnexpectedResponse);
+        }
+        Ok(result)
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        shutdown_descriptors(&self.inner.descriptors).await;
+    }
+}
+
+async fn discover_tools(
+    descriptor: &TransientMcpDescriptor,
+    session_id: &str,
+    lease_cancel: &CancellationToken,
+) -> Result<Vec<(Tool, Arc<str>)>, TransientMcpConnectError> {
+    let mut cursor = None;
+    let mut seen_cursors = HashSet::new();
+    let mut seen_names = HashSet::new();
+    let mut tools = Vec::new();
+    for _ in 0..TRANSIENT_MCP_MAX_CATALOG_PAGES {
+        let result = descriptor
+            .list_tools(session_id, cursor, lease_cancel.child_token())
+            .await
+            .map_err(|_| TransientMcpConnectError::CatalogRequest)?;
+        for tool in result.tools {
+            let original_name = tool.name.trim();
+            if !valid_original_tool_name(original_name)
+                || !seen_names.insert(original_name.to_owned())
+            {
+                return Err(if !valid_original_tool_name(original_name) {
+                    TransientMcpConnectError::InvalidCatalog
+                } else {
+                    TransientMcpConnectError::DuplicateTool
+                });
+            }
+            if tools.len() >= TRANSIENT_MCP_MAX_TOOLS_PER_SERVER {
+                return Err(TransientMcpConnectError::CatalogTooLarge);
+            }
+            let original_name: Arc<str> = original_name.to_owned().into();
+            tools.push((tool, original_name));
+        }
+        let Some(next_cursor) = result.next_cursor else {
+            return Ok(tools);
+        };
+        if next_cursor.is_empty() || !seen_cursors.insert(next_cursor.clone()) {
+            return Err(TransientMcpConnectError::InvalidCatalog);
+        }
+        cursor = Some(next_cursor);
+    }
+    Err(TransientMcpConnectError::CatalogTooLarge)
+}
+
+fn valid_tool_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'_' | b'-')
+}
+
+fn valid_server_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.len() <= TRANSIENT_MCP_MAX_PUBLIC_TOOL_NAME_BYTES.saturating_sub(3)
+        && key.bytes().all(valid_tool_name_byte)
+}
+
+fn valid_original_tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= TRANSIENT_MCP_MAX_PUBLIC_TOOL_NAME_BYTES
+        && name.bytes().all(valid_tool_name_byte)
+}
+
+fn valid_public_tool_name(name: &str) -> bool {
+    !name.is_empty()
+        && name.len() <= TRANSIENT_MCP_MAX_PUBLIC_TOOL_NAME_BYTES
+        && name.bytes().all(valid_tool_name_byte)
+}
+
+fn sanitize_catalog_tool(tool: &mut Tool, public_name: &str) {
+    // These descriptors are embedded only as variants of Maple's static
+    // ask-before `external_mcp` wrapper. Server-supplied permission or UI hints
+    // must not influence that host-owned boundary.
+    tool.name = public_name.to_owned().into();
+    tool.annotations = None;
+    tool.meta = None;
+    tool.icons = None;
+}
+
+fn sanitize_tool_result(result: &mut CallToolResult) {
+    use rmcp::model::{ContentBlock, ResourceContents};
+
+    // Protocol metadata and presentation annotations are untrusted server
+    // hints. Maple only forwards the actual result payload and error bit.
+    result.meta = None;
+    result.content.retain_mut(|content| {
+        match content {
+            ContentBlock::Text(content) => {
+                content.meta = None;
+                content.annotations = None;
+            }
+            ContentBlock::Image(content) => {
+                content.meta = None;
+                content.annotations = None;
+            }
+            ContentBlock::Audio(content) => {
+                content.meta = None;
+                content.annotations = None;
+            }
+            ContentBlock::Resource(content) => {
+                content.meta = None;
+                content.annotations = None;
+                match &mut content.resource {
+                    ResourceContents::TextResourceContents { meta, .. }
+                    | ResourceContents::BlobResourceContents { meta, .. } => *meta = None,
+                    _ => return false,
+                }
+            }
+            ContentBlock::ResourceLink(resource) => {
+                resource.meta = None;
+                resource.annotations = None;
+                resource.icons = None;
+            }
+            // `ContentBlock` is non-exhaustive. With the exact rmcp pin all
+            // current variants are handled above; fail closed if a future pin
+            // adds a host-active content type.
+            _ => return false,
+        }
+        true
+    });
+}
+
+async fn shutdown_descriptors(descriptors: &[TransientMcpDescriptor]) {
+    futures_util::future::join_all(descriptors.iter().map(TransientMcpDescriptor::shutdown)).await;
+}
+
+/// Safe, intentionally low-detail connection failures.
+///
+/// Source errors are not retained because transport errors can include a URL,
+/// headers or other caller-owned configuration.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TransientMcpConnectError {
+    InvalidConfiguration(&'static str),
+    HttpClient,
+    TimedOut,
+    Cancelled,
+    Initialize,
+    DuplicateServer,
+    CatalogRequest,
+    InvalidCatalog,
+    DuplicateTool,
+    CatalogTooLarge,
+}
+
+impl fmt::Display for TransientMcpConnectError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InvalidConfiguration(message) => formatter.write_str(message),
+            Self::HttpClient => formatter.write_str("could not construct MCP HTTP client"),
+            Self::TimedOut => formatter.write_str("MCP server initialization timed out"),
+            Self::Cancelled => formatter.write_str("MCP server initialization was cancelled"),
+            Self::Initialize => formatter.write_str("MCP server initialization failed"),
+            Self::DuplicateServer => formatter.write_str("MCP server names conflict"),
+            Self::CatalogRequest => formatter.write_str("MCP tool discovery failed"),
+            Self::InvalidCatalog => {
+                formatter.write_str("MCP server returned an invalid tool catalog")
+            }
+            Self::DuplicateTool => formatter.write_str("MCP tool names conflict"),
+            Self::CatalogTooLarge => formatter.write_str("MCP tool catalog exceeds its limit"),
+        }
+    }
+}
+
+impl std::error::Error for TransientMcpConnectError {}
+
+pub(crate) struct TransientMcpClient {
+    peer: Peer<RoleClient>,
+    server_info: Option<InitializeResult>,
+    request_timeout: Duration,
+    closed: CancellationToken,
+    running: Mutex<Option<RunningService<RoleClient, ()>>>,
+}
+
+impl TransientMcpClient {
+    async fn connect_streamable_http(
+        url: String,
+        headers: Vec<(String, String)>,
+        request_timeout: Duration,
+        lease_cancel: CancellationToken,
+    ) -> Result<Arc<Self>, TransientMcpConnectError> {
+        validate_loopback_http_url(&url)?;
+        let headers = parse_http_headers(headers)?;
+        let client = reqwest::Client::builder()
+            // Ambient HTTP(S)_PROXY settings must never redirect a bearer
+            // credential intended for Maple's loopback Paseo endpoint.
+            .no_proxy()
+            .pool_max_idle_per_host(0)
+            .redirect(reqwest::redirect::Policy::none())
+            .connect_timeout(request_timeout)
+            .timeout(request_timeout)
+            .build()
+            .map_err(|_| TransientMcpConnectError::HttpClient)?;
+        let transport_config = StreamableHttpClientTransportConfig::with_uri(url)
+            .custom_headers(headers)
+            .max_sse_event_size(TRANSIENT_MCP_MAX_SSE_EVENT_BYTES)
+            // Never replay an in-flight tool request after a session-expiry
+            // response; callers must make retry decisions at a higher layer.
+            .reinit_on_expired_session(false);
+        let transport = StreamableHttpClientTransport::with_client(client, transport_config);
+        let closed = lease_cancel.child_token();
+        let connect = ().serve(transport);
+        tokio::pin!(connect);
+        let running = tokio::select! {
+            biased;
+            _ = closed.cancelled() => return Err(TransientMcpConnectError::Cancelled),
+            result = &mut connect => result.map_err(|_| TransientMcpConnectError::Initialize)?,
+            _ = tokio::time::sleep(request_timeout) => {
+                return Err(TransientMcpConnectError::TimedOut);
+            }
+        };
+
+        let peer = running.peer().clone();
+        let server_info = running.peer_info().map(|info| {
+            let mut result = InitializeResult::new(info.capabilities.clone())
+                .with_protocol_version(info.protocol_version.clone());
+            if let Some(implementation) = &info.server_info {
+                result = result.with_server_info(implementation.clone());
+            }
+            result.instructions = info.instructions.clone();
+            result.meta = info.meta.clone();
+            result
+        });
+        let client = Arc::new(Self {
+            peer,
+            server_info,
+            request_timeout,
+            closed: closed.clone(),
+            running: Mutex::new(Some(running)),
+        });
+        Self::watch_lease(&client, lease_cancel, closed);
+        Ok(client)
+    }
+
+    fn watch_lease(client: &Arc<Self>, lease_cancel: CancellationToken, closed: CancellationToken) {
+        let client = Arc::downgrade(client);
+        tokio::spawn(async move {
+            tokio::select! {
+                _ = lease_cancel.cancelled() => {
+                    if let Some(client) = client.upgrade() {
+                        client.shutdown().await;
+                    }
+                }
+                _ = closed.cancelled() => {}
+            }
+        });
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.closed.cancel();
+        let running = self.running.lock().await.take();
+        if let Some(running) = running {
+            // Dropping the cancellation future on timeout also drops the
+            // RunningService, whose guard cancels the transport.
+            let _ = tokio::time::timeout(TRANSIENT_MCP_SHUTDOWN_TIMEOUT, running.cancel()).await;
+        }
+    }
+
+    async fn send_request(
+        &self,
+        request: ClientRequest,
+        cancel_token: CancellationToken,
+    ) -> Result<ServerResult, ServiceError> {
+        if self.closed.is_cancelled() || self.peer.is_transport_closed() {
+            return Err(ServiceError::TransportClosed);
+        }
+        let enqueue = self
+            .peer
+            .send_cancellable_request(request, PeerRequestOptions::no_options());
+        tokio::pin!(enqueue);
+        let handle = tokio::select! {
+            biased;
+            _ = self.closed.cancelled() => return Err(ServiceError::TransportClosed),
+            _ = cancel_token.cancelled() => {
+                return Err(ServiceError::Cancelled { reason: None });
+            }
+            result = &mut enqueue => result?,
+            _ = tokio::time::sleep(self.request_timeout) => {
+                return Err(ServiceError::Timeout { timeout: self.request_timeout });
+            }
+        };
+        let request_id = handle.id.clone();
+        let peer = handle.peer.clone();
+        let mut response = handle.rx;
+
+        tokio::select! {
+            biased;
+            _ = self.closed.cancelled() => {
+                send_cancel(&peer, request_id, "MCP lease revoked").await;
+                Err(ServiceError::TransportClosed)
+            }
+            _ = cancel_token.cancelled() => {
+                send_cancel(&peer, request_id, "operation cancelled").await;
+                Err(ServiceError::Cancelled { reason: None })
+            }
+            result = &mut response => {
+                result.map_err(|_| ServiceError::TransportClosed)?
+            }
+            _ = tokio::time::sleep(self.request_timeout) => {
+                send_cancel(&peer, request_id, "operation timed out").await;
+                Err(ServiceError::Timeout { timeout: self.request_timeout })
+            }
+        }
+    }
+}
+
+impl Drop for TransientMcpClient {
+    fn drop(&mut self) {
+        self.closed.cancel();
+        if let Ok(mut running) = self.running.try_lock() {
+            // RunningService's drop guard cancels its transport.
+            running.take();
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl McpClientTrait for TransientMcpClient {
+    async fn list_tools(
+        &self,
+        session_id: &str,
+        next_cursor: Option<String>,
+        cancel_token: CancellationToken,
+    ) -> Result<ListToolsResult, McpError> {
+        let response = self
+            .send_request(
+                with_session_context(
+                    ClientRequest::ListToolsRequest(RequestOptionalParam::with_param(
+                        PaginatedRequestParams::default().with_cursor(next_cursor),
+                    )),
+                    Some(session_id),
+                    None,
+                    None,
+                ),
+                cancel_token,
+            )
+            .await?;
+        match response {
+            ServerResult::ListToolsResult(result) => Ok(result),
+            _ => Err(ServiceError::UnexpectedResponse),
+        }
+    }
+
+    async fn call_tool(
+        &self,
+        context: &ToolCallContext,
+        name: &str,
+        arguments: Option<JsonObject>,
+        cancel_token: CancellationToken,
+    ) -> Result<CallToolResult, McpError> {
+        let mut params = CallToolRequestParams::new(name.to_owned());
+        if let Some(arguments) = arguments {
+            params = params.with_arguments(arguments);
+        }
+        let response = self
+            .send_request(
+                with_session_context(
+                    ClientRequest::CallToolRequest(Request::new(params)),
+                    Some(&context.session_id),
+                    context.working_dir_str(),
+                    context.tool_call_request_id.as_deref(),
+                ),
+                cancel_token,
+            )
+            .await?;
+        match response {
+            ServerResult::CallToolResult(result) => Ok(result),
+            _ => Err(ServiceError::UnexpectedResponse),
+        }
+    }
+
+    fn get_info(&self) -> Option<&InitializeResult> {
+        self.server_info.as_ref()
+    }
+
+    async fn list_resources(
+        &self,
+        session_id: &str,
+        next_cursor: Option<String>,
+        cancel_token: CancellationToken,
+    ) -> Result<ListResourcesResult, McpError> {
+        let response = self
+            .send_request(
+                with_session_context(
+                    ClientRequest::ListResourcesRequest(RequestOptionalParam::with_param(
+                        PaginatedRequestParams::default().with_cursor(next_cursor),
+                    )),
+                    Some(session_id),
+                    None,
+                    None,
+                ),
+                cancel_token,
+            )
+            .await?;
+        match response {
+            ServerResult::ListResourcesResult(result) => Ok(result),
+            _ => Err(ServiceError::UnexpectedResponse),
+        }
+    }
+
+    async fn read_resource(
+        &self,
+        session_id: &str,
+        uri: &str,
+        cancel_token: CancellationToken,
+    ) -> Result<ReadResourceResult, McpError> {
+        let response = self
+            .send_request(
+                with_session_context(
+                    ClientRequest::ReadResourceRequest(Request::new(
+                        ReadResourceRequestParams::new(uri.to_owned()),
+                    )),
+                    Some(session_id),
+                    None,
+                    None,
+                ),
+                cancel_token,
+            )
+            .await?;
+        match response {
+            ServerResult::ReadResourceResult(result) => Ok(result),
+            _ => Err(ServiceError::UnexpectedResponse),
+        }
+    }
+
+    async fn list_prompts(
+        &self,
+        session_id: &str,
+        next_cursor: Option<String>,
+        cancel_token: CancellationToken,
+    ) -> Result<ListPromptsResult, McpError> {
+        let response = self
+            .send_request(
+                with_session_context(
+                    ClientRequest::ListPromptsRequest(RequestOptionalParam::with_param(
+                        PaginatedRequestParams::default().with_cursor(next_cursor),
+                    )),
+                    Some(session_id),
+                    None,
+                    None,
+                ),
+                cancel_token,
+            )
+            .await?;
+        match response {
+            ServerResult::ListPromptsResult(result) => Ok(result),
+            _ => Err(ServiceError::UnexpectedResponse),
+        }
+    }
+
+    async fn get_prompt(
+        &self,
+        session_id: &str,
+        name: &str,
+        arguments: Value,
+        cancel_token: CancellationToken,
+    ) -> Result<GetPromptResult, McpError> {
+        let mut params = GetPromptRequestParams::new(name.to_owned());
+        if let Value::Object(arguments) = arguments {
+            params = params.with_arguments(arguments);
+        }
+        let response = self
+            .send_request(
+                with_session_context(
+                    ClientRequest::GetPromptRequest(Request::new(params)),
+                    Some(session_id),
+                    None,
+                    None,
+                ),
+                cancel_token,
+            )
+            .await?;
+        match response {
+            ServerResult::GetPromptResult(result) => Ok(result),
+            _ => Err(ServiceError::UnexpectedResponse),
+        }
+    }
+
+    async fn subscribe(&self) -> mpsc::Receiver<rmcp::model::ServerNotification> {
+        // `()` is deliberately used as the rmcp client handler so transient
+        // servers cannot invoke sampling, elicitation, or other host callbacks.
+        // Request-scoped results remain fully available; unsolicited server
+        // notifications are intentionally not exposed by this minimal host.
+        mpsc::channel(1).1
+    }
+}
+
+async fn send_cancel(peer: &Peer<RoleClient>, request_id: rmcp::model::RequestId, reason: &str) {
+    let notification = Notification::new(CancelledNotificationParam::new(
+        Some(request_id),
+        Some(reason.to_owned()),
+    ));
+    let _ = tokio::time::timeout(
+        TRANSIENT_MCP_CANCEL_SEND_TIMEOUT,
+        peer.send_notification(notification.into()),
+    )
+    .await;
+}
+
+fn with_session_context(
+    request: ClientRequest,
+    session_id: Option<&str>,
+    working_dir: Option<&str>,
+    tool_call_request_id: Option<&str>,
+) -> ClientRequest {
+    match request {
+        ClientRequest::ListResourcesRequest(mut request) => {
+            request.extensions = context_extensions(
+                request.extensions,
+                session_id,
+                working_dir,
+                tool_call_request_id,
+            );
+            ClientRequest::ListResourcesRequest(request)
+        }
+        ClientRequest::ReadResourceRequest(mut request) => {
+            request.extensions = context_extensions(
+                request.extensions,
+                session_id,
+                working_dir,
+                tool_call_request_id,
+            );
+            ClientRequest::ReadResourceRequest(request)
+        }
+        ClientRequest::ListToolsRequest(mut request) => {
+            request.extensions = context_extensions(
+                request.extensions,
+                session_id,
+                working_dir,
+                tool_call_request_id,
+            );
+            ClientRequest::ListToolsRequest(request)
+        }
+        ClientRequest::CallToolRequest(mut request) => {
+            request.extensions = context_extensions(
+                request.extensions,
+                session_id,
+                working_dir,
+                tool_call_request_id,
+            );
+            ClientRequest::CallToolRequest(request)
+        }
+        ClientRequest::ListPromptsRequest(mut request) => {
+            request.extensions = context_extensions(
+                request.extensions,
+                session_id,
+                working_dir,
+                tool_call_request_id,
+            );
+            ClientRequest::ListPromptsRequest(request)
+        }
+        ClientRequest::GetPromptRequest(mut request) => {
+            request.extensions = context_extensions(
+                request.extensions,
+                session_id,
+                working_dir,
+                tool_call_request_id,
+            );
+            ClientRequest::GetPromptRequest(request)
+        }
+        request => request,
+    }
+}
+
+fn context_extensions(
+    mut extensions: Extensions,
+    session_id: Option<&str>,
+    working_dir: Option<&str>,
+    tool_call_request_id: Option<&str>,
+) -> Extensions {
+    let mut metadata = extensions
+        .get::<MetaObject>()
+        .map(|metadata| metadata.0.clone())
+        .unwrap_or_default();
+    metadata.retain(|key, _| {
+        !key.eq_ignore_ascii_case(SESSION_ID_HEADER)
+            && !key.eq_ignore_ascii_case(WORKING_DIR_HEADER)
+            && !key.eq_ignore_ascii_case(TOOL_CALL_REQUEST_ID_HEADER)
+    });
+    if let Some(session_id) = session_id.filter(|value| !value.is_empty()) {
+        metadata.insert(
+            SESSION_ID_HEADER.to_owned(),
+            Value::String(session_id.to_owned()),
+        );
+    }
+    if let Some(working_dir) = working_dir.filter(|value| !value.is_empty()) {
+        metadata.insert(
+            WORKING_DIR_HEADER.to_owned(),
+            Value::String(working_dir.to_owned()),
+        );
+    }
+    if let Some(request_id) = tool_call_request_id.filter(|value| !value.is_empty()) {
+        metadata.insert(
+            TOOL_CALL_REQUEST_ID_HEADER.to_owned(),
+            Value::String(request_id.to_owned()),
+        );
+    }
+    extensions.insert(MetaObject(metadata));
+    extensions
+}
+
+fn validate_loopback_http_url(url: &str) -> Result<(), TransientMcpConnectError> {
+    let parsed = reqwest::Url::parse(url)
+        .map_err(|_| TransientMcpConnectError::InvalidConfiguration("MCP HTTP URL is invalid"))?;
+    let host = parsed
+        .host_str()
+        .ok_or(TransientMcpConnectError::InvalidConfiguration(
+            "MCP HTTP URL has no host",
+        ))?;
+    let loopback = host.eq_ignore_ascii_case("localhost")
+        || host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback());
+    if parsed.scheme() != "http" || !loopback {
+        return Err(TransientMcpConnectError::InvalidConfiguration(
+            "Transient MCP is restricted to loopback HTTP",
+        ));
+    }
+    if !parsed.username().is_empty() || parsed.password().is_some() || parsed.fragment().is_some() {
+        return Err(TransientMcpConnectError::InvalidConfiguration(
+            "MCP HTTP URL contains credentials or a fragment",
+        ));
+    }
+    Ok(())
+}
+
+fn parse_http_headers(
+    headers: Vec<(String, String)>,
+) -> Result<
+    HashMap<reqwest::header::HeaderName, reqwest::header::HeaderValue>,
+    TransientMcpConnectError,
+> {
+    let mut parsed = HashMap::with_capacity(headers.len());
+    let mut names = HashSet::with_capacity(headers.len());
+    for (name, value) in headers {
+        let normalized = name.to_ascii_lowercase();
+        if reserved_http_header(&normalized) {
+            return Err(TransientMcpConnectError::InvalidConfiguration(
+                "MCP HTTP header is reserved by the transport",
+            ));
+        }
+        if !names.insert(normalized) {
+            return Err(TransientMcpConnectError::InvalidConfiguration(
+                "MCP HTTP headers contain a duplicate name",
+            ));
+        }
+        let name = reqwest::header::HeaderName::from_bytes(name.as_bytes()).map_err(|_| {
+            TransientMcpConnectError::InvalidConfiguration("MCP HTTP header name is invalid")
+        })?;
+        let value = reqwest::header::HeaderValue::from_str(&value).map_err(|_| {
+            TransientMcpConnectError::InvalidConfiguration("MCP HTTP header value is invalid")
+        })?;
+        parsed.insert(name, value);
+    }
+    Ok(parsed)
+}
+
+fn reserved_http_header(name: &str) -> bool {
+    matches!(
+        name,
+        "accept"
+            | "connection"
+            | "content-length"
+            | "content-type"
+            | "forwarded"
+            | "host"
+            | "keep-alive"
+            | "last-event-id"
+            | "mcp-method"
+            | "mcp-name"
+            | "mcp-protocol-version"
+            | "mcp-session-id"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailer"
+            | "transfer-encoding"
+            | "upgrade"
+            | "via"
+            | "x-real-ip"
+    ) || name.starts_with("mcp-param-")
+        || name.starts_with("proxy-")
+        || name.starts_with("x-forwarded-")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn transient_catalog_tool_has_no_persistable_hints_or_host_metadata() {
+        let mut tool = Tool::new("original", "description", JsonObject::new());
+        tool.annotations = Some(rmcp::model::ToolAnnotations::new().read_only(true));
+        tool.meta = Some(MetaObject(JsonObject::new()));
+        tool.icons = Some(Vec::new());
+
+        sanitize_catalog_tool(&mut tool, "paseo__original");
+
+        assert_eq!(tool.name, "paseo__original");
+        assert!(tool.annotations.is_none());
+        assert!(tool.meta.is_none());
+        assert!(tool.icons.is_none());
+    }
+
+    #[test]
+    fn public_tool_names_use_the_provider_safe_subset_and_limit() {
+        assert!(valid_public_tool_name("paseo__read_file"));
+        assert!(!valid_public_tool_name("paseo__read.file"));
+        assert!(!valid_public_tool_name(
+            &"a".repeat(TRANSIENT_MCP_MAX_PUBLIC_TOOL_NAME_BYTES + 1)
+        ));
+    }
+}

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -2121,6 +2121,22 @@ pub async fn agent_acp_start(
 }
 
 #[tauri::command]
+pub async fn agent_acp_restore_enabled(
+    app_handle: AppHandle,
+    lifecycle: tauri::State<'_, AgentHostLifecycle>,
+    user_id: String,
+) -> Result<AgentAcpStatus, String> {
+    let _guard = lifecycle.lock().await;
+    if load_config(&app_handle, &user_id)?.enabled {
+        app_handle
+            .state::<MapleAgentService>()
+            .ensure_accepting_new_work()?;
+        start_service_locked(&app_handle, &user_id).await?;
+    }
+    status(&app_handle, &user_id).await
+}
+
+#[tauri::command]
 pub async fn agent_acp_stop(
     app_handle: AppHandle,
     lifecycle: tauri::State<'_, AgentHostLifecycle>,

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -1,18 +1,26 @@
 use crate::agent::{
-    AgentCreateSessionRequest, AgentHostEventPolicy, AgentPermissionDecision,
+    AgentCreateSessionRequest, AgentHostEventPolicy, AgentMcpKeyValue, AgentPermissionDecision,
     AgentPermissionRequest, AgentRunCancellation, AgentRunEvent, AgentRunPermissionResponder,
-    AgentRunTerminal, AgentRuntimeHandle, AgentSendMessageRequest, AgentTimelineItem,
-    AgentToolContextLease, AgentToolContextSpec, MapleAgentService,
+    AgentRunTerminal, AgentRunUsage, AgentRuntimeHandle, AgentSendMessageRequest,
+    AgentSessionSummary, AgentTimelineItem, AgentToolContextLease, AgentToolContextSpec,
+    AgentTransientMcpServer, AgentTransientMcpTransport, MapleAgentService,
     AGENT_TOOL_CONTEXT_INACTIVE_ERROR,
 };
 use crate::agent_host::AgentHostLifecycle;
 use crate::maple_api::{account_scope, MapleApiAuthState};
 use agent_client_protocol::schema::v1::{
-    AgentCapabilities, CancelNotification, ContentBlock, ContentChunk, Implementation,
-    InitializeRequest, InitializeResponse, McpServer, NewSessionRequest, NewSessionResponse,
+    AgentCapabilities, CancelNotification, CloseSessionRequest, CloseSessionResponse,
+    ConfigOptionUpdate, ContentBlock, ContentChunk, Implementation, InitializeRequest,
+    InitializeResponse, ListSessionsRequest, ListSessionsResponse, LoadSessionRequest,
+    LoadSessionResponse, McpCapabilities, McpServer, NewSessionRequest, NewSessionResponse,
     PermissionOption, PermissionOptionKind, PromptCapabilities, PromptRequest, PromptResponse,
-    RequestPermissionOutcome, RequestPermissionRequest, SessionId, SessionNotification,
-    SessionUpdate, StopReason, TextContent, ToolCall, ToolCallContent, ToolCallStatus, ToolKind,
+    RequestPermissionOutcome, RequestPermissionRequest, SessionCapabilities,
+    SessionCloseCapabilities, SessionConfigOption, SessionConfigOptionCategory,
+    SessionConfigSelectOption, SessionId, SessionInfo, SessionListCapabilities, SessionMode,
+    SessionModeState, SessionNotification, SessionUpdate, SetSessionConfigOptionRequest,
+    SetSessionConfigOptionResponse, SetSessionModeRequest, SetSessionModeResponse, StopReason,
+    TextContent, ToolCall, ToolCallContent, ToolCallLocation, ToolCallStatus, ToolCallUpdate,
+    ToolCallUpdateFields, ToolKind, Usage,
 };
 use agent_client_protocol::util::MatchDispatchFrom;
 use agent_client_protocol::{
@@ -22,7 +30,7 @@ use agent_client_protocol::{
 use futures_util::StreamExt as _;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
-use std::collections::{BTreeMap, BTreeSet, HashMap, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
@@ -47,6 +55,9 @@ const MAX_ACP_OUTBOUND_BYTES_IN_FLIGHT: usize = 4 * 1024 * 1024;
 const ACP_OUTBOUND_FRAME_OVERHEAD_BYTES: usize = 256;
 const ACP_CONNECTION_CLEANUP_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const ACP_SYNTHETIC_STOP_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const ACP_SESSION_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const ACP_TRANSIENT_MCP_TIMEOUT_SECONDS: u64 = 30;
+const ACP_LOADABLE_GOOSE_MODE: &str = "smart_approve";
 const BRIDGE_HELLO_METHOD: &str = "_maple/bridge/hello";
 const ALLOWED_BRIDGE_ENV: [&str; 6] = [
     "BUZZ_RELAY_URL",
@@ -63,6 +74,7 @@ const SENSITIVE_BRIDGE_ENV: [&str; 5] = [
     "BUZZ_API_TOKEN",
     "BUZZ_ACP_DISPLAY_NAME",
 ];
+static NEXT_ACP_MESSAGE_ID: AtomicUsize = AtomicUsize::new(1);
 
 #[cfg(unix)]
 struct BoundedLineReader<R> {
@@ -190,7 +202,7 @@ fn default_permission_mode() -> AgentAcpPermissionMode {
 }
 
 fn default_max_connections() -> usize {
-    1
+    8
 }
 
 impl Default for AgentAcpConfig {
@@ -269,7 +281,9 @@ struct AcpConnectionContext {
     config: Arc<RwLock<AgentAcpConfig>>,
     stats: Arc<AgentAcpStats>,
     bridge_environment: Mutex<HashMap<String, String>>,
-    sessions: Mutex<HashMap<String, AgentToolContextLease>>,
+    sessions: Mutex<HashMap<String, AcpSession>>,
+    session_operations: Mutex<HashMap<String, Arc<AcpSessionOperation>>>,
+    closing_sessions: Mutex<HashSet<String>>,
     prompt_states: Mutex<HashMap<String, AcpPromptState>>,
     background_tasks: Mutex<tokio::task::JoinSet<()>>,
     finalization: Mutex<()>,
@@ -277,6 +291,91 @@ struct AcpConnectionContext {
     closed: AtomicBool,
     has_credentials: AtomicBool,
     outbound: Arc<AcpOutboundTracker>,
+}
+
+struct AcpSession {
+    lease: Option<AgentToolContextLease>,
+    model: String,
+    available_models: Vec<String>,
+    message_count: usize,
+    created_here: bool,
+    prompted: bool,
+}
+
+struct UnpublishedAcpSession {
+    lease: Option<AgentToolContextLease>,
+    published: bool,
+}
+
+impl UnpublishedAcpSession {
+    fn new(lease: AgentToolContextLease) -> Self {
+        Self {
+            lease: Some(lease),
+            published: false,
+        }
+    }
+
+    fn publish(mut self) -> AgentToolContextLease {
+        self.published = true;
+        self.lease
+            .take()
+            .expect("an unpublished ACP session must still own its lease")
+    }
+}
+
+impl Drop for UnpublishedAcpSession {
+    fn drop(&mut self) {
+        if self.published {
+            return;
+        }
+        let Some(lease) = self.lease.take() else {
+            return;
+        };
+        lease.revoke();
+        if let Ok(runtime) = tokio::runtime::Handle::try_current() {
+            runtime.spawn(async move {
+                lease.discard_created_if_untouched().await;
+            });
+        }
+    }
+}
+
+struct AcpSessionOperation {
+    gate: Arc<Mutex<()>>,
+    cancellation: CancellationToken,
+}
+
+fn close_registration_may_be_released(
+    cancellation_completed: bool,
+    operation_drained: bool,
+    cleanup_completed: bool,
+) -> bool {
+    // A timed-out load may already have passed its final core cancellation
+    // check. Keep both its exact operation registration and the closing
+    // tombstone until connection teardown so it can never publish a lease
+    // after session/close has returned. The same fence stays in place while
+    // run cancellation or exact-match lease cleanup is still settling.
+    cancellation_completed && operation_drained && cleanup_completed
+}
+
+impl AcpSessionOperation {
+    fn new(connection_lifetime: &CancellationToken) -> Arc<Self> {
+        Arc::new(Self {
+            gate: Arc::new(Mutex::new(())),
+            cancellation: connection_lifetime.child_token(),
+        })
+    }
+}
+
+impl AcpSession {
+    fn config_options(&self) -> Vec<SessionConfigOption> {
+        acp_session_config_options(&self.model, &self.available_models, self.message_count)
+    }
+}
+
+#[derive(Default)]
+struct AcpToolProjection {
+    seen: HashSet<String>,
 }
 
 enum AcpPromptState {
@@ -408,6 +507,8 @@ impl AcpConnectionContext {
             stats,
             bridge_environment: Mutex::new(HashMap::new()),
             sessions: Mutex::new(HashMap::new()),
+            session_operations: Mutex::new(HashMap::new()),
+            closing_sessions: Mutex::new(HashSet::new()),
             prompt_states: Mutex::new(HashMap::new()),
             background_tasks: Mutex::new(tokio::task::JoinSet::new()),
             finalization: Mutex::new(()),
@@ -445,26 +546,38 @@ impl AcpConnectionContext {
             return Err(agent_client_protocol::Error::invalid_params()
                 .data("ACP session cwd must be an absolute path"));
         }
+        if !request.additional_directories.is_empty() {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Maple ACP does not support additional session directories"));
+        }
         let config = self.config.read().await.clone();
         let project_root = ensure_allowed_project_root(&request.cwd, &config.allowed_project_roots)
             .map_err(|error| agent_client_protocol::Error::invalid_params().data(error))?;
 
-        let mut environment = self.bridge_environment.lock().await.clone();
-        merge_mcp_environment(&mut environment, &request.mcp_servers)?;
+        let available_models = self.available_models().await?;
+        let model = available_models
+            .first()
+            .cloned()
+            .ok_or_else(|| internal_acp_error("Maple returned no models".to_string()))?;
+        let bridge_environment = self.bridge_environment.lock().await.clone();
+        let (environment, transient_mcp_servers) =
+            prepare_session_mcp(&bridge_environment, &request.mcp_servers)?;
         let tool_context = bridge_tool_context_spec(&environment).map_err(internal_acp_error)?;
         let mode = config.permission_mode.maple_mode().to_string();
         let created = self
             .agent
-            .create_session_with_tool_context(
+            .create_session_with_surface_context(
                 Some(AgentCreateSessionRequest {
                     project_root: Some(project_root.to_string_lossy().into_owned()),
-                    title: Some("Buzz ACP".to_string()),
-                    model: None,
+                    title: Some("Maple ACP".to_string()),
+                    model: Some(model.clone()),
                     context_limit: None,
                     mode: Some(mode),
                     mcp_server_names: None,
                 }),
                 Some(tool_context),
+                transient_mcp_servers,
+                self.lifetime.child_token(),
                 // The ACP caller is the only interactive surface for this task.
                 // Persisted history remains loadable in Maple Desktop, but live
                 // permission cards must never create a second approval broker.
@@ -472,26 +585,42 @@ impl AcpConnectionContext {
             )
             .await
             .map_err(internal_acp_error)?;
-        let session_id = created.detail.session.id;
+        let session_id = canonical_session_id_text(&created.detail.session.id)?;
         let lease = created
             .tool_context_lease
             .expect("an explicit Agent tool context must return a lease");
+        let unpublished = UnpublishedAcpSession::new(lease);
         let finalization = self.finalization.lock().await;
         if self.closed.load(Ordering::SeqCst) {
             drop(finalization);
-            self.discard_uncommitted_session(&session_id, lease).await;
+            drop(unpublished);
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection closed while configuring the session"));
         }
         let mut sessions = self.sessions.lock().await;
-        if sessions.contains_key(&session_id) {
+        let mut operations = self.session_operations.lock().await;
+        if sessions.contains_key(&session_id) || operations.contains_key(&session_id) {
+            drop(operations);
             drop(sessions);
             drop(finalization);
-            self.discard_uncommitted_session(&session_id, lease).await;
+            drop(unpublished);
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection duplicated a new session"));
         }
-        sessions.insert(session_id.clone(), lease);
+        let lease = unpublished.publish();
+        sessions.insert(
+            session_id.clone(),
+            AcpSession {
+                lease: Some(lease),
+                model: model.clone(),
+                available_models: available_models.clone(),
+                message_count: created.detail.session.message_count,
+                created_here: true,
+                prompted: false,
+            },
+        );
+        operations.insert(session_id.clone(), AcpSessionOperation::new(&self.lifetime));
+        drop(operations);
         drop(sessions);
         self.stats.active_sessions.fetch_add(1, Ordering::SeqCst);
         if has_buzz_credentials(&environment) && !self.has_credentials.swap(true, Ordering::SeqCst)
@@ -501,54 +630,524 @@ impl AcpConnectionContext {
                 .fetch_add(1, Ordering::SeqCst);
         }
         drop(finalization);
-        Ok(NewSessionResponse::new(session_id))
-    }
-
-    async fn discard_uncommitted_session(&self, session_id: &str, lease: AgentToolContextLease) {
-        lease.release().await;
-        let _ = self
-            .agent
-            .discard_session_during_cleanup(session_id.to_string())
-            .await;
+        Ok(NewSessionResponse::new(session_id)
+            .modes(acp_session_modes())
+            .config_options(acp_config_options(&model, &available_models)))
     }
 
     async fn retire_session(&self, session_id: &str) {
-        let lease = self.sessions.lock().await.remove(session_id);
-        if let Some(lease) = lease {
-            self.stats.active_sessions.fetch_sub(1, Ordering::SeqCst);
-            lease.release().await;
+        let session = self.sessions.lock().await.remove(session_id);
+        if let Some(operation) = self.session_operations.lock().await.remove(session_id) {
+            operation.cancellation.cancel();
         }
+        if let Some(mut session) = session {
+            self.stats.active_sessions.fetch_sub(1, Ordering::SeqCst);
+            if let Some(lease) = session.lease.take() {
+                lease.release().await;
+            }
+        }
+    }
+
+    async fn available_models(&self) -> Result<Vec<String>, agent_client_protocol::Error> {
+        tokio::select! {
+            biased;
+            _ = self.lifetime.cancelled() => Err(
+                agent_client_protocol::Error::internal_error()
+                    .data("The Maple ACP connection closed while loading models")
+            ),
+            result = self.agent.available_model_ids() => result.map_err(internal_acp_error),
+            _ = tokio::time::sleep(std::time::Duration::from_secs(30)) => Err(
+                agent_client_protocol::Error::internal_error()
+                    .data("Maple model discovery timed out")
+            ),
+        }
+    }
+
+    async fn remove_session_operation_if_same(
+        &self,
+        session_id: &str,
+        operation: &Arc<AcpSessionOperation>,
+    ) {
+        let mut operations = self.session_operations.lock().await;
+        if operations
+            .get(session_id)
+            .is_some_and(|registered| Arc::ptr_eq(registered, operation))
+        {
+            operations.remove(session_id);
+        }
+    }
+
+    async fn load_session(
+        &self,
+        cx: &ConnectionTo<Client>,
+        request: LoadSessionRequest,
+    ) -> Result<LoadSessionResponse, agent_client_protocol::Error> {
+        if self.closed.load(Ordering::SeqCst) {
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP connection is closing"));
+        }
+        if !request.cwd.is_absolute() || !request.additional_directories.is_empty() {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Maple ACP load requires one absolute cwd and no additional directories"));
+        }
+        let config = self.config.read().await.clone();
+        let project_root = ensure_allowed_project_root(&request.cwd, &config.allowed_project_roots)
+            .map_err(|error| agent_client_protocol::Error::invalid_params().data(error))?;
+        let project_root = project_root.to_string_lossy().into_owned();
+        let session_id = canonical_session_id(&request.session_id)?;
+        let persisted_sessions = self
+            .agent
+            .list_sessions(Some(project_root.clone()))
+            .await
+            .map_err(internal_acp_error)?;
+        let persisted = ensure_acp_session_is_loadable(&persisted_sessions, &session_id)
+            .map_err(|error| agent_client_protocol::Error::invalid_request().data(error))?;
+        let persisted_model = persisted.model.clone();
+        let available_models = self.available_models().await?;
+        if let Some(model) = persisted_model.as_ref() {
+            if !available_models.iter().any(|available| available == model) {
+                return Err(agent_client_protocol::Error::invalid_request().data(format!(
+                    "This Maple Agent task uses model '{model}', which is no longer available; the task remains available in Maple Desktop"
+                )));
+            }
+        }
+        let bridge_environment = self.bridge_environment.lock().await.clone();
+        let (environment, transient_mcp_servers) =
+            prepare_session_mcp(&bridge_environment, &request.mcp_servers)?;
+        let tool_context = bridge_tool_context_spec(&environment).map_err(internal_acp_error)?;
+        let protocol_session_id = SessionId::new(session_id.clone());
+        let operation = AcpSessionOperation::new(&self.lifetime);
+        let operation_guard = Arc::clone(&operation.gate).lock_owned().await;
+        {
+            // Register the operation before the fallible core attach. Close can
+            // now mark it closing and wait, while disconnect linearizes through
+            // the same finalization barrier used by session creation.
+            let _finalization = self.finalization.lock().await;
+            if self.closed.load(Ordering::SeqCst) {
+                return Err(agent_client_protocol::Error::internal_error()
+                    .data("The Maple ACP connection is closing"));
+            }
+            if self.closing_sessions.lock().await.contains(&session_id) {
+                return Err(agent_client_protocol::Error::invalid_request()
+                    .data("This ACP session is closing"));
+            }
+            if self.sessions.lock().await.contains_key(&session_id) {
+                return Err(agent_client_protocol::Error::invalid_request()
+                    .data("This ACP connection already owns the requested session"));
+            }
+            let mut operations = self.session_operations.lock().await;
+            if operations.contains_key(&session_id) {
+                return Err(agent_client_protocol::Error::invalid_request()
+                    .data("This ACP connection is already loading the requested session"));
+            }
+            operations.insert(session_id.clone(), Arc::clone(&operation));
+        }
+        let attached = match self
+            .agent
+            .attach_session_with_surface_context(
+                session_id.clone(),
+                project_root,
+                tool_context,
+                transient_mcp_servers,
+                operation.cancellation.child_token(),
+            )
+            .await
+        {
+            Ok(attached) => attached,
+            Err(error) => {
+                self.remove_session_operation_if_same(&session_id, &operation)
+                    .await;
+                return Err(internal_acp_error(error));
+            }
+        };
+        let lease = attached
+            .tool_context_lease
+            .expect("an attached ACP task must return a tool-context lease");
+        let Some(model) = attached
+            .detail
+            .session
+            .model
+            .clone()
+            .or_else(|| available_models.first().cloned())
+        else {
+            lease.release().await;
+            self.remove_session_operation_if_same(&session_id, &operation)
+                .await;
+            return Err(internal_acp_error("Maple returned no models".to_string()));
+        };
+        let timeline = attached.detail.timeline;
+        let message_count = attached.detail.session.message_count;
+        let finalization = self.finalization.lock().await;
+        if self.closed.load(Ordering::SeqCst)
+            || self.closing_sessions.lock().await.contains(&session_id)
+        {
+            drop(finalization);
+            lease.release().await;
+            self.remove_session_operation_if_same(&session_id, &operation)
+                .await;
+            return Err(agent_client_protocol::Error::internal_error()
+                .data("The Maple ACP session closed while it was loading"));
+        }
+        let mut sessions = self.sessions.lock().await;
+        if sessions.contains_key(&session_id) {
+            drop(sessions);
+            drop(finalization);
+            lease.release().await;
+            self.remove_session_operation_if_same(&session_id, &operation)
+                .await;
+            return Err(agent_client_protocol::Error::invalid_request()
+                .data("This ACP connection duplicated the requested session"));
+        }
+        sessions.insert(
+            session_id.clone(),
+            AcpSession {
+                lease: Some(lease),
+                model: model.clone(),
+                available_models: available_models.clone(),
+                message_count,
+                created_here: false,
+                prompted: false,
+            },
+        );
+        drop(sessions);
+        self.stats.active_sessions.fetch_add(1, Ordering::SeqCst);
+        drop(finalization);
+
+        let mut projection = AcpToolProjection::default();
+        for item in &timeline {
+            if let Some(update) = timeline_update(item, &mut projection, true) {
+                if let Err(error) = self
+                    .send_session_update(
+                        cx,
+                        SessionNotification::new(protocol_session_id.clone(), update),
+                        &operation.cancellation,
+                    )
+                    .await
+                {
+                    self.retire_session(&session_id).await;
+                    return Err(outbound_error(error));
+                }
+            }
+        }
+        drop(operation_guard);
+        Ok(LoadSessionResponse::new()
+            .modes(acp_session_modes())
+            .config_options(acp_session_config_options(
+                &model,
+                &available_models,
+                message_count,
+            )))
+    }
+
+    async fn list_sessions(
+        &self,
+        request: ListSessionsRequest,
+    ) -> Result<ListSessionsResponse, agent_client_protocol::Error> {
+        let config = self.config.read().await.clone();
+        let project_root = match request.cwd.as_deref() {
+            Some(cwd) => {
+                if !cwd.is_absolute() {
+                    return Err(agent_client_protocol::Error::invalid_params()
+                        .data("ACP session-list cwd must be an absolute path"));
+                }
+                Some(
+                    ensure_allowed_project_root(cwd, &config.allowed_project_roots).map_err(
+                        |error| agent_client_protocol::Error::invalid_params().data(error),
+                    )?,
+                )
+            }
+            None => None,
+        };
+        let sessions = self
+            .agent
+            .list_sessions(
+                project_root
+                    .as_ref()
+                    .map(|root| root.to_string_lossy().into_owned()),
+            )
+            .await
+            .map_err(internal_acp_error)?;
+        let visible = sessions
+            .into_iter()
+            .filter(|session| {
+                is_acp_loadable_session_mode(&session.mode)
+                    && ensure_allowed_project_root(
+                        Path::new(&session.project_root),
+                        &config.allowed_project_roots,
+                    )
+                    .is_ok()
+            })
+            .collect::<Vec<_>>();
+        let start = request
+            .cursor
+            .as_deref()
+            .map(str::parse::<usize>)
+            .transpose()
+            .map_err(|_| {
+                agent_client_protocol::Error::invalid_params()
+                    .data("Invalid Maple ACP session-list cursor")
+            })?
+            .unwrap_or(0);
+        if start > visible.len() {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Maple ACP session-list cursor is out of range"));
+        }
+        let end = start.saturating_add(100).min(visible.len());
+        let listed = visible[start..end]
+            .iter()
+            .map(|session| {
+                let mut info =
+                    SessionInfo::new(session.id.clone(), PathBuf::from(&session.project_root))
+                        .title(session.title.clone());
+                if let Some(updated_at) =
+                    chrono::DateTime::from_timestamp_millis(session.updated_ms)
+                {
+                    info = info.updated_at(updated_at.to_rfc3339());
+                }
+                info
+            })
+            .collect();
+        let mut response = ListSessionsResponse::new(listed);
+        if end < visible.len() {
+            response = response.next_cursor(end.to_string());
+        }
+        Ok(response)
+    }
+
+    async fn close_session(
+        &self,
+        request: CloseSessionRequest,
+    ) -> Result<CloseSessionResponse, agent_client_protocol::Error> {
+        let session_id = canonical_session_id(&request.session_id)?;
+        let operation = self
+            .session_operations
+            .lock()
+            .await
+            .get(&session_id)
+            .cloned()
+            .ok_or_else(|| {
+                agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                    .data("ACP session is not owned by this connection")
+            })?;
+        self.closing_sessions
+            .lock()
+            .await
+            .insert(session_id.clone());
+        operation.cancellation.cancel();
+        // Use one absolute deadline for every potentially blocking close
+        // phase. Paseo awaits this response before terminating the ACP child,
+        // so a fresh timeout per phase could still hang it for multiples of
+        // the advertised close bound.
+        let close_deadline = tokio::time::Instant::now() + ACP_SESSION_CLOSE_TIMEOUT;
+        let cancel_result =
+            tokio::time::timeout_at(close_deadline, self.cancel_session(&session_id)).await;
+        let cancellation_completed = matches!(&cancel_result, Ok(Ok(())));
+        // Starting and running prompts normally retain this guard through their
+        // terminal barrier. A broken provider must not make ACP close hang
+        // forever, though: after the bound, revoke the lease synchronously and
+        // let its Drop retry exact-match cleanup while Paseo can terminate the
+        // child process.
+        let operation_guard =
+            tokio::time::timeout_at(close_deadline, Arc::clone(&operation.gate).lock_owned())
+                .await
+                .ok();
+        let operation_drained = operation_guard.is_some();
+        let Some(mut session) = self.sessions.lock().await.remove(&session_id) else {
+            if close_registration_may_be_released(cancellation_completed, operation_drained, true) {
+                self.remove_session_operation_if_same(&session_id, &operation)
+                    .await;
+                self.closing_sessions.lock().await.remove(&session_id);
+            }
+            if let Ok(cancel_result) = cancel_result {
+                cancel_result?;
+            }
+            return Ok(CloseSessionResponse::new());
+        };
+        self.stats.active_sessions.fetch_sub(1, Ordering::SeqCst);
+        let discard = operation_drained && session.created_here && !session.prompted;
+        let cleanup_completed = if let Some(lease) = session.lease.take() {
+            if operation_drained {
+                tokio::time::timeout_at(close_deadline, async move {
+                    if discard {
+                        lease.discard_created_if_untouched().await;
+                    } else {
+                        lease.release().await;
+                    }
+                })
+                .await
+                .is_ok()
+            } else {
+                lease.revoke();
+                drop(lease);
+                false
+            }
+        } else {
+            operation_drained
+        };
+        if close_registration_may_be_released(
+            cancellation_completed,
+            operation_drained,
+            cleanup_completed,
+        ) {
+            self.remove_session_operation_if_same(&session_id, &operation)
+                .await;
+            self.closing_sessions.lock().await.remove(&session_id);
+        }
+        if let Ok(cancel_result) = cancel_result {
+            cancel_result?;
+        }
+        Ok(CloseSessionResponse::new())
+    }
+
+    async fn set_config_option(
+        &self,
+        request: SetSessionConfigOptionRequest,
+    ) -> Result<SetSessionConfigOptionResponse, agent_client_protocol::Error> {
+        let session_id = canonical_session_id(&request.session_id)?;
+        let operation = self
+            .session_operations
+            .lock()
+            .await
+            .get(&session_id)
+            .cloned()
+            .ok_or_else(|| {
+                agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                    .data("ACP session is not owned by this connection")
+            })?;
+        let _operation_guard = Arc::clone(&operation.gate).lock_owned().await;
+        if self.closed.load(Ordering::SeqCst)
+            || self.closing_sessions.lock().await.contains(&session_id)
+        {
+            return Err(
+                agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                    .data("ACP session is closing"),
+            );
+        }
+        let mut sessions = self.sessions.lock().await;
+        let session = sessions.get_mut(&session_id).ok_or_else(|| {
+            agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                .data("ACP session is not owned by this connection")
+        })?;
+        let selected_value = request.value.as_value_id().ok_or_else(|| {
+            agent_client_protocol::Error::invalid_params()
+                .data("Maple ACP configuration options require a select value")
+        })?;
+        match request.config_id.0.as_ref() {
+            "model" => {
+                let model = selected_value.0.as_ref();
+                if !session
+                    .available_models
+                    .iter()
+                    .any(|candidate| candidate == model)
+                {
+                    return Err(
+                        agent_client_protocol::Error::invalid_params().data("Unknown Maple model")
+                    );
+                }
+                if session.message_count > 0 && session.model != model {
+                    return Err(agent_client_protocol::Error::invalid_params()
+                        .data("Maple tasks are model-locked after their first message"));
+                }
+                session.model = model.to_string();
+            }
+            "mode" if selected_value.0.as_ref() == "interactive" => {}
+            "mode" => {
+                return Err(agent_client_protocol::Error::invalid_params()
+                    .data("Maple ACP supports only caller-mediated interactive mode"));
+            }
+            _ => {
+                return Err(agent_client_protocol::Error::invalid_params()
+                    .data("Unknown Maple ACP configuration option"));
+            }
+        }
+        Ok(SetSessionConfigOptionResponse::new(
+            session.config_options(),
+        ))
+    }
+
+    async fn set_mode(
+        &self,
+        request: SetSessionModeRequest,
+    ) -> Result<SetSessionModeResponse, agent_client_protocol::Error> {
+        let session_id = canonical_session_id(&request.session_id)?;
+        let operation = self
+            .session_operations
+            .lock()
+            .await
+            .get(&session_id)
+            .cloned()
+            .ok_or_else(|| {
+                agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                    .data("ACP session is not owned by this connection")
+            })?;
+        let _operation_guard = Arc::clone(&operation.gate).lock_owned().await;
+        if self.closed.load(Ordering::SeqCst)
+            || self.closing_sessions.lock().await.contains(&session_id)
+            || !self.sessions.lock().await.contains_key(&session_id)
+        {
+            return Err(
+                agent_client_protocol::Error::resource_not_found(Some(session_id))
+                    .data("ACP session is not available on this connection"),
+            );
+        }
+        if request.mode_id.0.as_ref() != "interactive" {
+            return Err(agent_client_protocol::Error::invalid_params()
+                .data("Maple ACP supports only caller-mediated interactive mode"));
+        }
+        Ok(SetSessionModeResponse::new())
     }
 
     async fn begin_prompt(
         &self,
         request: &PromptRequest,
-    ) -> Result<(String, CancellationToken), agent_client_protocol::Error> {
+    ) -> Result<
+        (
+            String,
+            String,
+            CancellationToken,
+            tokio::sync::OwnedMutexGuard<()>,
+        ),
+        agent_client_protocol::Error,
+    > {
         if self.closed.load(Ordering::SeqCst) {
             return Err(agent_client_protocol::Error::internal_error()
                 .data("The Maple ACP connection is closing"));
         }
-        let session_id = request.session_id.0.to_string();
-        if !self.sessions.lock().await.contains_key(&session_id) {
+        let session_id = canonical_session_id(&request.session_id)?;
+        let prompt = prompt_text(&request.prompt)?;
+        let operation = self
+            .session_operations
+            .lock()
+            .await
+            .get(&session_id)
+            .cloned()
+            .ok_or_else(|| {
+                agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
+                    .data("ACP session is not owned by this connection")
+            })?;
+        let operation_guard = Arc::clone(&operation.gate).lock_owned().await;
+        if self.closed.load(Ordering::SeqCst)
+            || self.closing_sessions.lock().await.contains(&session_id)
+            || !self.sessions.lock().await.contains_key(&session_id)
+        {
             return Err(
                 agent_client_protocol::Error::resource_not_found(Some(session_id.clone()))
-                    .data("ACP session is not owned by this connection"),
+                    .data("ACP session is not available on this connection"),
             );
         }
-        let prompt = prompt_text(&request.prompt)?;
         let mut states = self.prompt_states.lock().await;
         if states.contains_key(&session_id) {
             return Err(agent_client_protocol::Error::invalid_request()
                 .data("This ACP session already has an active prompt"));
         }
-        let cancellation = self.lifetime.child_token();
+        let cancellation = operation.cancellation.child_token();
         states.insert(
-            session_id,
+            session_id.clone(),
             AcpPromptState::Starting {
                 cancellation: cancellation.clone(),
             },
         );
-        Ok((prompt, cancellation))
+        Ok((prompt, session_id, cancellation, operation_guard))
     }
 
     async fn send_session_update(
@@ -576,13 +1175,18 @@ impl AcpConnectionContext {
         message: &str,
         cancellation: &CancellationToken,
     ) -> Result<(), AcpOutboundSendError> {
+        let message_id = format!(
+            "maple-acp-notice-{}",
+            NEXT_ACP_MESSAGE_ID.fetch_add(1, Ordering::Relaxed)
+        );
         self.send_session_update(
             cx,
             SessionNotification::new(
                 session_id,
-                SessionUpdate::AgentMessageChunk(ContentChunk::new(ContentBlock::Text(
-                    TextContent::new(message.to_string()),
-                ))),
+                SessionUpdate::AgentMessageChunk(
+                    ContentChunk::new(ContentBlock::Text(TextContent::new(message.to_string())))
+                        .message_id(message_id.as_str()),
+                ),
             ),
             cancellation,
         )
@@ -667,20 +1271,33 @@ impl AcpConnectionContext {
     async fn prompt(
         self: &Arc<Self>,
         cx: &ConnectionTo<Client>,
-        request: PromptRequest,
+        session_id: String,
         prompt: String,
         prompt_lifetime: CancellationToken,
+        operation_guard: tokio::sync::OwnedMutexGuard<()>,
     ) -> Result<PromptResponse, agent_client_protocol::Error> {
-        let session_id = request.session_id.0.to_string();
+        let mut operation_guard = Some(operation_guard);
+        let protocol_session_id = SessionId::new(session_id.clone());
         let config = self.config.read().await.clone();
-        let tool_context_access = match self.sessions.lock().await.get(&session_id) {
-            Some(lease) => lease.access(),
-            None => {
-                self.prompt_states.lock().await.remove(&session_id);
-                return Err(agent_client_protocol::Error::resource_not_found(Some(
-                    session_id.clone(),
-                ))
-                .data("ACP session is no longer owned by this connection"));
+        let (tool_context_access, model) = {
+            let sessions = self.sessions.lock().await;
+            match sessions.get(&session_id) {
+                Some(session) => (
+                    session
+                        .lease
+                        .as_ref()
+                        .expect("a runnable ACP session must own a lease")
+                        .access(),
+                    session.model.clone(),
+                ),
+                None => {
+                    drop(sessions);
+                    self.prompt_states.lock().await.remove(&session_id);
+                    return Err(agent_client_protocol::Error::resource_not_found(Some(
+                        session_id.clone(),
+                    ))
+                    .data("ACP session is no longer owned by this connection"));
+                }
             }
         };
         let run = match self
@@ -689,7 +1306,7 @@ impl AcpConnectionContext {
                 AgentSendMessageRequest {
                     session_id: session_id.clone(),
                     text: prompt,
-                    model: None,
+                    model: Some(model),
                     context_limit: None,
                     mode: Some(config.permission_mode.maple_mode().to_string()),
                     vision_capable: false,
@@ -703,6 +1320,10 @@ impl AcpConnectionContext {
             .await
         {
             Ok(run) => run,
+            Err(_) if prompt_lifetime.is_cancelled() => {
+                self.prompt_states.lock().await.remove(&session_id);
+                return Ok(PromptResponse::new(StopReason::Cancelled));
+            }
             Err(error) if error == AGENT_TOOL_CONTEXT_INACTIVE_ERROR => {
                 self.prompt_states.lock().await.remove(&session_id);
                 self.retire_session(&session_id).await;
@@ -716,8 +1337,18 @@ impl AcpConnectionContext {
                 return Err(internal_acp_error(error));
             }
         };
+        let locked_config_options = {
+            let mut sessions = self.sessions.lock().await;
+            sessions.get_mut(&session_id).and_then(|session| {
+                session.prompted = true;
+                let first_message = session.message_count == 0;
+                session.message_count = session.message_count.saturating_add(1);
+                first_message.then(|| session.config_options())
+            })
+        };
         let mut events = run.events;
         let mut terminal = run.terminal;
+        let usage = run.usage;
         let event_overflowed = run.event_overflowed;
         let Some(run_cancellation) = run.cancellation else {
             prompt_lifetime.cancel();
@@ -757,7 +1388,55 @@ impl AcpConnectionContext {
             let _ = run_cancellation.cancel().await;
         }
 
+        if let Some(config_options) = locked_config_options {
+            match self
+                .send_session_update(
+                    cx,
+                    SessionNotification::new(
+                        protocol_session_id.clone(),
+                        SessionUpdate::ConfigOptionUpdate(ConfigOptionUpdate::new(config_options)),
+                    ),
+                    &prompt_lifetime,
+                )
+                .await
+            {
+                Ok(()) => {}
+                Err(AcpOutboundSendError::Cancelled) => {
+                    let _ = run_cancellation.cancel().await;
+                    if matches!(
+                        self.prompt_states.lock().await.remove(&session_id),
+                        Some(AcpPromptState::Running { .. })
+                    ) {
+                        self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    return Ok(PromptResponse::new(StopReason::Cancelled));
+                }
+                Err(AcpOutboundSendError::UpdateTooLarge) => {
+                    let _ = run_cancellation.cancel().await;
+                    if matches!(
+                        self.prompt_states.lock().await.remove(&session_id),
+                        Some(AcpPromptState::Running { .. })
+                    ) {
+                        self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    return Err(agent_client_protocol::Error::internal_error()
+                        .data("Maple's locked model selector exceeded the ACP update limit"));
+                }
+                Err(AcpOutboundSendError::Transport(error)) => {
+                    let _ = run_cancellation.cancel().await;
+                    if matches!(
+                        self.prompt_states.lock().await.remove(&session_id),
+                        Some(AcpPromptState::Running { .. })
+                    ) {
+                        self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
+                    }
+                    return Err(error);
+                }
+            }
+        }
+
         let mut cancel_after_result = false;
+        let mut tool_projection = AcpToolProjection::default();
         let result = loop {
             if event_overflowed.load(Ordering::Acquire) {
                 cancel_after_result = true;
@@ -765,7 +1444,7 @@ impl AcpConnectionContext {
                 match self
                     .send_final_agent_message(
                         cx,
-                        request.session_id.clone(),
+                        protocol_session_id.clone(),
                         "Maple stopped this turn because its bounded ACP event stream overflowed.",
                         &self.lifetime,
                     )
@@ -787,7 +1466,7 @@ impl AcpConnectionContext {
                 match self
                     .send_final_agent_message(
                         cx,
-                        request.session_id.clone(),
+                        protocol_session_id.clone(),
                         "Maple stopped this turn because its bounded ACP event stream overflowed.",
                         &self.lifetime,
                     )
@@ -804,11 +1483,11 @@ impl AcpConnectionContext {
             }
             match event {
                 Some(AgentRunEvent::TimelineItem(item)) => {
-                    if let Some(update) = timeline_update(&item) {
+                    if let Some(update) = timeline_update(&item, &mut tool_projection, false) {
                         match self
                             .send_session_update(
                                 cx,
-                                SessionNotification::new(request.session_id.clone(), update),
+                                SessionNotification::new(protocol_session_id.clone(), update),
                                 &prompt_lifetime,
                             )
                             .await
@@ -819,7 +1498,7 @@ impl AcpConnectionContext {
                                 let _ = run_cancellation.cancel().await;
                                 match self.send_final_agent_message(
                                     cx,
-                                    request.session_id.clone(),
+                                    protocol_session_id.clone(),
                                     "Maple stopped this turn because one ACP update exceeded the 4 MiB transport limit.",
                                     &self.lifetime,
                                 )
@@ -849,7 +1528,7 @@ impl AcpConnectionContext {
                     match self
                         .request_permission_from_caller(
                             cx,
-                            request.session_id.clone(),
+                            protocol_session_id.clone(),
                             permission,
                             &item,
                             &permission_responder,
@@ -868,7 +1547,7 @@ impl AcpConnectionContext {
                             match self
                                 .send_final_agent_message(
                                     cx,
-                                    request.session_id.clone(),
+                                    protocol_session_id.clone(),
                                     "Maple stopped this turn because one ACP permission request exceeded the 4 MiB transport limit.",
                                     &self.lifetime,
                                 )
@@ -896,10 +1575,13 @@ impl AcpConnectionContext {
                             .send_session_update(
                                 cx,
                                 SessionNotification::new(
-                                    request.session_id.clone(),
-                                    SessionUpdate::AgentMessageChunk(ContentChunk::new(
-                                        ContentBlock::Text(TextContent::new(message)),
-                                    )),
+                                    protocol_session_id.clone(),
+                                    SessionUpdate::AgentMessageChunk(
+                                        ContentChunk::new(ContentBlock::Text(TextContent::new(
+                                            message,
+                                        )))
+                                        .message_id(item.id.as_str()),
+                                    ),
                                 ),
                                 &prompt_lifetime,
                             )
@@ -911,7 +1593,7 @@ impl AcpConnectionContext {
                                 let _ = run_cancellation.cancel().await;
                                 match self.send_final_agent_message(
                                     cx,
-                                    request.session_id.clone(),
+                                    protocol_session_id.clone(),
                                     "Maple stopped this turn because one ACP update exceeded the 4 MiB transport limit.",
                                     &self.lifetime,
                                 )
@@ -962,6 +1644,11 @@ impl AcpConnectionContext {
                 }
             }
         };
+        let turn_usage = usage.borrow().as_ref().copied().unwrap_or_default();
+        // ACP defines PromptResponse.usage as usage for this prompt turn. Paseo
+        // stores it as currentTurnUsage, so cumulative session totals would be
+        // double-counted on every later turn.
+        let result = result.map(|response| response.usage(acp_usage(turn_usage)));
         let mut deferred_prompt_cleanup = false;
         if cancel_after_result {
             // Synthetic stream stops settle only after the underlying run has
@@ -982,8 +1669,12 @@ impl AcpConnectionContext {
                 deferred_prompt_cleanup = true;
                 let context = Arc::clone(self);
                 let draining_session_id = session_id.clone();
+                let draining_operation_guard = operation_guard
+                    .take()
+                    .expect("a deferred ACP prompt must retain its session operation fence");
                 let mut tasks = self.background_tasks.lock().await;
                 tasks.spawn(async move {
+                    let _operation_guard = draining_operation_guard;
                     wait_for_retained_terminal(&mut terminal).await;
                     if matches!(
                         context
@@ -1008,6 +1699,7 @@ impl AcpConnectionContext {
         {
             self.stats.active_runs.fetch_sub(1, Ordering::SeqCst);
         }
+        drop(operation_guard);
         result
     }
 
@@ -1015,10 +1707,14 @@ impl AcpConnectionContext {
         &self,
         notification: CancelNotification,
     ) -> Result<(), agent_client_protocol::Error> {
-        let session_id = notification.session_id.0.to_string();
+        let session_id = canonical_session_id(&notification.session_id)?;
+        self.cancel_session(&session_id).await
+    }
+
+    async fn cancel_session(&self, session_id: &str) -> Result<(), agent_client_protocol::Error> {
         let (cancellation, run_cancellation) = {
             let states = self.prompt_states.lock().await;
-            match states.get(&session_id) {
+            match states.get(session_id) {
                 Some(AcpPromptState::Starting { cancellation }) => {
                     (Some(cancellation.clone()), None)
                 }
@@ -1074,32 +1770,80 @@ impl AcpConnectionContext {
                 }
             }
         }
-        let sessions = std::mem::take(&mut *self.sessions.lock().await);
-        let session_count = sessions.len();
         // Revoke every capability synchronously before awaiting registry cleanup.
         // No queued or detached task can launch another credential-bearing tool
         // after this barrier returns.
-        for lease in sessions.values() {
-            lease.revoke();
+        let session_ids = {
+            let sessions = self.sessions.lock().await;
+            for session in sessions.values() {
+                if let Some(lease) = session.lease.as_ref() {
+                    lease.revoke();
+                }
+            }
+            sessions.keys().cloned().collect::<Vec<_>>()
+        };
+        let mut retired_sessions = Vec::with_capacity(session_ids.len());
+        for session_id in session_ids {
+            let operation = self
+                .session_operations
+                .lock()
+                .await
+                .get(&session_id)
+                .cloned();
+            // A prompt marks the session as prompted while holding this gate.
+            // Waiting here closes the admission gap before deciding whether a
+            // newly created empty task may be discarded. At the cleanup
+            // deadline we preserve the durable row rather than risk deleting
+            // work whose admission is still settling.
+            let operation_drained = match operation {
+                Some(operation) => {
+                    tokio::time::timeout_at(deadline, Arc::clone(&operation.gate).lock_owned())
+                        .await
+                        .is_ok()
+                }
+                None => true,
+            };
+            let session = self.sessions.lock().await.remove(&session_id);
+            if let Some(session) = session {
+                let discard = operation_drained && session.created_here && !session.prompted;
+                retired_sessions.push((session_id, session, discard));
+                self.stats.active_sessions.fetch_sub(1, Ordering::SeqCst);
+            }
         }
-        self.stats
-            .active_sessions
-            .fetch_sub(session_count, Ordering::SeqCst);
-        let mut tasks = self.background_tasks.lock().await;
+        // Take ownership of the current task set before awaiting it. A prompt
+        // that is itself in this set may need to publish a retained drain task;
+        // leaving an empty shared set lets that path proceed without a mutex
+        // self-deadlock. Newly published tasks are collected on the next pass.
+        let mut tasks = {
+            let mut shared = self.background_tasks.lock().await;
+            std::mem::take(&mut *shared)
+        };
         for run_cancellation in running_cancellations {
             tasks.spawn(async move {
                 let _ = run_cancellation.cancel().await;
             });
         }
-        for lease in sessions.into_values() {
+        for (_session_id, mut session, discard) in retired_sessions {
             tasks.spawn(async move {
-                lease.release().await;
+                if let Some(lease) = session.lease.take() {
+                    if discard {
+                        lease.discard_created_if_untouched().await;
+                    } else {
+                        lease.release().await;
+                    }
+                }
             });
         }
-        loop {
+        'drain: loop {
             match tokio::time::timeout_at(deadline, tasks.join_next()).await {
                 Ok(Some(_)) => {}
-                Ok(None) => break,
+                Ok(None) => {
+                    let mut shared = self.background_tasks.lock().await;
+                    if shared.is_empty() {
+                        break 'drain;
+                    }
+                    tasks = std::mem::take(&mut *shared);
+                }
                 Err(_) => {
                     // Session creation and the pre-run prompt path both cross
                     // persistent core state before returning an ID. Aborting
@@ -1107,11 +1851,13 @@ impl AcpConnectionContext {
                     // their existing closed checks and rollback/cancel paths
                     // while keeping connection shutdown bounded.
                     tasks.detach_all();
-                    break;
+                    self.background_tasks.lock().await.detach_all();
+                    break 'drain;
                 }
             }
         }
-        drop(tasks);
+        self.session_operations.lock().await.clear();
+        self.closing_sessions.lock().await.clear();
     }
 }
 
@@ -1144,12 +1890,20 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                 .await
                 .if_request(
                     |_request: InitializeRequest, responder: Responder<InitializeResponse>| async {
-                        let capabilities = AgentCapabilities::new().prompt_capabilities(
-                            PromptCapabilities::new()
-                                .image(false)
-                                .audio(false)
-                                .embedded_context(false),
-                        );
+                        let capabilities = AgentCapabilities::new()
+                            .load_session(true)
+                            .prompt_capabilities(
+                                PromptCapabilities::new()
+                                    .image(false)
+                                    .audio(false)
+                                    .embedded_context(false),
+                            )
+                            .mcp_capabilities(McpCapabilities::new().http(true))
+                            .session_capabilities(
+                                SessionCapabilities::new()
+                                    .list(SessionListCapabilities::new())
+                                    .close(SessionCloseCapabilities::new()),
+                            );
                         responder.respond(
                             InitializeResponse::new(
                                 agent_client_protocol::schema::ProtocolVersion::V1,
@@ -1184,8 +1938,61 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                 .if_request({
                     let context = Arc::clone(&context);
                     let cx = cx.clone();
+                    |request: LoadSessionRequest, responder: Responder<LoadSessionResponse>| async move {
+                        let task_context = Arc::clone(&context);
+                        let task_cx = cx.clone();
+                        let mut tasks = context.background_tasks.lock().await;
+                        while tasks.try_join_next().is_some() {}
+                        if context.closed.load(Ordering::SeqCst) {
+                            responder.respond_with_error(
+                                agent_client_protocol::Error::internal_error()
+                                    .data("The Maple ACP connection is closing"),
+                            )?;
+                            return Ok(());
+                        }
+                        tasks.spawn(async move {
+                            let _ = responder.respond_with_result(
+                                task_context.load_session(&task_cx, request).await,
+                            );
+                        });
+                        Ok(())
+                    }
+                })
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    |request: ListSessionsRequest, responder: Responder<ListSessionsResponse>| async move {
+                        responder.respond_with_result(context.list_sessions(request).await)
+                    }
+                })
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    |request: CloseSessionRequest, responder: Responder<CloseSessionResponse>| async move {
+                        responder.respond_with_result(context.close_session(request).await)
+                    }
+                })
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    |request: SetSessionConfigOptionRequest, responder: Responder<SetSessionConfigOptionResponse>| async move {
+                        responder.respond_with_result(context.set_config_option(request).await)
+                    }
+                })
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    |request: SetSessionModeRequest, responder: Responder<SetSessionModeResponse>| async move {
+                        responder.respond_with_result(context.set_mode(request).await)
+                    }
+                })
+                .await
+                .if_request({
+                    let context = Arc::clone(&context);
+                    let cx = cx.clone();
                     |request: PromptRequest, responder: Responder<PromptResponse>| async move {
-                        let (prompt, prompt_lifetime) = match context.begin_prompt(&request).await {
+                        let (prompt, session_id, prompt_lifetime, operation_guard) =
+                            match context.begin_prompt(&request).await {
                             Ok(prepared) => prepared,
                             Err(error) => {
                                 responder.respond_with_error(error)?;
@@ -1197,9 +2004,7 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                         let mut tasks = context.background_tasks.lock().await;
                         while tasks.try_join_next().is_some() {}
                         if context.closed.load(Ordering::SeqCst) {
-                            context.prompt_states.lock().await.remove(
-                                &request.session_id.0.to_string(),
-                            );
+                            context.prompt_states.lock().await.remove(&session_id);
                             responder.respond_with_error(
                                 agent_client_protocol::Error::internal_error()
                                     .data("The Maple ACP connection is closing"),
@@ -1209,7 +2014,13 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                         tasks.spawn(async move {
                             let _ = responder.respond_with_result(
                                 prompt_context
-                                    .prompt(&prompt_cx, request, prompt, prompt_lifetime)
+                                    .prompt(
+                                        &prompt_cx,
+                                        session_id,
+                                        prompt,
+                                        prompt_lifetime,
+                                        operation_guard,
+                                    )
                                     .await,
                             );
                         });
@@ -1806,6 +2617,9 @@ fn normalize_config(mut config: AgentAcpConfig) -> Result<AgentAcpConfig, String
 }
 
 fn ensure_allowed_project_root(cwd: &Path, allowed_roots: &[String]) -> Result<PathBuf, String> {
+    if !cwd.is_absolute() {
+        return Err("ACP session cwd must be an absolute path".to_string());
+    }
     let cwd = cwd
         .canonicalize()
         .map_err(|error| format!("Failed to resolve ACP session cwd: {error}"))?;
@@ -1822,60 +2636,102 @@ fn ensure_allowed_project_root(cwd: &Path, allowed_roots: &[String]) -> Result<P
     Err("ACP session cwd is outside the configured project roots".to_string())
 }
 
-fn merge_mcp_environment(
-    environment: &mut HashMap<String, String>,
+fn prepare_session_mcp(
+    bridge_environment: &HashMap<String, String>,
     servers: &[McpServer],
-) -> Result<(), agent_client_protocol::Error> {
+) -> Result<(HashMap<String, String>, Vec<AgentTransientMcpServer>), agent_client_protocol::Error> {
+    let mut environment = bridge_environment.clone();
+    let mut transient = Vec::new();
     for server in servers {
-        let McpServer::Stdio(server) = server else {
-            return Err(agent_client_protocol::Error::invalid_params()
-                .data("Maple ACP currently supports only stdio MCP session definitions"));
-        };
-        let command = Path::new(&server.command);
-        let is_buzz_dev_mcp = server.name == "buzz-dev-mcp"
-            && command
-                .file_name()
-                .and_then(|name| name.to_str())
-                .is_some_and(|name| name == "buzz-dev-mcp" || name == "buzz-dev-mcp.exe")
-            && server.args.is_empty();
-        if !is_buzz_dev_mcp || !command.is_absolute() {
-            return Err(agent_client_protocol::Error::invalid_params().data(
-                "Maple ACP currently adapts only Buzz's absolute buzz-dev-mcp stdio definition",
-            ));
-        }
-        let metadata = std::fs::metadata(command).map_err(|_| {
-            agent_client_protocol::Error::invalid_params()
-                .data("Buzz buzz-dev-mcp command does not exist")
-        })?;
-        if !metadata.is_file() {
-            return Err(agent_client_protocol::Error::invalid_params()
-                .data("Buzz buzz-dev-mcp command is not a file"));
-        }
-        #[cfg(unix)]
-        if metadata.permissions().mode() & 0o111 == 0 {
-            return Err(agent_client_protocol::Error::invalid_params()
-                .data("Buzz buzz-dev-mcp command is not executable"));
-        }
-        // Maple already exposes a tightly controlled shell tool. For Buzz's
-        // dev MCP, adapt the exact child environment into that per-session
-        // shell rather than launching a second general-purpose shell server.
-        for variable in &server.env {
-            if !ALLOWED_BRIDGE_ENV.contains(&variable.name.as_str()) {
-                continue;
-            }
-            if let Some(existing) = environment.get(&variable.name) {
-                if existing != &variable.value {
-                    return Err(agent_client_protocol::Error::invalid_params().data(format!(
-                        "Conflicting ACP environment value for {}",
-                        variable.name
-                    )));
+        match server {
+            McpServer::Stdio(server) => {
+                let command = server.command.as_path();
+                let is_buzz_dev_mcp = server.name == "buzz-dev-mcp"
+                    && command
+                        .file_name()
+                        .and_then(|name| name.to_str())
+                        .is_some_and(|name| name == "buzz-dev-mcp" || name == "buzz-dev-mcp.exe")
+                    && server.args.is_empty();
+                if is_buzz_dev_mcp {
+                    if !command.is_absolute() {
+                        return Err(agent_client_protocol::Error::invalid_params()
+                            .data("Buzz buzz-dev-mcp command must be absolute"));
+                    }
+                    let metadata = std::fs::metadata(command).map_err(|_| {
+                        agent_client_protocol::Error::invalid_params()
+                            .data("Buzz buzz-dev-mcp command does not exist")
+                    })?;
+                    if !metadata.is_file() {
+                        return Err(agent_client_protocol::Error::invalid_params()
+                            .data("Buzz buzz-dev-mcp command is not a file"));
+                    }
+                    #[cfg(unix)]
+                    if metadata.permissions().mode() & 0o111 == 0 {
+                        return Err(agent_client_protocol::Error::invalid_params()
+                            .data("Buzz buzz-dev-mcp command is not executable"));
+                    }
+                    // Preserve the historical Buzz adapter: its exact MCP
+                    // definition contributes only the allowlisted shell env.
+                    for variable in &server.env {
+                        if !ALLOWED_BRIDGE_ENV.contains(&variable.name.as_str()) {
+                            continue;
+                        }
+                        if let Some(existing) = environment.get(&variable.name) {
+                            if existing != &variable.value {
+                                return Err(agent_client_protocol::Error::invalid_params().data(
+                                    format!(
+                                        "Conflicting ACP environment value for {}",
+                                        variable.name
+                                    ),
+                                ));
+                            }
+                        } else {
+                            environment.insert(variable.name.clone(), variable.value.clone());
+                        }
+                    }
+                    continue;
                 }
-            } else {
-                environment.insert(variable.name.clone(), variable.value.clone());
+                return Err(agent_client_protocol::Error::invalid_params().data(format!(
+                    "Transient stdio MCP server '{}' is disabled because it would execute caller-supplied native code without a Maple approval boundary",
+                    server.name
+                )));
+            }
+            McpServer::Http(server) => {
+                let mut headers = Vec::new();
+                let mut header_names = HashSet::new();
+                for header in &server.headers {
+                    if !header_names.insert(header.name.to_ascii_lowercase()) {
+                        return Err(agent_client_protocol::Error::invalid_params().data(format!(
+                            "Duplicate HTTP header in MCP server '{}'",
+                            server.name
+                        )));
+                    }
+                    headers.push(AgentMcpKeyValue {
+                        key: header.name.clone(),
+                        value: header.value.clone(),
+                    });
+                }
+                transient.push(AgentTransientMcpServer {
+                    name: server.name.clone(),
+                    description: "ACP session MCP server".to_string(),
+                    timeout_seconds: ACP_TRANSIENT_MCP_TIMEOUT_SECONDS,
+                    transport: AgentTransientMcpTransport::StreamableHttp {
+                        url: server.url.clone(),
+                        headers,
+                    },
+                });
+            }
+            McpServer::Sse(_) => {
+                return Err(agent_client_protocol::Error::invalid_params()
+                    .data("Maple ACP does not support legacy SSE MCP servers"));
+            }
+            _ => {
+                return Err(agent_client_protocol::Error::invalid_params()
+                    .data("Maple ACP does not support this MCP transport"));
             }
         }
     }
-    Ok(())
+    Ok((environment, transient))
 }
 
 fn filter_bridge_environment(environment: HashMap<String, String>) -> HashMap<String, String> {
@@ -1926,15 +2782,113 @@ fn has_buzz_credentials(environment: &HashMap<String, String>) -> bool {
             .is_some_and(|value| !value.is_empty())
 }
 
-fn prompt_text(blocks: &[ContentBlock]) -> Result<String, agent_client_protocol::Error> {
-    let text = blocks
+fn canonical_session_id(session_id: &SessionId) -> Result<String, agent_client_protocol::Error> {
+    canonical_session_id_text(&session_id.0)
+}
+
+fn canonical_session_id_text(session_id: &str) -> Result<String, agent_client_protocol::Error> {
+    let session_id = session_id.trim();
+    if session_id.is_empty() {
+        return Err(agent_client_protocol::Error::invalid_params()
+            .data("Maple ACP requires a non-empty session ID"));
+    }
+    Ok(session_id.to_string())
+}
+
+fn is_acp_loadable_session_mode(mode: &str) -> bool {
+    mode == ACP_LOADABLE_GOOSE_MODE
+}
+
+fn ensure_acp_session_is_loadable<'a>(
+    sessions: &'a [AgentSessionSummary],
+    session_id: &str,
+) -> Result<&'a AgentSessionSummary, String> {
+    let session = sessions
         .iter()
-        .filter_map(|block| match block {
-            ContentBlock::Text(text) => Some(text.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n\n");
+        .find(|session| session.id == session_id)
+        .ok_or_else(|| {
+            "The requested Maple Agent task does not exist in the supplied project directory"
+                .to_string()
+        })?;
+    if !is_acp_loadable_session_mode(&session.mode) {
+        return Err(
+            "Maple ACP can load only Read only Agent tasks; this task remains available in Maple Desktop"
+                .to_string(),
+        );
+    }
+    Ok(session)
+}
+
+fn acp_session_modes() -> SessionModeState {
+    SessionModeState::new(
+        "interactive",
+        vec![SessionMode::new("interactive", "Interactive")
+            .description("Maple asks the ACP caller to approve sensitive tools")],
+    )
+}
+
+fn acp_config_options(model: &str, available_models: &[String]) -> Vec<SessionConfigOption> {
+    let model_options = available_models
+        .iter()
+        .map(|model| SessionConfigSelectOption::new(model.clone(), model.clone()))
+        .collect::<Vec<_>>();
+    vec![
+        SessionConfigOption::select("model", "Model", model.to_string(), model_options)
+            .category(SessionConfigOptionCategory::Model),
+        SessionConfigOption::select(
+            "mode",
+            "Mode",
+            "interactive",
+            vec![SessionConfigSelectOption::new("interactive", "Interactive")],
+        )
+        .category(SessionConfigOptionCategory::Mode),
+    ]
+}
+
+fn acp_session_config_options(
+    model: &str,
+    available_models: &[String],
+    message_count: usize,
+) -> Vec<SessionConfigOption> {
+    if message_count == 0 {
+        acp_config_options(model, available_models)
+    } else {
+        let locked_models = [model.to_string()];
+        acp_config_options(model, &locked_models)
+    }
+}
+
+fn acp_usage(usage: AgentRunUsage) -> Usage {
+    Usage::new(usage.total_tokens, usage.input_tokens, usage.output_tokens)
+        .cached_read_tokens(usage.cached_read_tokens)
+        .cached_write_tokens(usage.cached_write_tokens)
+}
+
+fn outbound_error(error: AcpOutboundSendError) -> agent_client_protocol::Error {
+    match error {
+        AcpOutboundSendError::Transport(error) => error,
+        AcpOutboundSendError::UpdateTooLarge => agent_client_protocol::Error::internal_error()
+            .data("A Maple ACP history update exceeded the transport limit"),
+        AcpOutboundSendError::Cancelled => agent_client_protocol::Error::internal_error()
+            .data("The Maple ACP connection closed while replaying history"),
+    }
+}
+
+fn prompt_text(blocks: &[ContentBlock]) -> Result<String, agent_client_protocol::Error> {
+    let mut parts = Vec::new();
+    for block in blocks {
+        match block {
+            ContentBlock::Text(text) => parts.push(text.text.clone()),
+            ContentBlock::ResourceLink(link) => {
+                parts.push(format!("[Resource: {}]\n{}", link.name, link.uri));
+            }
+            _ => {
+                return Err(agent_client_protocol::Error::invalid_params()
+                    .data("Maple ACP currently accepts text and resource-link prompt blocks"));
+            }
+        }
+    }
+    let text = parts.join("\n\n");
     if text.trim().is_empty() {
         return Err(agent_client_protocol::Error::invalid_params()
             .data("Maple ACP requires at least one text prompt block"));
@@ -1965,7 +2919,8 @@ fn acp_permission_tool_call(
 fn acp_tool_kind(tool_name: &str) -> ToolKind {
     match tool_name.rsplit("__").next().unwrap_or(tool_name) {
         "shell" | "computer" => ToolKind::Execute,
-        "text_editor" => ToolKind::Edit,
+        "read" | "read_image" => ToolKind::Read,
+        "edit" | "write" | "text_editor" => ToolKind::Edit,
         "search" | "web_search" => ToolKind::Search,
         "open_url" => ToolKind::Fetch,
         _ => ToolKind::Other,
@@ -2027,18 +2982,196 @@ where
     });
 }
 
-fn timeline_update(item: &AgentTimelineItem) -> Option<SessionUpdate> {
-    let text = item.text.as_deref()?.to_string();
+fn timeline_update(
+    item: &AgentTimelineItem,
+    tools: &mut AcpToolProjection,
+    include_user_messages: bool,
+) -> Option<SessionUpdate> {
     match item.item_type.as_str() {
-        "message" if item.role.as_deref() == Some("assistant") => {
-            Some(SessionUpdate::AgentMessageChunk(ContentChunk::new(
-                ContentBlock::Text(TextContent::new(text)),
-            )))
+        "message" if include_user_messages && item.role.as_deref() == Some("user") => {
+            item.text.as_ref().map(|text| {
+                SessionUpdate::UserMessageChunk(
+                    ContentChunk::new(ContentBlock::Text(TextContent::new(text.clone())))
+                        .message_id(item.id.as_str()),
+                )
+            })
         }
-        "thinking" => Some(SessionUpdate::AgentThoughtChunk(ContentChunk::new(
-            ContentBlock::Text(TextContent::new(text)),
-        ))),
+        "message" if item.role.as_deref() == Some("assistant") => item.text.as_ref().map(|text| {
+            SessionUpdate::AgentMessageChunk(
+                ContentChunk::new(ContentBlock::Text(TextContent::new(text.clone())))
+                    .message_id(item.id.as_str()),
+            )
+        }),
+        "thinking" => item.text.as_ref().map(|text| {
+            SessionUpdate::AgentThoughtChunk(
+                ContentChunk::new(ContentBlock::Text(TextContent::new(text.clone())))
+                    .message_id(item.id.as_str()),
+            )
+        }),
+        "tool" => Some(acp_tool_update(item, tools)),
         _ => None,
+    }
+}
+
+fn acp_tool_update(item: &AgentTimelineItem, tools: &mut AcpToolProjection) -> SessionUpdate {
+    let status = match item.status.as_deref() {
+        Some("completed") => ToolCallStatus::Completed,
+        Some("failed" | "cancelled") => ToolCallStatus::Failed,
+        Some("pending") => ToolCallStatus::Pending,
+        _ => ToolCallStatus::InProgress,
+    };
+    let kind = timeline_tool_kind(item);
+    let content = timeline_tool_text(item).map(|text| {
+        vec![ToolCallContent::from(ContentBlock::Text(TextContent::new(
+            text,
+        )))]
+    });
+    let locations = timeline_tool_locations(item);
+    let raw_input = item.input.as_ref().map(bounded_raw_json);
+    let raw_output = timeline_tool_raw_output(item);
+    let title = item
+        .title
+        .clone()
+        .unwrap_or_else(|| "Maple tool".to_string());
+    if tools.seen.insert(item.id.clone()) {
+        let mut call = ToolCall::new(item.id.clone(), title)
+            .kind(kind)
+            .status(status);
+        if let Some(content) = content {
+            call = call.content(content);
+        }
+        if !locations.is_empty() {
+            call = call.locations(locations);
+        }
+        if let Some(raw_input) = raw_input {
+            call = call.raw_input(raw_input);
+        }
+        if let Some(raw_output) = raw_output {
+            call = call.raw_output(raw_output);
+        }
+        SessionUpdate::ToolCall(call)
+    } else {
+        let mut fields = ToolCallUpdateFields::new()
+            .title(title)
+            .kind(kind)
+            .status(status);
+        if let Some(content) = content {
+            fields = fields.content(content);
+        }
+        if !locations.is_empty() {
+            fields = fields.locations(locations);
+        }
+        if let Some(raw_input) = raw_input {
+            fields = fields.raw_input(raw_input);
+        }
+        if let Some(raw_output) = raw_output {
+            fields = fields.raw_output(raw_output);
+        }
+        SessionUpdate::ToolCallUpdate(ToolCallUpdate::new(item.id.clone(), fields))
+    }
+}
+
+fn timeline_tool_kind(item: &AgentTimelineItem) -> ToolKind {
+    let title = item
+        .title
+        .as_deref()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    let input = item.input.as_ref();
+    if input.and_then(|value| value.get("command")).is_some() || title.contains("terminal") {
+        ToolKind::Execute
+    } else if input.and_then(|value| value.get("url")).is_some()
+        || title.contains("web")
+        || title.contains("url")
+    {
+        ToolKind::Fetch
+    } else if input.and_then(|value| value.get("query")).is_some()
+        || input.and_then(|value| value.get("pattern")).is_some()
+        || title.contains("search")
+        || title.contains("find")
+    {
+        ToolKind::Search
+    } else if title.contains("read") {
+        ToolKind::Read
+    } else if input.and_then(tool_path).is_some()
+        || title.contains("edit")
+        || title.contains("write")
+    {
+        ToolKind::Edit
+    } else {
+        ToolKind::Other
+    }
+}
+
+fn timeline_tool_text(item: &AgentTimelineItem) -> Option<String> {
+    let output_text = || {
+        item.output
+            .as_ref()
+            .and_then(|output| output.get("text"))
+            .and_then(serde_json::Value::as_str)
+            .map(str::to_string)
+    };
+    let text = if matches!(
+        item.status.as_deref(),
+        Some("completed" | "failed" | "cancelled")
+    ) {
+        // Coalesced replay items retain the original request summary in
+        // item.text while the terminal tool result lives in output.text.
+        // Paseo renders ACP text content before rawOutput, so preferring the
+        // summary here would hide the actual imported result.
+        output_text().or_else(|| item.text.clone())
+    } else {
+        item.text.clone().or_else(output_text)
+    };
+    text.map(|text| text.chars().take(16_000).collect())
+}
+
+fn tool_path(value: &serde_json::Value) -> Option<&str> {
+    ["path", "file_path", "file"]
+        .into_iter()
+        .find_map(|key| value.get(key).and_then(serde_json::Value::as_str))
+}
+
+fn timeline_tool_locations(item: &AgentTimelineItem) -> Vec<ToolCallLocation> {
+    item.input
+        .as_ref()
+        .and_then(tool_path)
+        .filter(|path| Path::new(path).is_absolute())
+        .map(|path| vec![ToolCallLocation::new(PathBuf::from(path))])
+        .unwrap_or_default()
+}
+
+fn timeline_tool_raw_output(item: &AgentTimelineItem) -> Option<serde_json::Value> {
+    let output = item.output.as_ref()?;
+    let failure_message = matches!(item.status.as_deref(), Some("failed" | "cancelled"))
+        .then(|| {
+            output
+                .get("text")
+                .and_then(serde_json::Value::as_str)
+                .map(|text| text.chars().take(MAX_ACP_ERROR_CHARS).collect::<String>())
+        })
+        .flatten()
+        .filter(|message| !message.trim().is_empty());
+    let mut bounded = bounded_raw_json(output);
+    if let (Some(message), serde_json::Value::Object(fields)) = (failure_message, &mut bounded) {
+        // Paseo derives the failure badge from rawOutput.message/error. Maple's
+        // persisted tool shape uses output.text, so provide a bounded alias
+        // without changing the canonical result or exposing any extra data.
+        if !fields.contains_key("message") && !fields.contains_key("error") {
+            fields.insert("message".to_string(), serde_json::Value::String(message));
+        }
+    }
+    Some(bounded)
+}
+
+fn bounded_raw_json(value: &serde_json::Value) -> serde_json::Value {
+    match serde_json::to_vec(value) {
+        Ok(encoded) if encoded.len() <= 64 * 1024 => value.clone(),
+        Ok(encoded) => serde_json::json!({
+            "truncated": true,
+            "encodedBytes": encoded.len(),
+        }),
+        Err(_) => serde_json::json!({ "unavailable": true }),
     }
 }
 
@@ -2196,14 +3329,242 @@ async fn run_acp_connector_async() -> Result<(), String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use agent_client_protocol::schema::v1::SelectedPermissionOutcome;
+    use agent_client_protocol::schema::v1::{McpServerStdio, SelectedPermissionOutcome};
 
     #[test]
     fn default_config_is_disabled_and_caller_mediated() {
         let config = AgentAcpConfig::default();
         assert!(!config.enabled);
         assert_eq!(config.permission_mode, AgentAcpPermissionMode::ReadOnly);
-        assert_eq!(config.max_connections, 1);
+        assert_eq!(config.max_connections, 8);
+    }
+
+    #[test]
+    fn explicit_connection_limits_remain_configurable_below_the_default() {
+        let one = normalize_config(AgentAcpConfig {
+            max_connections: 1,
+            ..AgentAcpConfig::default()
+        })
+        .unwrap();
+        assert_eq!(one.max_connections, 1);
+
+        let capped = normalize_config(AgentAcpConfig {
+            max_connections: usize::MAX,
+            ..AgentAcpConfig::default()
+        })
+        .unwrap();
+        assert_eq!(capped.max_connections, MAX_ACP_CONNECTIONS);
+    }
+
+    #[test]
+    fn session_ids_are_canonicalized_and_empty_ids_are_rejected() {
+        assert_eq!(
+            canonical_session_id(&SessionId::new("  task-123  ")).unwrap(),
+            "task-123"
+        );
+        assert!(canonical_session_id(&SessionId::new(" \n\t ")).is_err());
+    }
+
+    fn session_summary_with_mode(id: &str, mode: &str) -> AgentSessionSummary {
+        AgentSessionSummary {
+            id: id.to_string(),
+            title: id.to_string(),
+            project_root: "/tmp/project".to_string(),
+            created_ms: 1,
+            updated_ms: 1,
+            message_count: 0,
+            model: Some("model".to_string()),
+            mode: mode.to_string(),
+        }
+    }
+
+    #[test]
+    fn session_list_loadability_is_fail_closed_to_read_only_tasks() {
+        let sessions = [
+            session_summary_with_mode("read-only", "smart_approve"),
+            session_summary_with_mode("allow-all", "auto"),
+            session_summary_with_mode("approval", "approve"),
+            session_summary_with_mode("chat", "chat"),
+            session_summary_with_mode("unknown", "future_mode"),
+        ];
+
+        let visible = sessions
+            .iter()
+            .filter(|session| is_acp_loadable_session_mode(&session.mode))
+            .map(|session| session.id.as_str())
+            .collect::<Vec<_>>();
+
+        assert_eq!(visible, vec!["read-only"]);
+    }
+
+    #[test]
+    fn session_load_preflight_rejects_non_read_only_and_missing_tasks() {
+        let sessions = [
+            session_summary_with_mode("read-only", "smart_approve"),
+            session_summary_with_mode("allow-all", "auto"),
+        ];
+
+        assert_eq!(
+            ensure_acp_session_is_loadable(&sessions, "read-only")
+                .unwrap()
+                .id,
+            "read-only"
+        );
+        assert!(ensure_acp_session_is_loadable(&sessions, "allow-all")
+            .unwrap_err()
+            .contains("only Read only"));
+        assert!(ensure_acp_session_is_loadable(&sessions, "missing")
+            .unwrap_err()
+            .contains("does not exist"));
+    }
+
+    #[tokio::test]
+    async fn session_operation_cancellation_keeps_close_behind_the_active_fence() {
+        let connection_lifetime = CancellationToken::new();
+        let operation = AcpSessionOperation::new(&connection_lifetime);
+        let active = Arc::clone(&operation.gate).lock_owned().await;
+        let waiting_gate = Arc::clone(&operation.gate);
+        let waiting = tokio::spawn(async move { waiting_gate.lock_owned().await });
+
+        operation.cancellation.cancel();
+        assert!(operation.cancellation.is_cancelled());
+        tokio::task::yield_now().await;
+        assert!(!waiting.is_finished());
+
+        drop(active);
+        let closing = tokio::time::timeout(std::time::Duration::from_secs(1), waiting)
+            .await
+            .unwrap()
+            .unwrap();
+        drop(closing);
+    }
+
+    #[test]
+    fn timed_out_close_keeps_its_resurrection_fence() {
+        assert!(close_registration_may_be_released(true, true, true));
+        assert!(!close_registration_may_be_released(false, true, true));
+        assert!(!close_registration_may_be_released(true, false, true));
+        assert!(!close_registration_may_be_released(true, true, false));
+    }
+
+    #[test]
+    fn completed_replayed_tool_prefers_result_over_request_summary() {
+        let item = AgentTimelineItem {
+            id: "tool-1".to_string(),
+            item_type: "tool".to_string(),
+            role: Some("assistant".to_string()),
+            title: Some("Terminal".to_string()),
+            text: Some("listing project root".to_string()),
+            status: Some("completed".to_string()),
+            input: Some(serde_json::json!({ "command": "pwd" })),
+            output: Some(serde_json::json!({ "text": "/tmp/project" })),
+            created_ms: 1,
+            merge: "replace".to_string(),
+        };
+        let mut projection = AcpToolProjection::default();
+        let encoded = serde_json::to_value(acp_tool_update(&item, &mut projection)).unwrap();
+
+        assert_eq!(timeline_tool_text(&item).as_deref(), Some("/tmp/project"));
+        assert_eq!(encoded["content"][0]["content"]["text"], "/tmp/project");
+        assert_eq!(encoded["rawInput"]["command"], "pwd");
+    }
+
+    #[test]
+    fn failed_replayed_tool_preserves_result_and_failure_badge_message() {
+        let mut projection = AcpToolProjection::default();
+        let pending = AgentTimelineItem {
+            id: "tool-1".to_string(),
+            item_type: "tool".to_string(),
+            role: Some("assistant".to_string()),
+            title: Some("Terminal".to_string()),
+            text: Some("running command".to_string()),
+            status: Some("pending".to_string()),
+            input: Some(serde_json::json!({ "command": "false" })),
+            output: None,
+            created_ms: 1,
+            merge: "replace".to_string(),
+        };
+        let _ = acp_tool_update(&pending, &mut projection);
+        let failed = AgentTimelineItem {
+            text: Some("running command".to_string()),
+            status: Some("failed".to_string()),
+            output: Some(serde_json::json!({
+                "text": "command exited with status 1",
+                "isError": true,
+            })),
+            ..pending
+        };
+        let encoded = serde_json::to_value(acp_tool_update(&failed, &mut projection)).unwrap();
+
+        assert_eq!(encoded["sessionUpdate"], "tool_call_update");
+        assert_eq!(
+            encoded["content"][0]["content"]["text"],
+            "command exited with status 1"
+        );
+        assert_eq!(
+            encoded["rawOutput"]["message"],
+            "command exited with status 1"
+        );
+    }
+
+    #[test]
+    fn prompt_usage_serializes_one_turn_without_session_accumulation() {
+        let turn = AgentRunUsage {
+            input_tokens: 10,
+            output_tokens: 4,
+            total_tokens: 14,
+            cached_read_tokens: 3,
+            cached_write_tokens: 1,
+        };
+        let encoded = serde_json::to_value(acp_usage(turn)).unwrap();
+
+        assert_eq!(encoded["inputTokens"], 10);
+        assert_eq!(encoded["outputTokens"], 4);
+        assert_eq!(encoded["totalTokens"], 14);
+        assert_eq!(encoded["cachedReadTokens"], 3);
+        assert_eq!(encoded["cachedWriteTokens"], 1);
+    }
+
+    #[test]
+    fn model_selector_locks_to_the_persisted_model_after_first_message() {
+        let models = vec!["model-a".to_string(), "model-b".to_string()];
+        let fresh = serde_json::to_value(acp_session_config_options("model-b", &models, 0))
+            .expect("fresh model options should serialize");
+        let locked = serde_json::to_value(acp_session_config_options("model-b", &models, 1))
+            .expect("locked model options should serialize");
+
+        assert_eq!(fresh[0]["currentValue"], "model-b");
+        assert_eq!(fresh[0]["options"].as_array().unwrap().len(), 2);
+        assert_eq!(locked[0]["currentValue"], "model-b");
+        assert_eq!(locked[0]["options"].as_array().unwrap().len(), 1);
+        assert_eq!(locked[0]["options"][0]["value"], "model-b");
+    }
+
+    #[test]
+    fn streamed_message_chunks_keep_the_timeline_item_id() {
+        let mut projection = AcpToolProjection::default();
+        for (role, item_type, expected_variant) in [
+            (Some("user"), "message", "user_message_chunk"),
+            (Some("assistant"), "message", "agent_message_chunk"),
+            (None, "thinking", "agent_thought_chunk"),
+        ] {
+            let item = AgentTimelineItem {
+                id: format!("stable-{expected_variant}"),
+                item_type: item_type.to_string(),
+                role: role.map(str::to_string),
+                title: None,
+                text: Some("delta".to_string()),
+                status: None,
+                input: None,
+                output: None,
+                created_ms: 1,
+                merge: "append".to_string(),
+            };
+            let update = timeline_update(&item, &mut projection, true).unwrap();
+            let encoded = serde_json::to_value(update).unwrap();
+            assert_eq!(encoded["sessionUpdate"], expected_variant);
+            assert_eq!(encoded["messageId"], item.id);
+        }
     }
 
     #[test]
@@ -2381,6 +3742,11 @@ mod tests {
     }
 
     #[test]
+    fn allowed_project_root_rejects_relative_paths() {
+        assert!(ensure_allowed_project_root(Path::new("relative/project"), &[]).is_err());
+    }
+
+    #[test]
     fn bridge_environment_is_strictly_allowlisted() {
         let filtered = filter_bridge_environment(HashMap::from([
             (
@@ -2391,6 +3757,16 @@ mod tests {
         ]));
         assert_eq!(filtered.len(), 1);
         assert!(filtered.contains_key("BUZZ_RELAY_URL"));
+    }
+
+    #[test]
+    fn arbitrary_stdio_mcp_is_rejected_before_any_process_can_start() {
+        let server = McpServer::Stdio(
+            McpServerStdio::new("untrusted", "/bin/sh")
+                .args(vec!["-c".to_string(), "exit 0".to_string()]),
+        );
+
+        assert!(prepare_session_mcp(&HashMap::new(), &[server]).is_err());
     }
 
     #[test]

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -4,10 +4,9 @@ use crate::agent::{
     AgentProjectRootRegistration, AgentProjectSkillsTrustStatus, AgentQueueControlRequest,
     AgentQueueUpdateRequest, AgentQueuedMessage, AgentRenameSessionRequest, AgentRunEvent,
     AgentRunResponse, AgentRunTerminal, AgentRuntimeHandle, AgentRuntimeStatus,
-    AgentSendMessageRequest,
-    AgentServiceEvent, AgentSessionDetail, AgentSessionMcpServer, AgentSessionSummary,
-    AgentSetSessionMcpServerRequest, AgentStartRequest, AgentTimelineItem, MapleAgentService,
-    RecentProjectRoot,
+    AgentSendMessageRequest, AgentServiceEvent, AgentSessionDetail, AgentSessionMcpServer,
+    AgentSessionSummary, AgentSetSessionMcpServerRequest, AgentStartRequest, AgentTimelineItem,
+    MapleAgentService, RecentProjectRoot,
 };
 use crate::agent_host::{AgentHostLifecycle, AgentRuntimeLifecycleOutcome};
 use crate::maple_api::MapleApiAuthState;

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -207,6 +207,7 @@ pub fn run() {
             agent_acp::agent_acp_load_config,
             agent_acp::agent_acp_save_config,
             agent_acp::agent_acp_start,
+            agent_acp::agent_acp_restore_enabled,
             agent_acp::agent_acp_stop,
             agent_acp::agent_acp_get_status,
             maple_api::maple_api_set_auth,

--- a/frontend/src-tauri/src/main.rs
+++ b/frontend/src-tauri/src/main.rs
@@ -1,14 +1,65 @@
 // Prevents additional console window on Windows in release, DO NOT REMOVE!!
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
-fn main() {
-    let mut args = std::env::args().skip(1);
-    if args.next().as_deref() == Some("acp") {
-        if let Err(error) = app_lib::run_acp_connector() {
-            eprintln!("{error}");
-            std::process::exit(1);
-        }
-        return;
+#[derive(Debug, PartialEq, Eq)]
+enum StartupMode {
+    Acp,
+    Version,
+    Desktop,
+}
+
+fn startup_mode(args: impl IntoIterator<Item = String>) -> StartupMode {
+    match args.into_iter().next().as_deref() {
+        Some("acp") => StartupMode::Acp,
+        Some("--version" | "-V") => StartupMode::Version,
+        _ => StartupMode::Desktop,
     }
-    app_lib::run();
+}
+
+fn version_text() -> &'static str {
+    concat!("maple ", env!("CARGO_PKG_VERSION"))
+}
+
+fn main() {
+    match startup_mode(std::env::args().skip(1)) {
+        StartupMode::Acp => {
+            if let Err(error) = app_lib::run_acp_connector() {
+                eprintln!("{error}");
+                std::process::exit(1);
+            }
+        }
+        StartupMode::Version => println!("{}", version_text()),
+        StartupMode::Desktop => app_lib::run(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{startup_mode, version_text, StartupMode};
+
+    fn mode(args: &[&str]) -> StartupMode {
+        startup_mode(args.iter().map(|arg| (*arg).to_owned()))
+    }
+
+    #[test]
+    fn version_flags_use_the_fast_path() {
+        assert_eq!(mode(&["--version"]), StartupMode::Version);
+        assert_eq!(mode(&["-V"]), StartupMode::Version);
+        assert_eq!(
+            version_text(),
+            format!("maple {}", env!("CARGO_PKG_VERSION"))
+        );
+    }
+
+    #[test]
+    fn acp_subcommand_keeps_precedence_over_following_flags() {
+        assert_eq!(mode(&["acp"]), StartupMode::Acp);
+        assert_eq!(mode(&["acp", "--version"]), StartupMode::Acp);
+    }
+
+    #[test]
+    fn other_arguments_keep_desktop_startup() {
+        assert_eq!(mode(&[]), StartupMode::Desktop);
+        assert_eq!(mode(&["--unknown"]), StartupMode::Desktop);
+    }
 }

--- a/frontend/src-tauri/src/maple_api.rs
+++ b/frontend/src-tauri/src/maple_api.rs
@@ -247,6 +247,14 @@ impl MapleApiSession {
         Ok(())
     }
 
+    pub(crate) async fn model_ids(&self) -> Result<Vec<String>, String> {
+        let snapshot = self.client_snapshot().await?;
+        let response = snapshot.client.get_models().await;
+        self.record_refresh(&snapshot).await?;
+        let response = response.map_err(map_sdk_error)?;
+        Ok(response.data.into_iter().map(|model| model.id).collect())
+    }
+
     pub(crate) async fn send_inference_request(
         self: Arc<Self>,
         request: InferenceRequest,

--- a/frontend/src/components/settings/AgentConnectionsSettings.tsx
+++ b/frontend/src/components/settings/AgentConnectionsSettings.tsx
@@ -596,8 +596,8 @@ export function AgentConnectionsSettings() {
             <Server className="h-4 w-4" />
             <AlertDescription>
               In Buzz managed-agent settings, set parallelism to {BUZZ_MAPLE_AGENT_PARALLELISM}.
-              Buzz defaults to {BUZZ_DEFAULT_AGENT_PARALLELISM}, while Maple accepts one local ACP
-              connection by default.
+              Buzz defaults to {BUZZ_DEFAULT_AGENT_PARALLELISM}; Maple's default local ACP limit is{" "}
+              {BUZZ_MAPLE_AGENT_PARALLELISM}.
             </AlertDescription>
           </Alert>
 

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -1,6 +1,7 @@
 import { isTauriDesktop } from "@/utils/platform";
 import { agentOperationFence, type AgentOperationBlock } from "@/services/agentOperationFence";
 import { AgentAuthLifecycleCoordinator } from "@/services/agentAuthLifecycle";
+import { mapleAcpService } from "@/services/mapleAcpService";
 import { mapleApiAuthService } from "@/services/mapleApiAuthService";
 
 export interface AgentConfig {
@@ -552,6 +553,13 @@ const agentAuthLifecycle = new AgentAuthLifecycleCoordinator(
   async (userId) => {
     await mapleApiAuthService.activate(userId);
     agentOperationFence.activateUserSession(userId);
+    try {
+      await mapleAcpService.restoreEnabled(userId);
+    } catch {
+      // ACP is optional. Keep ordinary Agent Mode available when its saved
+      // listener cannot be restored; Settings exposes the explicit retry.
+      console.warn("Maple could not restore the enabled ACP service");
+    }
   }
 );
 

--- a/frontend/src/services/mapleAcpService.test.ts
+++ b/frontend/src/services/mapleAcpService.test.ts
@@ -5,6 +5,7 @@ import {
   BUZZ_MAPLE_HARNESS_ID,
   BUZZ_MAPLE_HARNESS_NAME,
   DEFAULT_MAPLE_ACP_CONFIG,
+  MAX_MAPLE_ACP_CONNECTIONS,
   MapleAcpService,
   buildBuzzCustomHarness,
   isMapleAcpConfigReady,
@@ -136,6 +137,17 @@ describe("Maple ACP response normalization", () => {
     });
   });
 
+  test("keeps explicit connection limits inside the native range", () => {
+    expect(normalizeMapleAcpConfig({ maxConnections: 0 }).maxConnections).toBe(1);
+    expect(normalizeMapleAcpConfig({ maxConnections: 1 }).maxConnections).toBe(1);
+    expect(
+      normalizeMapleAcpConfig({ maxConnections: MAX_MAPLE_ACP_CONNECTIONS }).maxConnections
+    ).toBe(MAX_MAPLE_ACP_CONNECTIONS);
+    expect(normalizeMapleAcpConfig({ maxConnections: 999 }).maxConnections).toBe(
+      MAX_MAPLE_ACP_CONNECTIONS
+    );
+  });
+
   test("migrates the former Maple-owned allow-all bypass to caller-owned approvals", () => {
     expect(
       normalizeMapleAcpConfig({
@@ -202,8 +214,8 @@ describe("Buzz custom harness output", () => {
     expect(serialized).not.toContain("endpoint");
   });
 
-  test("documents Buzz parallelism that matches Maple's default connection limit", () => {
-    expect(BUZZ_MAPLE_AGENT_PARALLELISM).toBe(1);
+  test("keeps Buzz parallelism within Maple's default connection limit", () => {
+    expect(BUZZ_MAPLE_AGENT_PARALLELISM).toBe(MAX_MAPLE_ACP_CONNECTIONS);
     expect(BUZZ_DEFAULT_AGENT_PARALLELISM).toBe(10);
     expect(DEFAULT_MAPLE_ACP_CONFIG.maxConnections).toBe(Number(BUZZ_MAPLE_AGENT_PARALLELISM));
   });

--- a/frontend/src/services/mapleAcpService.test.ts
+++ b/frontend/src/services/mapleAcpService.test.ts
@@ -60,6 +60,24 @@ describe("MapleAcpService", () => {
     expect(bridge.lastArgs).toEqual({ userId: "user-a" });
   });
 
+  test("saved service restoration stays authenticated and account-fenced", async () => {
+    const bridge = new RecordingBridge();
+    bridge.result = { running: true, enabled: true, harness };
+    const service = new MapleAcpService(bridge);
+
+    expect(await service.restoreEnabled("user-a")).toMatchObject({
+      running: true,
+      enabled: true
+    });
+
+    expect(bridge.events).toEqual([
+      "fence:user-a",
+      "sync:user-a",
+      "invoke:agent_acp_restore_enabled"
+    ]);
+    expect(bridge.lastArgs).toEqual({ userId: "user-a" });
+  });
+
   test("stop and polling remain account-fenced without refreshing credentials", async () => {
     const bridge = new RecordingBridge();
     bridge.result = { running: false };
@@ -114,6 +132,7 @@ describe("MapleAcpService", () => {
       "available in Maple Desktop"
     );
     await expect(service.start("user-a")).rejects.toThrow("available in Maple Desktop");
+    await expect(service.restoreEnabled("user-a")).rejects.toThrow("available in Maple Desktop");
     await expect(service.stop("user-a")).rejects.toThrow("available in Maple Desktop");
     await expect(service.getStatus("user-a")).rejects.toThrow("available in Maple Desktop");
     expect(bridge.events).toEqual([]);

--- a/frontend/src/services/mapleAcpService.ts
+++ b/frontend/src/services/mapleAcpService.ts
@@ -40,7 +40,8 @@ export interface BuzzCustomHarnessDefinition {
 
 export const BUZZ_MAPLE_HARNESS_ID = "maple" as const;
 export const BUZZ_MAPLE_HARNESS_NAME = "Maple" as const;
-export const BUZZ_MAPLE_AGENT_PARALLELISM = 1 as const;
+export const MAX_MAPLE_ACP_CONNECTIONS = 8 as const;
+export const BUZZ_MAPLE_AGENT_PARALLELISM = MAX_MAPLE_ACP_CONNECTIONS;
 export const BUZZ_DEFAULT_AGENT_PARALLELISM = 10 as const;
 
 export interface MapleAcpBridge {
@@ -54,7 +55,7 @@ export const DEFAULT_MAPLE_ACP_CONFIG: MapleAcpConfig = Object.freeze({
   enabled: false,
   permissionMode: "read_only",
   allowedProjectRoots: [],
-  maxConnections: 1
+  maxConnections: MAX_MAPLE_ACP_CONNECTIONS
 });
 
 const defaultBridge: MapleAcpBridge = {
@@ -136,14 +137,17 @@ export function normalizeMapleAcpConfig(value: unknown): MapleAcpConfig {
         (root): root is string => typeof root === "string" && root.trim().length > 0
       )
     : DEFAULT_MAPLE_ACP_CONFIG.allowedProjectRoots;
-  const maxConnections = safeCount(record?.maxConnections, DEFAULT_MAPLE_ACP_CONFIG.maxConnections);
+  const maxConnections =
+    typeof record?.maxConnections === "number" && Number.isSafeInteger(record.maxConnections)
+      ? record.maxConnections
+      : DEFAULT_MAPLE_ACP_CONFIG.maxConnections;
 
   return {
     enabled:
       typeof record?.enabled === "boolean" ? record.enabled : DEFAULT_MAPLE_ACP_CONFIG.enabled,
     permissionMode: normalizePermissionMode(record?.permissionMode),
     allowedProjectRoots: [...new Set(roots.map((root) => root.trim()))],
-    maxConnections: Math.max(1, maxConnections)
+    maxConnections: Math.min(MAX_MAPLE_ACP_CONNECTIONS, Math.max(1, maxConnections))
   };
 }
 

--- a/frontend/src/services/mapleAcpService.ts
+++ b/frontend/src/services/mapleAcpService.ts
@@ -86,6 +86,11 @@ export class MapleAcpService {
     return normalizeMapleAcpStatus(raw);
   }
 
+  async restoreEnabled(userId: string): Promise<MapleAcpStatus> {
+    const raw = await this.invokeAuthenticated<unknown>(userId, "agent_acp_restore_enabled");
+    return normalizeMapleAcpStatus(raw);
+  }
+
   async stop(userId: string): Promise<MapleAcpStatus> {
     // Stopping is a local control-plane operation. It must remain available
     // when credentials are expired or are being cleared during logout.


### PR DESCRIPTION
## Summary

This draft expands Maple's existing ACP preview into a Paseo-compatible edge over the existing authenticated `MapleAgentService`. It intentionally keeps normal Maple Desktop Agent Mode on the direct embedded-Goose path.

The current snapshot adds:

- dynamic authenticated Maple model discovery and pre-first-message selection;
- ACP session list, load, close, ordered replay, per-turn usage, stable message IDs, and richer tool lifecycle projection;
- caller-owned one-shot permission handling and stronger session/run/lease cancellation fencing;
- provisional ACP task cleanup and probe hygiene;
- a lease-scoped, loopback-only Streamable HTTP MCP client that stays outside Goose's extension registry, OAuth store, and persisted MCP configuration;
- one static ask-before `external_mcp` wrapper with exact frozen routing to injected Paseo tools;
- bounded connection parallelism, a non-GUI `--version` fast path for provider diagnostics, and updated ACP/Paseo documentation.

## Draft status

This is a preservation and review checkpoint, not a merge-ready claim.

- The implementation is based on `c0b3f607` and is currently 26 commits behind `master`.
- It has deliberately **not** been rebased yet, so independent review can inspect the exact locally tested snapshot before conflict resolution.
- A current-master rebase/update, conflict review, complete validation, and renewed Paseo end-to-end smoke are still required.
- Generic caller-supplied stdio MCP remains rejected because accepting it would execute arbitrary local code before a Maple permission boundary. The injected Paseo path is loopback HTTP only.
- Images, audio, embedded resources, SSE MCP, resume/fork/delete, and Windows ACP UI exposure remain outside this draft's supported surface.

## Security and architecture notes

Transient Paseo MCP definitions, authorization headers, and clients are held only by the revocable calling-surface tool context. They are not registered with Goose's extension manager, do not use Goose OAuth fallback, and are not serialized into Maple session configuration. Goose sees only the static `external_mcp` wrapper, which remains in the explicit ask-before policy.

Review attention is especially welcome on:

- lease publication, cancellation, disconnect, close, and dropped-future cleanup;
- preservation of Desktop task ownership and permission mode;
- provisional-task deletion conditions and load/close concurrency;
- transient MCP credential lifetime, result/catalog bounds, and exact routing;
- ACP history/tool projection and compatibility with Paseo's generic adapter.

## Validation at this checkpoint

The repository pre-commit gate passed on macOS/aarch64:

- Prettier format check;
- TypeScript build and Vite production build;
- 661 Bun tests;
- Rust `cargo test --all-targets`: 334 library tests passed, 2 ignored, plus 3 binary tests passed;
- `git diff --check`.

Development-time Paseo smoke exercised the exact workspace Maple executable, dynamic provider/model discovery, normal chat, caller-owned permissions, and injected Paseo MCP tool routing. That runtime evidence must be repeated after updating onto current `master`; it is not packaged or cross-platform release evidence.
