### PR TITLE
fix(windows): prevent Agent task creation stack overflow

### DIFF
--- a/frontend/src-tauri/build.rs
+++ b/frontend/src-tauri/build.rs
@@ -6,6 +6,13 @@ fn main() {
         println!("cargo:rustc-link-lib=c++");
     }
 
+    let target_arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
+    let target_env = std::env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+    if target_os == "windows" && target_arch == "x86_64" && target_env == "msvc" {
+        const WINDOWS_STACK_RESERVE_BYTES: usize = 8 * 1024 * 1024;
+        println!("cargo:rustc-link-arg-bin=maple=/STACK:{WINDOWS_STACK_RESERVE_BYTES}");
+    }
+
     tauri_build::build();
 
     // The deep-link plugin's build.rs overwrites CFBundleURLTypes in Info.plist

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -394,6 +394,7 @@ pub async fn agent_save_project_root_order(
         .await
 }
 
+#[deny(clippy::large_futures, clippy::large_stack_frames)]
 #[tauri::command(async)]
 pub fn agent_create_session(
     app_handle: AppHandle,
@@ -404,11 +405,13 @@ pub fn agent_create_session(
     let _ = app_handle;
     let service = MapleAgentService::clone(state.inner());
     Box::pin(async move {
-        service
-            .handle_for_user(&user_id)
-            .await?
-            .create_session(request)
-            .await
+        let handle = service.handle_for_user(&user_id).await?;
+        #[allow(
+            clippy::large_futures,
+            reason = "the enclosing command future is heap-boxed before it crosses Tauri"
+        )]
+        let result = handle.create_session(request).await;
+        result
     })
 }
 

--- a/frontend/src-tauri/src/agent_tauri.rs
+++ b/frontend/src-tauri/src/agent_tauri.rs
@@ -10,6 +10,7 @@ use crate::agent::{
 };
 use crate::agent_host::{AgentHostLifecycle, AgentRuntimeLifecycleOutcome};
 use crate::maple_api::MapleApiAuthState;
+use futures_util::future::BoxFuture;
 use serde::Serialize;
 use std::sync::Arc;
 use tauri::{AppHandle, Emitter, State};
@@ -393,18 +394,22 @@ pub async fn agent_save_project_root_order(
         .await
 }
 
-#[tauri::command]
-pub async fn agent_create_session(
+#[tauri::command(async)]
+pub fn agent_create_session(
     app_handle: AppHandle,
     state: State<'_, MapleAgentService>,
     user_id: String,
     request: Option<AgentCreateSessionRequest>,
-) -> Result<AgentSessionDetail, String> {
+) -> BoxFuture<'static, Result<AgentSessionDetail, String>> {
     let _ = app_handle;
-    handle_for_user(&state, &user_id)
-        .await?
-        .create_session(request)
-        .await
+    let service = MapleAgentService::clone(state.inner());
+    Box::pin(async move {
+        service
+            .handle_for_user(&user_id)
+            .await?
+            .create_session(request)
+            .await
+    })
 }
 
 #[tauri::command]
@@ -640,6 +645,22 @@ mod tests {
     use super::*;
     use serde_json::json;
     use std::collections::HashMap;
+
+    #[test]
+    fn create_session_command_keeps_the_tauri_boundary_boxed() {
+        let _: for<'a> fn(
+            AppHandle,
+            State<'a, MapleAgentService>,
+            String,
+            Option<AgentCreateSessionRequest>,
+        ) -> std::pin::Pin<
+            Box<
+                dyn std::future::Future<Output = Result<AgentSessionDetail, String>>
+                    + Send
+                    + 'static,
+            >,
+        > = agent_create_session;
+    }
 
     #[test]
     fn service_events_project_to_the_stable_desktop_wire_contract() {


### PR DESCRIPTION
## Summary

- heap-box the Agent session-creation future before it crosses Tauri's IPC boundary, without adding a detached task or changing cancellation behavior
- reserve an 8 MiB stack for the `x86_64-pc-windows-msvc` Maple executable
- pin the boxed command signature at compile time and apply the large-future/large-stack Clippy guard only at this boundary

Fixes #818.

## Validation

- repository pre-commit hook (Prettier, frontend production build/tests, and Rust tests)
- `nix develop --no-update-lock-file .#ci -c just rust-lint`
- focused boxed-signature Rust test
- isolated `opensecret-workspaces` backend smoke
- `nix develop --no-update-lock-file .#ci -c just desktop-build-debug-overlay`
- exact packaged macOS app smoke: local Pro login, isolated project selection, **New Task** creation through native IPC, active task/composer verification, and clean app exit

Windows runtime behavior was not exercised locally; this draft relies on the existing Windows PR build for the target-specific build signal.
