### PR TITLE
Security: enforce daily RustSec advisory checks

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -1,9 +1,11 @@
-name: Rust supply-chain denylist
+name: Rust supply-chain checks
 
 on:
   pull_request:
   push:
     branches: [master]
+  schedule:
+    - cron: "41 6 * * *"
   workflow_dispatch:
 
 permissions:
@@ -11,7 +13,7 @@ permissions:
 
 jobs:
   cargo-deny:
-    name: Known malicious crates
+    name: RustSec advisories and malicious crates
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -20,9 +22,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Check incident denylist
+      - name: Check RustSec advisories and incident denylist
         uses: EmbarkStudios/cargo-deny-action@3c6349835b2b7b196a839186cb8b78e02f7b5f25 # v2.1.1
         with:
           manifest-path: frontend/src-tauri/Cargo.toml
-          command: check bans
+          command: check advisories bans
           arguments: --all-features --locked

--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,11 @@
+[advisories]
+# Vulnerability and unsoundness advisories are blocking. Unmaintained-package
+# notices are tracked separately because they often require API migrations.
+unmaintained = "none"
+
 [bans]
 # Emergency supply-chain containment for the August 2026 crates.io campaign.
-# Keep this check focused on known malicious packages; broader policy and
-# locked dependency enforcement are intentionally separate follow-up work.
+# Keep these explicit package bans alongside the blocking RustSec checks.
 multiple-versions = "allow"
 wildcards = "allow"
 deny = [

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -3528,9 +3528,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.12"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
+checksum = "839c0e8a181239723652be9062bb56ca5bf5f64011f73b623f6f4fc59086a228"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -4960,7 +4960,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7836,7 +7836,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -9466,7 +9466,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- upgrades patch-compatible RustSec-affected dependencies
- makes vulnerability and unsoundness advisories blocking in cargo-deny
- keeps the August 2026 malicious-crate denylist active
- adds a staggered daily supply-chain scan

## Validation

- `cargo deny --all-features --locked check advisories bans`
- repository-native compile/check coverage