### PR TITLE
Bump Agent Mode Goose pin to 1.47.0

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -72,17 +72,19 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16302d16c7531355db16593d99c38c8297db0c4653aa7dd80c3556bb17f4cd8c"
+checksum = "6d87bc7769eba641753ba5dc52f73ec3765d51022c6753bf040967125ddc86a8"
 dependencies = [
  "agent-client-protocol-derive",
  "agent-client-protocol-schema",
+ "async-io",
  "async-process",
  "blocking",
  "futures",
  "futures-concurrency",
  "rustc-hash",
+ "rustix",
  "schemars 1.0.5",
  "serde",
  "serde_json",
@@ -94,19 +96,19 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-derive"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd5ca63f112bd2459bcaf9eda0683b9ba95fc3b5e5fdd9036ca941c6a09345b1"
+checksum = "3abd4080f51e4f24f5042beb7fb7a66ede29a2dc1c2582c329532e1c27264ddc"
 dependencies = [
  "quote",
- "syn 2.0.108",
+ "syn 3.0.3",
 ]
 
 [[package]]
 name = "agent-client-protocol-http"
-version = "1.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31ff55efe7a6bb92a5d0226f6055c2f277b7591060d5095c7764f445289ebda3"
+checksum = "4b4d8db045bc66b84526dfe4ef2ffb87d651b81c4ff945f91c63a2bc677a582c"
 dependencies = [
  "agent-client-protocol",
  "async-stream",
@@ -121,9 +123,9 @@ dependencies = [
 
 [[package]]
 name = "agent-client-protocol-schema"
-version = "1.1.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac542aba230234b1591ace7286a47c0514fe3efc3037d43296bde31ba7ee5728"
+checksum = "d5c231915b4ab578c722eca2d1bd7df4d300bfd6cac3b8e9f0d1e3ddc95b187c"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -321,7 +323,7 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -707,7 +709,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
+ "sha1 0.10.6",
  "sync_wrapper",
  "tokio",
  "tokio-tungstenite",
@@ -1382,6 +1384,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "color_quant"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1769,6 +1777,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "curve25519-dalek"
 version = "4.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2086,6 +2103,7 @@ dependencies = [
  "block-buffer 0.12.1",
  "const-oid 0.10.2",
  "crypto-common 0.2.2",
+ "ctutils",
 ]
 
 [[package]]
@@ -2106,7 +2124,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2181,7 +2199,7 @@ checksum = "521e380c0c8afb8d9a1e83a1822ee03556fc3e3e7dbc1fd30be14e37f9cb3f89"
 dependencies = [
  "bit-set",
  "cssparser",
- "foldhash 0.2.0",
+ "foldhash",
  "html5ever",
  "precomputed-hash",
  "selectors",
@@ -2280,7 +2298,7 @@ dependencies = [
  "ff",
  "generic-array",
  "group",
- "hkdf",
+ "hkdf 0.12.4",
  "pem-rfc7468",
  "pkcs8",
  "rand_core 0.6.4",
@@ -2431,7 +2449,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2439,17 +2457,6 @@ name = "error-code"
 version = "3.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
-
-[[package]]
-name = "etcetera"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
-dependencies = [
- "cfg-if",
- "home",
- "windows-sys 0.48.0",
-]
 
 [[package]]
 name = "etcetera"
@@ -2662,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -2676,12 +2683,6 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
-name = "foldhash"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -3264,8 +3265,8 @@ dependencies = [
 
 [[package]]
 name = "goose"
-version = "1.46.0"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "1.47.0"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-http",
@@ -3280,12 +3281,13 @@ dependencies = [
  "chrono",
  "clap",
  "dirs",
- "etcetera 0.11.0",
+ "etcetera",
  "fs-err",
  "fs2",
  "futures",
  "gethostname",
  "goose-acp-macros",
+ "goose-agent",
  "goose-context-management",
  "goose-download-manager",
  "goose-providers",
@@ -3359,17 +3361,32 @@ dependencies = [
 
 [[package]]
 name = "goose-acp-macros"
-version = "1.46.0"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "1.47.0"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "quote",
  "syn 2.0.108",
 ]
 
 [[package]]
+name = "goose-agent"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "goose-provider-types",
+ "rmcp",
+ "serde_json",
+ "tokio",
+ "tokio-util",
+ "uuid",
+]
+
+[[package]]
 name = "goose-context-management"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3384,8 +3401,8 @@ dependencies = [
 
 [[package]]
 name = "goose-download-manager"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "anyhow",
  "once_cell",
@@ -3397,8 +3414,8 @@ dependencies = [
 
 [[package]]
 name = "goose-provider-types"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3423,8 +3440,8 @@ dependencies = [
 
 [[package]]
 name = "goose-providers"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -3447,8 +3464,8 @@ dependencies = [
 
 [[package]]
 name = "goose-sdk-types"
-version = "0.1.0-alpha.5"
-source = "git+https://github.com/aaif-goose/goose.git?rev=98c11ce2ee7b9b302978aa64b1eab7d0895607c7#98c11ce2ee7b9b302978aa64b1eab7d0895607c7"
+version = "0.1.0-alpha.6"
+source = "git+https://github.com/aaif-goose/goose.git?rev=f9c7aaccde4834810dfd13d5efa8f0d39ba28a20#f9c7aaccde4834810dfd13d5efa8f0d39ba28a20"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3573,20 +3590,14 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash 0.1.5",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashbrown"
@@ -3596,16 +3607,16 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.2.0",
+ "foldhash",
 ]
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "824e001ac4f3012dd16a264bec811403a67ca9deb6c102fc5049b32c4574b35f"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
 ]
 
 [[package]]
@@ -3659,7 +3670,16 @@ version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
+]
+
+[[package]]
+name = "hkdf"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
+dependencies = [
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -3672,12 +3692,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.12"
+name = "hmac"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
- "windows-sys 0.61.2",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3823,7 +3843,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -4512,9 +4532,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin",
-]
 
 [[package]]
 name = "lebe"
@@ -4819,16 +4836,6 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "md-5"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
@@ -5107,7 +5114,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5132,22 +5139,6 @@ checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
-]
-
-[[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
 ]
 
 [[package]]
@@ -5260,7 +5251,7 @@ version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
 dependencies = [
- "base64 0.21.7",
+ "base64 0.22.1",
  "chrono",
  "getrandom 0.2.16",
  "http",
@@ -5610,7 +5601,7 @@ dependencies = [
  "eventsource-stream",
  "futures",
  "hex",
- "hkdf",
+ "hkdf 0.12.4",
  "http",
  "p256",
  "percent-encoding",
@@ -5885,7 +5876,7 @@ dependencies = [
  "jpeg-decoder",
  "libc",
  "log",
- "md-5 0.11.0",
+ "md-5",
  "memchr",
  "ndarray",
  "nom 8.0.0",
@@ -6094,17 +6085,6 @@ dependencies = [
  "atomic-waker",
  "fastrand",
  "futures-io",
-]
-
-[[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der",
- "pkcs8",
- "spki",
 ]
 
 [[package]]
@@ -6528,7 +6508,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6944,7 +6924,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -7075,26 +7055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c20b6793b5c2fa6553b250154b78d6d0db37e72700ae35fad9387a46f487c97"
 
 [[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "rust-ini"
 version = "0.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7177,7 +7137,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7236,7 +7196,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7664,6 +7624,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7908,9 +7879,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7921,12 +7892,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64 0.22.1",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -7936,12 +7908,11 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.0",
  "hashlink",
  "indexmap 2.12.0",
  "log",
  "memchr",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -7956,9 +7927,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7969,15 +7940,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -7988,58 +7959,43 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn 2.0.108",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64 0.22.1",
  "bitflags 2.10.0",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5 0.10.6",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -8048,23 +8004,21 @@ dependencies = [
  "chrono",
  "crc",
  "dotenvy",
- "etcetera 0.8.0",
+ "etcetera",
  "futures-channel",
  "futures-core",
  "futures-util",
  "hex",
- "hkdf",
- "hmac",
- "home",
+ "hkdf 0.13.0",
+ "hmac 0.13.0",
  "itoa",
  "log",
- "md-5 0.10.6",
+ "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.2",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -8075,13 +8029,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -8091,7 +8046,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -8873,7 +8827,7 @@ dependencies = [
  "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9606,7 +9560,7 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -9999,12 +9953,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10254,13 +10202,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "626c4bac6755d76ffc12cb01b2eac751db1996b9e0041de9aa02c8c211ddc82c"
 
 [[package]]
 name = "wide"
@@ -10294,7 +10238,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10521,15 +10465,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -10577,21 +10512,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -10662,12 +10582,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -10686,12 +10600,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -10707,12 +10615,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -10746,12 +10648,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -10767,12 +10663,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -10794,12 +10684,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -10815,12 +10699,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -64,15 +64,15 @@ ort = { version = "=2.0.0-rc.11", default-features = false, features = ["std", "
 # Pin Goose to an exact official upstream commit. Keep this as a git dependency
 # instead of a submodule so ordinary Maple checkouts do not need the full Goose
 # history.
-goose = { git = "https://github.com/aaif-goose/goose.git", rev = "98c11ce2ee7b9b302978aa64b1eab7d0895607c7", package = "goose", default-features = false }
-goose-providers = { git = "https://github.com/aaif-goose/goose.git", rev = "98c11ce2ee7b9b302978aa64b1eab7d0895607c7", package = "goose-providers", default-features = false }
+goose = { git = "https://github.com/aaif-goose/goose.git", rev = "f9c7aaccde4834810dfd13d5efa8f0d39ba28a20", package = "goose", default-features = false }
+goose-providers = { git = "https://github.com/aaif-goose/goose.git", rev = "f9c7aaccde4834810dfd13d5efa8f0d39ba28a20", package = "goose-providers", default-features = false }
 opensecret = "3.6.2"
 rand = "0.8.6"
 async-trait = "0.1"
 rmcp = { version = "=3.1.2", default-features = false, features = ["client", "transport-streamable-http-client-reqwest"] }
 tauri-plugin-dialog = "2.7.1"
 tokio-util = { version = "0.7", features = ["codec", "compat", "io"] }
-agent-client-protocol = { version = "=1.0.1", default-features = false, features = ["unstable_elicitation", "unstable_end_turn_token_usage"] }
+agent-client-protocol = { version = "=2.0.0", default-features = false, features = ["unstable_elicitation", "unstable_end_turn_token_usage"] }
 chrono = { version = "0.4", default-features = false, features = ["std"] }
 httpdate = "1"
 process-wrap = { version = "=9.1.0", default-features = false, features = ["tokio1", "creation-flags", "job-object", "process-group"] }

--- a/frontend/src-tauri/src/agent.rs
+++ b/frontend/src-tauri/src/agent.rs
@@ -7671,6 +7671,7 @@ fn message_error_item(
     created_ms: u128,
 ) -> AgentTimelineItem {
     let title = match error.kind {
+        MessageErrorKind::Authentication => "Authentication failed",
         MessageErrorKind::ContextLengthExceeded => "Context limit exceeded",
         MessageErrorKind::CreditsExhausted => "Credits exhausted",
         MessageErrorKind::Other => "Agent error",
@@ -8288,6 +8289,9 @@ fn mcp_server_to_extension(server: &AgentMcpServer) -> Result<ExtensionConfig, S
                     .collect(),
                 timeout: Some(server.timeout_seconds),
                 socket: None,
+                client_id: None,
+                client_secret_key: None,
+                scopes: Vec::new(),
                 bundled: Some(false),
                 available_tools: Vec::new(),
             })

--- a/frontend/src-tauri/src/agent/provider.rs
+++ b/frontend/src-tauri/src/agent/provider.rs
@@ -7,7 +7,6 @@ use goose_providers::errors::ProviderError;
 use goose_providers::formats::openai::{
     create_request_with_options, response_to_streaming_message, OpenAiFormatOptions,
 };
-use goose_providers::http_status::is_context_length_exceeded_message;
 use goose_providers::images::ImageFormat;
 use goose_providers::model::ModelConfig;
 use goose_providers::request_log::{start_log, LoggerHandleExt};
@@ -749,6 +748,112 @@ fn error_message(payload: Option<&Value>) -> Option<&str> {
             .or_else(|| payload.get("message"))
             .and_then(Value::as_str)
     })
+}
+
+/// Local copy of goose 1.47's private classifier. Maple still needs this for
+/// 400 bodies after goose stopped exporting `is_context_length_exceeded_message`.
+fn is_context_length_exceeded_message(text: &str) -> bool {
+    let text_lower = text.to_lowercase();
+
+    let direct_context_phrases = [
+        "context length",
+        "context_length_exceeded",
+        "context window",
+        "context_window_exceeded",
+        "context limit",
+        "maximum context",
+        "max context",
+        "maximum prompt length",
+        "max prompt length",
+    ];
+    if direct_context_phrases
+        .iter()
+        .any(|phrase| text_lower.contains(phrase))
+    {
+        return true;
+    }
+
+    if text_lower.contains("reduce the length")
+        && ["message", "messages", "input", "prompt"]
+            .iter()
+            .any(|word| text_lower.contains(word))
+    {
+        return true;
+    }
+
+    if [
+        "input is too long",
+        "input too long",
+        "prompt is too long",
+        "prompt too long",
+    ]
+    .iter()
+    .any(|phrase| text_lower.contains(phrase))
+    {
+        return true;
+    }
+
+    let mentions_prompt_input_tokens = [
+        "input token",
+        "input length",
+        "prompt token",
+        "prompt length",
+        "message token",
+        "messages token",
+        "request token",
+        "total token",
+    ]
+    .iter()
+    .any(|phrase| text_lower.contains(phrase));
+    let mentions_limit = [
+        "model limit",
+        "model's limit",
+        "maximum allowed",
+        "max allowed",
+        "maximum number of tokens",
+        "token limit",
+        "tokens limit",
+    ]
+    .iter()
+    .any(|phrase| text_lower.contains(phrase));
+    let mentions_overflow = ["exceed", "too long", "too large", "over the limit"]
+        .iter()
+        .any(|phrase| text_lower.contains(phrase));
+
+    let words = text_lower.split(|character: char| !character.is_ascii_alphanumeric());
+    let mentions_request = words.clone().any(|word| word == "request");
+    let mentions_bytes = words.clone().any(|word| matches!(word, "byte" | "bytes"));
+    let mentions_content_length = ["content length", "content-length"]
+        .iter()
+        .any(|phrase| text_lower.contains(phrase));
+    let mentions_request_data_size = [
+        "request size",
+        "requestsize",
+        "request body size",
+        "request payload size",
+        "payload size",
+        "body size",
+    ]
+    .iter()
+    .any(|phrase| text_lower.contains(phrase));
+    let request_data_too_large = [
+        "request body is too large",
+        "request body too large",
+        "request payload is too large",
+        "request payload too large",
+        "payload is too large",
+        "payload too large",
+    ]
+    .iter()
+    .any(|phrase| text_lower.contains(phrase));
+    let mentions_byte_limit = mentions_request_data_size
+        || request_data_too_large
+        || (mentions_content_length && (mentions_request || mentions_bytes));
+    if mentions_byte_limit && mentions_overflow {
+        return true;
+    }
+
+    mentions_prompt_input_tokens && mentions_limit && mentions_overflow
 }
 
 fn map_opensecret_error(error: opensecret::Error) -> ProviderError {

--- a/frontend/src-tauri/src/agent_acp.rs
+++ b/frontend/src-tauri/src/agent_acp.rs
@@ -2295,7 +2295,7 @@ impl HandleDispatchFrom<Client> for MapleAcpHandler {
                                 )?;
                             }
                             Dispatch::Response(result, router) => {
-                                router.respond_with_result(result)?;
+                                router.route_with_result(result)?;
                             }
                             Dispatch::Notification(_) => {}
                         }


### PR DESCRIPTION
## Summary

- pin official `aaif-goose/goose` crates from `98c11ce2` (v1.46.0) to the `v1.47.0` release commit `f9c7aaccde4834810dfd13d5efa8f0d39ba28a20`
- unify Maple's direct `agent-client-protocol` crate from `=1.0.1` / schema `1.1.0` to `=2.0.0` / schema `1.5.0` so cargo can resolve goose 1.47 (exact 1.x schema pins cannot coexist)
- keep Maple ACP on **protocol v1**; the 2.0.0 crate is an SDK/transport bump, not an ACP v2 wire change
- no system-prompt re-diff: goose 1.47 `system.md` matches the current Maple template

## Compatibility

- ACP unhandled `Dispatch::Response` now uses `route_with_result` (1.0.1's `respond_with_result` was renamed)
- Streamable HTTP MCP configs fill goose 1.47's new OAuth client fields as unset (`client_id` / `client_secret_key` / `scopes`)
- timeline error titles cover the new `MessageErrorKind::Authentication`
- Maple keeps a local copy of goose's 400 context-length classifier after goose made `is_context_length_exceeded_message` private

Maple's 4k-line ACP adapter did **not** need a transport rewrite: ACP 2.0.0 still exposes the `Lines` + `HandleDispatchFrom` path Maple already uses.

## Validation

- `cargo test --locked --all-targets` with desktop ONNX: 376 + 3 passed, 0 failed, 2 ignored (OCR model-backed)
- `cargo fmt --check` and `cargo clippy --locked -- -D warnings` pass
- prompt-drift test is unchanged and still in the suite
- pre-commit ran Prettier, the frontend production build, TypeScript, and the staged Rust tests
- not run: desktop Agent Mode smoke, packaged builds, standalone frontend Bun CI script