### PR TITLE
feat(agent): support image attachments

### DIFF
--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -1,3 +1,4 @@
+mod attachments;
 mod developer_tools;
 #[cfg(target_os = "macos")]
 mod macos_login_path;
@@ -10,6 +11,9 @@ mod web_permission;
 mod web_tools;
 
 use crate::maple_api::{account_scope, MapleApiSession};
+use attachments::{
+    AgentAttachmentStore, AgentImageAttachment, AgentImageUpload, PreparedAgentImage,
+};
 use developer_tools::MapleDeveloperClient;
 #[cfg(test)]
 use developer_tools::EXTERNAL_MCP_TOOL_NAME;
@@ -131,6 +135,7 @@ static NEXT_QUEUE_ID: AtomicU64 = AtomicU64::new(1);
 static NEXT_TOOL_CONTEXT_INSTALLATION_ID: AtomicU64 = AtomicU64::new(1);
 const MAX_DESKTOP_QUEUE_ITEMS: usize = 16;
 const MAX_DESKTOP_QUEUE_TEXT_BYTES: usize = 32 * 1024;
+const MAPLE_IMAGE_ATTACHMENTS_OPERATION: &str = "mapleImageAttachments";
 
 fn validate_session_model_lock(
     message_count: usize,
@@ -372,6 +377,8 @@ pub struct AgentSendMessageRequest {
     pub steer: bool,
     #[serde(default)]
     pub queue_id: Option<String>,
+    #[serde(default)]
+    pub attachments: Vec<AgentImageUpload>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -451,7 +458,10 @@ pub struct AgentQueuedMessage {
     pub message_id: String,
     pub session_id: String,
     pub text: String,
+    pub attachments: Vec<AgentImageAttachment>,
     pub created_ms: u128,
+    #[serde(skip)]
+    message: Message,
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -2490,7 +2500,8 @@ impl AgentRuntimeHandle {
         let account_dir = account_config_dir_path(&state.host.paths, &self.user_id)
             .map_err(|error| error.to_string())?;
         clear_agent_history(&account_dir)
-            .map_err(|error| format!("Failed to clear Agent Mode history: {error}"))
+            .map_err(|error| format!("Failed to clear Agent Mode history: {error}"))?;
+        account_attachment_store(&state.host.paths, &self.user_id)?.clear()
     }
 }
 
@@ -3743,6 +3754,26 @@ impl AgentRuntimeHandle {
         Ok(summary)
     }
 
+    pub(crate) async fn load_image_attachment(
+        &self,
+        session_id: String,
+        attachment_id: String,
+    ) -> Result<String, String> {
+        let state = &self.service;
+        let user_id = self.user_id.as_ref();
+        let _runtime_lifecycle_guard = state.runtime_lifecycle.lock().await;
+        self.verify_generation().await?;
+        let _session_lifecycle_guard = state.session_lifecycle.lock().await;
+        account_session_manager(&state.host.paths, user_id)?
+            .get_session(&session_id, false)
+            .await
+            .map_err(|error| format!("Failed to find Agent task {session_id}: {error}"))?;
+        let store = account_attachment_store(&state.host.paths, user_id)?;
+        tokio::task::spawn_blocking(move || store.data_url(&session_id, &attachment_id))
+            .await
+            .map_err(|error| format!("Agent image attachment task failed: {error}"))?
+    }
+
     pub(crate) async fn list_session_mcp_servers(
         &self,
         session_id: String,
@@ -3980,6 +4011,14 @@ impl AgentRuntimeHandle {
             &session_id,
         )
         .await?;
+        match account_attachment_store(&state.host.paths, user_id)
+            .and_then(|store| store.delete_session(&session_id))
+        {
+            Ok(()) => {}
+            Err(error) => {
+                log::warn!("Deleted Agent task {session_id}, but failed to clear images: {error}")
+            }
+        }
         if let Some(agent_manager) = agent_manager {
             if let Err(error) = agent_manager.remove_session_if_loaded(&session_id).await {
                 log::warn!(
@@ -4281,20 +4320,45 @@ impl AgentRuntimeHandle {
         self.verify_generation().await?;
         self.ensure_accepting_new_work()?;
         let text = request.text.trim().to_string();
-        if text.is_empty() && desktop_send == DesktopSendDisposition::StartOnly {
+        if !request.attachments.is_empty() && desktop_send == DesktopSendDisposition::StartOnly {
+            return Err("Image attachments are available only in Maple Agent Mode".to_string());
+        }
+        if text.is_empty()
+            && request.attachments.is_empty()
+            && desktop_send == DesktopSendDisposition::StartOnly
+        {
             return Err("Prompt cannot be empty".to_string());
         }
 
         let session_lifecycle_guard = state.session_lifecycle.lock().await;
+        let prepared_images = if request.attachments.is_empty() {
+            Vec::new()
+        } else {
+            let session_manager = account_session_manager(&state.host.paths, user_id)?;
+            session_manager
+                .get_session(&request.session_id, false)
+                .await
+                .map_err(|error| {
+                    format!("Failed to find Agent task {}: {error}", request.session_id)
+                })?;
+            let store = account_attachment_store(&state.host.paths, user_id)?;
+            let session_id = request.session_id.clone();
+            let uploads = request.attachments.clone();
+            tokio::task::spawn_blocking(move || store.store_uploads(&session_id, &uploads))
+                .await
+                .map_err(|error| format!("Agent image attachment task failed: {error}"))??
+        };
+        let draft_message = (!text.is_empty() || !prepared_images.is_empty())
+            .then(|| user_message_with_images(&text, &prepared_images, request.vision_capable));
         let (launch_messages, mut started_queue, consume_queue_ids) = match desktop_send {
             DesktopSendDisposition::StageOrStart => {
-                match self.take_desktop_send_plan(&request).await? {
+                match self.take_desktop_send_plan(&request, draft_message).await? {
                     DesktopSendPlan::Staged {
                         run_id,
                         queued,
                         queue,
                     } => {
-                        return Ok(staged_run_handle(run_id, queued, queue));
+                        return Ok(staged_run_handle(run_id, *queued, queue));
                     }
                     DesktopSendPlan::Steered { run_id, queue } => {
                         return Ok(steered_run_handle(run_id, queue));
@@ -5079,22 +5143,36 @@ impl AgentRuntimeHandle {
     async fn take_desktop_send_plan(
         &self,
         request: &AgentSendMessageRequest,
+        draft_message: Option<Message>,
     ) -> Result<DesktopSendPlan, String> {
         let state = &self.service;
         let account_scope = self.account_scope.as_ref();
         reject_foreign_surface_session(state, account_scope, &request.session_id).await?;
         let text = request.text.trim();
         if request.steer {
-            return take_desktop_steer_plan(state, account_scope, request, text).await;
+            return take_desktop_steer_plan(
+                state,
+                account_scope,
+                request,
+                text,
+                draft_message.as_ref(),
+            )
+            .await;
         }
         if let Some(run_id) =
             desktop_run_id_for_session(state, account_scope, &request.session_id).await?
         {
-            if text.is_empty() {
+            let Some(draft_message) = draft_message else {
                 return Err("Prompt cannot be empty".to_string());
-            }
-            let (queued, snapshot) =
-                enqueue_desktop_queue_item(state, account_scope, &request.session_id, text).await?;
+            };
+            let (queued, snapshot) = enqueue_desktop_queue_message(
+                state,
+                account_scope,
+                &request.session_id,
+                text,
+                draft_message,
+            )
+            .await?;
             publish_desktop_queue_changed(
                 state,
                 account_scope,
@@ -5105,12 +5183,18 @@ impl AgentRuntimeHandle {
             return Ok(DesktopSendPlan::Staged {
                 run_id,
                 queue: snapshot,
-                queued,
+                queued: Box::new(queued),
             });
         }
 
-        let launch =
-            prepare_desktop_launch(state, account_scope, &request.session_id, text).await?;
+        let launch = prepare_desktop_launch_message(
+            state,
+            account_scope,
+            &request.session_id,
+            text,
+            draft_message,
+        )
+        .await?;
         Ok(DesktopSendPlan::Start {
             launch_messages: launch.launch_messages,
             queue: launch.queue,
@@ -6812,6 +6896,10 @@ async fn configure_session_agent(
         developer_context.extension_manager = Some(Arc::downgrade(&agent.extension_manager));
     }
     let web_transport: Arc<dyn crate::maple_api::MapleWebTransport> = maple_api_session.clone();
+    let attachment_store = Arc::new(account_attachment_store(
+        skills_scope.paths,
+        skills_scope.user_id,
+    )?);
     let developer_client = MapleDeveloperClient::new(
         developer_context,
         primary_model_supports_vision,
@@ -6819,7 +6907,8 @@ async fn configure_session_agent(
         Arc::clone(web_tool_state),
         tool_context.clone(),
     )
-    .map_err(|e| format!("Failed to create Maple developer tools: {e}"))?;
+    .map_err(|e| format!("Failed to create Maple developer tools: {e}"))?
+    .with_attachment_store(attachment_store);
     agent
         .extension_manager
         .add_client(
@@ -7095,14 +7184,22 @@ fn message_to_timeline_items_with_thinking(
         unix_ms()
     };
     let merge = if live { "append" } else { "replace" }.to_string();
-    let visible_text = message
-        .content
-        .iter()
-        .filter_map(|content| match content {
-            MessageContent::Text(text) => Some(text.text.as_str()),
-            _ => None,
+    let image_attachments = message_image_attachments(&message);
+    let visible_text = message_original_user_text(&message).unwrap_or_else(|| {
+        message
+            .content
+            .iter()
+            .filter_map(|content| match content {
+                MessageContent::Text(text) => Some(text.text.as_str()),
+                _ => None,
+            })
+            .collect::<String>()
+    });
+    let image_input = (!image_attachments.is_empty()).then(|| {
+        json!({
+            "imageAttachments": image_attachments,
         })
-        .collect::<String>();
+    });
 
     let mut emitted_text = false;
     let mut emitted_thinking = false;
@@ -7123,7 +7220,7 @@ fn message_to_timeline_items_with_thinking(
                     title: None,
                     text: Some(visible_text.clone()),
                     status: None,
-                    input: None,
+                    input: image_input.clone(),
                     output: None,
                     created_ms,
                     merge: merge.clone(),
@@ -8602,6 +8699,15 @@ fn account_local_data_dir_path(
     Ok(paths.local_data_root.join("accounts").join(scope))
 }
 
+fn account_attachment_store(
+    paths: &AgentPathLayout,
+    user_id: &str,
+) -> Result<AgentAttachmentStore, String> {
+    account_local_data_dir_path(paths, user_id)
+        .map(AgentAttachmentStore::new)
+        .map_err(|error| error.to_string())
+}
+
 fn agent_config_dir(paths: &AgentPathLayout, user_id: &str) -> Result<PathBuf, anyhow::Error> {
     let path = account_config_dir_path(paths, user_id)?;
     fs::create_dir_all(&path)?;
@@ -9020,7 +9126,7 @@ fn has_active_session_run(active_runs: &HashMap<String, ActiveAgentRun>, session
 enum DesktopSendPlan {
     Staged {
         run_id: String,
-        queued: AgentQueuedMessage,
+        queued: Box<AgentQueuedMessage>,
         queue: AgentDesktopQueueSnapshot,
     },
     Steered {
@@ -9038,13 +9144,131 @@ fn user_message_from_prompt(text: &str) -> Message {
     Message::user().with_text(text).with_generated_id()
 }
 
+fn user_message_with_images(
+    text: &str,
+    images: &[PreparedAgentImage],
+    vision_capable: bool,
+) -> Message {
+    if images.is_empty() {
+        return user_message_from_prompt(text);
+    }
+    let attachments = images
+        .iter()
+        .map(|image| image.attachment.clone())
+        .collect::<Vec<_>>();
+    let mut message =
+        Message::user().with_text(agent_image_prompt(text, &attachments, vision_capable));
+    if vision_capable {
+        for image in images {
+            message = message.with_image(&image.base64_data, &image.attachment.mime_type);
+        }
+    }
+    message.metadata.set_operation_note(
+        MAPLE_IMAGE_ATTACHMENTS_OPERATION,
+        "userText",
+        Value::String(text.to_string()),
+    );
+    message.metadata.set_operation_note(
+        MAPLE_IMAGE_ATTACHMENTS_OPERATION,
+        "items",
+        serde_json::to_value(&attachments).unwrap_or(Value::Array(Vec::new())),
+    );
+    message.metadata.set_operation_note(
+        MAPLE_IMAGE_ATTACHMENTS_OPERATION,
+        "visionCapable",
+        Value::Bool(vision_capable),
+    );
+    message.with_generated_id()
+}
+
+fn agent_image_prompt(
+    text: &str,
+    attachments: &[AgentImageAttachment],
+    vision_capable: bool,
+) -> String {
+    let mut prompt = text.trim().to_string();
+    if !prompt.is_empty() {
+        prompt.push_str("\n\n");
+    }
+    prompt.push_str("The user attached the following image");
+    if attachments.len() == 1 {
+        prompt.push_str(":\n");
+    } else {
+        prompt.push_str("s:\n");
+    }
+    for attachment in attachments {
+        let name = serde_json::to_string(&attachment.name).unwrap_or_else(|_| "\"image\"".into());
+        if vision_capable {
+            prompt.push_str(&format!("- {name}\n"));
+        } else {
+            prompt.push_str(&format!("- {name}: {}\n", attachment.source));
+        }
+    }
+    if !vision_capable {
+        prompt.push_str(
+            "Use read_image with an attachment source when you need visual details from that image.",
+        );
+    }
+    prompt
+}
+
+fn message_image_attachments(message: &Message) -> Vec<AgentImageAttachment> {
+    message
+        .metadata
+        .operation_note(MAPLE_IMAGE_ATTACHMENTS_OPERATION, "items")
+        .cloned()
+        .and_then(|value| serde_json::from_value(value).ok())
+        .unwrap_or_default()
+}
+
+fn message_original_user_text(message: &Message) -> Option<String> {
+    message
+        .metadata
+        .operation_note(MAPLE_IMAGE_ATTACHMENTS_OPERATION, "userText")
+        .and_then(Value::as_str)
+        .map(ToOwned::to_owned)
+}
+
+fn replace_queued_message_text(message: &mut Message, text: &str) {
+    let attachments = message_image_attachments(message);
+    if attachments.is_empty() {
+        let message_id = message.id.clone();
+        *message = user_message_from_prompt(text);
+        if let Some(message_id) = message_id {
+            message.id = Some(message_id);
+        }
+        return;
+    }
+    let vision_capable = message
+        .metadata
+        .operation_note(MAPLE_IMAGE_ATTACHMENTS_OPERATION, "visionCapable")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let replacement =
+        Message::user().with_text(agent_image_prompt(text, &attachments, vision_capable));
+    if let Some(content) = replacement.content.into_iter().next() {
+        if let Some(first) = message.content.first_mut() {
+            *first = content;
+        }
+    }
+    message.metadata.set_operation_note(
+        MAPLE_IMAGE_ATTACHMENTS_OPERATION,
+        "userText",
+        Value::String(text.to_string()),
+    );
+}
+
 async fn take_desktop_steer_plan(
     state: &MapleAgentService,
     account_scope: &str,
     request: &AgentSendMessageRequest,
     text: &str,
+    draft_message: Option<&Message>,
 ) -> Result<DesktopSendPlan, String> {
     reject_foreign_surface_session(state, account_scope, &request.session_id).await?;
+    if request.queue_id.is_some() && !request.attachments.is_empty() {
+        return Err("New images cannot be added while sending a queued message".to_string());
+    }
     if let Some(run_id) =
         desktop_run_id_for_session(state, account_scope, &request.session_id).await?
     {
@@ -9081,7 +9305,7 @@ async fn take_desktop_steer_plan(
                 queue: snapshot,
             });
         }
-        if text.is_empty() {
+        if draft_message.is_none() {
             let Some((items, snapshot)) = take_all_desktop_queue_items_from_map(
                 &state.desktop_queues,
                 account_scope,
@@ -9126,7 +9350,7 @@ async fn take_desktop_steer_plan(
             state,
             account_scope,
             &request.session_id,
-            &user_message_from_prompt(text),
+            draft_message.expect("non-empty draft checked above"),
         )
         .await?;
         return Ok(DesktopSendPlan::Steered {
@@ -9153,7 +9377,14 @@ async fn take_desktop_steer_plan(
         });
     }
 
-    let launch = prepare_desktop_launch(state, account_scope, &request.session_id, text).await?;
+    let launch = prepare_desktop_launch_message(
+        state,
+        account_scope,
+        &request.session_id,
+        text,
+        draft_message.cloned(),
+    )
+    .await?;
     Ok(DesktopSendPlan::Start {
         launch_messages: launch.launch_messages,
         queue: launch.queue,
@@ -9362,7 +9593,7 @@ struct DesktopLaunchPlan {
 }
 
 fn queued_user_message(queued: &AgentQueuedMessage) -> Message {
-    let mut message = user_message_from_prompt(&queued.text);
+    let mut message = queued.message.clone();
     message.id = Some(queued.message_id.clone());
     message
 }
@@ -9417,25 +9648,39 @@ async fn emit_promoted_queue_items(
     }
 }
 
+#[cfg(test)]
 async fn prepare_desktop_launch(
     state: &MapleAgentService,
     account_scope: &str,
     session_id: &str,
     draft_text: &str,
 ) -> Result<DesktopLaunchPlan, String> {
+    let draft_message = (!draft_text.is_empty()).then(|| user_message_from_prompt(draft_text));
+    prepare_desktop_launch_message(state, account_scope, session_id, draft_text, draft_message)
+        .await
+}
+
+async fn prepare_desktop_launch_message(
+    state: &MapleAgentService,
+    account_scope: &str,
+    session_id: &str,
+    draft_text: &str,
+    draft_message: Option<Message>,
+) -> Result<DesktopLaunchPlan, String> {
     let leftover = snapshot_desktop_queue(state, account_scope, session_id).await;
     if leftover.items.is_empty() {
-        if draft_text.is_empty() {
+        let Some(draft_message) = draft_message else {
             return Err("Prompt cannot be empty".to_string());
-        }
+        };
         return Ok(DesktopLaunchPlan {
-            launch_messages: vec![user_message_from_prompt(draft_text)],
+            launch_messages: vec![draft_message],
             consume_queue_ids: Vec::new(),
             queue: leftover,
         });
     }
-    if !draft_text.is_empty() {
-        enqueue_desktop_queue_item(state, account_scope, session_id, draft_text).await?;
+    if let Some(draft_message) = draft_message {
+        enqueue_desktop_queue_message(state, account_scope, session_id, draft_text, draft_message)
+            .await?;
     }
     let snapshot = snapshot_desktop_queue(state, account_scope, session_id).await;
     if snapshot.items.is_empty() {
@@ -9452,16 +9697,33 @@ async fn prepare_desktop_launch(
     })
 }
 
+#[cfg(test)]
 async fn enqueue_desktop_queue_item(
     state: &MapleAgentService,
     account_scope: &str,
     session_id: &str,
     text: &str,
 ) -> Result<(AgentQueuedMessage, AgentDesktopQueueSnapshot), String> {
+    enqueue_desktop_queue_message(
+        state,
+        account_scope,
+        session_id,
+        text,
+        user_message_from_prompt(text),
+    )
+    .await
+}
+
+async fn enqueue_desktop_queue_message(
+    state: &MapleAgentService,
+    account_scope: &str,
+    session_id: &str,
+    text: &str,
+    message: Message,
+) -> Result<(AgentQueuedMessage, AgentDesktopQueueSnapshot), String> {
     if text.len() > MAX_DESKTOP_QUEUE_TEXT_BYTES {
         return Err("Queued Agent message is too large".to_string());
     }
-    let message = user_message_from_prompt(text);
     let message_id = message
         .id
         .clone()
@@ -9471,7 +9733,9 @@ async fn enqueue_desktop_queue_item(
         message_id,
         session_id: session_id.to_string(),
         text: text.to_string(),
+        attachments: message_image_attachments(&message),
         created_ms: unix_ms(),
+        message,
     };
     let mut queues = state.desktop_queues.lock().await;
     let queue = queues
@@ -9543,6 +9807,7 @@ async fn update_desktop_queue_item(
         return Err("Queued Agent message has already been sent".to_string());
     };
     item.text = text.to_string();
+    replace_queued_message_text(&mut item.message, text);
     queue.editing_queue_id = None;
     queue.revision = queue.revision.saturating_add(1);
     Ok((item.clone(), queue.snapshot()))
@@ -10363,6 +10628,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             }),
         )
         .await
@@ -10378,6 +10644,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -10443,6 +10710,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -10460,6 +10728,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -10474,6 +10743,7 @@ mod tests {
                 vision_capable: false,
                 steer: true,
                 queue_id: Some(first_chip),
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -10638,6 +10908,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
         {
@@ -10843,8 +11114,10 @@ mod tests {
                 vision_capable: false,
                 steer: true,
                 queue_id: Some(first_id.clone()),
+                attachments: Vec::new(),
             },
             "",
+            None,
         )
         .await
         .unwrap();
@@ -11020,6 +11293,7 @@ mod tests {
                 vision_capable: false,
                 steer: true,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
         {
@@ -11038,6 +11312,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -11051,6 +11326,7 @@ mod tests {
                 vision_capable: false,
                 steer: false,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -11072,6 +11348,7 @@ mod tests {
                 vision_capable: false,
                 steer: true,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
         {
@@ -11096,6 +11373,7 @@ mod tests {
                 vision_capable: false,
                 steer: true,
                 queue_id: None,
+                attachments: Vec::new(),
             })
             .await
             .unwrap();
@@ -13006,6 +13284,56 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "image-message-text");
         assert_eq!(items[0].text.as_deref(), Some("Inspect this image"));
+    }
+
+    #[test]
+    fn agent_image_messages_keep_the_ui_projection_clean_and_model_routing_truthful() {
+        let image = PreparedAgentImage {
+            attachment: AgentImageAttachment {
+                id: "0123456789abcdef0123456789abcdef".to_string(),
+                name: "dialog.png".to_string(),
+                mime_type: "image/png".to_string(),
+                source: "maple-attachment://0123456789abcdef0123456789abcdef".to_string(),
+            },
+            base64_data: "aW1hZ2U=".to_string(),
+        };
+
+        let nonvision = user_message_with_images(
+            "Why is this misaligned?",
+            std::slice::from_ref(&image),
+            false,
+        );
+        assert!(nonvision
+            .as_concat_text()
+            .contains(&image.attachment.source));
+        assert!(!nonvision
+            .content
+            .iter()
+            .any(|content| matches!(content, MessageContent::Image(_))));
+        let nonvision_item = message_to_timeline_items(&nonvision, false)
+            .into_iter()
+            .next()
+            .unwrap();
+        assert_eq!(
+            nonvision_item.text.as_deref(),
+            Some("Why is this misaligned?")
+        );
+        assert_eq!(
+            nonvision_item
+                .input
+                .as_ref()
+                .and_then(|input| input.get("imageAttachments"))
+                .and_then(Value::as_array)
+                .map(Vec::len),
+            Some(1)
+        );
+
+        let vision = user_message_with_images("Why is this misaligned?", &[image], true);
+        assert!(!vision.as_concat_text().contains("maple-attachment://"));
+        assert!(vision
+            .content
+            .iter()
+            .any(|content| matches!(content, MessageContent::Image(_))));
     }
 
     #[test]

--- a/frontend/src-tauri/src/agent/attachments.rs
+++ b/frontend/src-tauri/src/agent/attachments.rs
@@ -1,0 +1,372 @@
+use base64::{engine::general_purpose::STANDARD as BASE64_STANDARD, Engine as _};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::fs::{self, OpenOptions};
+use std::io::{Read, Write};
+use std::path::{Path, PathBuf};
+
+pub(super) const MAX_AGENT_IMAGE_BYTES: usize = 10 * 1024 * 1024;
+pub(super) const MAX_AGENT_IMAGES_PER_MESSAGE: usize = 10;
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentImageUpload {
+    pub name: String,
+    pub data_url: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(crate) struct AgentImageAttachment {
+    pub id: String,
+    pub name: String,
+    pub mime_type: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct PreparedAgentImage {
+    pub attachment: AgentImageAttachment,
+    pub base64_data: String,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct AgentAttachmentStore {
+    root: PathBuf,
+}
+
+impl AgentAttachmentStore {
+    pub(super) fn new(account_local_data_dir: PathBuf) -> Self {
+        Self {
+            root: account_local_data_dir.join("attachments"),
+        }
+    }
+
+    pub(super) fn store_uploads(
+        &self,
+        session_id: &str,
+        uploads: &[AgentImageUpload],
+    ) -> Result<Vec<PreparedAgentImage>, String> {
+        if uploads.len() > MAX_AGENT_IMAGES_PER_MESSAGE {
+            return Err(format!(
+                "Attach at most {MAX_AGENT_IMAGES_PER_MESSAGE} images at a time"
+            ));
+        }
+        if uploads.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let session_dir = self.session_dir(session_id)?;
+        if let Some(account_dir) = self.root.parent() {
+            create_owner_only_dir(account_dir)?;
+        }
+        create_owner_only_dir(&self.root)?;
+        create_owner_only_dir(&session_dir)?;
+
+        let mut prepared = Vec::with_capacity(uploads.len());
+        let mut created_paths = Vec::with_capacity(uploads.len());
+        for upload in uploads {
+            let result = self.store_upload(&session_dir, upload);
+            match result {
+                Ok((image, path)) => {
+                    created_paths.push(path);
+                    prepared.push(image);
+                }
+                Err(error) => {
+                    for path in created_paths {
+                        let _ = fs::remove_file(path);
+                    }
+                    return Err(error);
+                }
+            }
+        }
+        Ok(prepared)
+    }
+
+    pub(super) fn read(&self, session_id: &str, attachment_id: &str) -> Result<Vec<u8>, String> {
+        validate_attachment_id(attachment_id)?;
+        let path = self.session_dir(session_id)?.join(attachment_id);
+        let metadata = fs::symlink_metadata(&path)
+            .map_err(|error| format!("Failed to find Agent image attachment: {error}"))?;
+        if !metadata.file_type().is_file() || metadata.file_type().is_symlink() {
+            return Err("Agent image attachment is not a regular file".to_string());
+        }
+        if metadata.len() > MAX_AGENT_IMAGE_BYTES as u64 {
+            return Err("Agent image attachment exceeds the 10MB limit".to_string());
+        }
+        let mut options = OpenOptions::new();
+        options.read(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.custom_flags(libc::O_NOFOLLOW);
+        }
+        let file = options
+            .open(&path)
+            .map_err(|error| format!("Failed to read Agent image attachment: {error}"))?;
+        if !file
+            .metadata()
+            .map_err(|error| format!("Failed to inspect Agent image attachment: {error}"))?
+            .is_file()
+        {
+            return Err("Agent image attachment is not a regular file".to_string());
+        }
+        let mut bytes = Vec::with_capacity(metadata.len() as usize);
+        file.take(MAX_AGENT_IMAGE_BYTES as u64 + 1)
+            .read_to_end(&mut bytes)
+            .map_err(|error| format!("Failed to read Agent image attachment: {error}"))?;
+        if bytes.len() > MAX_AGENT_IMAGE_BYTES {
+            return Err("Agent image attachment exceeds the 10MB limit".to_string());
+        }
+        supported_image_mime(&bytes)?;
+        Ok(bytes)
+    }
+
+    pub(super) fn data_url(&self, session_id: &str, attachment_id: &str) -> Result<String, String> {
+        let bytes = self.read(session_id, attachment_id)?;
+        let mime_type = supported_image_mime(&bytes)?;
+        Ok(format!(
+            "data:{mime_type};base64,{}",
+            BASE64_STANDARD.encode(bytes)
+        ))
+    }
+
+    pub(super) fn delete_session(&self, session_id: &str) -> Result<(), String> {
+        let path = self.session_dir(session_id)?;
+        remove_exact_path(&path)
+            .map_err(|error| format!("Failed to remove Agent image attachments: {error}"))
+    }
+
+    pub(super) fn clear(&self) -> Result<(), String> {
+        remove_exact_path(&self.root)
+            .map_err(|error| format!("Failed to clear Agent image attachments: {error}"))
+    }
+
+    fn store_upload(
+        &self,
+        session_dir: &Path,
+        upload: &AgentImageUpload,
+    ) -> Result<(PreparedAgentImage, PathBuf), String> {
+        let (declared_mime, base64_data) = parse_data_url(&upload.data_url)?;
+        if base64_data.len() > maximum_base64_chars(MAX_AGENT_IMAGE_BYTES) {
+            return Err("Image too large (max 10MB)".to_string());
+        }
+        let bytes = BASE64_STANDARD
+            .decode(base64_data)
+            .map_err(|_| "Image attachment is not valid base64".to_string())?;
+        if bytes.len() > MAX_AGENT_IMAGE_BYTES {
+            return Err("Image too large (max 10MB)".to_string());
+        }
+        let detected_mime = supported_image_mime(&bytes)?;
+        if normalize_mime(declared_mime) != detected_mime {
+            return Err("Image content does not match its declared type".to_string());
+        }
+
+        let id = format!("{:032x}", rand::random::<u128>());
+        let path = session_dir.join(&id);
+        let mut options = OpenOptions::new();
+        options.write(true).create_new(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            options.mode(0o600);
+        }
+        let mut file = options
+            .open(&path)
+            .map_err(|error| format!("Failed to store Agent image attachment: {error}"))?;
+        if let Err(error) = file.write_all(&bytes).and_then(|_| file.sync_all()) {
+            let _ = fs::remove_file(&path);
+            return Err(format!("Failed to store Agent image attachment: {error}"));
+        }
+
+        let attachment = AgentImageAttachment {
+            source: format!("maple-attachment://{id}"),
+            id,
+            name: safe_display_name(&upload.name),
+            mime_type: detected_mime.to_string(),
+        };
+        Ok((
+            PreparedAgentImage {
+                attachment,
+                base64_data: base64_data.to_string(),
+            },
+            path,
+        ))
+    }
+
+    fn session_dir(&self, session_id: &str) -> Result<PathBuf, String> {
+        let session_id = session_id.trim();
+        if session_id.is_empty() {
+            return Err("Agent task ID cannot be empty".to_string());
+        }
+        let digest = Sha256::digest(session_id.as_bytes());
+        Ok(self.root.join(format!("{digest:x}")))
+    }
+}
+
+pub(super) fn attachment_id_from_source(source: &str) -> Option<&str> {
+    source
+        .strip_prefix("maple-attachment://")
+        .and_then(|id| (!id.is_empty() && !id.contains(['/', '\\', '?', '#'])).then_some(id))
+}
+
+fn parse_data_url(data_url: &str) -> Result<(&str, &str), String> {
+    let (header, data) = data_url
+        .split_once(',')
+        .ok_or_else(|| "Image attachment must be a base64 data URL".to_string())?;
+    let mime = header
+        .strip_prefix("data:")
+        .and_then(|value| value.strip_suffix(";base64"))
+        .ok_or_else(|| "Image attachment must be a base64 data URL".to_string())?;
+    if data.is_empty() {
+        return Err("Image attachment cannot be empty".to_string());
+    }
+    Ok((mime, data))
+}
+
+fn maximum_base64_chars(bytes: usize) -> usize {
+    bytes.div_ceil(3).saturating_mul(4)
+}
+
+fn normalize_mime(mime: &str) -> &str {
+    if mime.eq_ignore_ascii_case("image/jpg") {
+        "image/jpeg"
+    } else {
+        mime
+    }
+}
+
+fn supported_image_mime(bytes: &[u8]) -> Result<&'static str, String> {
+    if bytes.starts_with(b"\x89PNG\r\n\x1a\n") {
+        Ok("image/png")
+    } else if bytes.starts_with(&[0xff, 0xd8, 0xff]) {
+        Ok("image/jpeg")
+    } else if bytes.len() >= 12 && bytes.starts_with(b"RIFF") && &bytes[8..12] == b"WEBP" {
+        Ok("image/webp")
+    } else {
+        Err("Only JPEG, PNG, and WebP images are supported".to_string())
+    }
+}
+
+fn safe_display_name(name: &str) -> String {
+    let name = name
+        .rsplit(['/', '\\'])
+        .next()
+        .unwrap_or_default()
+        .trim()
+        .chars()
+        .filter(|character| !character.is_control())
+        .take(255)
+        .collect::<String>();
+    if name.is_empty() {
+        "image".to_string()
+    } else {
+        name
+    }
+}
+
+fn validate_attachment_id(id: &str) -> Result<(), String> {
+    if id.len() == 32 && id.bytes().all(|byte| byte.is_ascii_hexdigit()) {
+        Ok(())
+    } else {
+        Err("Invalid Agent image attachment ID".to_string())
+    }
+}
+
+fn create_owner_only_dir(path: &Path) -> Result<(), String> {
+    fs::create_dir_all(path)
+        .map_err(|error| format!("Failed to create Agent attachment cache: {error}"))?;
+    let metadata = fs::symlink_metadata(path)
+        .map_err(|error| format!("Failed to inspect Agent attachment cache: {error}"))?;
+    if metadata.file_type().is_symlink() || !metadata.is_dir() {
+        return Err("Agent attachment cache is not a regular directory".to_string());
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(path, fs::Permissions::from_mode(0o700))
+            .map_err(|error| format!("Failed to secure Agent attachment cache: {error}"))?;
+    }
+    Ok(())
+}
+
+fn remove_exact_path(path: &Path) -> std::io::Result<()> {
+    let metadata = match fs::symlink_metadata(path) {
+        Ok(metadata) => metadata,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+        Err(error) => return Err(error),
+    };
+    if metadata.file_type().is_symlink() || metadata.is_file() {
+        fs::remove_file(path)
+    } else if metadata.is_dir() {
+        fs::remove_dir_all(path)
+    } else {
+        Err(std::io::Error::other("unsupported attachment cache entry"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    const PNG_1X1: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+    #[test]
+    fn stores_reads_and_deletes_session_scoped_images() {
+        let temp = tempdir().unwrap();
+        let store = AgentAttachmentStore::new(temp.path().to_path_buf());
+        let prepared = store
+            .store_uploads(
+                "session-a",
+                &[AgentImageUpload {
+                    name: "../screen.png".to_string(),
+                    data_url: format!("data:image/png;base64,{PNG_1X1}"),
+                }],
+            )
+            .unwrap();
+
+        assert_eq!(prepared[0].attachment.name, "screen.png");
+        assert_eq!(
+            store.read("session-a", &prepared[0].attachment.id).unwrap(),
+            BASE64_STANDARD.decode(PNG_1X1).unwrap()
+        );
+        assert!(store.read("session-b", &prepared[0].attachment.id).is_err());
+
+        store.delete_session("session-a").unwrap();
+        assert!(store.read("session-a", &prepared[0].attachment.id).is_err());
+    }
+
+    #[test]
+    fn rejects_mime_mismatches_and_unsupported_images() {
+        let temp = tempdir().unwrap();
+        let store = AgentAttachmentStore::new(temp.path().to_path_buf());
+
+        let mismatch = store.store_uploads(
+            "session-a",
+            &[AgentImageUpload {
+                name: "screen.jpg".to_string(),
+                data_url: format!("data:image/jpeg;base64,{PNG_1X1}"),
+            }],
+        );
+        assert_eq!(
+            mismatch.unwrap_err(),
+            "Image content does not match its declared type"
+        );
+
+        let unsupported = store.store_uploads(
+            "session-a",
+            &[AgentImageUpload {
+                name: "screen.gif".to_string(),
+                data_url: format!(
+                    "data:image/gif;base64,{}",
+                    BASE64_STANDARD.encode(b"GIF89a")
+                ),
+            }],
+        );
+        assert_eq!(
+            unsupported.unwrap_err(),
+            "Only JPEG, PNG, and WebP images are supported"
+        );
+    }
+}

--- a/frontend/src-tauri/src/agent/developer_tools.rs
+++ b/frontend/src-tauri/src/agent/developer_tools.rs
@@ -1,3 +1,4 @@
+use super::attachments::{attachment_id_from_source, AgentAttachmentStore};
 use super::web_tools::{
     bound_open_url_tool_error, bound_web_search_tool_error, execute_open_url, execute_web_search,
     open_url_tool, web_search_tool, OpenUrlParams, WebSearchParams, WebToolState,
@@ -145,6 +146,7 @@ pub(crate) struct MapleDeveloperClient {
     web_state: Arc<WebToolState>,
     tool_context: SharedAgentToolContext,
     contextual_image_context: Option<PlatformExtensionContext>,
+    attachment_store: Option<Arc<AgentAttachmentStore>>,
     #[cfg(not(windows))]
     login_path_probe: ShellTool,
     #[cfg(not(windows))]
@@ -175,11 +177,17 @@ impl MapleDeveloperClient {
             web_state,
             tool_context,
             contextual_image_context,
+            attachment_store: None,
             #[cfg(not(windows))]
             login_path_probe: ShellTool::new(true)?,
             #[cfg(not(windows))]
             login_path: OnceCell::new(),
         })
+    }
+
+    pub(super) fn with_attachment_store(mut self, store: Arc<AgentAttachmentStore>) -> Self {
+        self.attachment_store = Some(store);
+        self
     }
 
     #[cfg(not(windows))]
@@ -300,10 +308,10 @@ impl MapleDeveloperClient {
 
     fn read_image_tool(mut tool: Tool, requires_context: bool) -> Tool {
         tool.description = Some(if requires_context {
-            "Read an image from a local file path or http(s) URL and return a detailed visual description. Include focused task context describing what you need to learn from the image. Remote URLs require approval in Read only mode. Supports png, jpeg, gif, and webp."
+            "Read an image from a Maple attachment reference, local file path, or http(s) URL and return a detailed visual description. Include focused task context describing what you need to learn from the image. Remote URLs require approval in Read only mode. Supports png, jpeg, gif, and webp."
                 .into()
         } else {
-            "Read an image from a local file path or http(s) URL and return it as image content for the model to inspect. Remote URLs require approval in Read only mode. Supports png, jpeg, gif, and webp."
+            "Read an image from a Maple attachment reference, local file path, or http(s) URL and return it as image content for the model to inspect. Remote URLs require approval in Read only mode. Supports png, jpeg, gif, and webp."
                 .into()
         });
         let mut schema = tool.input_schema.as_ref().clone();
@@ -316,7 +324,7 @@ impl MapleDeveloperClient {
                 .and_then(serde_json::Value::as_object_mut)
             {
                 source.insert("description".to_string(), serde_json::Value::String(
-                    "Local file path or http(s) URL. Remote URLs require approval in Read only mode."
+                    "Maple attachment reference, local file path, or http(s) URL. Remote URLs require approval in Read only mode."
                         .to_string(),
                 ));
             }
@@ -578,6 +586,7 @@ impl McpClientTrait for MapleDeveloperClient {
                     ctx,
                     name,
                     arguments,
+                    self.attachment_store.as_deref(),
                     cancel_token.clone(),
                 )
                 .await?;
@@ -1571,7 +1580,8 @@ fn normalize_read_image_arguments(
     let Some(source) = source else {
         return arguments;
     };
-    if is_remote_file_source(&source)
+    if attachment_id_from_source(&source).is_some()
+        || is_remote_file_source(&source)
         || reqwest::Url::parse(&source).is_ok_and(|url| url.scheme() == "file")
     {
         return arguments;
@@ -1632,6 +1642,7 @@ async fn call_bounded_read_image(
     ctx: &ToolCallContext,
     name: &str,
     arguments: Option<JsonObject>,
+    attachment_store: Option<&AgentAttachmentStore>,
     cancel_token: CancellationToken,
 ) -> Result<CallToolResult, Error> {
     let Some(source) = arguments
@@ -1643,13 +1654,29 @@ async fn call_bounded_read_image(
         return goose.call_tool(ctx, name, arguments, cancel_token).await;
     };
 
-    let bytes =
+    let bytes = if let Some(attachment_id) = attachment_id_from_source(&source) {
+        let Some(store) = attachment_store.cloned() else {
+            return Ok(error_result("Maple image attachment is unavailable"));
+        };
+        let session_id = ctx.session_id.clone();
+        let attachment_id = attachment_id.to_string();
+        match tokio::task::spawn_blocking(move || store.read(&session_id, &attachment_id)).await {
+            Ok(Ok(bytes)) => bytes,
+            Ok(Err(error)) => return Ok(error_result(error)),
+            Err(error) => {
+                return Ok(error_result(format!(
+                    "Agent image attachment task failed: {error}"
+                )))
+            }
+        }
+    } else {
         match load_bounded_image_bytes(&source, ctx.working_dir.as_deref(), cancel_token.clone())
             .await
         {
             Ok(bytes) => bytes,
             Err(error) => return Ok(error_result(error)),
-        };
+        }
+    };
     if cancel_token.is_cancelled() {
         return Ok(error_result("Image read cancelled"));
     }
@@ -2423,6 +2450,7 @@ fn mutation_key(path: &Path) -> PathBuf {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::attachments::AgentImageUpload;
     use crate::agent::tool_context::AgentToolContextSpec;
     use crate::agent::transient_mcp::{TransientMcpConfig, TransientMcpRouter};
     use axum::response::IntoResponse;
@@ -3325,11 +3353,19 @@ mod tests {
     }
 
     #[test]
-    fn read_image_keeps_remote_urls_and_normalizes_local_paths() {
+    fn read_image_keeps_urls_and_maple_attachments_and_normalizes_local_paths() {
         let remote = object!({ "source": "https://example.com/pixel.png" });
         assert_eq!(
             normalize_read_image_arguments(Some(remote.clone()), Some(Path::new("/tmp"))),
             Some(remote)
+        );
+
+        let attachment = object!({
+            "source": "maple-attachment://0123456789abcdef0123456789abcdef"
+        });
+        assert_eq!(
+            normalize_read_image_arguments(Some(attachment.clone()), Some(Path::new("/tmp"))),
+            Some(attachment)
         );
 
         let local = normalize_read_image_arguments(
@@ -3338,6 +3374,48 @@ mod tests {
         )
         .unwrap();
         assert_eq!(local["source"], "/tmp/project/images/pixel.png");
+    }
+
+    #[tokio::test]
+    async fn read_image_resolves_session_scoped_maple_attachments() {
+        const PNG_1X1: &str = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+        let temp = TestDir::new();
+        let store = AgentAttachmentStore::new(temp.path().join("account"));
+        let prepared = store
+            .store_uploads(
+                "session-a",
+                &[AgentImageUpload {
+                    name: "screen.png".to_string(),
+                    data_url: format!("data:image/png;base64,{PNG_1X1}"),
+                }],
+            )
+            .unwrap();
+        let source = prepared[0].attachment.source.clone();
+        let client =
+            test_client(temp.path().join("sessions"), true).with_attachment_store(Arc::new(store));
+
+        let result = client
+            .call_tool(
+                &ToolCallContext::new("session-a".to_string(), None, None),
+                "read_image",
+                Some(object!({ "source": source.clone() })),
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.is_error, Some(false));
+        assert!(result
+            .content
+            .iter()
+            .any(|content| matches!(content, ContentBlock::Image(_))));
+        assert!(result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("source"))
+            .and_then(serde_json::Value::as_str)
+            .is_some_and(|value| value == source));
     }
 
     #[tokio::test]

--- a/frontend/src-tauri/src/agent/shell_permission.rs
+++ b/frontend/src-tauri/src/agent/shell_permission.rs
@@ -97,6 +97,9 @@ impl ShellPermissionRequest {
 
 pub(crate) fn is_remote_file_source(source: &str) -> bool {
     let source = source.trim();
+    if source.starts_with("maple-attachment://") {
+        return false;
+    }
     if source.starts_with(r"\\") || source.starts_with("//") {
         return true;
     }
@@ -435,6 +438,7 @@ mod tests {
         for source in [
             "file:///tmp/pixel.png",
             "file://localhost/tmp/pixel.png",
+            "maple-attachment://0123456789abcdef0123456789abcdef",
             r"C:\pixel.png",
         ] {
             assert!(!is_remote_file_source(source));

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -1556,6 +1556,7 @@ impl AcpConnectionContext {
                     vision_capable: false,
                     steer: false,
                     queue_id: None,
+                    attachments: Vec::new(),
                 },
                 tool_context_access,
                 prompt_lifetime.clone(),

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -436,6 +436,21 @@ pub async fn agent_load_session(
 }
 
 #[tauri::command]
+pub async fn agent_load_image_attachment(
+    app_handle: AppHandle,
+    state: State<'_, MapleAgentService>,
+    user_id: String,
+    session_id: String,
+    attachment_id: String,
+) -> Result<String, String> {
+    let _ = app_handle;
+    handle_for_user(&state, &user_id)
+        .await?
+        .load_image_attachment(session_id, attachment_id)
+        .await
+}
+
+#[tauri::command]
 pub async fn agent_rename_session(
     state: State<'_, MapleAgentService>,
     api_auth_state: State<'_, MapleApiAuthState>,

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -189,6 +189,7 @@ pub fn run() {
             agent_tauri::agent_create_session,
             agent_tauri::agent_list_sessions,
             agent_tauri::agent_load_session,
+            agent_tauri::agent_load_image_attachment,
             agent_tauri::agent_rename_session,
             agent_tauri::agent_list_session_mcp_servers,
             agent_tauri::agent_set_session_mcp_server_enabled,

--- a/frontend/src/components/AgentMode.tsx
+++ b/frontend/src/components/AgentMode.tsx
@@ -28,6 +28,7 @@ import {
   FolderOpen,
   FolderPlus,
   Globe2,
+  Image,
   Loader2,
   Lock,
   MessageSquare,
@@ -114,6 +115,7 @@ import {
   awaitAgentAuthUser,
   type AgentConfig,
   type AgentEventEnvelope,
+  type AgentImageAttachment,
   type AgentMcpServer,
   type AgentPermissionDecision,
   type AgentProjectTrustStatus,
@@ -204,8 +206,13 @@ import {
   useIsLandscapeMobile,
   useIsMobile
 } from "@/utils/utils";
-import { isTauriDesktop } from "@/utils/platform";
+import { isLinux, isTauri, isTauriDesktop } from "@/utils/platform";
 import { useLazyRef } from "@/utils/useLazyRef";
+import { fileToDataURL } from "@/utils/file";
+import {
+  getImageFilesFromClipboardItems,
+  maybeReadLinuxTauriClipboardImages
+} from "@/utils/imagePaste";
 import { revealAgentProjectFolder } from "@/services/agentProjectFolder";
 import {
   aggregateAgentSidebarStatus,
@@ -240,6 +247,15 @@ import type {
 const DEFAULT_MODEL = DEFAULT_AGENT_MODEL;
 const DEFAULT_MODE = "smart_approve";
 const NEW_SESSION_PENDING_KEY = "__maple-agent-new-session__";
+const MAX_AGENT_DRAFT_IMAGES = 10;
+const MAX_AGENT_DRAFT_IMAGE_BYTES = 10 * 1024 * 1024;
+const SUPPORTED_AGENT_IMAGE_TYPES = new Set(["image/jpeg", "image/jpg", "image/png", "image/webp"]);
+
+interface AgentDraftImage {
+  file: File;
+  url: string;
+}
+
 const NEW_PROJECT_OPTION_VALUE = "__maple-agent-new-project__";
 const MAX_STABLE_SESSION_LOAD_ATTEMPTS = 3;
 const THOUGHT_PHASE_SEED_RETRY_MS = 250;
@@ -413,6 +429,7 @@ export function AgentMode({ userId }: { userId: string }) {
   const os = useOpenSecret();
   const { availableModels, setAvailableModels, modelAliases, setModelAliases, setHasWhisperModel } =
     useModelState();
+  const { billingStatus } = useBillingState();
   const { agentSessionSelection } = usePersistentHomeNavigation();
   const { showNotification } = useNotification();
   const isMobile = useIsMobile();
@@ -474,6 +491,12 @@ export function AgentMode({ userId }: { userId: string }) {
   const [isSessionMcpServersLoading, setIsSessionMcpServersLoading] = useState(false);
   const [isMcpServerTogglePending, setIsMcpServerTogglePending] = useState(false);
   const [input, setInput] = useState("");
+  const [draftImages, setDraftImages] = useState<AgentDraftImage[]>([]);
+  const draftImagesRef = useRef(draftImages);
+  draftImagesRef.current = draftImages;
+  const [imageAttachmentError, setImageAttachmentError] = useState<string | null>(null);
+  const [imageUpgradeDialogOpen, setImageUpgradeDialogOpen] = useState(false);
+  const imagePasteGenerationRef = useRef(0);
   const promptHistoryEntries = useMemo(() => agentPromptHistory(timelineItems), [timelineItems]);
   const promptHistoryEntriesRef = useRef<readonly string[]>(promptHistoryEntries);
   const promptHistoryNavigationRef = useRef<AgentPromptHistoryNavigation | null>(null);
@@ -995,11 +1018,104 @@ export function AgentMode({ userId }: { userId: string }) {
     isStopping
   });
   const isSending = Boolean(activeRunId) || isSubmitting;
-  const queuedMessages = activeSessionId ? (queueBySession[activeSessionId]?.items ?? []) : [];
+  const queuedMessages = useMemo(
+    () => (activeSessionId ? (queueBySession[activeSessionId]?.items ?? []) : []),
+    [activeSessionId, queueBySession]
+  );
   const editingQueueId =
     queueEdit && activeSessionId && queueEdit.sessionId === activeSessionId
       ? queueEdit.queueId
       : null;
+  const planName = billingStatus?.product_name?.toLowerCase() || "";
+  const canUseAgentImages =
+    planName.includes("pro") || planName.includes("max") || planName.includes("team");
+
+  const clearDraftImages = useCallback(() => {
+    setDraftImages((current) => {
+      current.forEach((image) => URL.revokeObjectURL(image.url));
+      return [];
+    });
+    setImageAttachmentError(null);
+  }, []);
+
+  const attachAgentImages = useCallback(
+    (files: File[]) => {
+      if (files.length === 0 || isAgentSendLocked || queueEditRef.current) return;
+      if (!canUseAgentImages) {
+        setImageUpgradeDialogOpen(true);
+        return;
+      }
+
+      let validationError: string | null = null;
+      const valid = files.filter((file) => {
+        if (!SUPPORTED_AGENT_IMAGE_TYPES.has(file.type.toLowerCase())) {
+          validationError = "Only JPEG, PNG, and WebP images are supported";
+          return false;
+        }
+        if (file.size > MAX_AGENT_DRAFT_IMAGE_BYTES) {
+          validationError = "Image too large (max 10MB)";
+          return false;
+        }
+        return true;
+      });
+      if (validationError) setImageAttachmentError(validationError);
+      if (valid.length === 0) return;
+
+      setDraftImages((current) => {
+        const available = Math.max(0, MAX_AGENT_DRAFT_IMAGES - current.length);
+        const selected = valid.slice(0, available);
+        if (selected.length < valid.length) {
+          setImageAttachmentError(`Attach at most ${MAX_AGENT_DRAFT_IMAGES} images at a time`);
+        }
+        return [...current, ...selected.map((file) => ({ file, url: URL.createObjectURL(file) }))];
+      });
+    },
+    [canUseAgentImages, isAgentSendLocked]
+  );
+
+  const removeAgentImage = useCallback((index: number) => {
+    setDraftImages((current) => {
+      const image = current[index];
+      if (!image) return current;
+      URL.revokeObjectURL(image.url);
+      return current.filter((_, candidateIndex) => candidateIndex !== index);
+    });
+  }, []);
+
+  const handleAgentImagePaste = useCallback(
+    (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+      const generation = imagePasteGenerationRef.current + 1;
+      imagePasteGenerationRef.current = generation;
+      const items = event.clipboardData?.items;
+      if (!items) return;
+
+      const images = getImageFilesFromClipboardItems(items);
+      if (images.length > 0) {
+        event.preventDefault();
+        attachAgentImages(images);
+        return;
+      }
+
+      const fallback = maybeReadLinuxTauriClipboardImages({
+        eventItemTypes: Array.from(items, (item) => item.type),
+        isTauri: isTauri(),
+        isLinux: isLinux(),
+        readClipboard: () => navigator.clipboard?.read?.()
+      });
+      void fallback?.then((fallbackImages) => {
+        if (imagePasteGenerationRef.current !== generation) return;
+        attachAgentImages(fallbackImages);
+      });
+    },
+    [attachAgentImages]
+  );
+
+  useEffect(
+    () => () => {
+      draftImagesRef.current.forEach((image) => URL.revokeObjectURL(image.url));
+    },
+    []
+  );
 
   useEffect(() => {
     const current = queueEditRef.current;
@@ -2352,6 +2468,7 @@ export function AgentMode({ userId }: { userId: string }) {
   const sendMessage = useCallback(
     async (restoreComposerFocus = false, steerNow = false, steerQueueId?: string) => {
       let text = input.trim();
+      const pendingImages = draftImagesRef.current;
       const requestedSessionId = activeSessionIdRef.current;
       let pendingSessionKey = requestedSessionId || NEW_SESSION_PENDING_KEY;
       const canSteerExistingChip = Boolean(steerQueueId);
@@ -2364,6 +2481,7 @@ export function AgentMode({ userId }: { userId: string }) {
           hasInFlightSend: pendingSendTokensRef.current.has(pendingSessionKey),
           hasQueuedMessages: queuedMessages.length > 0,
           hasActiveRun: Boolean(activeRunId),
+          hasAttachments: pendingImages.length > 0 && !queueEditRef.current,
           steerNow
         })
       ) {
@@ -2434,6 +2552,7 @@ export function AgentMode({ userId }: { userId: string }) {
 
       const keepComposerDraft = Boolean(steerQueueId) && !editingSteeredChip;
       const requestText = keepComposerDraft ? "" : text;
+      const requestImages = steerQueueId ? [] : pendingImages;
       setError(null);
       resetPromptHistoryNavigation();
       if (!keepComposerDraft) {
@@ -2462,6 +2581,12 @@ export function AgentMode({ userId }: { userId: string }) {
           if (cancelledPendingSendTokensRef.current.has(sendToken)) {
             throw new PendingAgentSendCancelledError();
           }
+          const attachments = await Promise.all(
+            requestImages.map(async ({ file }) => ({
+              name: file.name,
+              dataUrl: await fileToDataURL(file)
+            }))
+          );
           const response = await agentRuntimeService.sendMessage(userId, {
             sessionId,
             text: requestText,
@@ -2474,8 +2599,10 @@ export function AgentMode({ userId }: { userId: string }) {
               modelAliases
             ),
             steer: steerNow,
-            queueId: steerQueueId ?? editingSteeredChip?.queueId
+            queueId: steerQueueId ?? editingSteeredChip?.queueId,
+            attachments
           });
+          if (requestImages.length > 0) clearDraftImages();
           if (cancelledPendingSendTokensRef.current.has(sendToken)) {
             // The native command may have crossed the start boundary while the
             // user clicked Cancel. Cancel the concrete run before returning.
@@ -2534,6 +2661,7 @@ export function AgentMode({ userId }: { userId: string }) {
       availableModels,
       cancelledPendingSendTokensRef,
       clearPendingSend,
+      clearDraftImages,
       contextLimitForModel,
       deletedSessionIdsRef,
       ensureRuntimeAndSession,
@@ -2817,12 +2945,14 @@ export function AgentMode({ userId }: { userId: string }) {
         setActiveSessionId(null);
         setTimelineItems([]);
         setInput("");
+        clearDraftImages();
         restoreNewTaskModel();
       }
     },
     [
       agentSessionSelection,
       cancelThoughtLabelDisplays,
+      clearDraftImages,
       clearActiveRun,
       deletedSessionIdsRef,
       forgetSessionQueue,
@@ -3365,6 +3495,12 @@ export function AgentMode({ userId }: { userId: string }) {
         />
       }
     >
+      <UpgradePromptDialog
+        open={imageUpgradeDialogOpen}
+        onOpenChange={setImageUpgradeDialogOpen}
+        feature="image"
+      />
+
       {projectToRename ? (
         <RenameAgentProjectDialog
           key={projectToRename.path}
@@ -3573,6 +3709,9 @@ export function AgentMode({ userId }: { userId: string }) {
                   activeRootLabel={activeRootLabel}
                   areSettingsDisabled={areAgentSettingsLocked}
                   input={input}
+                  draftImages={draftImages}
+                  imageAttachmentError={imageAttachmentError}
+                  canUseImages={canUseAgentImages}
                   isSendDisabled={isAgentSendLocked}
                   isSending={isSending}
                   isStarting={isStarting}
@@ -3590,6 +3729,10 @@ export function AgentMode({ userId }: { userId: string }) {
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={handleAgentInputChange}
                   onInputPointerDown={resetPromptHistoryNavigation}
+                  onImageAccessRequired={() => setImageUpgradeDialogOpen(true)}
+                  onImageFiles={attachAgentImages}
+                  onImagePaste={handleAgentImagePaste}
+                  onRemoveImage={removeAgentImage}
                   onKeyDown={handleKeyDown}
                   onBeforeInput={handleBeforeInput}
                   onManageMcpServers={handleManageMcpServers}
@@ -3613,6 +3756,7 @@ export function AgentMode({ userId }: { userId: string }) {
                   isRunActive={Boolean(activeRunId) && !isSubmitting}
                   generatedThoughtLabels={generatedThoughtLabels}
                   sessionId={activeSessionId}
+                  userId={userId}
                   onPermissionDecision={respondToPermission}
                 />
               )}
@@ -3626,6 +3770,9 @@ export function AgentMode({ userId }: { userId: string }) {
                   activeRootLabel={activeRootLabel}
                   areSettingsDisabled={areAgentSettingsLocked}
                   input={input}
+                  draftImages={draftImages}
+                  imageAttachmentError={imageAttachmentError}
+                  canUseImages={canUseAgentImages}
                   isSendDisabled={isAgentSendLocked}
                   isSending={isSending}
                   isStarting={isStarting}
@@ -3642,6 +3789,10 @@ export function AgentMode({ userId }: { userId: string }) {
                   onChooseProjectRoot={chooseProjectRoot}
                   onInputChange={handleAgentInputChange}
                   onInputPointerDown={resetPromptHistoryNavigation}
+                  onImageAccessRequired={() => setImageUpgradeDialogOpen(true)}
+                  onImageFiles={attachAgentImages}
+                  onImagePaste={handleAgentImagePaste}
+                  onRemoveImage={removeAgentImage}
                   onKeyDown={handleKeyDown}
                   onBeforeInput={handleBeforeInput}
                   onManageMcpServers={handleManageMcpServers}
@@ -4803,6 +4954,9 @@ interface AgentComposerProps {
   activeRootLabel: string;
   areSettingsDisabled: boolean;
   input: string;
+  draftImages: AgentDraftImage[];
+  imageAttachmentError: string | null;
+  canUseImages: boolean;
   isSendDisabled: boolean;
   isSending: boolean;
   isStarting: boolean;
@@ -4820,6 +4974,10 @@ interface AgentComposerProps {
   onChooseProjectRoot: () => void;
   onInputChange: (value: string) => void;
   onInputPointerDown: () => void;
+  onImageAccessRequired: () => void;
+  onImageFiles: (files: File[]) => void;
+  onImagePaste: (event: React.ClipboardEvent<HTMLTextAreaElement>) => void;
+  onRemoveImage: (index: number) => void;
   onBeforeInput: (event: React.FormEvent<HTMLTextAreaElement>) => void;
   onKeyDown: (event: React.KeyboardEvent<HTMLTextAreaElement>) => void;
   onManageMcpServers: () => void;
@@ -4841,6 +4999,9 @@ function AgentComposer({
   activeRootLabel,
   areSettingsDisabled,
   input,
+  draftImages,
+  imageAttachmentError,
+  canUseImages,
   isSendDisabled,
   isSending,
   isStarting,
@@ -4858,6 +5019,10 @@ function AgentComposer({
   onChooseProjectRoot,
   onInputChange,
   onInputPointerDown,
+  onImageAccessRequired,
+  onImageFiles,
+  onImagePaste,
+  onRemoveImage,
   onBeforeInput,
   onKeyDown,
   onManageMcpServers,
@@ -4875,6 +5040,7 @@ function AgentComposer({
   onDiscardQueuedMessageEdit
 }: AgentComposerProps) {
   const rootOptions = recentRoots;
+  const imageInputRef = useRef<HTMLInputElement>(null);
 
   useLayoutEffect(() => {
     const textarea = textareaRef.current;
@@ -4917,7 +5083,7 @@ function AgentComposer({
               )}
             >
               <span className="min-w-0 flex-1 truncate" title={item.text}>
-                {item.text}
+                {item.text || `${item.attachments?.length ?? 0} image attachment(s)`}
               </span>
               {onCancelQueuedMessage ? (
                 <button
@@ -4955,6 +5121,33 @@ function AgentComposer({
           ))}
         </div>
       ) : null}
+      {!editingQueueId && draftImages.length > 0 ? (
+        <div className="flex flex-wrap gap-2 px-3 pt-3">
+          {draftImages.map((image, index) => (
+            <div key={image.url} className="group relative">
+              <img
+                src={image.url}
+                alt={image.file.name || `Attachment ${index + 1}`}
+                className="h-16 w-16 rounded-xl border object-cover"
+              />
+              <button
+                type="button"
+                onClick={() => onRemoveImage(index)}
+                disabled={isSendDisabled}
+                aria-label={`Remove attachment ${index + 1}`}
+                className="absolute -right-1 -top-1 rounded-full border bg-background p-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 disabled:pointer-events-none disabled:opacity-40"
+              >
+                <X className="h-3 w-3" />
+              </button>
+            </div>
+          ))}
+        </div>
+      ) : null}
+      {imageAttachmentError ? (
+        <p className="px-3 pt-2 text-sm text-maple-error" role="alert">
+          {imageAttachmentError}
+        </p>
+      ) : null}
       <Textarea
         ref={textareaRef}
         id="agent-message"
@@ -4963,6 +5156,7 @@ function AgentComposer({
         onPointerDown={onInputPointerDown}
         onBeforeInput={onBeforeInput}
         onKeyDown={onKeyDown}
+        onPaste={onImagePaste}
         disabled={isSendDisabled}
         placeholder={
           editingQueueId
@@ -5001,6 +5195,25 @@ function AgentComposer({
             onToggle={onMcpToggle}
             onManage={onManageMcpServers}
           />
+
+          <Button
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-8 w-8"
+            disabled={isSendDisabled || Boolean(editingQueueId)}
+            onClick={() => {
+              if (!canUseImages) {
+                onImageAccessRequired();
+                return;
+              }
+              imageInputRef.current?.click();
+            }}
+            aria-label="Add images"
+            title="Add images"
+          >
+            <Image className="h-4 w-4" />
+          </Button>
 
           <Select
             disabled={areSettingsDisabled}
@@ -5066,7 +5279,8 @@ function AgentComposer({
                 isSendDisabled,
                 projectRoot,
                 hasQueuedMessages: queuedMessages.length > 0,
-                hasActiveRun: isSending
+                hasActiveRun: isSending,
+                hasAttachments: draftImages.length > 0 && !editingQueueId
               })
             }
             aria-label="Send agent message"
@@ -5079,6 +5293,18 @@ function AgentComposer({
           </button>
         </div>
       </div>
+      <input
+        ref={imageInputRef}
+        type="file"
+        accept="image/jpeg,image/jpg,image/png,image/webp"
+        multiple
+        className="hidden"
+        onChange={(event) => {
+          const files = Array.from(event.currentTarget.files ?? []);
+          event.currentTarget.value = "";
+          onImageFiles(files);
+        }}
+      />
     </ChatComposerSurface>
   );
 }
@@ -5461,6 +5687,7 @@ function AgentTimeline({
   isRunActive,
   generatedThoughtLabels,
   sessionId,
+  userId,
   onPermissionDecision
 }: {
   items: AgentTimelineItem[];
@@ -5468,6 +5695,7 @@ function AgentTimeline({
   isRunActive: boolean;
   generatedThoughtLabels: Record<string, Record<string, string>>;
   sessionId: string | null;
+  userId: string;
   onPermissionDecision: (item: AgentTimelineItem, decision: AgentPermissionDecision) => void;
 }) {
   const visibleItems = coalesceAdjacentThinkingItems(items).filter(isRenderableAgentTimelineItem);
@@ -5483,6 +5711,7 @@ function AgentTimeline({
         const copyText = getAgentTurnCopyText(turn);
 
         if (turn.type === "user") {
+          const imageAttachments = agentTimelineImageAttachments(turn.item);
           const previousTurn = turnIndex > 0 ? turns[turnIndex - 1] : undefined;
           const nextTurn = turns[turnIndex + 1];
           const previousShowsPending =
@@ -5497,7 +5726,21 @@ function AgentTimeline({
                 stackedBottom={stackedBottom}
                 actions={copyText ? <ChatCopyButton text={copyText} /> : undefined}
               >
-                <Markdown content={turn.item.text || ""} />
+                <div className="space-y-2">
+                  {imageAttachments.length > 0 && sessionId ? (
+                    <div className="flex flex-wrap gap-2">
+                      {imageAttachments.map((attachment) => (
+                        <AgentImageAttachmentPreview
+                          key={attachment.id}
+                          attachment={attachment}
+                          sessionId={sessionId}
+                          userId={userId}
+                        />
+                      ))}
+                    </div>
+                  ) : null}
+                  {turn.item.text?.trim() ? <Markdown content={turn.item.text} /> : null}
+                </div>
               </ChatUserTurn>
               {pendingAfterUserTurnId === turn.id ? <ChatAssistantPendingTurn /> : null}
             </div>
@@ -5537,6 +5780,74 @@ function AgentTimeline({
           </ChatAssistantTurn>
         );
       })}
+    </div>
+  );
+}
+
+function agentTimelineImageAttachments(item: AgentTimelineItem): AgentImageAttachment[] {
+  if (!item.input || typeof item.input !== "object" || Array.isArray(item.input)) return [];
+  const attachments = (item.input as { imageAttachments?: unknown }).imageAttachments;
+  if (!Array.isArray(attachments)) return [];
+  return attachments.filter((attachment): attachment is AgentImageAttachment => {
+    if (!attachment || typeof attachment !== "object" || Array.isArray(attachment)) return false;
+    const candidate = attachment as Partial<AgentImageAttachment>;
+    return (
+      typeof candidate.id === "string" &&
+      typeof candidate.name === "string" &&
+      typeof candidate.mimeType === "string" &&
+      typeof candidate.source === "string"
+    );
+  });
+}
+
+function AgentImageAttachmentPreview({
+  attachment,
+  sessionId,
+  userId
+}: {
+  attachment: AgentImageAttachment;
+  sessionId: string;
+  userId: string;
+}) {
+  const [dataUrl, setDataUrl] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    setDataUrl(null);
+    setFailed(false);
+    void agentRuntimeService
+      .loadImageAttachment(userId, sessionId, attachment.id)
+      .then((value) => {
+        if (!cancelled) setDataUrl(value);
+      })
+      .catch(() => {
+        if (!cancelled) setFailed(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [attachment.id, sessionId, userId]);
+
+  if (dataUrl) {
+    return (
+      <img
+        src={dataUrl}
+        alt={attachment.name}
+        title={attachment.name}
+        className="max-h-64 max-w-full rounded-xl border object-contain"
+      />
+    );
+  }
+
+  return (
+    <div className="flex h-16 min-w-32 items-center gap-2 rounded-xl border bg-muted/40 px-3 text-xs text-muted-foreground">
+      {failed ? (
+        <AlertCircle className="h-4 w-4 shrink-0" />
+      ) : (
+        <Loader2 className="h-4 w-4 shrink-0 animate-spin" />
+      )}
+      <span className="max-w-44 truncate">{attachment.name}</span>
     </div>
   );
 }

--- a/frontend/src/services/agentComposerQueue.ts
+++ b/frontend/src/services/agentComposerQueue.ts
@@ -3,6 +3,7 @@ export interface AgentQueuedMessage {
   messageId: string;
   sessionId: string;
   text: string;
+  attachments?: Array<{ id: string; name: string; mimeType: string; source: string }>;
   createdMs: number;
 }
 

--- a/frontend/src/services/agentComposerSend.test.ts
+++ b/frontend/src/services/agentComposerSend.test.ts
@@ -49,6 +49,23 @@ describe("agent composer send policy", () => {
         hasInFlightSend: false
       })
     ).toBe(true);
+    expect(
+      canSubmitAgentComposerMessage({
+        text: "",
+        hasAttachments: true,
+        isSendLocked: false,
+        isSessionSelectionPending: false,
+        hasInFlightSend: false
+      })
+    ).toBe(true);
+    expect(
+      agentComposerCanSend({
+        text: "",
+        hasAttachments: true,
+        isSendDisabled: false,
+        projectRoot: "/tmp/project"
+      })
+    ).toBe(true);
   });
 
   test("still blocks empty, locked, in-flight, and selection-pending submits", () => {

--- a/frontend/src/services/agentComposerSend.ts
+++ b/frontend/src/services/agentComposerSend.ts
@@ -17,6 +17,7 @@ export function canSubmitAgentComposerMessage({
   hasInFlightSend,
   hasQueuedMessages = false,
   hasActiveRun = false,
+  hasAttachments = false,
   steerNow = false
 }: {
   text: string;
@@ -25,9 +26,10 @@ export function canSubmitAgentComposerMessage({
   hasInFlightSend: boolean;
   hasQueuedMessages?: boolean;
   hasActiveRun?: boolean;
+  hasAttachments?: boolean;
   steerNow?: boolean;
 }): boolean {
-  const hasSendableText = Boolean(text.trim());
+  const hasSendableText = Boolean(text.trim()) || hasAttachments;
   const canFlushQueuedOnly = hasQueuedMessages && !hasActiveRun;
   const canSteerQueuedStack = steerNow && hasQueuedMessages && !hasSendableText;
   return (
@@ -85,15 +87,17 @@ export function agentComposerCanSend({
   isSendDisabled,
   projectRoot,
   hasQueuedMessages = false,
-  hasActiveRun = false
+  hasActiveRun = false,
+  hasAttachments = false
 }: {
   text: string;
   isSendDisabled: boolean;
   projectRoot: string;
   hasQueuedMessages?: boolean;
   hasActiveRun?: boolean;
+  hasAttachments?: boolean;
 }): boolean {
-  const hasSendableText = Boolean(text.trim());
+  const hasSendableText = Boolean(text.trim()) || hasAttachments;
   const canFlushQueuedOnly = hasQueuedMessages && !hasActiveRun;
   return (hasSendableText || canFlushQueuedOnly) && !isSendDisabled && Boolean(projectRoot);
 }

--- a/frontend/src/services/agentRuntimeService.test.ts
+++ b/frontend/src/services/agentRuntimeService.test.ts
@@ -89,6 +89,22 @@ describe("AgentRuntimeService", () => {
     expect(bridge.lastArgs).toEqual({ userId: "user-a", request });
   });
 
+  test("image history loads through the account-fenced local attachment command", async () => {
+    const bridge = new RecordingBridge();
+    bridge.response = "data:image/png;base64,aW1hZ2U=";
+    const service = new AgentRuntimeService(bridge);
+
+    const result = await service.loadImageAttachment("user-a", "session-1", "attachment-1");
+
+    expect(result).toBe("data:image/png;base64,aW1hZ2U=");
+    expect(bridge.events).toEqual(["fence:user-a", "invoke:agent_load_image_attachment"]);
+    expect(bridge.lastArgs).toEqual({
+      userId: "user-a",
+      sessionId: "session-1",
+      attachmentId: "attachment-1"
+    });
+  });
+
   test("session creation forwards the selected model context limit", async () => {
     const bridge = new RecordingBridge();
     const service = new AgentRuntimeService(bridge);

--- a/frontend/src/services/agentRuntimeService.ts
+++ b/frontend/src/services/agentRuntimeService.ts
@@ -138,7 +138,20 @@ export interface AgentQueuedMessage {
   messageId: string;
   sessionId: string;
   text: string;
+  attachments?: AgentImageAttachment[];
   createdMs: number;
+}
+
+export interface AgentImageUpload {
+  name: string;
+  dataUrl: string;
+}
+
+export interface AgentImageAttachment {
+  id: string;
+  name: string;
+  mimeType: string;
+  source: string;
 }
 
 export interface AgentDesktopQueueSnapshot {
@@ -173,6 +186,7 @@ export interface AgentSendMessageRequest {
   visionCapable: boolean;
   steer?: boolean;
   queueId?: string | null;
+  attachments?: AgentImageUpload[];
 }
 
 export interface AgentRunResponse {
@@ -410,6 +424,18 @@ export class AgentRuntimeService {
 
   async deleteSession(userId: string, sessionId: string): Promise<void> {
     await this.invokeForUser(userId, "agent_delete_session", { userId, sessionId });
+  }
+
+  async loadImageAttachment(
+    userId: string,
+    sessionId: string,
+    attachmentId: string
+  ): Promise<string> {
+    return await this.invokeLocalForUser<string>(userId, "agent_load_image_attachment", {
+      userId,
+      sessionId,
+      attachmentId
+    });
   }
 
   async sendMessage(userId: string, request: AgentSendMessageRequest): Promise<AgentRunResponse> {

--- a/frontend/src/services/agentTimeline.test.ts
+++ b/frontend/src/services/agentTimeline.test.ts
@@ -10,6 +10,7 @@ import {
   groupAgentTimelineItems,
   hasAgentUserMessage,
   hasRenderableThinkingText,
+  isRenderableAgentTimelineItem,
   agentPendingAssistantLoader,
   shouldShowAgentAssistantLoader
 } from "./agentTimeline";
@@ -56,6 +57,26 @@ describe("hasAgentUserMessage", () => {
       ])
     ).toBe(false);
     expect(hasAgentUserMessage([item("user", "message", "user")])).toBe(true);
+  });
+});
+
+describe("isRenderableAgentTimelineItem", () => {
+  test("keeps image-only user messages in the timeline", () => {
+    expect(
+      isRenderableAgentTimelineItem({
+        ...item("image", "message", "user", ""),
+        input: {
+          imageAttachments: [
+            {
+              id: "attachment",
+              name: "screen.png",
+              mimeType: "image/png",
+              source: "maple-attachment://attachment"
+            }
+          ]
+        }
+      })
+    ).toBe(true);
   });
 });
 

--- a/frontend/src/services/agentTimeline.ts
+++ b/frontend/src/services/agentTimeline.ts
@@ -290,7 +290,15 @@ export function hasRenderableThinkingText(text: string | null | undefined): bool
 }
 
 export function isRenderableAgentTimelineItem(item: AgentTimelineItem): boolean {
-  if (item.itemType === "message") return Boolean(item.text?.trim());
+  if (item.itemType === "message") {
+    const imageAttachments =
+      item.input && typeof item.input === "object" && !Array.isArray(item.input)
+        ? (item.input as { imageAttachments?: unknown }).imageAttachments
+        : undefined;
+    return (
+      Boolean(item.text?.trim()) || (Array.isArray(imageAttachments) && imageAttachments.length > 0)
+    );
+  }
   if (item.itemType === "thinking") return hasRenderableThinkingText(item.text);
   if (item.itemType === "system" || item.itemType === "error") {
     return Boolean(item.title?.trim() || item.text?.trim());


### PR DESCRIPTION
## Summary

- add the standard multi-image composer experience to Agent Mode, including image-only sends, queueing, and persisted history previews
- send images directly to vision-capable models; give non-vision models opaque `maple-attachment://` references that they can pass through a genuine `read_image` tool call
- store validated image bytes in an account- and session-scoped Maple cache, with bounded input sizes and cleanup on task deletion or history clearing

Closes #812.

## Validation

- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/frontend.sh` — 713 tests passed; typecheck/format/lint passed (13 existing lint warnings, 0 errors)
- `nix develop --no-update-lock-file .#ci -c just rust-lint` — passed
- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/rust.sh` — 379 tests passed, 2 ignored
- `nix develop --no-update-lock-file .#ci -c just desktop-build-debug-overlay` — packaged macOS overlay built successfully
- local managed OpenSecret + billing + Maple Pro smoke:
  - GLM 5.2 called `read_image` itself on the opaque Maple attachment and returned an accurate description
  - Kimi K2.6 received the image directly and did not call `read_image`
  - image previews survived app relaunch; deleting the task removed its session cache

Packaged runtime smoke was performed on macOS. Windows and Linux packaged runtimes were not exercised locally.