### PR TITLE
chore: bump version to 3.3.5

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.4",
+  "version": "3.3.5",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4618,7 +4618,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.4"
+version = "3.3.5"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.4"
+version = "3.3.5"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.4</string>
+	<string>3.3.5</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.4</string>
+	<string>3.3.5</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.4
-        CFBundleVersion: 3.3.4
+        CFBundleShortVersionString: 3.3.5
+        CFBundleVersion: 3.3.5
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.4",
+  "version": "3.3.5",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -97,7 +97,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028015
+      "versionCode": 2000028016
     },
     "windows": {
       "certificateThumbprint": null,

--- a/justfile
+++ b/justfile
@@ -130,24 +130,7 @@ update-version version:
     echo "Calculated Android versionCode: $android_version_code (previous + 1)"
     
     # Update package.json
-    sed -i 's/"version": "[^"]*"/"version": "{{version}}"/' frontend/package.json
-    
-    # Update tauri.conf.json version
-    sed -i 's/"version": "[^"]*"/"version": "{{version}}"/' frontend/src-tauri/tauri.conf.json
-    
-    # Update tauri.conf.json Android versionCode
-    sed -i "s/\"versionCode\": [0-9]*/\"versionCode\": $android_version_code/" frontend/src-tauri/tauri.conf.json
-    
-    # Update Cargo.toml
-    sed -i 's/^version = "[^"]*"/version = "{{version}}"/' frontend/src-tauri/Cargo.toml
-    
-    # Update project.yml
-    sed -i 's/CFBundleShortVersionString: .*/CFBundleShortVersionString: {{version}}/' frontend/src-tauri/gen/apple/project.yml
-    sed -i 's/CFBundleVersion: .*/CFBundleVersion: {{version}}/' frontend/src-tauri/gen/apple/project.yml
-    
-    # Update Info.plist
-    sed -i '/<key>CFBundleShortVersionString<\/key>/{n;s/<string>[^<]*<\/string>/<string>{{version}}<\/string>/;}' frontend/src-tauri/gen/apple/maple_iOS/Info.plist
-    sed -i '/<key>CFBundleVersion<\/key>/{n;s/<string>[^<]*<\/string>/<string>{{version}}<\/string>/;}' frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+    python3 scripts/update-version.py "{{version}}" "$android_version_code"
     
     # Run cargo check to update Cargo.lock
     echo "Running cargo check to update Cargo.lock..."

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Update Maple's release-version sources consistently."""
+
+import re
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def replace_once(path: Path, pattern: str, replacement: str) -> None:
+    contents = path.read_text()
+    updated, count = re.subn(pattern, replacement, contents, count=1, flags=re.MULTILINE)
+    if count != 1:
+        raise SystemExit(f"Expected one version field in {path.relative_to(ROOT)}, found {count}.")
+    path.write_text(updated)
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        raise SystemExit("Usage: update-version.py X.Y.Z ANDROID_VERSION_CODE")
+
+    version, android_version_code = sys.argv[1:]
+    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise SystemExit(f"Invalid version: {version}")
+    if not android_version_code.isdecimal():
+        raise SystemExit(f"Invalid Android version code: {android_version_code}")
+
+    replace_once(
+        ROOT / "frontend/package.json",
+        r'("version": ")[^"]*(")',
+        rf"\g<1>{version}\g<2>",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/tauri.conf.json",
+        r'("version": ")[^"]*(")',
+        rf"\g<1>{version}\g<2>",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/tauri.conf.json",
+        r'("versionCode": )\d+',
+        rf"\g<1>{android_version_code}",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/Cargo.toml",
+        r'^(version = ")[^"]*(")$',
+        rf"\g<1>{version}\g<2>",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/gen/apple/project.yml",
+        r'^(\s*CFBundleShortVersionString: ).*$',
+        rf"\g<1>{version}",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/gen/apple/project.yml",
+        r'^(\s*CFBundleVersion: ).*$',
+        rf"\g<1>{version}",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/gen/apple/maple_iOS/Info.plist",
+        r'(<key>CFBundleShortVersionString</key>\s*<string>)[^<]*(</string>)',
+        rf"\g<1>{version}\g<2>",
+    )
+    replace_once(
+        ROOT / "frontend/src-tauri/gen/apple/maple_iOS/Info.plist",
+        r'(<key>CFBundleVersion</key>\s*<string>)[^<]*(</string>)',
+        rf"\g<1>{version}\g<2>",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/update-version.py
+++ b/scripts/update-version.py
@@ -11,7 +11,7 @@ ROOT = Path(__file__).resolve().parents[1]
 
 def replace_once(path: Path, pattern: str, replacement: str) -> None:
     contents = path.read_text()
-    updated, count = re.subn(pattern, replacement, contents, count=1, flags=re.MULTILINE)
+    updated, count = re.subn(pattern, replacement, contents, flags=re.MULTILINE)
     if count != 1:
         raise SystemExit(f"Expected one version field in {path.relative_to(ROOT)}, found {count}.")
     path.write_text(updated)
@@ -22,9 +22,9 @@ def main() -> None:
         raise SystemExit("Usage: update-version.py X.Y.Z ANDROID_VERSION_CODE")
 
     version, android_version_code = sys.argv[1:]
-    if not re.fullmatch(r"\d+\.\d+\.\d+", version):
+    if not re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", version):
         raise SystemExit(f"Invalid version: {version}")
-    if not android_version_code.isdecimal():
+    if not re.fullmatch(r"[0-9]+", android_version_code):
         raise SystemExit(f"Invalid Android version code: {android_version_code}")
 
     replace_once(


### PR DESCRIPTION
## Summary
- bump Maple to `3.3.5` and increment the Android version code to `2000028016`
- make `just update-version` and the bump helpers portable across macOS and Nix/CI by replacing BSD/GNU `sed -i` assumptions with a validated Python updater

## Validation
- `MAPLE_NIX_XCODE_VERSION=26.6 nix develop .#ci -c just bump-patch`
- `python3 -m py_compile scripts/update-version.py`
- `plutil -lint frontend/src-tauri/gen/apple/maple_iOS/Info.plist`
- `git diff --check`
- repository pre-commit hook: Prettier, production frontend build, 698 frontend tests, and 323 Rust tests passed (2 ignored)