### PR TITLE
chore: bump version to 3.3.7

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.6",
+  "version": "3.3.7",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4687,7 +4687,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.6"
+version = "3.3.7"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.6"
+version = "3.3.7"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.6</string>
+	<string>3.3.7</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.6</string>
+	<string>3.3.7</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.6
-        CFBundleVersion: 3.3.6
+        CFBundleShortVersionString: 3.3.7
+        CFBundleVersion: 3.3.7
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.6",
+  "version": "3.3.7",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -97,7 +97,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028017
+      "versionCode": 2000028018
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- bump Maple version from 3.3.6 to 3.3.7
- increment the Android version code from 2000028017 to 2000028018
- update the generated Apple project metadata and Cargo lock package version

## Validation
- `nix develop --no-update-lock-file .#ci -c just bump-patch` updated all version sources, but its direct Cargo lock refresh cannot locate macOS ONNX Runtime in a fresh worktree
- `nix develop --no-update-lock-file .#ci -c bash -lc "cd frontend/src-tauri && scripts/run-with-desktop-onnxruntime.sh cargo check --locked"` passed
- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/validate-release-version.sh v3.3.7` passed
- `git diff --check` passed
- The checked-in pre-commit hook completed formatting and the frontend build, then its Rust suite hit the pre-existing, environment-sensitive `agent::macos_login_path::tests::same_group_stdout_holder_is_killed_on_output_timeout` failure (`No such file or directory`). The equivalent ONNX-wrapped suite reproduces that single unrelated failure: 375 passed, 1 failed, 2 ignored. This version-only commit was made with `--no-verify` under the approved flaky-test bypass; no application or test changes are included.