### PR TITLE
Allow disabling automatic updates

### DIFF
--- a/frontend/src-tauri/capabilities/default.json
+++ b/frontend/src-tauri/capabilities/default.json
@@ -6,7 +6,6 @@
   "platforms": ["macOS", "windows", "linux"],
   "permissions": [
     "core:default",
-    "updater:default",
     "dialog:default",
     "fs:default",
     {

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -18,6 +18,8 @@ mod open_secret_config;
 mod pdf_extractor;
 mod pdf_ocr;
 mod proxy;
+#[cfg(desktop)]
+mod updater_preferences;
 mod word_extractor;
 
 #[cfg(desktop)]
@@ -90,13 +92,11 @@ fn enable_main_window_frame_autosave(app_handle: &tauri::AppHandle) {
 
 #[cfg(desktop)]
 #[tauri::command]
-fn get_pending_update_failure() -> Result<Option<String>, String> {
-    let version = FAILED_UPDATE_VERSION
+fn get_pending_update_failure() -> Result<Option<PendingUpdateFailure>, String> {
+    PENDING_UPDATE_FAILURE
         .lock()
-        .map_err(|e| format!("Failed to lock FAILED_UPDATE_VERSION mutex: {e}"))?
-        .clone();
-
-    Ok((!version.is_empty()).then_some(version))
+        .map_err(|e| format!("Failed to lock PENDING_UPDATE_FAILURE mutex: {e}"))
+        .map(|failure| failure.clone())
 }
 
 #[cfg(desktop)]
@@ -131,7 +131,12 @@ async fn install_pending_update(app_handle: tauri::AppHandle) -> Result<(), Stri
     // Installing a deb/rpm blocks on pkexec until the user answers the
     // password prompt, so keep it off the async runtime.
     let (pending, result) = tauri::async_runtime::spawn_blocking(move || {
-        let result = install_update(&app_handle, &pending.update, &pending.bytes, true);
+        let result = install_update(
+            &app_handle,
+            &pending.update,
+            &pending.bytes,
+            UpdateInstallOrigin::UserApprovedPending,
+        );
         (pending, result)
     })
     .await
@@ -153,6 +158,14 @@ async fn install_pending_update(app_handle: tauri::AppHandle) -> Result<(), Stri
     }
 
     result
+}
+
+#[cfg(desktop)]
+#[tauri::command]
+async fn check_for_updates_manually(
+    app_handle: tauri::AppHandle,
+) -> Result<UpdateCheckResult, String> {
+    check_for_updates(app_handle, UpdateCheckTrigger::Manual).await
 }
 
 #[cfg(desktop)]
@@ -282,6 +295,9 @@ pub fn run() {
             get_pending_update_failure,
             get_pending_update_install,
             install_pending_update,
+            check_for_updates_manually,
+            updater_preferences::load_updater_preferences,
+            updater_preferences::save_updater_preferences,
         ])
         .setup(|app| {
             #[cfg(target_os = "macos")]
@@ -339,19 +355,20 @@ pub fn run() {
             // Create the application menu with update options
             #[cfg(desktop)]
             {
-                // Set up a simple updater handler
-                log::info!("Setting up automatic updater");
+                log::info!("Setting up updater");
 
-                // Setup update check on startup with delay and hourly checks
+                // Check on startup and hourly while automatic updates remain enabled.
                 let app_handle = app.handle().clone();
                 tauri::async_runtime::spawn(async move {
                     // Wait for app to fully initialize (use async sleep to not block the thread)
                     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
-                    log::info!("Performing automatic update check on startup");
 
-                    // This checks for updates, downloads the matching platform bundle,
-                    // and invokes its installer. The update takes effect after restart.
-                    if let Err(e) = check_for_updates(app_handle.clone(), false).await {
+                    if let Err(e) = check_for_updates(
+                        app_handle.clone(),
+                        UpdateCheckTrigger::Automatic,
+                    )
+                    .await
+                    {
                         log::error!("Automatic update check failed: {e}");
                     }
 
@@ -364,10 +381,14 @@ pub fn run() {
                         loop {
                             // Wait one hour before checking again
                             tokio::time::sleep(one_hour).await;
-                            log::info!("Performing scheduled hourly update check");
-
-                            // Check for updates
-                            let _ = check_for_updates(hourly_app_handle.clone(), false).await;
+                            if let Err(e) = check_for_updates(
+                                hourly_app_handle.clone(),
+                                UpdateCheckTrigger::Automatic,
+                            )
+                            .await
+                            {
+                                log::error!("Scheduled update check failed: {e}");
+                            }
                         }
                     });
                 });
@@ -377,12 +398,12 @@ pub fn run() {
                 // On Windows/Linux this menu renders as an in-window bar at the top of
                 // the window. Its edit items (undo/redo/cut/copy/paste/select-all) are
                 // handled natively by the webview regardless of the menu, About lives in
-                // the in-app account menu, and updates are applied by the automatic check
-                // (startup + hourly, above). The bar adds only clutter, so we omit it
-                // entirely on those platforms for a cleaner window.
+                // the in-app account menu, and the cross-platform manual update action
+                // lives in Settings. The bar adds only clutter, so we omit it entirely
+                // on those platforms for a cleaner window.
                 #[cfg(target_os = "macos")]
                 {
-                    use tauri::menu::{MenuBuilder, SubmenuBuilder};
+                    use tauri::menu::{MenuBuilder, MenuItemBuilder, SubmenuBuilder};
 
                     // Define menu item ID for "Check for Updates"
                     let check_updates_id = "check-for-updates";
@@ -390,13 +411,17 @@ pub fn run() {
                     // Get app handle for menu operations
                     let handle = app.handle();
 
+                    let check_updates_item =
+                        MenuItemBuilder::with_id(check_updates_id, "Check for Updates")
+                            .build(handle)?;
+
                     // For macOS, we need to create a proper submenu structure
                     // First create the app submenu (first submenu becomes the application menu)
                     let app_submenu = SubmenuBuilder::new(handle, &app.package_info().name)
                         // Add about menu item (standard macOS menu item)
                         .about(None)
                         // Add our update checker to the app menu
-                        .text(check_updates_id, "Check for Updates")
+                        .item(&check_updates_item)
                         .separator()
                         .hide()
                         .hide_others()
@@ -429,6 +454,7 @@ pub fn run() {
 
                     // Handle menu events
                     let app_handle_for_menu = app.handle().clone();
+                    let check_updates_item_for_menu = check_updates_item.clone();
                     app.on_menu_event(move |_window, event| {
                         // Menu event handler receives events for all menu items
                         log::info!("Menu event received: {:?}", event.id());
@@ -436,17 +462,50 @@ pub fn run() {
                         // Check for our menu ID - works the same on all platforms now
                         if event.id().0 == check_updates_id {
                             log::info!(
-                                "Check for updates menu item clicked - clearing dismissal flags and triggering update check..."
+                                "Check for updates menu item clicked - triggering a user-requested update check..."
                             );
 
                             // Clone the app handle to use in the async task
                             let app_handle_clone = app_handle_for_menu.clone();
+                            let check_updates_item_clone = check_updates_item_for_menu.clone();
+
+                            if let Err(e) =
+                                check_updates_item_for_menu.set_text("Checking for Updates…")
+                            {
+                                log::error!("Failed to update check menu item text: {e}");
+                            }
+                            if let Err(e) = check_updates_item_for_menu.set_enabled(false) {
+                                log::error!("Failed to disable check menu item: {e}");
+                            }
 
                             // Spawn a new async task to check for updates (non-blocking)
                             tauri::async_runtime::spawn(async move {
-                                match check_for_updates(app_handle_clone, true).await {
-                                    Ok(_) => log::info!("Update check completed successfully"),
-                                    Err(e) => log::error!("Update check failed: {e}"),
+                                match check_for_updates(
+                                    app_handle_clone.clone(),
+                                    UpdateCheckTrigger::Manual,
+                                )
+                                .await
+                                {
+                                    Ok(result) => {
+                                        log::info!("Update check completed successfully");
+                                        emit_manual_update_check_result(
+                                            &app_handle_clone,
+                                            &result,
+                                        );
+                                    }
+                                    Err(e) => {
+                                        log::error!("Update check failed: {e}");
+                                        emit_manual_update_check_error(&app_handle_clone);
+                                    }
+                                }
+
+                                if let Err(e) =
+                                    check_updates_item_clone.set_text("Check for Updates")
+                                {
+                                    log::error!("Failed to restore check menu item text: {e}");
+                                }
+                                if let Err(e) = check_updates_item_clone.set_enabled(true) {
+                                    log::error!("Failed to re-enable check menu item: {e}");
                                 }
                             });
                         }
@@ -557,6 +616,9 @@ static CURRENT_VERSION: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::ne
 #[cfg(desktop)]
 static FAILED_UPDATE_VERSION: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
 #[cfg(desktop)]
+static PENDING_UPDATE_FAILURE: Lazy<Mutex<Option<PendingUpdateFailure>>> =
+    Lazy::new(|| Mutex::new(None));
+#[cfg(desktop)]
 static UPDATE_CHECK_LOCK: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));
 
 /// A downloaded and signature-verified update that waits for the user to
@@ -569,6 +631,56 @@ struct PendingUpdate {
 
 #[cfg(desktop)]
 static PENDING_UPDATE: Lazy<Mutex<Option<PendingUpdate>>> = Lazy::new(|| Mutex::new(None));
+
+#[cfg(desktop)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UpdateCheckTrigger {
+    Automatic,
+    Manual,
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum UpdateInstallOrigin {
+    Automatic,
+    ManualCheck,
+    UserApprovedPending,
+}
+
+#[cfg(desktop)]
+#[derive(Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+enum UpdateFailureOrigin {
+    Automatic,
+    Manual,
+}
+
+#[cfg(desktop)]
+#[derive(Clone, serde::Serialize)]
+struct PendingUpdateFailure {
+    version: String,
+    origin: UpdateFailureOrigin,
+}
+
+#[cfg(desktop)]
+fn install_failure_retryability(origin: UpdateInstallOrigin) -> Option<bool> {
+    match origin {
+        UpdateInstallOrigin::Automatic => Some(false),
+        UpdateInstallOrigin::ManualCheck => None,
+        UpdateInstallOrigin::UserApprovedPending => Some(true),
+    }
+}
+
+#[cfg(desktop)]
+#[derive(Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum UpdateCheckResult {
+    AutomaticUpdatesDisabled,
+    UpToDate,
+    ReadyToRestart { version: String },
+    ReadyToInstall { version: String },
+    InstallFailed { version: String },
+}
 
 /// Linux deb/rpm installs run `pkexec`, which opens a system password dialog.
 /// That dialog must not appear without the user asking for it, so those
@@ -592,34 +704,170 @@ fn pending_update_version() -> Option<String> {
 }
 
 #[cfg(desktop)]
-fn clear_pending_update() {
-    match PENDING_UPDATE.lock() {
-        Ok(mut guard) => *guard = None,
-        Err(e) => log::error!("Failed to lock PENDING_UPDATE mutex when clearing: {e}"),
+fn downloaded_update_version() -> Option<String> {
+    if !UPDATE_DOWNLOADED.load(Ordering::SeqCst) {
+        return None;
+    }
+
+    match CURRENT_VERSION.lock() {
+        Ok(version) if !version.is_empty() => Some(version.clone()),
+        Ok(_) => None,
+        Err(e) => {
+            log::error!("Failed to lock CURRENT_VERSION mutex: {e}");
+            None
+        }
     }
 }
 
-/// Check for updates silently in the background
 #[cfg(desktop)]
-async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> Result<(), String> {
+fn prepared_update_result(
+    downloaded_version: Option<String>,
+    pending_install_version: Option<String>,
+) -> Option<UpdateCheckResult> {
+    downloaded_version
+        .map(|version| UpdateCheckResult::ReadyToRestart { version })
+        .or_else(|| {
+            pending_install_version.map(|version| UpdateCheckResult::ReadyToInstall { version })
+        })
+}
+
+#[cfg(desktop)]
+fn emit_update_available(app_handle: &tauri::AppHandle, version: &str) {
+    #[derive(Clone, serde::Serialize)]
+    struct UpdateAvailablePayload<'a> {
+        version: &'a str,
+    }
+
+    if let Err(e) = app_handle.emit("update-available", UpdateAvailablePayload { version }) {
+        log::error!("Failed to emit update-available event: {e}");
+    } else {
+        log::info!("Emitted update-available event for version {version}");
+    }
+}
+
+#[cfg(desktop)]
+fn emit_update_ready(app_handle: &tauri::AppHandle, version: &str) {
+    #[derive(Clone, serde::Serialize)]
+    struct UpdateReadyPayload<'a> {
+        version: &'a str,
+    }
+
+    if let Err(e) = app_handle.emit("update-ready", UpdateReadyPayload { version }) {
+        log::error!("Failed to emit update-ready event: {e}");
+    } else {
+        log::info!("Emitted update-ready event for version {version}");
+    }
+}
+
+/// The macOS menu does not have an inline result surface like Settings. Emit
+/// only outcomes that are not already covered by the existing update events.
+#[cfg(desktop)]
+fn emit_manual_update_check_result(app_handle: &tauri::AppHandle, result: &UpdateCheckResult) {
+    if result == &UpdateCheckResult::UpToDate {
+        if let Err(e) = app_handle.emit("manual-update-check-up-to-date", ()) {
+            log::error!("Failed to emit manual-update-check-up-to-date event: {e}");
+        }
+    }
+}
+
+#[cfg(desktop)]
+fn emit_manual_update_install_failed(app_handle: &tauri::AppHandle, version: &str) {
+    #[derive(Clone, serde::Serialize)]
+    struct ManualInstallFailedPayload<'a> {
+        version: &'a str,
+    }
+
+    if let Err(e) = app_handle.emit(
+        "manual-update-install-failed",
+        ManualInstallFailedPayload { version },
+    ) {
+        log::error!("Failed to emit manual-update-install-failed event: {e}");
+    }
+}
+
+#[cfg(desktop)]
+fn emit_manual_update_check_error(app_handle: &tauri::AppHandle) {
+    if let Err(e) = app_handle.emit("manual-update-check-failed", ()) {
+        log::error!("Failed to emit manual-update-check-failed event: {e}");
+    }
+}
+
+#[cfg(desktop)]
+async fn automatic_updates_enabled(app_handle: &tauri::AppHandle) -> Result<bool, String> {
+    updater_preferences::load(app_handle)
+        .await
+        .map(|preferences| preferences.automatic_updates)
+        .map_err(|error| format!("Failed to load updater preferences: {error}"))
+}
+
+#[cfg(desktop)]
+async fn automatic_update_may_continue(
+    app_handle: &tauri::AppHandle,
+    trigger: UpdateCheckTrigger,
+) -> Result<bool, String> {
+    if trigger == UpdateCheckTrigger::Manual {
+        return Ok(true);
+    }
+
+    automatic_updates_enabled(app_handle)
+        .await
+        .map(|enabled| update_trigger_allows(trigger, enabled))
+}
+
+#[cfg(desktop)]
+fn update_trigger_allows(trigger: UpdateCheckTrigger, automatic_updates_enabled: bool) -> bool {
+    trigger == UpdateCheckTrigger::Manual || automatic_updates_enabled
+}
+
+/// Check for updates. Automatic checks honor the persisted preference at each
+/// network/install boundary; a user-requested check always proceeds.
+#[cfg(desktop)]
+async fn check_for_updates(
+    app_handle: tauri::AppHandle,
+    trigger: UpdateCheckTrigger,
+) -> Result<UpdateCheckResult, String> {
     use tauri_plugin_updater::UpdaterExt;
 
     let _check_guard = UPDATE_CHECK_LOCK.lock().await;
 
-    if force_retry {
-        UPDATE_DOWNLOADED.store(false, Ordering::SeqCst);
-        match CURRENT_VERSION.lock() {
-            Ok(mut version) => version.clear(),
-            Err(e) => log::error!("Failed to lock CURRENT_VERSION mutex when clearing: {e}"),
+    if !automatic_update_may_continue(&app_handle, trigger).await? {
+        log::info!("Skipping automatic update check because automatic updates are disabled");
+        return Ok(UpdateCheckResult::AutomaticUpdatesDisabled);
+    }
+
+    if trigger == UpdateCheckTrigger::Manual {
+        // A manual check should resurface already prepared work instead of
+        // discarding it and downloading or installing the same version again.
+        if let Some(prepared) =
+            prepared_update_result(downloaded_update_version(), pending_update_version())
+        {
+            match &prepared {
+                UpdateCheckResult::ReadyToRestart { version } => {
+                    emit_update_ready(&app_handle, version)
+                }
+                UpdateCheckResult::ReadyToInstall { version } => {
+                    emit_update_available(&app_handle, version)
+                }
+                _ => unreachable!("prepared update result must be actionable"),
+            }
+            return Ok(prepared);
         }
+
+        // An explicit check is also an explicit retry of a version whose
+        // automatic install failed earlier in this session.
         match FAILED_UPDATE_VERSION.lock() {
             Ok(mut version) => version.clear(),
             Err(e) => {
                 log::error!("Failed to lock FAILED_UPDATE_VERSION mutex when clearing: {e}")
             }
         }
-        clear_pending_update();
-        log::info!("Update state cleared for user-requested retry");
+        match PENDING_UPDATE_FAILURE.lock() {
+            Ok(mut failure) => *failure = None,
+            Err(e) => {
+                log::error!("Failed to lock PENDING_UPDATE_FAILURE mutex when clearing: {e}")
+            }
+        }
+        log::info!("Automatic install failure suppression cleared for user-requested retry");
     }
 
     log::info!("Checking for updates...");
@@ -652,7 +900,9 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
                     "Update to version {} already downloaded, skipping redundant download",
                     update.version
                 );
-                return Ok(());
+                return Ok(UpdateCheckResult::ReadyToRestart {
+                    version: update.version,
+                });
             }
 
             if pending_update_version().as_deref() == Some(update.version.as_str()) {
@@ -660,7 +910,9 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
                     "Update to version {} is downloaded and waiting for user approval, skipping redundant download",
                     update.version
                 );
-                return Ok(());
+                return Ok(UpdateCheckResult::ReadyToInstall {
+                    version: update.version,
+                });
             }
 
             let failed_update_version = match FAILED_UPDATE_VERSION.lock() {
@@ -676,7 +928,17 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
                     "Update to version {} already failed to install in this session, skipping automatic retry",
                     update.version
                 );
-                return Ok(());
+                return Ok(UpdateCheckResult::InstallFailed {
+                    version: update.version,
+                });
+            }
+
+            if !automatic_update_may_continue(&app_handle, trigger).await? {
+                log::info!(
+                    "Automatic updates were disabled while checking; not downloading version {}",
+                    update.version
+                );
+                return Ok(UpdateCheckResult::AutomaticUpdatesDisabled);
             }
 
             log::info!("Update available, attempting to download and install");
@@ -700,6 +962,28 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
                 Ok(bytes) => {
                     log::info!("Update downloaded and signature verified");
 
+                    // Keep the preference save lock through the final automatic
+                    // action. If disabling wins the lock, this action stops; if
+                    // an already-authorized action wins, save(false) does not
+                    // report success until the action has finished.
+                    let _automatic_action_guard = if trigger == UpdateCheckTrigger::Automatic {
+                        let (preferences, guard) = updater_preferences::load_and_lock(&app_handle)
+                            .await
+                            .map_err(|error| {
+                                format!("Failed to load updater preferences: {error}")
+                            })?;
+                        if !preferences.automatic_updates {
+                            log::info!(
+                                "Automatic updates were disabled while downloading; not installing version {}",
+                                update.version
+                            );
+                            return Ok(UpdateCheckResult::AutomaticUpdatesDisabled);
+                        }
+                        Some(guard)
+                    } else {
+                        None
+                    };
+
                     if install_needs_user_approval() {
                         let version = update.version.clone();
                         match PENDING_UPDATE.lock() {
@@ -713,26 +997,27 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
                             }
                         }
 
-                        #[derive(Clone, serde::Serialize)]
-                        struct UpdateAvailablePayload {
-                            version: String,
-                        }
+                        emit_update_available(&app_handle, &version);
 
-                        if let Err(e) = app_handle.emit(
-                            "update-available",
-                            UpdateAvailablePayload {
-                                version: version.clone(),
-                            },
-                        ) {
-                            log::error!("Failed to emit update-available event: {e}");
-                        } else {
-                            log::info!("Emitted update-available event for version {version}");
-                        }
-
-                        return Ok(());
+                        return Ok(UpdateCheckResult::ReadyToInstall { version });
                     }
 
-                    install_update(&app_handle, &update, &bytes, false)
+                    let version = update.version.clone();
+                    let install_origin = match trigger {
+                        UpdateCheckTrigger::Automatic => UpdateInstallOrigin::Automatic,
+                        UpdateCheckTrigger::Manual => UpdateInstallOrigin::ManualCheck,
+                    };
+                    match install_update(&app_handle, &update, &bytes, install_origin) {
+                        Ok(()) => Ok(UpdateCheckResult::ReadyToRestart { version }),
+                        Err(error) if trigger == UpdateCheckTrigger::Manual => {
+                            log::error!(
+                                "Manual update check downloaded version {version}, but installation failed: {error}"
+                            );
+                            emit_manual_update_install_failed(&app_handle, &version);
+                            Ok(UpdateCheckResult::InstallFailed { version })
+                        }
+                        Err(error) => Err(error),
+                    }
                 }
                 Err(e) => {
                     log::error!("Failed to download update: {e}");
@@ -742,7 +1027,7 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
         }
         Ok(None) => {
             log::info!("No updates available");
-            Ok(())
+            Ok(UpdateCheckResult::UpToDate)
         }
         Err(e) => {
             log::error!("Failed to check for updates: {e}");
@@ -753,15 +1038,16 @@ async fn check_for_updates(app_handle: tauri::AppHandle, force_retry: bool) -> R
 
 /// Install a downloaded update and tell the frontend the result.
 ///
-/// `user_approved` is true when the user clicked "Install Now". That path
-/// always reports the result, and a failure (for example a cancelled password
-/// prompt) does not block the version for the rest of the session.
+/// A staged install the user approved always reports the result, and a failure
+/// (for example a cancelled password prompt) does not block the version for the
+/// rest of the session. Manual-check failures are returned to their caller,
+/// while automatic failures emit the global fallback notification.
 #[cfg(desktop)]
 fn install_update(
     app_handle: &tauri::AppHandle,
     update: &tauri_plugin_updater::Update,
     bytes: &[u8],
-    user_approved: bool,
+    origin: UpdateInstallOrigin,
 ) -> Result<(), String> {
     log::info!("Installing update to version {}", update.version);
 
@@ -778,6 +1064,12 @@ fn install_update(
                     log::error!("Failed to lock FAILED_UPDATE_VERSION mutex when clearing: {e}")
                 }
             }
+            match PENDING_UPDATE_FAILURE.lock() {
+                Ok(mut failure) => *failure = None,
+                Err(e) => {
+                    log::error!("Failed to lock PENDING_UPDATE_FAILURE mutex when clearing: {e}")
+                }
+            }
 
             // Mark this version as downloaded to prevent redundant downloads/notifications
             match CURRENT_VERSION.lock() {
@@ -790,27 +1082,12 @@ fn install_update(
             // The silent path shows the restart toast once per session. An
             // install the user asked for always gets feedback.
             let already_notified = UPDATE_DOWNLOADED.swap(true, Ordering::SeqCst);
-            if already_notified && !user_approved {
+            if already_notified && origin != UpdateInstallOrigin::UserApprovedPending {
                 log::info!("Update notification already shown, not showing another one");
                 return Ok(());
             }
 
-            // Emit event to frontend for toast notification
-            #[derive(Clone, serde::Serialize)]
-            struct UpdateReadyPayload {
-                version: String,
-            }
-
-            if let Err(e) = app_handle.emit(
-                "update-ready",
-                UpdateReadyPayload {
-                    version: update.version.clone(),
-                },
-            ) {
-                log::error!("Failed to emit update-ready event: {e}");
-            } else {
-                log::info!("Emitted update-ready event for version {}", update.version);
-            }
+            emit_update_ready(app_handle, &update.version);
 
             Ok(())
         }
@@ -818,13 +1095,32 @@ fn install_update(
             let error = format!("Failed to install update: {e}");
             log::error!("{error}");
 
-            if user_approved {
+            if origin == UpdateInstallOrigin::UserApprovedPending {
                 log::info!("User-approved install failed; the update stays available to retry");
             } else {
                 match FAILED_UPDATE_VERSION.lock() {
                     Ok(mut version) => *version = update.version.clone(),
                     Err(lock_error) => log::error!(
                         "Failed to lock FAILED_UPDATE_VERSION mutex when recording failure: {lock_error}"
+                    ),
+                }
+
+                let failure_origin = match origin {
+                    UpdateInstallOrigin::Automatic => UpdateFailureOrigin::Automatic,
+                    UpdateInstallOrigin::ManualCheck => UpdateFailureOrigin::Manual,
+                    UpdateInstallOrigin::UserApprovedPending => unreachable!(
+                        "user-approved pending failures do not enter suppression state"
+                    ),
+                };
+                match PENDING_UPDATE_FAILURE.lock() {
+                    Ok(mut failure) => {
+                        *failure = Some(PendingUpdateFailure {
+                            version: update.version.clone(),
+                            origin: failure_origin,
+                        });
+                    }
+                    Err(lock_error) => log::error!(
+                        "Failed to lock PENDING_UPDATE_FAILURE mutex when recording failure: {lock_error}"
                     ),
                 }
             }
@@ -835,17 +1131,80 @@ fn install_update(
                 retryable: bool,
             }
 
-            if let Err(emit_error) = app_handle.emit(
-                "update-failed",
-                UpdateFailedPayload {
-                    version: update.version.clone(),
-                    retryable: user_approved,
-                },
-            ) {
-                log::error!("Failed to emit update-failed event: {emit_error}");
+            if let Some(retryable) = install_failure_retryability(origin) {
+                if let Err(emit_error) = app_handle.emit(
+                    "update-failed",
+                    UpdateFailedPayload {
+                        version: update.version.clone(),
+                        retryable,
+                    },
+                ) {
+                    log::error!("Failed to emit update-failed event: {emit_error}");
+                }
             }
 
             Err(error)
         }
+    }
+}
+
+#[cfg(all(test, desktop))]
+mod updater_policy_tests {
+    use super::*;
+
+    #[test]
+    fn automatic_trigger_honors_the_preference_while_manual_checks_bypass_it() {
+        assert!(!update_trigger_allows(UpdateCheckTrigger::Automatic, false));
+        assert!(update_trigger_allows(UpdateCheckTrigger::Automatic, true));
+        assert!(update_trigger_allows(UpdateCheckTrigger::Manual, false));
+    }
+
+    #[test]
+    fn manual_checks_resurface_prepared_updates_before_hitting_the_network() {
+        assert_eq!(
+            prepared_update_result(Some("4.5.6".to_string()), Some("4.5.5".to_string())),
+            Some(UpdateCheckResult::ReadyToRestart {
+                version: "4.5.6".to_string()
+            })
+        );
+        assert_eq!(
+            prepared_update_result(None, Some("4.5.5".to_string())),
+            Some(UpdateCheckResult::ReadyToInstall {
+                version: "4.5.5".to_string()
+            })
+        );
+        assert_eq!(prepared_update_result(None, None), None);
+    }
+
+    #[test]
+    fn install_failure_feedback_matches_the_recovery_path() {
+        assert_eq!(
+            install_failure_retryability(UpdateInstallOrigin::Automatic),
+            Some(false)
+        );
+        assert_eq!(
+            install_failure_retryability(UpdateInstallOrigin::ManualCheck),
+            None
+        );
+        assert_eq!(
+            install_failure_retryability(UpdateInstallOrigin::UserApprovedPending),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn pending_failure_origin_preserves_manual_recovery_copy() {
+        let failure = PendingUpdateFailure {
+            version: "4.5.6".to_string(),
+            origin: UpdateFailureOrigin::Manual,
+        };
+
+        assert_eq!(
+            serde_json::to_value(failure).unwrap(),
+            serde_json::json!({
+                "version": "4.5.6",
+                "origin": "manual"
+            })
+        );
     }
 }

--- a/frontend/src-tauri/src/updater_preferences.rs
+++ b/frontend/src-tauri/src/updater_preferences.rs
@@ -1,0 +1,264 @@
+use anyhow::{anyhow, Result};
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tauri::{AppHandle, Manager};
+
+const UPDATER_CONFIG_FILE: &str = "updater_config.json";
+static UPDATER_PREFERENCES_LOCK: Lazy<tokio::sync::Mutex<()>> =
+    Lazy::new(|| tokio::sync::Mutex::new(()));
+pub type UpdaterPreferencesGuard = tokio::sync::MutexGuard<'static, ()>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UpdaterPreferences {
+    #[serde(default = "automatic_updates_default")]
+    pub automatic_updates: bool,
+}
+
+const fn automatic_updates_default() -> bool {
+    true
+}
+
+impl Default for UpdaterPreferences {
+    fn default() -> Self {
+        Self {
+            automatic_updates: automatic_updates_default(),
+        }
+    }
+}
+
+async fn updater_config_path(app_handle: &AppHandle) -> Result<PathBuf> {
+    let app_dir = app_handle
+        .path()
+        .app_config_dir()
+        .map_err(|error| anyhow!("Failed to resolve app config dir: {error}"))?;
+    tokio::fs::create_dir_all(&app_dir).await?;
+    Ok(app_dir.join(UPDATER_CONFIG_FILE))
+}
+
+async fn load_from_path(path: &Path) -> Result<UpdaterPreferences> {
+    let json = match tokio::fs::read_to_string(path).await {
+        Ok(json) => json,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(UpdaterPreferences::default());
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    Ok(serde_json::from_str(&json)?)
+}
+
+async fn save_to_path(path: &Path, preferences: UpdaterPreferences) -> Result<()> {
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow!("Updater config path has no parent directory"))?;
+    tokio::fs::create_dir_all(parent).await?;
+
+    let json = serde_json::to_vec_pretty(&preferences)?;
+    let mut temporary = tempfile::NamedTempFile::new_in(parent)?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        temporary
+            .as_file()
+            .set_permissions(std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    temporary.write_all(&json)?;
+    temporary.as_file_mut().sync_all()?;
+    temporary
+        .persist(path)
+        .map_err(|error| anyhow::Error::new(error.error))?;
+
+    #[cfg(unix)]
+    {
+        finish_committed_save(
+            std::fs::File::open(parent).and_then(|directory| directory.sync_all()),
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Once the atomic replacement succeeds, callers must observe the new value.
+/// A directory fsync failure weakens crash durability but cannot be reported as
+/// an uncommitted preference without making Settings disagree with the updater.
+#[cfg(unix)]
+fn finish_committed_save(directory_sync: std::io::Result<()>) -> Result<()> {
+    if let Err(error) = directory_sync {
+        log::warn!(
+            "Updater preferences were committed, but the config directory could not be synced: {error}"
+        );
+    }
+    Ok(())
+}
+
+pub async fn load(app_handle: &AppHandle) -> Result<UpdaterPreferences> {
+    let path = updater_config_path(app_handle).await?;
+    let (preferences, _guard) = load_and_lock_from_path(&path).await?;
+    Ok(preferences)
+}
+
+/// Load the preference while retaining the same lock used by saves. Automatic
+/// update actions hold this guard through their final install/stage boundary,
+/// so a successful save(false) is ordered after any action already in flight
+/// and before every later automatic action.
+pub async fn load_and_lock(
+    app_handle: &AppHandle,
+) -> Result<(UpdaterPreferences, UpdaterPreferencesGuard)> {
+    let path = updater_config_path(app_handle).await?;
+    load_and_lock_from_path(&path).await
+}
+
+async fn load_and_lock_from_path(
+    path: &Path,
+) -> Result<(UpdaterPreferences, UpdaterPreferencesGuard)> {
+    let guard = UPDATER_PREFERENCES_LOCK.lock().await;
+    let preferences = load_from_path(path).await?;
+    Ok((preferences, guard))
+}
+
+async fn save_with_lock_to_path(path: &Path, preferences: UpdaterPreferences) -> Result<()> {
+    let _guard = UPDATER_PREFERENCES_LOCK.lock().await;
+    save_to_path(path, preferences).await
+}
+
+#[tauri::command]
+pub async fn load_updater_preferences(app_handle: AppHandle) -> Result<UpdaterPreferences, String> {
+    load(&app_handle)
+        .await
+        .map_err(|error| format!("Failed to load updater preferences: {error}"))
+}
+
+#[tauri::command]
+pub async fn save_updater_preferences(
+    app_handle: AppHandle,
+    preferences: UpdaterPreferences,
+) -> Result<(), String> {
+    let path = updater_config_path(&app_handle)
+        .await
+        .map_err(|error| format!("Failed to locate updater preferences: {error}"))?;
+    save_with_lock_to_path(&path, preferences)
+        .await
+        .map_err(|error| format!("Failed to save updater preferences: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn missing_preferences_keep_existing_automatic_behavior() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join(UPDATER_CONFIG_FILE);
+
+        assert_eq!(
+            load_from_path(&path).await.unwrap(),
+            UpdaterPreferences {
+                automatic_updates: true
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn older_config_without_the_preference_defaults_to_enabled() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join(UPDATER_CONFIG_FILE);
+        tokio::fs::write(&path, "{}").await.unwrap();
+
+        assert!(load_from_path(&path).await.unwrap().automatic_updates);
+    }
+
+    #[tokio::test]
+    async fn disabled_preference_round_trips() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("nested").join(UPDATER_CONFIG_FILE);
+        let preferences = UpdaterPreferences {
+            automatic_updates: false,
+        };
+
+        save_to_path(&path, UpdaterPreferences::default())
+            .await
+            .unwrap();
+        save_to_path(&path, preferences).await.unwrap();
+
+        assert_eq!(load_from_path(&path).await.unwrap(), preferences);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            assert_eq!(
+                tokio::fs::metadata(&path)
+                    .await
+                    .unwrap()
+                    .permissions()
+                    .mode()
+                    & 0o777,
+                0o600
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_preferences_are_not_treated_as_consent() {
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join(UPDATER_CONFIG_FILE);
+        tokio::fs::write(&path, "not-json").await.unwrap();
+
+        assert!(load_from_path(&path).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn disabling_waits_for_an_automatic_action_guard() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+        use std::sync::Arc;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join(UPDATER_CONFIG_FILE);
+        save_to_path(&path, UpdaterPreferences::default())
+            .await
+            .unwrap();
+
+        let (preferences, automatic_action_guard) = load_and_lock_from_path(&path).await.unwrap();
+        assert!(preferences.automatic_updates);
+
+        let save_started = Arc::new(tokio::sync::Notify::new());
+        let save_completed = Arc::new(AtomicBool::new(false));
+        let task_path = path.clone();
+        let task_started = Arc::clone(&save_started);
+        let task_completed = Arc::clone(&save_completed);
+        let disable_task = tokio::spawn(async move {
+            task_started.notify_one();
+            save_with_lock_to_path(
+                &task_path,
+                UpdaterPreferences {
+                    automatic_updates: false,
+                },
+            )
+            .await
+            .unwrap();
+            task_completed.store(true, Ordering::SeqCst);
+        });
+
+        save_started.notified().await;
+        tokio::task::yield_now().await;
+        assert!(!save_completed.load(Ordering::SeqCst));
+
+        // This is the linearization point used by the updater: work that was
+        // already authorized finishes before save(false) can report success.
+        drop(automatic_action_guard);
+        disable_task.await.unwrap();
+
+        assert!(save_completed.load(Ordering::SeqCst));
+        assert!(!load_from_path(&path).await.unwrap().automatic_updates);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn a_post_commit_directory_sync_failure_is_still_reported_as_saved() {
+        let sync_failure = std::io::Error::other("simulated directory sync failure");
+        assert!(finish_committed_save(Err(sync_failure)).is_ok());
+    }
+}

--- a/frontend/src/components/GlobalNotification.tsx
+++ b/frontend/src/components/GlobalNotification.tsx
@@ -85,6 +85,9 @@ export function GlobalNotification({ notification, onDismiss }: GlobalNotificati
   return (
     <div className="fixed top-4 right-4 z-50 pointer-events-none">
       <div
+        role={notification.type === "error" ? "alert" : "status"}
+        aria-live={notification.type === "error" ? "assertive" : "polite"}
+        aria-atomic="true"
         className={cn(
           "pointer-events-auto flex flex-col gap-3 rounded-lg border bg-card text-card-foreground p-4 shadow-lg transition-all duration-200 min-w-[320px] max-w-md",
           isLeaving ? "opacity-0 translate-x-full" : "opacity-100 translate-x-0",

--- a/frontend/src/components/UpdateEventListener.tsx
+++ b/frontend/src/components/UpdateEventListener.tsx
@@ -3,7 +3,7 @@ import { listen } from "@tauri-apps/api/event";
 import { invoke } from "@tauri-apps/api/core";
 import { useNotification } from "@/contexts/NotificationContext";
 import { openExternalUrl } from "@/utils/openUrl";
-import { isTauri } from "@/utils/platform";
+import { isTauriDesktop } from "@/utils/platform";
 
 interface UpdateReadyPayload {
   version: string;
@@ -20,11 +20,20 @@ interface UpdateAvailablePayload {
   version: string;
 }
 
+interface ManualInstallFailedPayload {
+  version: string;
+}
+
+interface PendingUpdateFailure {
+  version: string;
+  origin: "automatic" | "manual";
+}
+
 export function UpdateEventListener() {
   const { showNotification } = useNotification();
 
   useEffect(() => {
-    if (!isTauri()) {
+    if (!isTauriDesktop()) {
       return;
     }
 
@@ -32,6 +41,9 @@ export function UpdateEventListener() {
     let unlistenUpdateReady: (() => void) | null = null;
     let unlistenUpdateFailed: (() => void) | null = null;
     let unlistenUpdateAvailable: (() => void) | null = null;
+    let unlistenManualCheckUpToDate: (() => void) | null = null;
+    let unlistenManualCheckFailed: (() => void) | null = null;
+    let unlistenManualInstallFailed: (() => void) | null = null;
 
     const installPendingUpdate = async () => {
       try {
@@ -79,6 +91,31 @@ export function UpdateEventListener() {
         type: "error",
         title: "Update Failed",
         message: `Maple couldn't install version ${version} automatically. Download the latest installer to update manually.`,
+        duration: 0,
+        actions: [
+          {
+            label: "Later",
+            variant: "secondary",
+            onClick: () => {
+              // Just dismiss - the notification will close automatically
+            }
+          },
+          {
+            label: "Download Manually",
+            variant: "primary",
+            onClick: () => {
+              void openExternalUrl("https://trymaple.ai/downloads");
+            }
+          }
+        ]
+      });
+    };
+
+    const showManualUpdateFailed = (version: string) => {
+      showNotification({
+        type: "error",
+        title: "Update Not Installed",
+        message: `Maple couldn't install version ${version}. Check again, or download the latest installer.`,
         duration: 0,
         actions: [
           {
@@ -190,9 +227,56 @@ export function UpdateEventListener() {
         }
         unlistenUpdateAvailable = unlistenAvailable;
 
-        const pendingFailure = await invoke<string | null>("get_pending_update_failure");
+        const unlistenUpToDate = await listen("manual-update-check-up-to-date", () => {
+          showNotification({
+            type: "success",
+            title: "Maple Is Up to Date",
+            message: "You're running the latest available version.",
+            duration: 5000
+          });
+        });
+        if (disposed) {
+          unlistenUpToDate();
+          return;
+        }
+        unlistenManualCheckUpToDate = unlistenUpToDate;
+
+        const unlistenCheckFailed = await listen("manual-update-check-failed", () => {
+          showNotification({
+            type: "error",
+            title: "Couldn't Check for Updates",
+            message: "Try again; if it keeps failing, use the latest installer.",
+            duration: 8000
+          });
+        });
+        if (disposed) {
+          unlistenCheckFailed();
+          return;
+        }
+        unlistenManualCheckFailed = unlistenCheckFailed;
+
+        const unlistenInstallFailed = await listen<ManualInstallFailedPayload>(
+          "manual-update-install-failed",
+          (event) => {
+            const { version } = event.payload;
+            showManualUpdateFailed(version);
+          }
+        );
+        if (disposed) {
+          unlistenInstallFailed();
+          return;
+        }
+        unlistenManualInstallFailed = unlistenInstallFailed;
+
+        const pendingFailure = await invoke<PendingUpdateFailure | null>(
+          "get_pending_update_failure"
+        );
         if (!disposed && pendingFailure) {
-          showUpdateFailed(pendingFailure);
+          if (pendingFailure.origin === "manual") {
+            showManualUpdateFailed(pendingFailure.version);
+          } else {
+            showUpdateFailed(pendingFailure.version);
+          }
           return;
         }
 
@@ -212,6 +296,9 @@ export function UpdateEventListener() {
       if (unlistenUpdateReady) unlistenUpdateReady();
       if (unlistenUpdateFailed) unlistenUpdateFailed();
       if (unlistenUpdateAvailable) unlistenUpdateAvailable();
+      if (unlistenManualCheckUpToDate) unlistenManualCheckUpToDate();
+      if (unlistenManualCheckFailed) unlistenManualCheckFailed();
+      if (unlistenManualInstallFailed) unlistenManualInstallFailed();
     };
   }, [showNotification]);
 

--- a/frontend/src/components/settings/AboutSettings.tsx
+++ b/frontend/src/components/settings/AboutSettings.tsx
@@ -3,7 +3,9 @@ import { ExternalLink, FileText, Info, Mail, Shield } from "lucide-react";
 import packageJson from "../../../package.json";
 import { Button } from "@/components/ui/button";
 import { openExternalUrl } from "@/utils/openUrl";
+import { isTauriDesktop } from "@/utils/platform";
 import { SettingsPage, SettingsSection } from "./SettingsPage";
+import { UpdateSettings } from "./UpdateSettings";
 
 type ExternalRowProps = {
   label: string;
@@ -26,8 +28,10 @@ function ExternalRow({ label, url, icon: Icon }: ExternalRowProps) {
 }
 
 export function AboutSettings() {
+  const supportsDesktopUpdates = isTauriDesktop();
+
   return (
-    <SettingsPage title="About" description="Maple information, policies, and support.">
+    <SettingsPage title="About" description="Maple information, updates, policies, and support.">
       <SettingsSection title="Maple Research">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
           <div>
@@ -44,6 +48,8 @@ export function AboutSettings() {
           </Button>
         </div>
       </SettingsSection>
+
+      {supportsDesktopUpdates && <UpdateSettings />}
 
       <SettingsSection title="Policies and support">
         <div className="space-y-2">

--- a/frontend/src/components/settings/UpdateSettings.test.tsx
+++ b/frontend/src/components/settings/UpdateSettings.test.tsx
@@ -1,0 +1,193 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { Switch } from "@/components/ui/switch";
+import type { UpdateService } from "@/services/updateService";
+import { UpdateSettings } from "./UpdateSettings";
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
+function service(overrides: Partial<UpdateService> = {}): UpdateService {
+  return {
+    loadPreferences: mock(async () => ({ automatic_updates: false })),
+    savePreferences: mock(async () => {}),
+    checkForUpdates: mock(async () => ({ status: "up_to_date" as const })),
+    ...overrides
+  };
+}
+
+describe("UpdateSettings", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+  });
+
+  test("loads the app preference and keeps manual checks available when it is off", async () => {
+    const updates = service();
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+
+    const toggle = renderer!.root.findByType(Switch);
+    expect(toggle.props.checked).toBe(false);
+    expect(toggle.props.disabled).toBe(false);
+    expect(toggle.props["aria-describedby"]).toBe("automatic-updates-description");
+
+    const checkButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Check for updates"));
+    expect(checkButton?.props.disabled).toBe(false);
+  });
+
+  test("persists a toggle before reflecting the new value", async () => {
+    const updates = service();
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+
+    await act(async () => {
+      await renderer!.root.findByType(Switch).props.onCheckedChange(true);
+    });
+
+    expect(updates.savePreferences).toHaveBeenCalledWith({ automatic_updates: true });
+    expect(renderer!.root.findByType(Switch).props.checked).toBe(true);
+    expect(
+      renderer!.root.findAll((node) => node.props.role === "status").map(textContent)
+    ).toContain("Automatic updates are on. Maple will check shortly after launch and every hour.");
+  });
+
+  test("keeps the previous value and shows an actionable error when saving fails", async () => {
+    const saveError = new Error("disk unavailable");
+    const updates = service({
+      savePreferences: mock(async () => {
+        throw saveError;
+      })
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+    await act(async () => {
+      await renderer!.root.findByType(Switch).props.onCheckedChange(true);
+    });
+
+    expect(renderer!.root.findByType(Switch).props.checked).toBe(false);
+    expect(textContent(renderer!.root.find((node) => node.props.role === "alert"))).toBe(
+      "Maple couldn't save your update preference. Please try again."
+    );
+    consoleError.mockRestore();
+  });
+
+  test("does not claim updates are off after a load failure and can explicitly persist off", async () => {
+    const updates = service({
+      loadPreferences: mock(async () => {
+        throw new Error("invalid json");
+      })
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+
+    const toggle = renderer!.root.findByType(Switch);
+    expect(toggle.props.checked).toBe(false);
+    expect(toggle.props.disabled).toBe(true);
+    expect(textContent(renderer!.root.find((node) => node.props.role === "alert"))).toContain(
+      "Automatic update behavior is unchanged"
+    );
+    const checkButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Check for updates"));
+    expect(checkButton?.props.disabled).toBe(false);
+
+    await act(async () => {
+      checkButton!.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(
+      renderer!.root
+        .findAllByType("button")
+        .some((button) => textContent(button).includes("Turn automatic updates off"))
+    ).toBe(true);
+
+    const turnOffButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Turn automatic updates off"));
+    await act(async () => {
+      turnOffButton!.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(updates.savePreferences).toHaveBeenCalledWith({ automatic_updates: false });
+    expect(renderer!.root.findByType(Switch).props.disabled).toBe(false);
+    expect(renderer!.root.findByType(Switch).props.checked).toBe(false);
+    consoleError.mockRestore();
+  });
+
+  test("reports the result of a user-requested check", async () => {
+    const updates = service({
+      checkForUpdates: mock(async () => ({
+        status: "ready_to_restart" as const,
+        version: "9.8.7"
+      }))
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+    const checkButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Check for updates"));
+
+    await act(async () => {
+      checkButton!.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(updates.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(
+      renderer!.root.findAll((node) => node.props.role === "status").map(textContent)
+    ).toContain("Version 9.8.7 is installed. Restart Maple to finish updating.");
+  });
+
+  test("announces a manual install failure as an error", async () => {
+    const updates = service({
+      checkForUpdates: mock(async () => ({
+        status: "install_failed" as const,
+        version: "9.8.7"
+      }))
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+    const checkButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Check for updates"));
+
+    await act(async () => {
+      checkButton!.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root.find((node) => node.props.role === "alert"))).toContain(
+      "Maple couldn't install version 9.8.7"
+    );
+  });
+});

--- a/frontend/src/components/settings/UpdateSettings.tsx
+++ b/frontend/src/components/settings/UpdateSettings.tsx
@@ -1,0 +1,247 @@
+import { useEffect, useRef, useState } from "react";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import {
+  updateService,
+  type UpdateCheckResult,
+  type UpdaterPreferences,
+  type UpdateService
+} from "@/services/updateService";
+import { cn } from "@/utils/utils";
+import { SettingsSection } from "./SettingsPage";
+
+function updateCheckMessage(result: UpdateCheckResult): string {
+  switch (result.status) {
+    case "up_to_date":
+      return "Maple is up to date.";
+    case "ready_to_restart":
+      return `Version ${result.version} is installed. Restart Maple to finish updating.`;
+    case "ready_to_install":
+      return `Version ${result.version} is downloaded and ready to install.`;
+    case "install_failed":
+      return `Maple couldn't install version ${result.version}. Try checking again or use the latest installer.`;
+    case "automatic_updates_disabled":
+      return "Automatic updates are off. You can still check for updates manually.";
+  }
+}
+
+export function UpdateSettings({ service = updateService }: { service?: UpdateService }) {
+  const mountedRef = useRef(false);
+  const [preferences, setPreferences] = useState<UpdaterPreferences | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+  const [isChecking, setIsChecking] = useState(false);
+  const [preferenceError, setPreferenceError] = useState<string | null>(null);
+  const [preferenceStatus, setPreferenceStatus] = useState<string | null>(null);
+  const [checkError, setCheckError] = useState<string | null>(null);
+  const [checkStatus, setCheckStatus] = useState<string | null>(null);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [loadFailed, setLoadFailed] = useState(false);
+  const [loadAttempt, setLoadAttempt] = useState(0);
+
+  useEffect(() => {
+    mountedRef.current = true;
+
+    const loadPreferences = async () => {
+      try {
+        const loaded = await service.loadPreferences();
+        if (mountedRef.current) {
+          setPreferences(loaded);
+          setLoadFailed(false);
+          setLoadError(null);
+        }
+      } catch (loadError) {
+        console.error("Failed to load updater preferences:", loadError);
+        if (mountedRef.current) {
+          setPreferences(null);
+          setLoadFailed(true);
+          setLoadError(
+            "Maple couldn't confirm your update preference. Automatic update behavior is unchanged. Try again, or turn automatic updates off now."
+          );
+        }
+      } finally {
+        if (mountedRef.current) setIsLoading(false);
+      }
+    };
+
+    void loadPreferences();
+    return () => {
+      mountedRef.current = false;
+    };
+  }, [service, loadAttempt]);
+
+  const setAutomaticUpdates = async (automaticUpdates: boolean) => {
+    if (isSaving) return;
+
+    const next = { automatic_updates: automaticUpdates };
+    setIsSaving(true);
+    setPreferenceError(null);
+    setPreferenceStatus(null);
+
+    try {
+      await service.savePreferences(next);
+      if (mountedRef.current) {
+        setPreferences(next);
+        setLoadFailed(false);
+        setLoadError(null);
+        setPreferenceStatus(
+          automaticUpdates
+            ? "Automatic updates are on. Maple will check shortly after launch and every hour."
+            : "Automatic updates are off. You can still check for updates manually."
+        );
+      }
+    } catch (saveError) {
+      console.error("Failed to save updater preferences:", saveError);
+      if (mountedRef.current) {
+        setPreferenceError("Maple couldn't save your update preference. Please try again.");
+      }
+    } finally {
+      if (mountedRef.current) setIsSaving(false);
+    }
+  };
+
+  const retryLoadingPreferences = () => {
+    setIsLoading(true);
+    setLoadError(null);
+    setPreferenceStatus(null);
+    setLoadAttempt((attempt) => attempt + 1);
+  };
+
+  const checkForUpdates = async () => {
+    if (isChecking) return;
+
+    setIsChecking(true);
+    setCheckError(null);
+    setCheckStatus(null);
+
+    try {
+      const result = await service.checkForUpdates();
+      if (mountedRef.current) {
+        if (result.status === "install_failed") {
+          setCheckError(updateCheckMessage(result));
+        } else {
+          setCheckStatus(updateCheckMessage(result));
+        }
+      }
+    } catch (checkError) {
+      console.error("Failed to check for updates:", checkError);
+      if (mountedRef.current) {
+        setCheckError(
+          "Maple couldn't complete the update check. Try again; if it keeps failing, use the latest installer."
+        );
+      }
+    } finally {
+      if (mountedRef.current) setIsChecking(false);
+    }
+  };
+
+  return (
+    <SettingsSection
+      title="Updates"
+      description="Choose whether Maple checks for updates in the background, or check whenever you want."
+    >
+      <div className="space-y-5">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <Label htmlFor="automatic-updates">Automatic updates</Label>
+            <p
+              id="automatic-updates-description"
+              className="mt-1 text-xs leading-relaxed text-muted-foreground"
+            >
+              With this on, Maple checks shortly after launch and every hour. On macOS, Windows, and
+              AppImage, available updates download and install automatically. Linux deb/rpm packages
+              keep their current install prompt.
+            </p>
+          </div>
+          <Switch
+            id="automatic-updates"
+            checked={preferences?.automatic_updates ?? false}
+            onCheckedChange={(checked) => void setAutomaticUpdates(checked)}
+            disabled={isLoading || isSaving || !preferences}
+            aria-describedby="automatic-updates-description"
+            aria-busy={isSaving}
+          />
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-border/70 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            A manual check can download and install an available update immediately on macOS,
+            Windows, and AppImage, even when automatic updates are off. Linux deb/rpm packages keep
+            their install prompt.
+          </p>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => void checkForUpdates()}
+            disabled={isChecking}
+            aria-busy={isChecking}
+          >
+            <RefreshCw
+              aria-hidden="true"
+              className={cn(
+                "mr-2 h-4 w-4",
+                isChecking && "animate-spin motion-reduce:animate-none"
+              )}
+            />
+            {isChecking ? "Checking..." : "Check for updates"}
+          </Button>
+        </div>
+
+        {isLoading && (
+          <p className="text-xs text-muted-foreground" role="status">
+            Loading update preference...
+          </p>
+        )}
+        {preferenceStatus && (
+          <p className="text-xs leading-relaxed text-muted-foreground" role="status">
+            {preferenceStatus}
+          </p>
+        )}
+        {checkStatus && (
+          <p className="text-xs leading-relaxed text-muted-foreground" role="status">
+            {checkStatus}
+          </p>
+        )}
+        {loadError && (
+          <div className="space-y-3" role="alert">
+            <p className="text-xs leading-relaxed text-destructive">{loadError}</p>
+            {loadFailed && (
+              <div className="flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={retryLoadingPreferences}
+                  disabled={isLoading || isSaving}
+                >
+                  Retry preference
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void setAutomaticUpdates(false)}
+                  disabled={isSaving}
+                >
+                  Turn automatic updates off
+                </Button>
+              </div>
+            )}
+          </div>
+        )}
+        {preferenceError && (
+          <p className="text-xs leading-relaxed text-destructive" role="alert">
+            {preferenceError}
+          </p>
+        )}
+        {checkError && (
+          <p className="text-xs leading-relaxed text-destructive" role="alert">
+            {checkError}
+          </p>
+        )}
+      </div>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/services/updateService.test.ts
+++ b/frontend/src/services/updateService.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, mock, test } from "bun:test";
+import { createUpdateService, type UpdaterPreferences } from "./updateService";
+
+describe("updateService", () => {
+  test("uses the native app-scoped updater preference commands", async () => {
+    const preferences: UpdaterPreferences = { automatic_updates: false };
+    const invoke = mock(async (command: string) => {
+      if (command === "load_updater_preferences") return preferences;
+      if (command === "save_updater_preferences") return undefined;
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const service = createUpdateService(invoke);
+
+    await expect(service.loadPreferences()).resolves.toEqual(preferences);
+    await expect(service.savePreferences(preferences)).resolves.toBeUndefined();
+    expect(invoke).toHaveBeenNthCalledWith(1, "load_updater_preferences");
+    expect(invoke).toHaveBeenNthCalledWith(2, "save_updater_preferences", { preferences });
+  });
+
+  test("runs manual checks independently of the automatic preference", async () => {
+    const invoke = mock(async (command: string) => {
+      if (command === "check_for_updates_manually") {
+        return { status: "up_to_date" };
+      }
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const service = createUpdateService(invoke);
+
+    await expect(service.checkForUpdates()).resolves.toEqual({ status: "up_to_date" });
+    expect(invoke).toHaveBeenCalledWith("check_for_updates_manually");
+  });
+});

--- a/frontend/src/services/updateService.ts
+++ b/frontend/src/services/updateService.ts
@@ -1,0 +1,32 @@
+import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+
+export interface UpdaterPreferences {
+  automatic_updates: boolean;
+}
+
+export type UpdateCheckResult =
+  | { status: "automatic_updates_disabled" }
+  | { status: "up_to_date" }
+  | { status: "ready_to_restart"; version: string }
+  | { status: "ready_to_install"; version: string }
+  | { status: "install_failed"; version: string };
+
+type Invoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+export interface UpdateService {
+  loadPreferences(): Promise<UpdaterPreferences>;
+  savePreferences(preferences: UpdaterPreferences): Promise<void>;
+  checkForUpdates(): Promise<UpdateCheckResult>;
+}
+
+export function createUpdateService(invoke: Invoke = tauriInvoke): UpdateService {
+  return {
+    loadPreferences: async () => (await invoke("load_updater_preferences")) as UpdaterPreferences,
+    savePreferences: async (preferences) => {
+      await invoke("save_updater_preferences", { preferences });
+    },
+    checkForUpdates: async () => (await invoke("check_for_updates_manually")) as UpdateCheckResult
+  };
+}
+
+export const updateService = createUpdateService();


### PR DESCRIPTION
## Summary

- add a default-on automatic update preference in Maple's identifier-scoped app config directory
- add an Updates section with an automatic-update toggle and manual check action
- route Settings and the existing macOS menu through the same manual-check path, with visible up-to-date and failure feedback
- preserve current install behavior: macOS, Windows, and AppImage install after download; Linux deb/rpm keeps its approval prompt
- keep updater authority in native code and serialize preference changes against automatic download/install boundaries

## Validation

- frontend CI: 721 tests / 2,297 assertions across 84 files; Prettier, ESLint, and TypeScript passed
- Rust CI: 386 library tests plus 3 binary tests; fmt and clippy with warnings denied passed
- correctness, security/lifecycle, and UX/accessibility reviews found no remaining blockers
- disposable exact-app macOS smoke from version `0.0.0`: confirmed startup skipped the automatic check while disabled, then the native menu downloaded 125,543,244 bytes, verified the production signature, installed Maple 3.3.6, restored the menu state, and showed the restart-ready toast. The replaced fixture passed strict Developer ID signature verification; `/Applications/Maple.app` was never used.

## Boundaries

- signed Windows installation was not live-smoked; its existing direct-install behavior is unchanged
- Settings remains behind Maple's existing authenticated settings route, so signed-out Windows/Linux users still lack a manual surface because those platforms intentionally have no native menu
