### PR TITLE
docs: prefer Codex built-in Computer Use

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -192,7 +192,7 @@ the changed boundary and classify it by behavior, not file path:
 For changes requiring full lifecycle coverage, continue through the remaining
 baseline:
 
-4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task. CUA only: the native picker is not a Maple window — see `$validate-maple` **CUA only: macOS Open/Save**.
+4. Sign in, open Agent Mode, select the disposable project, choose the intended model, keep `Read only`, and start a new task. Codex must use its built-in Computer Use instead of CUA, even when CUA is installed. CUA only: the native picker is not a Maple window — see `$validate-maple` **CUA only: macOS Open/Save**.
 5. Send: `Read README.md using the read tool. Reply only with the exact marker. Do not use shell.` Confirm the visible user row, tool activity, exact marker result, final answer, and completed terminal state.
 6. Send: `Create agent-smoke-output.txt containing exactly <marker> using the write tool. Do not use shell.` Confirm a single pending permission card. Choose `Deny once`; verify the card settles as denied, the run terminates coherently, and the file does not exist.
 7. Repeat the write request and choose `Allow once`. Verify one settled permission card, exact on-disk contents, a visible tool result, final answer, and completed state. Do not use `Allow all` merely to make the smoke easier.

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -307,8 +307,9 @@ Choose only scenarios relevant to the change, but cross every changed boundary.
 
 ### CUA only: macOS Open/Save
 
-Skip unless you drive the GUI with cua-driver (pid + `window_id`). Codex
-computer use and other full-desktop screenshot drivers should ignore this.
+Codex must use its built-in Computer Use instead of CUA, even when CUA is
+installed. Other agents should skip this unless driving the GUI with
+cua-driver (pid + `window_id`).
 
 On macOS every Maple native file or folder picker — Agent project folder,
 chat photo/document upload, Save, and any other Tauri `dialog` — is hosted


### PR DESCRIPTION
## Summary

- tell Codex to use its built-in Computer Use instead of CUA, even when CUA is installed
- keep the existing cua-driver guidance available for non-Codex agents

## Validation

- Maple pre-commit hook
- Prettier check
- production frontend build
- 707 frontend tests