### PR TITLE
feat(agent): show last-updated date on sidebar hover info card

### DIFF
--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -93,6 +93,7 @@ import { RenameAgentTaskDialog } from "@/components/RenameAgentTaskDialog";
 import { UpgradePromptDialog } from "@/components/UpgradePromptDialog";
 import { AgentMcpMenu, AgentMcpServersDialog } from "@/components/agent/AgentMcpControls";
 import { AgentSidebarInfoCard } from "@/components/agent/AgentSidebarInfoCard";
+import { latestAgentSidebarUpdatedMs } from "@/components/agent/agentSidebarInfoCardDate";
 import {
   isDeliberateAgentComposerFocusTarget,
   settleAgentComposerFocusRequest,
@@ -3820,6 +3821,7 @@ function AgentSidebarTaskRow({
               onOpenProjectFolder={() => onRevealProjectRoot(session.projectRoot)}
               progressLabel={isInProgress ? "In progress" : "Not in progress"}
               title={title}
+              updatedMs={session.updatedMs}
             />
           </HoverCardContent>
         ) : null}
@@ -4492,6 +4494,9 @@ function AgentSidebarContent({
                           onOpenProjectFolder={() => onRevealProjectRoot(root.path)}
                           progressLabel={agentProjectProgressLabel(inProgressSessionCount)}
                           title={root.displayName}
+                          updatedMs={latestAgentSidebarUpdatedMs(
+                            projectSessions.map((session) => session.updatedMs)
+                          )}
                         />
                       </HoverCardContent>
                     ) : null}

--- a/frontend/src/components/agent/AgentSidebarInfoCard.test.tsx
+++ b/frontend/src/components/agent/AgentSidebarInfoCard.test.tsx
@@ -4,6 +4,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 import { act, create, type ReactTestRenderer } from "react-test-renderer";
 
 import { AgentSidebarInfoCard } from "./AgentSidebarInfoCard";
+import { formatAgentSidebarDate, latestAgentSidebarUpdatedMs } from "./agentSidebarInfoCardDate";
 
 const LONG_PROJECT_PATH = "/Users/admin/workspaces/agent-mode-sidebar/maple/frontend";
 
@@ -39,6 +40,30 @@ describe("AgentSidebarInfoCard", () => {
     expect(markup).toContain(`aria-label="Open project folder: ${LONG_PROJECT_PATH}"`);
     expect(markup).toContain(`<span class="sr-only">${LONG_PROJECT_PATH}</span>`);
     expect(markup).toContain('<span aria-hidden="true">/Users/admin/…/maple/frontend</span>');
+    expect(markup).not.toContain("<time");
+  });
+
+  test("places a compact last-updated date in the top-right of the header", () => {
+    const updatedMs = Date.UTC(2026, 7, 20, 14, 5);
+    const dateLabel = formatAgentSidebarDate(updatedMs, Date.UTC(2026, 7, 20))!;
+    const markup = renderToStaticMarkup(
+      <AgentSidebarInfoCard
+        folderPath={LONG_PROJECT_PATH}
+        icon={Folder}
+        isInProgress={false}
+        metadata="1 task"
+        metadataIcon={MessageSquare}
+        onDismiss={() => {}}
+        onOpenProjectFolder={() => {}}
+        progressLabel="No tasks in progress"
+        title="Maple sidebar"
+        updatedMs={updatedMs}
+      />
+    );
+
+    expect(markup).toContain(`dateTime="${new Date(updatedMs).toISOString()}"`);
+    expect(markup).toContain(`>${dateLabel}</time>`);
+    expect(markup).toContain("text-[11px] font-medium leading-4 text-muted-foreground");
   });
 
   test("isolates the folder interaction, dismisses the card, and opens the folder once", () => {
@@ -82,5 +107,38 @@ describe("AgentSidebarInfoCard", () => {
     expect(onDismiss).toHaveBeenCalledTimes(1);
     expect(onOpenProjectFolder).toHaveBeenCalledTimes(1);
     expect(callOrder).toEqual(["dismiss", "open"]);
+  });
+});
+
+describe("formatAgentSidebarDate", () => {
+  test("uses a compact same-year date and includes the year otherwise", () => {
+    const nowMs = Date.UTC(2026, 7, 20);
+    expect(formatAgentSidebarDate(Date.UTC(2026, 7, 3), nowMs)).toBe(
+      new Date(Date.UTC(2026, 7, 3)).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric"
+      })
+    );
+    expect(formatAgentSidebarDate(Date.UTC(2025, 11, 31), nowMs)).toBe(
+      new Date(Date.UTC(2025, 11, 31)).toLocaleDateString(undefined, {
+        month: "short",
+        day: "numeric",
+        year: "numeric"
+      })
+    );
+  });
+
+  test("omits invalid timestamps", () => {
+    expect(formatAgentSidebarDate(0)).toBeNull();
+    expect(formatAgentSidebarDate(Number.NaN)).toBeNull();
+    expect(formatAgentSidebarDate(-1)).toBeNull();
+  });
+});
+
+describe("latestAgentSidebarUpdatedMs", () => {
+  test("returns the newest valid timestamp", () => {
+    expect(latestAgentSidebarUpdatedMs([100, 0, 250, Number.NaN, -3])).toBe(250);
+    expect(latestAgentSidebarUpdatedMs([])).toBeUndefined();
+    expect(latestAgentSidebarUpdatedMs([0, Number.NaN])).toBeUndefined();
   });
 });

--- a/frontend/src/components/agent/AgentSidebarInfoCard.tsx
+++ b/frontend/src/components/agent/AgentSidebarInfoCard.tsx
@@ -1,5 +1,10 @@
 import { FolderOpen, type LucideIcon } from "lucide-react";
 
+import {
+  agentSidebarDateTime,
+  agentSidebarDateTitle,
+  formatAgentSidebarDate
+} from "@/components/agent/agentSidebarInfoCardDate";
 import { truncatePathMiddle } from "@/utils/path";
 import { cn } from "@/utils/utils";
 
@@ -13,6 +18,7 @@ interface AgentSidebarInfoCardProps {
   onOpenProjectFolder: () => void;
   progressLabel: string;
   title: string;
+  updatedMs?: number | null;
 }
 
 export function AgentSidebarInfoCard({
@@ -24,8 +30,13 @@ export function AgentSidebarInfoCard({
   onDismiss,
   onOpenProjectFolder,
   progressLabel,
-  title
+  title,
+  updatedMs
 }: AgentSidebarInfoCardProps) {
+  const dateLabel = updatedMs == null ? null : formatAgentSidebarDate(updatedMs);
+  const dateTime = updatedMs == null ? null : agentSidebarDateTime(updatedMs);
+  const dateTitle = updatedMs == null ? null : agentSidebarDateTitle(updatedMs);
+
   return (
     <div>
       <div className="flex min-w-0 items-start gap-2.5">
@@ -33,7 +44,20 @@ export function AgentSidebarInfoCard({
           <Icon aria-hidden="true" className="h-4 w-4" />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="break-words text-[13px] font-semibold leading-5">{title}</p>
+          <div className="flex min-w-0 items-start gap-2">
+            <p className="min-w-0 flex-1 break-words text-[13px] font-semibold leading-5">
+              {title}
+            </p>
+            {dateLabel && dateTime ? (
+              <time
+                className="mt-0.5 shrink-0 whitespace-nowrap text-[11px] font-medium leading-4 text-muted-foreground"
+                dateTime={dateTime}
+                title={dateTitle ?? undefined}
+              >
+                {dateLabel}
+              </time>
+            ) : null}
+          </div>
           <div className="mt-0.5 flex min-w-0 items-start gap-1.5 text-xs leading-4 text-muted-foreground">
             <MetadataIcon aria-hidden="true" className="mt-px h-3.5 w-3.5 shrink-0" />
             <span className="min-w-0 break-words">{metadata}</span>

--- a/frontend/src/components/agent/agentSidebarInfoCardDate.ts
+++ b/frontend/src/components/agent/agentSidebarInfoCardDate.ts
@@ -1,0 +1,52 @@
+const SAME_YEAR_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric"
+};
+
+const OTHER_YEAR_DATE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric"
+};
+
+const FULL_DATE_TITLE_FORMAT: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+  year: "numeric",
+  hour: "numeric",
+  minute: "2-digit"
+};
+
+function validAgentSidebarDate(updatedMs: number): Date | null {
+  if (!Number.isFinite(updatedMs) || updatedMs <= 0) return null;
+  const date = new Date(updatedMs);
+  if (Number.isNaN(date.getTime())) return null;
+  return date;
+}
+
+export function formatAgentSidebarDate(updatedMs: number, nowMs = Date.now()): string | null {
+  const date = validAgentSidebarDate(updatedMs);
+  if (!date) return null;
+  const now = new Date(nowMs);
+  const options =
+    date.getFullYear() === now.getFullYear() ? SAME_YEAR_DATE_FORMAT : OTHER_YEAR_DATE_FORMAT;
+  return date.toLocaleDateString(undefined, options);
+}
+
+export function agentSidebarDateTime(updatedMs: number): string | null {
+  return validAgentSidebarDate(updatedMs)?.toISOString() ?? null;
+}
+
+export function agentSidebarDateTitle(updatedMs: number): string | null {
+  const date = validAgentSidebarDate(updatedMs);
+  if (!date) return null;
+  return date.toLocaleString(undefined, FULL_DATE_TITLE_FORMAT);
+}
+
+export function latestAgentSidebarUpdatedMs(updatedMsList: number[]): number | undefined {
+  const latest = updatedMsList.reduce((max, value) => {
+    if (!Number.isFinite(value) || value <= 0) return max;
+    return Math.max(max, value);
+  }, 0);
+  return latest > 0 ? latest : undefined;
+}


### PR DESCRIPTION
## Summary
- Adds a compact last-updated date in the top-right of the Agent Mode sidebar hover card (`AgentSidebarInfoCard`) for both tasks and projects.
- Uses existing `updatedMs` on session summaries; projects show the newest task date. Same-year dates stay short (`Aug 20`); older dates include the year.

Closes #802

## Test plan
- [x] `bun --no-env-file test ./src/components/agent/AgentSidebarInfoCard.test.tsx`
- [x] Pre-commit: Prettier, `tsc -b && vite build`, 702 frontend tests
- [x] Local OpenSecret + billing workspace started; Maple desktop-dev launched, signed in, Agent Mode opened
- [x] Hovered a task/project in Agent Mode; date sits in the top-right and looks aligned