### PR TITLE
feat(agent): simplify ACP connection setup

### DIFF
--- a/frontend/src/components/settings/AgentConnectionGuides.test.tsx
+++ b/frontend/src/components/settings/AgentConnectionGuides.test.tsx
@@ -1,0 +1,35 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { AgentConnectionGuides } from "./AgentConnectionGuides";
+import type { MapleAcpStatus } from "@/services/mapleAcpService";
+
+const status: MapleAcpStatus = {
+  running: true,
+  enabled: true,
+  connectedClients: 1,
+  activeSessions: 1,
+  activeRuns: 0,
+  endpoint: "/tmp/maple.sock",
+  endpointKind: "unix_socket",
+  protocolVersion: 1,
+  error: null,
+  buzzCredentialsAvailable: false,
+  harness: {
+    command: "/Applications/Maple.app/Contents/MacOS/maple",
+    args: ["acp"]
+  }
+};
+
+describe("AgentConnectionGuides", () => {
+  test("leads with Paseo and keeps Buzz as a client-specific tab", () => {
+    const markup = renderToStaticMarkup(<AgentConnectionGuides status={status} />);
+
+    expect(markup).toContain(">Paseo</button>");
+    expect(markup).toContain(">Buzz</button>");
+    expect(markup.indexOf(">Paseo</button>")).toBeLessThan(markup.indexOf(">Buzz</button>"));
+    expect(markup).toContain("Paseo provider configuration");
+    expect(markup).toContain("~/.paseo/config.json");
+    expect(markup).toContain("maple-acp");
+    expect(markup).toContain("supportsMcpServers");
+  });
+});

--- a/frontend/src/components/settings/AgentConnectionGuides.tsx
+++ b/frontend/src/components/settings/AgentConnectionGuides.tsx
@@ -1,0 +1,252 @@
+import { type ReactNode, useState } from "react";
+import { AlertCircle, Check, Copy, Server, ShieldCheck, Terminal } from "lucide-react";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  BUZZ_DEFAULT_AGENT_PARALLELISM,
+  BUZZ_MAPLE_AGENT_PARALLELISM,
+  BUZZ_MAPLE_HARNESS_ID,
+  BUZZ_MAPLE_HARNESS_NAME,
+  PASEO_MAPLE_PROVIDER_ID,
+  serializeBuzzCustomHarness,
+  serializePaseoCustomProviderConfig,
+  type MapleAcpStatus
+} from "@/services/mapleAcpService";
+
+function CopyButton({ value, label }: { value: string; label: string }) {
+  const [copyState, setCopyState] = useState<"idle" | "copied" | "error">("idle");
+
+  const copyValue = async () => {
+    try {
+      await navigator.clipboard.writeText(value);
+      setCopyState("copied");
+      window.setTimeout(() => setCopyState("idle"), 2_000);
+    } catch {
+      setCopyState("error");
+    }
+  };
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      className="h-7 w-7 shrink-0"
+      onClick={() => void copyValue()}
+      disabled={!value}
+      aria-label={
+        copyState === "copied"
+          ? `${label} copied`
+          : copyState === "error"
+            ? `Copy ${label} failed`
+            : `Copy ${label}`
+      }
+    >
+      {copyState === "copied" ? (
+        <Check className="h-3.5 w-3.5 text-maple-success" />
+      ) : copyState === "error" ? (
+        <AlertCircle className="h-3.5 w-3.5 text-destructive" />
+      ) : (
+        <Copy className="h-3.5 w-3.5" />
+      )}
+      <span className="sr-only" aria-live="polite">
+        {copyState === "copied"
+          ? `${label} copied`
+          : copyState === "error"
+            ? `Copy ${label} failed`
+            : ""}
+      </span>
+    </Button>
+  );
+}
+
+function SetupField({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="min-w-0 rounded-lg border border-border/70 bg-background/60 p-3">
+      <p className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <div className="mt-1 flex min-w-0 items-center justify-between gap-2">
+        <code className="min-w-0 break-all text-xs text-foreground">{value || "Unavailable"}</code>
+        <CopyButton value={value} label={label} />
+      </div>
+    </div>
+  );
+}
+
+function CodeExample({ label, code }: { label: string; code: string }) {
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/70 bg-background">
+      <div className="flex items-center justify-between border-b border-border/70 px-3 py-2">
+        <span className="text-xs font-medium">{label}</span>
+        <CopyButton value={code} label={label} />
+      </div>
+      {code ? (
+        <pre className="max-h-72 overflow-auto p-3 text-xs leading-relaxed">
+          <code>{code}</code>
+        </pre>
+      ) : (
+        <p className="p-3 text-xs text-muted-foreground">
+          Start Maple's ACP service to resolve this app's executable path.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function Step({ number, children }: { number: number; children: ReactNode }) {
+  return (
+    <li className="flex gap-3 text-sm leading-relaxed">
+      <span
+        aria-hidden="true"
+        className="mt-0.5 flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-[hsl(var(--maple-primary-container))] text-[11px] font-semibold text-foreground"
+      >
+        {number}
+      </span>
+      <span>{children}</span>
+    </li>
+  );
+}
+
+export function AgentConnectionGuides({ status }: { status: MapleAcpStatus | null }) {
+  const harness = status?.harness ?? null;
+  const paseoConfig = harness ? serializePaseoCustomProviderConfig(harness) : "";
+  const buzzConfig = harness ? serializeBuzzCustomHarness(harness) : "";
+
+  return (
+    <div className="space-y-4">
+      <Tabs defaultValue="paseo" className="w-full">
+        <TabsList className="grid h-auto w-full grid-cols-2">
+          <TabsTrigger value="paseo">Paseo</TabsTrigger>
+          <TabsTrigger value="buzz">Buzz</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="paseo" className="space-y-4 pt-2">
+          <ol className="space-y-3">
+            <Step number={1}>Start Maple's local ACP service above.</Step>
+            <Step number={2}>
+              Merge the provider below into <code>~/.paseo/config.json</code>. Keep your existing
+              settings and add <code>{PASEO_MAPLE_PROVIDER_ID}</code> under{" "}
+              <code>agents.providers</code>.
+            </Step>
+            <Step number={3}>
+              Save the file, then fully quit and reopen Paseo Desktop. If you run a standalone
+              daemon, restart that daemon instead.
+            </Step>
+          </ol>
+
+          <CodeExample label="Paseo provider configuration" code={paseoConfig} />
+
+          <Alert role="note">
+            <Server className="h-4 w-4" />
+            <AlertDescription>
+              Maple supplies its signed-in model list dynamically. Paseo tool injection stays
+              enabled, so no static model list or Maple API key belongs in this configuration.
+            </AlertDescription>
+          </Alert>
+        </TabsContent>
+
+        <TabsContent value="buzz" className="space-y-4 pt-2">
+          <ol className="space-y-3">
+            <Step number={1}>Start Maple's local ACP service above.</Step>
+            <Step number={2}>Open Buzz Desktop's custom harness form.</Step>
+            <Step number={3}>Enter the separate values below and connect.</Step>
+          </ol>
+
+          <div className="grid gap-2 sm:grid-cols-2">
+            <SetupField label="Name" value={BUZZ_MAPLE_HARNESS_NAME} />
+            <SetupField label="ID" value={BUZZ_MAPLE_HARNESS_ID} />
+            <SetupField label="Command" value={harness?.command ?? ""} />
+            <SetupField label="Argument" value={harness?.args[0] ?? ""} />
+          </div>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            Keep <code>acp</code> as a separate argument in Buzz; do not append it to Command.
+          </p>
+
+          <Alert role="note">
+            <Server className="h-4 w-4" />
+            <AlertDescription>
+              Set Buzz managed-agent parallelism to {BUZZ_MAPLE_AGENT_PARALLELISM}. Buzz defaults to{" "}
+              {BUZZ_DEFAULT_AGENT_PARALLELISM}, while Maple accepts {BUZZ_MAPLE_AGENT_PARALLELISM}{" "}
+              local ACP connections by default.
+            </AlertDescription>
+          </Alert>
+
+          <details className="group rounded-lg border border-border/70">
+            <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
+              Advanced configuration
+            </summary>
+            <div className="space-y-3 border-t border-border/70 p-4">
+              <CodeExample label="Buzz harness JSON" code={buzzConfig} />
+              <p className="text-xs leading-relaxed text-muted-foreground">
+                Use this JSON only for manual configuration. Buzz's custom harness form uses the
+                separate fields above.
+              </p>
+            </div>
+          </details>
+
+          <details className="group rounded-lg border border-border/70">
+            <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
+              Connection diagnostics
+            </summary>
+            <dl className="grid gap-3 border-t border-border/70 p-4 text-xs sm:grid-cols-2">
+              <Diagnostic label="Transport" value={formatEndpointKind(status?.endpointKind)} />
+              <Diagnostic label="Endpoint" value={status?.endpoint || "Not listening"} mono />
+              <Diagnostic
+                label="Protocol"
+                value={status?.protocolVersion ? `ACP ${status.protocolVersion}` : "ACP"}
+              />
+              <Diagnostic
+                label="Buzz relay credentials"
+                value={status?.buzzCredentialsAvailable ? "Available" : "Waiting for Buzz"}
+              />
+            </dl>
+          </details>
+
+          {!status?.buzzCredentialsAvailable && status?.connectedClients ? (
+            <Alert className="border-maple-warning/40 bg-maple-warning/10">
+              <Terminal className="h-4 w-4 text-maple-warning" />
+              <AlertDescription>
+                A client is connected without Buzz relay credentials. Streaming works, but Maple may
+                not be able to post a durable reply to the Buzz channel.
+              </AlertDescription>
+            </Alert>
+          ) : null}
+        </TabsContent>
+      </Tabs>
+
+      <div className="flex gap-2 text-xs leading-relaxed text-muted-foreground">
+        <ShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-maple-success" />
+        <p>These setup values contain no Maple access token or API key.</p>
+      </div>
+    </div>
+  );
+}
+
+function Diagnostic({
+  label,
+  value,
+  mono = false
+}: {
+  label: string;
+  value: string;
+  mono?: boolean;
+}) {
+  return (
+    <div className="min-w-0">
+      <dt className="font-medium text-muted-foreground">{label}</dt>
+      <dd className={mono ? "mt-1 break-all font-mono" : "mt-1 break-words"}>{value}</dd>
+    </div>
+  );
+}
+
+function formatEndpointKind(value?: string | null): string {
+  if (!value) return "Local IPC";
+  return value
+    .split("_")
+    .filter(Boolean)
+    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
+    .join(" ");
+}

--- a/frontend/src/components/settings/AgentConnectionsSettings.tsx
+++ b/frontend/src/components/settings/AgentConnectionsSettings.tsx
@@ -1,50 +1,21 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useOpenSecret } from "@opensecret/react";
-import {
-  AlertCircle,
-  Check,
-  Copy,
-  Loader2,
-  Play,
-  RefreshCw,
-  Server,
-  ShieldCheck,
-  Square,
-  Terminal
-} from "lucide-react";
+import { AlertCircle, Loader2, Play, RefreshCw, Server, ShieldCheck, Square } from "lucide-react";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 import { useSettingsNavigationLock } from "@/contexts/SettingsNavigationLockContext";
 import { awaitAgentAuthUser } from "@/services/agentRuntimeService";
 import {
-  BUZZ_DEFAULT_AGENT_PARALLELISM,
-  BUZZ_MAPLE_AGENT_PARALLELISM,
-  BUZZ_MAPLE_HARNESS_ID,
-  BUZZ_MAPLE_HARNESS_NAME,
   isMapleAcpConfigReady,
-  isMapleAcpPolicyDirty,
   mapleAcpService,
-  serializeBuzzCustomHarness,
   type MapleAcpConfig,
-  type MapleAcpPermissionMode,
   type MapleAcpStatus
 } from "@/services/mapleAcpService";
+import { AgentConnectionGuides } from "./AgentConnectionGuides";
 import { SettingsPage, SettingsSection } from "./SettingsPage";
 
 const STATUS_POLL_INTERVAL_MS = 2_500;
-
-type CopyTarget = "name" | "id" | "command" | "argument" | "harness";
 
 export function AgentConnectionsSettings() {
   const os = useOpenSecret();
@@ -55,12 +26,10 @@ export function AgentConnectionsSettings() {
   const [status, setStatus] = useState<MapleAcpStatus | null>(null);
   const [isConfigLoading, setIsConfigLoading] = useState(true);
   const [isStatusLoading, setIsStatusLoading] = useState(true);
-  const [operation, setOperation] = useState<"start" | "stop" | "save" | "refresh" | null>(null);
+  const [operation, setOperation] = useState<"start" | "stop" | "refresh" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [configLoadError, setConfigLoadError] = useState<string | null>(null);
   const [statusLoadError, setStatusLoadError] = useState<string | null>(null);
-  const [message, setMessage] = useState<string | null>(null);
-  const [copied, setCopied] = useState<CopyTarget | null>(null);
   const userIdRef = useRef(userId);
   const operationRef = useRef(operation);
   const statusRequestGenerationRef = useRef(0);
@@ -79,7 +48,6 @@ export function AgentConnectionsSettings() {
     const shouldRetryConfig = savedConfig === null || configUserId !== userId;
     setOperation("refresh");
     setError(null);
-    setMessage(null);
     setIsStatusLoading(true);
     setStatusLoadError(null);
     if (shouldRetryConfig) {
@@ -125,15 +93,9 @@ export function AgentConnectionsSettings() {
         if (userIdRef.current === userId) setIsStatusLoading(false);
       });
 
-    const [configLoaded, statusLoaded] = await Promise.all([configRequest, statusRequest]);
+    await Promise.all([configRequest, statusRequest]);
     if (userIdRef.current !== userId) return;
     setOperation(null);
-
-    if (configLoaded && statusLoaded) {
-      setMessage(shouldRetryConfig ? "Agent policy and status refreshed." : "Status refreshed.");
-    } else if (configLoaded && shouldRetryConfig) {
-      setMessage("Agent policy loaded. Service status is still unavailable.");
-    }
   }, [configUserId, savedConfig, userId]);
 
   useEffect(() => {
@@ -148,7 +110,6 @@ export function AgentConnectionsSettings() {
       setConfigLoadError(null);
       setStatusLoadError(null);
       setError(null);
-      setMessage(null);
       setOperation(null);
       return;
     }
@@ -165,7 +126,6 @@ export function AgentConnectionsSettings() {
     setConfigLoadError(null);
     setStatusLoadError(null);
     setError(null);
-    setMessage(null);
     setOperation(null);
 
     const authReady = awaitAgentAuthUser(userId);
@@ -235,37 +195,12 @@ export function AgentConnectionsSettings() {
     };
   }, [userId]);
 
-  const savePolicy = async (): Promise<MapleAcpConfig | null> => {
-    if (!userId || !config || !savedConfig || configUserId !== userId) return null;
-    const operationUserId = userId;
-    setOperation("save");
-    setError(null);
-    setMessage(null);
-    try {
-      const nextConfig = await mapleAcpService.saveConfig(userId, {
-        ...config,
-        enabled: status?.enabled ?? config.enabled
-      });
-      if (userIdRef.current !== operationUserId) return null;
-      setConfig(nextConfig);
-      setSavedConfig(nextConfig);
-      setMessage("Agent policy saved.");
-      return nextConfig;
-    } catch (saveError) {
-      if (userIdRef.current === operationUserId) setError(errorMessage(saveError));
-      return null;
-    } finally {
-      if (userIdRef.current === operationUserId) setOperation(null);
-    }
-  };
-
   const startService = async () => {
     if (!userId || !config || !savedConfig || configUserId !== userId) return;
     statusRequestGenerationRef.current += 1;
     const operationUserId = userId;
     setOperation("start");
     setError(null);
-    setMessage(null);
     try {
       const nextConfig = await mapleAcpService.saveConfig(userId, {
         ...config,
@@ -278,7 +213,6 @@ export function AgentConnectionsSettings() {
       setConfig(startedConfig);
       setSavedConfig(startedConfig);
       setStatus(nextStatus);
-      setMessage("Maple is ready for local ACP clients.");
     } catch (startError) {
       if (userIdRef.current === operationUserId) setError(errorMessage(startError));
     } finally {
@@ -292,14 +226,12 @@ export function AgentConnectionsSettings() {
     const operationUserId = userId;
     setOperation("stop");
     setError(null);
-    setMessage(null);
     try {
       const nextStatus = await mapleAcpService.stop(userId);
       if (userIdRef.current !== operationUserId) return;
       setStatus(nextStatus);
       setConfig((current) => (current ? { ...current, enabled: false } : current));
       setSavedConfig((current) => (current ? { ...current, enabled: false } : current));
-      setMessage("Local ACP connections are disabled.");
     } catch (stopError) {
       if (userIdRef.current === operationUserId) setError(errorMessage(stopError));
     } finally {
@@ -307,29 +239,11 @@ export function AgentConnectionsSettings() {
     }
   };
 
-  const harnessJson = useMemo(
-    () => (status?.harness ? serializeBuzzCustomHarness(status.harness) : ""),
-    [status?.harness]
-  );
   const displayedConfig = configUserId === userId ? config : null;
   const displayedSavedConfig = configUserId === userId ? savedConfig : null;
   const running = status?.running === true;
   const configReady = isMapleAcpConfigReady(displayedConfig, displayedSavedConfig);
-  const permissionMode = displayedConfig?.permissionMode ?? "read_only";
-  const policyDirty = isMapleAcpPolicyDirty(displayedConfig, displayedSavedConfig);
   const mutationsDisabled = isBusy || !userId || !configReady;
-  const policyMutationsDisabled = mutationsDisabled || running;
-
-  const copyText = async (target: CopyTarget, value: string) => {
-    if (!value) return;
-    try {
-      await navigator.clipboard.writeText(value);
-      setCopied(target);
-      window.setTimeout(() => setCopied((current) => (current === target ? null : current)), 2_000);
-    } catch (copyError) {
-      setError(errorMessage(copyError, "Maple could not copy to the clipboard."));
-    }
-  };
 
   const statusLabel =
     status === null
@@ -343,15 +257,12 @@ export function AgentConnectionsSettings() {
   return (
     <SettingsPage
       title="Agent connections"
-      description="Let trusted local ACP clients such as Buzz use Maple Agent through this desktop app."
+      description="Use Maple Agent from local apps that support the Agent Client Protocol."
       actions={<Badge variant="outline">Preview</Badge>}
     >
-      <span className="sr-only" aria-live="polite">
-        {copied ? `${copied === "harness" ? "Harness JSON" : copied} copied to clipboard.` : ""}
-      </span>
       <SettingsSection
         title="Local ACP service"
-        description="Maple Desktop owns your authenticated Agent runtime. Keep Maple open and signed in while connected clients are working."
+        description="Start the bridge, then keep Maple open while a client is connected."
       >
         <div className="space-y-4">
           {error && (
@@ -364,8 +275,8 @@ export function AgentConnectionsSettings() {
             <Alert variant="destructive">
               <AlertCircle className="h-4 w-4" />
               <AlertDescription>
-                {configLoadError} Policy controls remain locked so Maple cannot replace your saved
-                policy with defaults. Use refresh to try again.
+                {configLoadError} Starting remains locked so Maple cannot replace your saved
+                connection settings with defaults. Use refresh to try again.
               </AlertDescription>
             </Alert>
           )}
@@ -375,12 +286,6 @@ export function AgentConnectionsSettings() {
               <AlertDescription>
                 {statusLoadError} The last known status is preserved. Use refresh to try again.
               </AlertDescription>
-            </Alert>
-          )}
-          {message && !error && (
-            <Alert role="status" aria-live="polite">
-              <Check className="h-4 w-4 text-maple-success" />
-              <AlertDescription>{message}</AlertDescription>
             </Alert>
           )}
           {status?.error && !error && (
@@ -402,10 +307,14 @@ export function AgentConnectionsSettings() {
                 <div className="flex flex-wrap items-center gap-2">
                   <p className="font-medium">
                     {isStatusLoading
-                      ? "Checking local ACP service"
-                      : status
-                        ? `ACP service ${statusLabel.toLowerCase()}`
-                        : "ACP service status unavailable"}
+                      ? "Checking service"
+                      : status === null
+                        ? "Status unavailable"
+                        : running
+                          ? status.connectedClients > 0
+                            ? `${status.connectedClients} client${status.connectedClients === 1 ? "" : "s"} connected`
+                            : "Ready for connections"
+                          : "Service stopped"}
                   </p>
                   <Badge variant={running ? "secondary" : "outline"}>
                     {isStatusLoading ? "Checking" : statusLabel}
@@ -413,15 +322,20 @@ export function AgentConnectionsSettings() {
                 </div>
                 <p className="mt-1 text-xs leading-relaxed text-muted-foreground">
                   {isStatusLoading
-                    ? "Reading the local service status."
+                    ? "Reading the current status."
                     : status === null
-                      ? "Refresh to retry. Maple will not assume the service is stopped."
+                      ? "Refresh to try again."
                       : running
-                        ? status?.connectedClients
-                          ? `${status.connectedClients} local client${status.connectedClients === 1 ? " is" : "s are"} connected.`
-                          : "Waiting for a trusted local ACP client to connect."
-                        : "Disabled by default. Start it when you are ready to connect Buzz."}
+                        ? "Maple is accepting local ACP sessions."
+                        : "Start it when you want an ACP client to connect."}
                 </p>
+                {running && status ? (
+                  <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted-foreground">
+                    <StatusMetric label="clients" value={status.connectedClients} />
+                    <StatusMetric label="sessions" value={status.activeSessions} />
+                    <StatusMetric label="active runs" value={status.activeRuns} />
+                  </div>
+                ) : null}
               </div>
             </div>
             <div className="flex shrink-0 gap-2">
@@ -470,283 +384,32 @@ export function AgentConnectionsSettings() {
             </div>
           </div>
 
-          <div className="grid grid-cols-3 gap-2 text-center">
-            <StatusMetric label="Clients" value={status?.connectedClients ?? 0} />
-            <StatusMetric label="Sessions" value={status?.activeSessions ?? 0} />
-            <StatusMetric label="Active runs" value={status?.activeRuns ?? 0} />
-          </div>
-
-          <Alert role="note">
-            <ShieldCheck className="h-4 w-4" />
-            <AlertDescription>
-              The bridge does not put your Maple access tokens, API keys, or Buzz private key in its
-              command or harness configuration. Stopping it disconnects every local client.
-            </AlertDescription>
-          </Alert>
-        </div>
-      </SettingsSection>
-
-      <SettingsSection
-        title="ACP approvals"
-        description="The connected ACP client handles unresolved tool approvals."
-      >
-        <div className="space-y-4">
-          <div className="grid gap-2">
-            <Label htmlFor="agent-acp-permission-mode">Permission mode</Label>
-            <Select
-              value={permissionMode}
-              onValueChange={(value) => {
-                if (!displayedConfig) return;
-                setConfig((current) => ({
-                  ...(current ?? displayedConfig),
-                  permissionMode: value as MapleAcpPermissionMode
-                }));
-                setMessage(null);
-              }}
-              disabled={policyMutationsDisabled}
-            >
-              <SelectTrigger id="agent-acp-permission-mode">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="read_only">ACP client decides</SelectItem>
-              </SelectContent>
-            </Select>
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              {displayedConfig === null
-                ? isConfigLoading
-                  ? "Loading your saved agent policy."
-                  : "Your saved policy is unavailable. Refresh before changing or starting ACP."
-                : running
-                  ? "Stop the ACP service before changing its policy. Maple sends guarded requests to the connected client, which may prompt, deny, or approve automatically."
-                  : "Maple sends guarded requests to the connected client. Buzz currently selects Allow once automatically, so trusted prompts can run unattended."}
-            </p>
-          </div>
-
           <Alert role="note" className="border-maple-warning/40 bg-maple-warning/10">
-            <AlertCircle className="h-4 w-4 text-maple-warning" />
+            <ShieldCheck className="h-4 w-4 text-maple-warning" />
             <AlertDescription>
-              This preview does not yet expose project-root allowlisting. A connected client can
-              select any absolute working directory Maple can access. Neither policy is an
-              operating-system sandbox.
+              Only connect ACP clients you trust. They can choose any folder Maple can access; Read
+              only asks before guarded actions but is not an operating-system sandbox.
             </AlertDescription>
           </Alert>
-
-          <div className="flex justify-end">
-            <Button
-              type="button"
-              variant="outline"
-              onClick={() => void savePolicy()}
-              disabled={policyMutationsDisabled || !policyDirty}
-            >
-              {operation === "save" && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {operation === "save" ? "Saving..." : "Save policy"}
-            </Button>
-          </div>
         </div>
       </SettingsSection>
 
       <SettingsSection
-        title="Connect Buzz"
-        description="Enter these values as separate fields in Buzz Desktop's custom harness form."
+        title="Connect your tools"
+        description="Choose an ACP client and follow its setup guide."
       >
-        <div className="space-y-5">
-          <div className="grid gap-4 sm:grid-cols-2">
-            <CopyableHarnessField
-              id="agent-acp-buzz-name"
-              label="Name"
-              value={BUZZ_MAPLE_HARNESS_NAME}
-              target="name"
-              copied={copied}
-              onCopy={copyText}
-            />
-            <CopyableHarnessField
-              id="agent-acp-buzz-id"
-              label="ID"
-              value={BUZZ_MAPLE_HARNESS_ID}
-              target="id"
-              copied={copied}
-              onCopy={copyText}
-            />
-            <CopyableHarnessField
-              id="agent-acp-buzz-command"
-              label="Command"
-              value={status?.harness?.command ?? ""}
-              placeholder="Exact Maple executable unavailable"
-              target="command"
-              copied={copied}
-              onCopy={copyText}
-            />
-            <CopyableHarnessField
-              id="agent-acp-buzz-argument"
-              label="Argument"
-              value={status?.harness?.args[0] ?? ""}
-              placeholder="Bridge argument unavailable"
-              target="argument"
-              copied={copied}
-              onCopy={copyText}
-            />
-          </div>
-          <p className="text-xs leading-relaxed text-muted-foreground">
-            Command is the executable path only. Add <code className="font-mono">acp</code> as a
-            separate argument row in Buzz; do not append it to Command.
-          </p>
-
-          <Alert role="note">
-            <Server className="h-4 w-4" />
-            <AlertDescription>
-              In Buzz managed-agent settings, set parallelism to {BUZZ_MAPLE_AGENT_PARALLELISM}.
-              Buzz defaults to {BUZZ_DEFAULT_AGENT_PARALLELISM}; Maple's default local ACP limit is{" "}
-              {BUZZ_MAPLE_AGENT_PARALLELISM}.
-            </AlertDescription>
-          </Alert>
-
-          <div className="grid gap-2">
-            <div className="flex items-center justify-between gap-3">
-              <Label htmlFor="agent-acp-buzz-json">Advanced/manual configuration JSON</Label>
-              <Button
-                type="button"
-                size="sm"
-                variant="outline"
-                onClick={() => void copyText("harness", harnessJson)}
-                disabled={!harnessJson}
-              >
-                {copied === "harness" ? (
-                  <Check className="mr-2 h-4 w-4 text-maple-success" />
-                ) : (
-                  <Copy className="mr-2 h-4 w-4" />
-                )}
-                {copied === "harness" ? "Copied" : "Copy JSON"}
-              </Button>
-            </div>
-            <Textarea
-              id="agent-acp-buzz-json"
-              value={harnessJson}
-              readOnly
-              placeholder="Harness configuration unavailable"
-              className="min-h-40 resize-y font-mono text-xs"
-            />
-            <p className="text-xs leading-relaxed text-muted-foreground">
-              This JSON is for advanced or manual configuration. Buzz Desktop's custom harness form
-              uses the separate fields above. Keep this Maple Desktop instance running after setup.
-            </p>
-          </div>
-
-          <details className="group rounded-lg border border-border/70">
-            <summary className="cursor-pointer select-none px-4 py-3 text-sm font-medium">
-              Connection diagnostics
-            </summary>
-            <dl className="grid gap-3 border-t border-border/70 p-4 text-xs sm:grid-cols-2">
-              <Diagnostic label="Transport" value={formatEndpointKind(status?.endpointKind)} />
-              <Diagnostic label="Endpoint" value={status?.endpoint || "Not listening"} mono />
-              <Diagnostic
-                label="Protocol"
-                value={status?.protocolVersion ? `ACP ${status.protocolVersion}` : "ACP"}
-              />
-              <Diagnostic
-                label="Buzz relay credentials"
-                value={status?.buzzCredentialsAvailable ? "Available" : "Waiting for Buzz"}
-              />
-            </dl>
-          </details>
-
-          {!status?.buzzCredentialsAvailable && status?.connectedClients ? (
-            <Alert className="border-maple-warning/40 bg-maple-warning/10">
-              <Terminal className="h-4 w-4 text-maple-warning" />
-              <AlertDescription>
-                A client is connected without Buzz relay credentials. Maple can stream ACP output,
-                but it may not be able to post a durable reply to the Buzz channel.
-              </AlertDescription>
-            </Alert>
-          ) : null}
-        </div>
+        <AgentConnectionGuides status={status} />
       </SettingsSection>
     </SettingsPage>
   );
 }
 
-function CopyableHarnessField({
-  id,
-  label,
-  value,
-  placeholder,
-  target,
-  copied,
-  onCopy
-}: {
-  id: string;
-  label: string;
-  value: string;
-  placeholder?: string;
-  target: CopyTarget;
-  copied: CopyTarget | null;
-  onCopy: (target: CopyTarget, value: string) => Promise<void>;
-}) {
-  const wasCopied = copied === target;
-
-  return (
-    <div className="grid gap-2">
-      <Label htmlFor={id}>{label}</Label>
-      <div className="flex gap-2">
-        <Input
-          id={id}
-          value={value}
-          readOnly
-          placeholder={placeholder}
-          className="font-mono text-xs"
-        />
-        <Button
-          type="button"
-          size="icon"
-          variant="outline"
-          onClick={() => void onCopy(target, value)}
-          disabled={!value}
-          aria-label={wasCopied ? `${label} copied` : `Copy ${label}`}
-        >
-          {wasCopied ? (
-            <Check className="h-4 w-4 text-maple-success" />
-          ) : (
-            <Copy className="h-4 w-4" />
-          )}
-        </Button>
-      </div>
-    </div>
-  );
-}
-
 function StatusMetric({ label, value }: { label: string; value: number }) {
   return (
-    <div className="rounded-lg border border-border/70 bg-muted/30 px-2 py-3">
-      <p className="text-lg font-semibold tabular-nums">{value}</p>
-      <p className="text-[11px] text-muted-foreground">{label}</p>
-    </div>
+    <span>
+      <strong className="font-medium tabular-nums text-foreground">{value}</strong> {label}
+    </span>
   );
-}
-
-function Diagnostic({
-  label,
-  value,
-  mono = false
-}: {
-  label: string;
-  value: string;
-  mono?: boolean;
-}) {
-  return (
-    <div className="min-w-0">
-      <dt className="font-medium text-muted-foreground">{label}</dt>
-      <dd className={mono ? "mt-1 break-all font-mono" : "mt-1 break-words"}>{value}</dd>
-    </div>
-  );
-}
-
-function formatEndpointKind(value?: string | null): string {
-  if (!value) return "Local IPC";
-  return value
-    .split("_")
-    .filter(Boolean)
-    .map((part) => `${part[0]?.toUpperCase() ?? ""}${part.slice(1)}`)
-    .join(" ");
 }
 
 function errorMessage(

--- a/frontend/src/services/mapleAcpService.test.ts
+++ b/frontend/src/services/mapleAcpService.test.ts
@@ -6,13 +6,16 @@ import {
   BUZZ_MAPLE_HARNESS_NAME,
   DEFAULT_MAPLE_ACP_CONFIG,
   MAX_MAPLE_ACP_CONNECTIONS,
+  PASEO_MAPLE_PROVIDER_ID,
+  PASEO_MAPLE_PROVIDER_NAME,
   MapleAcpService,
   buildBuzzCustomHarness,
+  buildPaseoCustomProviderConfig,
   isMapleAcpConfigReady,
-  isMapleAcpPolicyDirty,
   normalizeMapleAcpConfig,
   normalizeMapleAcpStatus,
   serializeBuzzCustomHarness,
+  serializePaseoCustomProviderConfig,
   type MapleAcpBridge,
   type MapleAcpHarness
 } from "./mapleAcpService";
@@ -240,6 +243,30 @@ describe("Buzz custom harness output", () => {
   });
 });
 
+describe("Paseo custom provider output", () => {
+  test("builds a dynamic ACP provider with Paseo tool injection enabled", () => {
+    const config = buildPaseoCustomProviderConfig(harness);
+    const provider = config.agents.providers[PASEO_MAPLE_PROVIDER_ID];
+
+    expect(provider).toEqual({
+      extends: "acp",
+      label: PASEO_MAPLE_PROVIDER_NAME,
+      description: "Maple's signed-in Agent Mode over local ACP",
+      command: [harness.command, "acp"],
+      params: {
+        supportsMcpServers: true
+      }
+    });
+    expect(provider).not.toHaveProperty("models");
+
+    const serialized = serializePaseoCustomProviderConfig(harness);
+    expect(JSON.parse(serialized)).toEqual(config);
+    expect(serialized).toContain(harness.command);
+    expect(serialized).not.toContain("accessToken");
+    expect(serialized).not.toContain("apiKey");
+  });
+});
+
 describe("Agent connections policy state", () => {
   const savedConfig = {
     enabled: true,
@@ -253,14 +280,5 @@ describe("Agent connections policy state", () => {
     expect(isMapleAcpConfigReady(savedConfig, null)).toBe(false);
     expect(isMapleAcpConfigReady(null, savedConfig)).toBe(false);
     expect(isMapleAcpConfigReady(savedConfig, savedConfig)).toBe(true);
-  });
-
-  test("never treats a missing config as a dirty default policy", () => {
-    const editedConfig = { ...savedConfig, permissionMode: "read_only" as const };
-
-    expect(isMapleAcpPolicyDirty(null, savedConfig)).toBe(false);
-    expect(isMapleAcpPolicyDirty(editedConfig, null)).toBe(false);
-    expect(isMapleAcpPolicyDirty(savedConfig, savedConfig)).toBe(false);
-    expect(isMapleAcpPolicyDirty(editedConfig, savedConfig)).toBe(true);
   });
 });

--- a/frontend/src/services/mapleAcpService.ts
+++ b/frontend/src/services/mapleAcpService.ts
@@ -38,8 +38,26 @@ export interface BuzzCustomHarnessDefinition {
   env: Record<string, never>;
 }
 
+export interface PaseoCustomProviderConfig {
+  agents: {
+    providers: {
+      "maple-acp": {
+        extends: "acp";
+        label: "Maple Agent";
+        description: string;
+        command: string[];
+        params: {
+          supportsMcpServers: true;
+        };
+      };
+    };
+  };
+}
+
 export const BUZZ_MAPLE_HARNESS_ID = "maple" as const;
 export const BUZZ_MAPLE_HARNESS_NAME = "Maple" as const;
+export const PASEO_MAPLE_PROVIDER_ID = "maple-acp" as const;
+export const PASEO_MAPLE_PROVIDER_NAME = "Maple Agent" as const;
 export const MAX_MAPLE_ACP_CONNECTIONS = 8 as const;
 export const BUZZ_MAPLE_AGENT_PARALLELISM = MAX_MAPLE_ACP_CONNECTIONS;
 export const BUZZ_DEFAULT_AGENT_PARALLELISM = 10 as const;
@@ -197,20 +215,35 @@ export function serializeBuzzCustomHarness(harness: MapleAcpHarness): string {
   return JSON.stringify(buildBuzzCustomHarness(harness), null, 2);
 }
 
+export function buildPaseoCustomProviderConfig(
+  harness: MapleAcpHarness
+): PaseoCustomProviderConfig {
+  return {
+    agents: {
+      providers: {
+        [PASEO_MAPLE_PROVIDER_ID]: {
+          extends: "acp",
+          label: PASEO_MAPLE_PROVIDER_NAME,
+          description: "Maple's signed-in Agent Mode over local ACP",
+          command: [harness.command, ...harness.args],
+          params: {
+            supportsMcpServers: true
+          }
+        }
+      }
+    }
+  };
+}
+
+export function serializePaseoCustomProviderConfig(harness: MapleAcpHarness): string {
+  return JSON.stringify(buildPaseoCustomProviderConfig(harness), null, 2);
+}
+
 export function isMapleAcpConfigReady(
   config: MapleAcpConfig | null,
   savedConfig: MapleAcpConfig | null
 ): boolean {
   return config !== null && savedConfig !== null;
-}
-
-export function isMapleAcpPolicyDirty(
-  config: MapleAcpConfig | null,
-  savedConfig: MapleAcpConfig | null
-): boolean {
-  return (
-    config !== null && savedConfig !== null && config.permissionMode !== savedConfig.permissionMode
-  );
 }
 
 async function invokeMapleAcp<T>(command: string, args?: Record<string, unknown>): Promise<T> {


### PR DESCRIPTION
## Summary

- make Agent connections client-neutral and add compact Paseo and Buzz setup tabs
- generate a dynamic Paseo ACP provider configuration with MCP injection enabled
- remove the inert single-choice approvals UI and simplify service status
- keep Buzz-only diagnostics and advanced JSON inside the Buzz guide

## Validation

- `nix develop .#ci -c ./scripts/ci/frontend.sh` (710 tests passed)
- focused guide and ACP service tests (14 tests passed)
- `git diff --check`

## Stack

This is stacked on #801, which is stacked on #799. Review and merge in that order.

## Runtime note

The existing packaged Maple instance had active ACP clients, so I preserved it rather than restarting it for a native screenshot. The new UI is covered by static rendering, frontend type checking, linting, formatting, and the full frontend test suite.
