### PR TITLE
Require explicit installation for downloaded updates

### DIFF
--- a/frontend/src-tauri/src/agent_host.rs
+++ b/frontend/src-tauri/src/agent_host.rs
@@ -131,6 +131,18 @@ impl AgentHostLifecycle {
     pub(crate) async fn shutdown_for_update(&self, app_handle: &AppHandle) -> Result<(), String> {
         self.shutdown_services(app_handle, true).await
     }
+
+    /// A Windows updater launch normally exits Maple and never returns. If it
+    /// does return with an error, reopen admission so the still-running app is
+    /// not left permanently in draining mode. Already stopped Agent/ACP work
+    /// is not recreated; the user can retry or restart it explicitly.
+    #[cfg(target_os = "windows")]
+    pub(crate) async fn reopen_after_failed_update_install(&self, app_handle: &AppHandle) {
+        let _guard = self.lock().await;
+        app_handle
+            .state::<MapleAgentService>()
+            .reopen_after_failed_shutdown();
+    }
 }
 
 fn combine_surface_results<T>(

--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -25,7 +25,11 @@ mod word_extractor;
 #[cfg(desktop)]
 #[tauri::command]
 async fn restart_for_update(app_handle: tauri::AppHandle) -> Result<(), String> {
-    log::info!("User requested restart for update");
+    // Never restart while a bundle replacement is in progress, and do not let
+    // renderer code turn this updater-only command into a general restart.
+    let _install_guard = UPDATE_INSTALL_LOCK.lock().await;
+    let version = update_ready_to_restart_version()?;
+    log::info!("User requested restart to apply update version {version}");
     let lifecycle = app_handle.state::<agent_host::AgentHostLifecycle>();
     lifecycle.shutdown_for_update(&app_handle).await?;
     app_handle.request_restart();
@@ -92,72 +96,86 @@ fn enable_main_window_frame_autosave(app_handle: &tauri::AppHandle) {
 
 #[cfg(desktop)]
 #[tauri::command]
-fn get_pending_update_failure() -> Result<Option<PendingUpdateFailure>, String> {
-    PENDING_UPDATE_FAILURE
-        .lock()
-        .map_err(|e| format!("Failed to lock PENDING_UPDATE_FAILURE mutex: {e}"))
-        .map(|failure| failure.clone())
+fn get_prepared_update() -> Result<Option<PreparedUpdate>, String> {
+    prepared_update_snapshot()
 }
 
 #[cfg(desktop)]
 #[tauri::command]
-fn get_pending_update_install() -> Result<Option<String>, String> {
-    Ok(PENDING_UPDATE
-        .lock()
-        .map_err(|e| format!("Failed to lock PENDING_UPDATE mutex: {e}"))?
-        .as_ref()
-        .map(|pending| pending.update.version.clone()))
-}
+async fn install_pending_update(
+    app_handle: tauri::AppHandle,
+    expected_version: String,
+) -> Result<PreparedUpdate, String> {
+    // Only one native bundle mutation may run. A second visible Install action
+    // coalesces behind the first and receives its resulting native state; it
+    // must never launch a second package-manager/UAC prompt automatically.
+    let _install_guard = match UPDATE_INSTALL_LOCK.try_lock() {
+        Ok(guard) => guard,
+        Err(_) => {
+            log::info!("Another update lifecycle action is active; waiting for its result");
+            let _coalesced_guard = UPDATE_INSTALL_LOCK.lock().await;
+            let prepared = prepared_update_snapshot()?
+                .ok_or_else(|| "No prepared update remains after the active action".to_string())?;
+            return validate_returned_prepared_update(prepared, &expected_version);
+        }
+    };
 
-#[cfg(desktop)]
-#[tauri::command]
-async fn install_pending_update(app_handle: tauri::AppHandle) -> Result<(), String> {
-    // Hold the check lock for the whole install so the hourly check cannot
-    // download and offer the same version again while the password prompt
-    // is open.
+    // Hold the check lock for the whole install so the hourly scheduler cannot
+    // race the prepared state transition.
     let _check_guard = UPDATE_CHECK_LOCK.lock().await;
 
-    let pending = PENDING_UPDATE
-        .lock()
-        .map_err(|e| format!("Failed to lock PENDING_UPDATE mutex: {e}"))?
-        .take()
-        .ok_or_else(|| "No downloaded update is waiting to be installed".to_string())?;
+    let pending = pending_update_snapshot(&expected_version)?;
 
     log::info!(
         "User requested install of downloaded update to version {}",
         pending.update.version
     );
 
-    // Installing a deb/rpm blocks on pkexec until the user answers the
-    // password prompt, so keep it off the async runtime.
-    let (pending, result) = tauri::async_runtime::spawn_blocking(move || {
-        let result = install_update(
-            &app_handle,
-            &pending.update,
-            &pending.bytes,
-            UpdateInstallOrigin::UserApprovedPending,
-        );
-        (pending, result)
-    })
-    .await
-    .map_err(|e| format!("Update install task failed: {e}"))?;
-
-    if result.is_err() {
-        // A cancelled password prompt lands here. The bytes are already
-        // signature-verified, so keep them for "Try Again".
-        match PENDING_UPDATE.lock() {
-            Ok(mut guard) => {
-                if guard.is_none() {
-                    *guard = Some(pending);
-                }
-            }
-            Err(e) => {
-                log::error!("Failed to lock PENDING_UPDATE mutex when restoring update: {e}")
-            }
+    // The Windows updater launches NSIS and exits the process directly, which
+    // bypasses Maple's async RunEvent cleanup. Drain Agent services first.
+    #[cfg(target_os = "windows")]
+    {
+        let lifecycle = app_handle.state::<agent_host::AgentHostLifecycle>();
+        if let Err(error) = lifecycle.shutdown_for_update(&app_handle).await {
+            emit_update_install_failed(&app_handle, &pending.update.version);
+            return Err(error);
         }
     }
 
-    result
+    // Package installation may block on OS UI or filesystem work, so keep it
+    // off the async runtime. The verified pending object stays in native state
+    // until installation succeeds, including if this task fails to join.
+    let version = pending.update.version.clone();
+    let install_app_handle = app_handle.clone();
+    let install_result = tauri::async_runtime::spawn_blocking(move || {
+        install_update(&install_app_handle, &pending.update, &pending.bytes)
+    })
+    .await;
+
+    let result = match install_result {
+        Ok(result) => result,
+        Err(error) => {
+            let error = format!("Update install task failed: {error}");
+            log::error!("{error}");
+            emit_update_install_failed(&app_handle, &version);
+            #[cfg(target_os = "windows")]
+            app_handle
+                .state::<agent_host::AgentHostLifecycle>()
+                .reopen_after_failed_update_install(&app_handle)
+                .await;
+            return Err(error);
+        }
+    };
+
+    #[cfg(target_os = "windows")]
+    if result.is_err() {
+        app_handle
+            .state::<agent_host::AgentHostLifecycle>()
+            .reopen_after_failed_update_install(&app_handle)
+            .await;
+    }
+
+    result.map(|()| PreparedUpdate::ReadyToRestart { version })
 }
 
 #[cfg(desktop)]
@@ -199,6 +217,10 @@ fn handle_desktop_run_event(app_handle: &tauri::AppHandle, event: tauri::RunEven
 
     let app_handle = app_handle.clone();
     tauri::async_runtime::spawn(async move {
+        // A normal quit may race an explicit install. Let the native bundle
+        // replacement finish before stopping services and exiting, without
+        // making exit wait for an unrelated network update check/download.
+        let _install_guard = UPDATE_INSTALL_LOCK.lock().await;
         let lifecycle = app_handle.state::<agent_host::AgentHostLifecycle>();
         if let Err(error) = lifecycle.shutdown_for_exit(&app_handle).await {
             log::error!("Failed to stop Agent services during app exit: {error}");
@@ -292,8 +314,7 @@ pub fn run() {
             proxy::test_proxy_port,
             pdf_extractor::extract_document_content,
             restart_for_update,
-            get_pending_update_failure,
-            get_pending_update_install,
+            get_prepared_update,
             install_pending_update,
             check_for_updates_manually,
             updater_preferences::load_updater_preferences,
@@ -603,34 +624,39 @@ use once_cell::sync::Lazy;
 #[cfg(desktop)]
 use std::sync::atomic::{AtomicBool, Ordering};
 #[cfg(desktop)]
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 
-#[cfg(desktop)]
-static UPDATE_DOWNLOADED: AtomicBool = AtomicBool::new(false);
 #[cfg(desktop)]
 static AGENT_EXIT_CLEANUP_STARTED: AtomicBool = AtomicBool::new(false);
 #[cfg(desktop)]
 static AGENT_EXIT_CLEANUP_COMPLETE: AtomicBool = AtomicBool::new(false);
 #[cfg(desktop)]
-static CURRENT_VERSION: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
-#[cfg(desktop)]
-static FAILED_UPDATE_VERSION: Lazy<Mutex<String>> = Lazy::new(|| Mutex::new(String::new()));
-#[cfg(desktop)]
-static PENDING_UPDATE_FAILURE: Lazy<Mutex<Option<PendingUpdateFailure>>> =
-    Lazy::new(|| Mutex::new(None));
-#[cfg(desktop)]
 static UPDATE_CHECK_LOCK: Lazy<tokio::sync::Mutex<()>> = Lazy::new(|| tokio::sync::Mutex::new(()));
+#[cfg(desktop)]
+static UPDATE_INSTALL_LOCK: Lazy<tokio::sync::Mutex<()>> =
+    Lazy::new(|| tokio::sync::Mutex::new(()));
 
 /// A downloaded and signature-verified update that waits for the user to
 /// approve the install.
 #[cfg(desktop)]
 struct PendingUpdate {
     update: tauri_plugin_updater::Update,
+    // PendingUpdate itself is shared behind Arc, so retain the updater's Vec
+    // directly instead of allocating/copying the full artifact into Arc<[u8]>.
     bytes: Vec<u8>,
+    requires_system_approval: bool,
 }
 
 #[cfg(desktop)]
-static PENDING_UPDATE: Lazy<Mutex<Option<PendingUpdate>>> = Lazy::new(|| Mutex::new(None));
+enum PreparedUpdateState {
+    None,
+    ReadyToInstall(Arc<PendingUpdate>),
+    ReadyToRestart { version: String },
+}
+
+#[cfg(desktop)]
+static PREPARED_UPDATE: Lazy<Mutex<PreparedUpdateState>> =
+    Lazy::new(|| Mutex::new(PreparedUpdateState::None));
 
 #[cfg(desktop)]
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -640,105 +666,190 @@ enum UpdateCheckTrigger {
 }
 
 #[cfg(desktop)]
-#[derive(Clone, Copy, PartialEq, Eq)]
-enum UpdateInstallOrigin {
-    Automatic,
-    ManualCheck,
-    UserApprovedPending,
-}
-
-#[cfg(desktop)]
-#[derive(Clone, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
-enum UpdateFailureOrigin {
-    Automatic,
-    Manual,
-}
-
-#[cfg(desktop)]
-#[derive(Clone, serde::Serialize)]
-struct PendingUpdateFailure {
-    version: String,
-    origin: UpdateFailureOrigin,
-}
-
-#[cfg(desktop)]
-fn install_failure_retryability(origin: UpdateInstallOrigin) -> Option<bool> {
-    match origin {
-        UpdateInstallOrigin::Automatic => Some(false),
-        UpdateInstallOrigin::ManualCheck => None,
-        UpdateInstallOrigin::UserApprovedPending => Some(true),
-    }
-}
-
-#[cfg(desktop)]
 #[derive(Debug, PartialEq, Eq, serde::Serialize)]
 #[serde(tag = "status", rename_all = "snake_case")]
 enum UpdateCheckResult {
     AutomaticUpdatesDisabled,
     UpToDate,
-    ReadyToRestart { version: String },
-    ReadyToInstall { version: String },
-    InstallFailed { version: String },
+    ReadyToRestart {
+        version: String,
+    },
+    ReadyToInstall {
+        version: String,
+        requires_system_approval: bool,
+    },
+}
+
+#[cfg(desktop)]
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+#[serde(tag = "status", rename_all = "snake_case")]
+enum PreparedUpdate {
+    ReadyToInstall {
+        version: String,
+        requires_system_approval: bool,
+    },
+    ReadyToRestart {
+        version: String,
+    },
 }
 
 /// Linux deb/rpm installs run `pkexec`, which opens a system password dialog.
-/// That dialog must not appear without the user asking for it, so those
-/// installs wait for approval. AppImage, macOS and Windows install silently.
+/// Report that native bundle detail so the renderer never guesses from the OS;
+/// AppImage updates do not require the same system approval.
 #[cfg(desktop)]
-fn install_needs_user_approval() -> bool {
+fn install_requires_system_approval() -> bool {
     use tauri::utils::{config::BundleType, platform::bundle_type};
 
     cfg!(target_os = "linux") && matches!(bundle_type(), Some(BundleType::Deb | BundleType::Rpm))
 }
 
 #[cfg(desktop)]
-fn pending_update_version() -> Option<String> {
-    match PENDING_UPDATE.lock() {
-        Ok(guard) => guard.as_ref().map(|pending| pending.update.version.clone()),
-        Err(e) => {
-            log::error!("Failed to lock PENDING_UPDATE mutex: {e}");
-            None
+fn prepared_update_snapshot() -> Result<Option<PreparedUpdate>, String> {
+    let state = PREPARED_UPDATE
+        .lock()
+        .map_err(|e| format!("Failed to lock PREPARED_UPDATE mutex: {e}"))?;
+
+    Ok(match &*state {
+        PreparedUpdateState::None => None,
+        PreparedUpdateState::ReadyToInstall(pending) => Some(PreparedUpdate::ReadyToInstall {
+            version: pending.update.version.clone(),
+            requires_system_approval: pending.requires_system_approval,
+        }),
+        PreparedUpdateState::ReadyToRestart { version } => Some(PreparedUpdate::ReadyToRestart {
+            version: version.clone(),
+        }),
+    })
+}
+
+#[cfg(desktop)]
+fn prepared_update_result(prepared: Option<PreparedUpdate>) -> Option<UpdateCheckResult> {
+    prepared.map(|prepared| match prepared {
+        PreparedUpdate::ReadyToInstall {
+            version,
+            requires_system_approval,
+        } => UpdateCheckResult::ReadyToInstall {
+            version,
+            requires_system_approval,
+        },
+        PreparedUpdate::ReadyToRestart { version } => UpdateCheckResult::ReadyToRestart { version },
+    })
+}
+
+#[cfg(desktop)]
+fn update_ready_to_restart_version() -> Result<String, String> {
+    validate_update_ready_to_restart(prepared_update_snapshot()?)
+}
+
+#[cfg(desktop)]
+fn validate_update_ready_to_restart(prepared: Option<PreparedUpdate>) -> Result<String, String> {
+    match prepared {
+        Some(PreparedUpdate::ReadyToRestart { version }) => Ok(version),
+        Some(PreparedUpdate::ReadyToInstall { version, .. }) => Err(format!(
+            "Version {version} is downloaded but has not been installed"
+        )),
+        None => Err("No installed update is waiting for Maple to restart".to_string()),
+    }
+}
+
+#[cfg(desktop)]
+fn validate_expected_update_version(
+    prepared_version: Option<&str>,
+    expected_version: &str,
+) -> Result<(), String> {
+    match prepared_version {
+        Some(version) if version == expected_version => Ok(()),
+        Some(version) => Err(format!(
+            "Downloaded update changed from version {expected_version} to {version}; review it before installing"
+        )),
+        None => Err("No downloaded update is waiting to be installed".to_string()),
+    }
+}
+
+#[cfg(desktop)]
+fn validate_returned_prepared_update(
+    prepared: PreparedUpdate,
+    expected_version: &str,
+) -> Result<PreparedUpdate, String> {
+    let version = match &prepared {
+        PreparedUpdate::ReadyToInstall { version, .. }
+        | PreparedUpdate::ReadyToRestart { version } => version,
+    };
+    validate_expected_update_version(Some(version), expected_version)?;
+    Ok(prepared)
+}
+
+#[cfg(desktop)]
+fn pending_update_snapshot(expected_version: &str) -> Result<Arc<PendingUpdate>, String> {
+    let state = PREPARED_UPDATE
+        .lock()
+        .map_err(|e| format!("Failed to lock PREPARED_UPDATE mutex: {e}"))?;
+
+    match &*state {
+        PreparedUpdateState::ReadyToInstall(pending) => {
+            validate_expected_update_version(Some(&pending.update.version), expected_version)?;
+            Ok(Arc::clone(pending))
+        }
+        PreparedUpdateState::ReadyToRestart { version } => Err(format!(
+            "Version {version} is already installed and waiting for Maple to restart"
+        )),
+        PreparedUpdateState::None => {
+            Err("No downloaded update is waiting to be installed".to_string())
         }
     }
 }
 
 #[cfg(desktop)]
-fn downloaded_update_version() -> Option<String> {
-    if !UPDATE_DOWNLOADED.load(Ordering::SeqCst) {
-        return None;
-    }
+fn store_pending_update(pending: PendingUpdate) -> Result<(), String> {
+    let mut state = PREPARED_UPDATE
+        .lock()
+        .map_err(|e| format!("Failed to lock PREPARED_UPDATE mutex: {e}"))?;
+    *state = PreparedUpdateState::ReadyToInstall(Arc::new(pending));
+    Ok(())
+}
 
-    match CURRENT_VERSION.lock() {
-        Ok(version) if !version.is_empty() => Some(version.clone()),
-        Ok(_) => None,
-        Err(e) => {
-            log::error!("Failed to lock CURRENT_VERSION mutex: {e}");
-            None
+#[cfg(desktop)]
+fn mark_update_installed(expected_version: &str) -> Result<(), String> {
+    let mut state = PREPARED_UPDATE
+        .lock()
+        .map_err(|e| format!("Failed to lock PREPARED_UPDATE mutex: {e}"))?;
+
+    match &*state {
+        PreparedUpdateState::ReadyToInstall(pending) => {
+            validate_expected_update_version(Some(&pending.update.version), expected_version)?;
+        }
+        PreparedUpdateState::ReadyToRestart { version } => {
+            return validate_expected_update_version(Some(version), expected_version);
+        }
+        PreparedUpdateState::None => {
+            return validate_expected_update_version(None, expected_version);
         }
     }
+
+    *state = PreparedUpdateState::ReadyToRestart {
+        version: expected_version.to_string(),
+    };
+    Ok(())
 }
 
 #[cfg(desktop)]
-fn prepared_update_result(
-    downloaded_version: Option<String>,
-    pending_install_version: Option<String>,
-) -> Option<UpdateCheckResult> {
-    downloaded_version
-        .map(|version| UpdateCheckResult::ReadyToRestart { version })
-        .or_else(|| {
-            pending_install_version.map(|version| UpdateCheckResult::ReadyToInstall { version })
-        })
-}
-
-#[cfg(desktop)]
-fn emit_update_available(app_handle: &tauri::AppHandle, version: &str) {
+fn emit_update_available(
+    app_handle: &tauri::AppHandle,
+    version: &str,
+    requires_system_approval: bool,
+) {
     #[derive(Clone, serde::Serialize)]
     struct UpdateAvailablePayload<'a> {
         version: &'a str,
+        requires_system_approval: bool,
     }
 
-    if let Err(e) = app_handle.emit("update-available", UpdateAvailablePayload { version }) {
+    if let Err(e) = app_handle.emit(
+        "update-available",
+        UpdateAvailablePayload {
+            version,
+            requires_system_approval,
+        },
+    ) {
         log::error!("Failed to emit update-available event: {e}");
     } else {
         log::info!("Emitted update-available event for version {version}");
@@ -767,21 +878,6 @@ fn emit_manual_update_check_result(app_handle: &tauri::AppHandle, result: &Updat
         if let Err(e) = app_handle.emit("manual-update-check-up-to-date", ()) {
             log::error!("Failed to emit manual-update-check-up-to-date event: {e}");
         }
-    }
-}
-
-#[cfg(desktop)]
-fn emit_manual_update_install_failed(app_handle: &tauri::AppHandle, version: &str) {
-    #[derive(Clone, serde::Serialize)]
-    struct ManualInstallFailedPayload<'a> {
-        version: &'a str,
-    }
-
-    if let Err(e) = app_handle.emit(
-        "manual-update-install-failed",
-        ManualInstallFailedPayload { version },
-    ) {
-        log::error!("Failed to emit manual-update-install-failed event: {e}");
     }
 }
 
@@ -820,7 +916,8 @@ fn update_trigger_allows(trigger: UpdateCheckTrigger, automatic_updates_enabled:
 }
 
 /// Check for updates. Automatic checks honor the persisted preference at each
-/// network/install boundary; a user-requested check always proceeds.
+/// network/download boundary; a user-requested check always proceeds. Every
+/// verified download waits for an explicit install action.
 #[cfg(desktop)]
 async fn check_for_updates(
     app_handle: tauri::AppHandle,
@@ -835,39 +932,23 @@ async fn check_for_updates(
         return Ok(UpdateCheckResult::AutomaticUpdatesDisabled);
     }
 
-    if trigger == UpdateCheckTrigger::Manual {
-        // A manual check should resurface already prepared work instead of
-        // discarding it and downloading or installing the same version again.
-        if let Some(prepared) =
-            prepared_update_result(downloaded_update_version(), pending_update_version())
-        {
+    // A prepared update owns the updater flow until it is installed/restarted.
+    // Manual checks resurface it; automatic checks quietly avoid another
+    // network request or redundant download.
+    if let Some(prepared) = prepared_update_result(prepared_update_snapshot()?) {
+        if trigger == UpdateCheckTrigger::Manual {
             match &prepared {
                 UpdateCheckResult::ReadyToRestart { version } => {
                     emit_update_ready(&app_handle, version)
                 }
-                UpdateCheckResult::ReadyToInstall { version } => {
-                    emit_update_available(&app_handle, version)
-                }
+                UpdateCheckResult::ReadyToInstall {
+                    version,
+                    requires_system_approval,
+                } => emit_update_available(&app_handle, version, *requires_system_approval),
                 _ => unreachable!("prepared update result must be actionable"),
             }
-            return Ok(prepared);
         }
-
-        // An explicit check is also an explicit retry of a version whose
-        // automatic install failed earlier in this session.
-        match FAILED_UPDATE_VERSION.lock() {
-            Ok(mut version) => version.clear(),
-            Err(e) => {
-                log::error!("Failed to lock FAILED_UPDATE_VERSION mutex when clearing: {e}")
-            }
-        }
-        match PENDING_UPDATE_FAILURE.lock() {
-            Ok(mut failure) => *failure = None,
-            Err(e) => {
-                log::error!("Failed to lock PENDING_UPDATE_FAILURE mutex when clearing: {e}")
-            }
-        }
-        log::info!("Automatic install failure suppression cleared for user-requested retry");
+        return Ok(prepared);
     }
 
     log::info!("Checking for updates...");
@@ -884,55 +965,6 @@ async fn check_for_updates(
     // Check for updates
     match updater.check().await {
         Ok(Some(update)) => {
-            // Check if we've already downloaded this specific version
-            let current_downloaded_version = match CURRENT_VERSION.lock() {
-                Ok(guard) => guard.clone(),
-                Err(e) => {
-                    log::error!("Failed to lock CURRENT_VERSION mutex: {e}");
-                    String::new() // Use empty string if lock fails
-                }
-            };
-
-            if UPDATE_DOWNLOADED.load(Ordering::SeqCst)
-                && current_downloaded_version == update.version
-            {
-                log::info!(
-                    "Update to version {} already downloaded, skipping redundant download",
-                    update.version
-                );
-                return Ok(UpdateCheckResult::ReadyToRestart {
-                    version: update.version,
-                });
-            }
-
-            if pending_update_version().as_deref() == Some(update.version.as_str()) {
-                log::info!(
-                    "Update to version {} is downloaded and waiting for user approval, skipping redundant download",
-                    update.version
-                );
-                return Ok(UpdateCheckResult::ReadyToInstall {
-                    version: update.version,
-                });
-            }
-
-            let failed_update_version = match FAILED_UPDATE_VERSION.lock() {
-                Ok(guard) => guard.clone(),
-                Err(e) => {
-                    log::error!("Failed to lock FAILED_UPDATE_VERSION mutex: {e}");
-                    String::new()
-                }
-            };
-
-            if failed_update_version == update.version {
-                log::info!(
-                    "Update to version {} already failed to install in this session, skipping automatic retry",
-                    update.version
-                );
-                return Ok(UpdateCheckResult::InstallFailed {
-                    version: update.version,
-                });
-            }
-
             if !automatic_update_may_continue(&app_handle, trigger).await? {
                 log::info!(
                     "Automatic updates were disabled while checking; not downloading version {}",
@@ -941,7 +973,7 @@ async fn check_for_updates(
                 return Ok(UpdateCheckResult::AutomaticUpdatesDisabled);
             }
 
-            log::info!("Update available, attempting to download and install");
+            log::info!("Update available, downloading it for user approval");
 
             // Download the update
             let mut downloaded = 0_u64;
@@ -974,7 +1006,7 @@ async fn check_for_updates(
                             })?;
                         if !preferences.automatic_updates {
                             log::info!(
-                                "Automatic updates were disabled while downloading; not installing version {}",
+                                "Automatic updates were disabled while downloading; not preparing version {}",
                                 update.version
                             );
                             return Ok(UpdateCheckResult::AutomaticUpdatesDisabled);
@@ -984,40 +1016,20 @@ async fn check_for_updates(
                         None
                     };
 
-                    if install_needs_user_approval() {
-                        let version = update.version.clone();
-                        match PENDING_UPDATE.lock() {
-                            Ok(mut guard) => *guard = Some(PendingUpdate { update, bytes }),
-                            Err(e) => {
-                                let error = format!(
-                                    "Failed to lock PENDING_UPDATE mutex when storing update: {e}"
-                                );
-                                log::error!("{error}");
-                                return Err(error);
-                            }
-                        }
-
-                        emit_update_available(&app_handle, &version);
-
-                        return Ok(UpdateCheckResult::ReadyToInstall { version });
-                    }
-
                     let version = update.version.clone();
-                    let install_origin = match trigger {
-                        UpdateCheckTrigger::Automatic => UpdateInstallOrigin::Automatic,
-                        UpdateCheckTrigger::Manual => UpdateInstallOrigin::ManualCheck,
-                    };
-                    match install_update(&app_handle, &update, &bytes, install_origin) {
-                        Ok(()) => Ok(UpdateCheckResult::ReadyToRestart { version }),
-                        Err(error) if trigger == UpdateCheckTrigger::Manual => {
-                            log::error!(
-                                "Manual update check downloaded version {version}, but installation failed: {error}"
-                            );
-                            emit_manual_update_install_failed(&app_handle, &version);
-                            Ok(UpdateCheckResult::InstallFailed { version })
-                        }
-                        Err(error) => Err(error),
-                    }
+                    let requires_system_approval = install_requires_system_approval();
+                    store_pending_update(PendingUpdate {
+                        update,
+                        bytes,
+                        requires_system_approval,
+                    })?;
+
+                    emit_update_available(&app_handle, &version, requires_system_approval);
+
+                    Ok(UpdateCheckResult::ReadyToInstall {
+                        version,
+                        requires_system_approval,
+                    })
                 }
                 Err(e) => {
                     log::error!("Failed to download update: {e}");
@@ -1036,113 +1048,51 @@ async fn check_for_updates(
     }
 }
 
-/// Install a downloaded update and tell the frontend the result.
-///
-/// A staged install the user approved always reports the result, and a failure
-/// (for example a cancelled password prompt) does not block the version for the
-/// rest of the session. Manual-check failures are returned to their caller,
-/// while automatic failures emit the global fallback notification.
+#[cfg(desktop)]
+fn emit_update_install_failed(app_handle: &tauri::AppHandle, version: &str) {
+    #[derive(Clone, serde::Serialize)]
+    struct UpdateFailedPayload<'a> {
+        version: &'a str,
+        retryable: bool,
+    }
+
+    if let Err(error) = app_handle.emit(
+        "update-failed",
+        UpdateFailedPayload {
+            version,
+            retryable: true,
+        },
+    ) {
+        log::error!("Failed to emit update-failed event: {error}");
+    }
+}
+
+/// Install a signature-verified update after the user explicitly approves it.
+/// The prepared object remains in native memory on every failure so Settings
+/// can offer the same verified bytes again.
 #[cfg(desktop)]
 fn install_update(
     app_handle: &tauri::AppHandle,
     update: &tauri_plugin_updater::Update,
     bytes: &[u8],
-    origin: UpdateInstallOrigin,
 ) -> Result<(), String> {
     log::info!("Installing update to version {}", update.version);
 
     match update.install(bytes) {
         Ok(_) => {
-            // Log that the update is ready
             log::info!(
                 "Update installed successfully. Will be applied on next application restart."
             );
 
-            match FAILED_UPDATE_VERSION.lock() {
-                Ok(mut version) => version.clear(),
-                Err(e) => {
-                    log::error!("Failed to lock FAILED_UPDATE_VERSION mutex when clearing: {e}")
-                }
-            }
-            match PENDING_UPDATE_FAILURE.lock() {
-                Ok(mut failure) => *failure = None,
-                Err(e) => {
-                    log::error!("Failed to lock PENDING_UPDATE_FAILURE mutex when clearing: {e}")
-                }
-            }
-
-            // Mark this version as downloaded to prevent redundant downloads/notifications
-            match CURRENT_VERSION.lock() {
-                Ok(mut version) => *version = update.version.clone(),
-                Err(e) => {
-                    log::error!("Failed to lock CURRENT_VERSION mutex when updating version: {e}")
-                }
-            }
-
-            // The silent path shows the restart toast once per session. An
-            // install the user asked for always gets feedback.
-            let already_notified = UPDATE_DOWNLOADED.swap(true, Ordering::SeqCst);
-            if already_notified && origin != UpdateInstallOrigin::UserApprovedPending {
-                log::info!("Update notification already shown, not showing another one");
-                return Ok(());
-            }
-
+            mark_update_installed(&update.version)?;
             emit_update_ready(app_handle, &update.version);
-
             Ok(())
         }
         Err(e) => {
             let error = format!("Failed to install update: {e}");
             log::error!("{error}");
-
-            if origin == UpdateInstallOrigin::UserApprovedPending {
-                log::info!("User-approved install failed; the update stays available to retry");
-            } else {
-                match FAILED_UPDATE_VERSION.lock() {
-                    Ok(mut version) => *version = update.version.clone(),
-                    Err(lock_error) => log::error!(
-                        "Failed to lock FAILED_UPDATE_VERSION mutex when recording failure: {lock_error}"
-                    ),
-                }
-
-                let failure_origin = match origin {
-                    UpdateInstallOrigin::Automatic => UpdateFailureOrigin::Automatic,
-                    UpdateInstallOrigin::ManualCheck => UpdateFailureOrigin::Manual,
-                    UpdateInstallOrigin::UserApprovedPending => unreachable!(
-                        "user-approved pending failures do not enter suppression state"
-                    ),
-                };
-                match PENDING_UPDATE_FAILURE.lock() {
-                    Ok(mut failure) => {
-                        *failure = Some(PendingUpdateFailure {
-                            version: update.version.clone(),
-                            origin: failure_origin,
-                        });
-                    }
-                    Err(lock_error) => log::error!(
-                        "Failed to lock PENDING_UPDATE_FAILURE mutex when recording failure: {lock_error}"
-                    ),
-                }
-            }
-
-            #[derive(Clone, serde::Serialize)]
-            struct UpdateFailedPayload {
-                version: String,
-                retryable: bool,
-            }
-
-            if let Some(retryable) = install_failure_retryability(origin) {
-                if let Err(emit_error) = app_handle.emit(
-                    "update-failed",
-                    UpdateFailedPayload {
-                        version: update.version.clone(),
-                        retryable,
-                    },
-                ) {
-                    log::error!("Failed to emit update-failed event: {emit_error}");
-                }
-            }
-
+            log::info!("User-approved install failed; the verified update remains available");
+            emit_update_install_failed(app_handle, &update.version);
             Err(error)
         }
     }
@@ -1162,49 +1112,92 @@ mod updater_policy_tests {
     #[test]
     fn manual_checks_resurface_prepared_updates_before_hitting_the_network() {
         assert_eq!(
-            prepared_update_result(Some("4.5.6".to_string()), Some("4.5.5".to_string())),
+            prepared_update_result(Some(PreparedUpdate::ReadyToRestart {
+                version: "4.5.6".to_string(),
+            })),
             Some(UpdateCheckResult::ReadyToRestart {
                 version: "4.5.6".to_string()
             })
         );
         assert_eq!(
-            prepared_update_result(None, Some("4.5.5".to_string())),
+            prepared_update_result(Some(PreparedUpdate::ReadyToInstall {
+                version: "4.5.5".to_string(),
+                requires_system_approval: true,
+            })),
             Some(UpdateCheckResult::ReadyToInstall {
-                version: "4.5.5".to_string()
+                version: "4.5.5".to_string(),
+                requires_system_approval: true,
             })
         );
-        assert_eq!(prepared_update_result(None, None), None);
+        assert_eq!(prepared_update_result(None), None);
     }
 
     #[test]
-    fn install_failure_feedback_matches_the_recovery_path() {
+    fn renderer_must_confirm_the_exact_prepared_version() {
         assert_eq!(
-            install_failure_retryability(UpdateInstallOrigin::Automatic),
-            Some(false)
+            validate_expected_update_version(Some("4.5.6"), "4.5.6"),
+            Ok(())
         );
         assert_eq!(
-            install_failure_retryability(UpdateInstallOrigin::ManualCheck),
-            None
+            validate_expected_update_version(Some("4.5.7"), "4.5.6"),
+            Err(
+                "Downloaded update changed from version 4.5.6 to 4.5.7; review it before installing"
+                    .to_string()
+            )
         );
         assert_eq!(
-            install_failure_retryability(UpdateInstallOrigin::UserApprovedPending),
-            Some(true)
+            validate_expected_update_version(None, "4.5.6"),
+            Err("No downloaded update is waiting to be installed".to_string())
+        );
+        assert_eq!(
+            validate_returned_prepared_update(
+                PreparedUpdate::ReadyToRestart {
+                    version: "4.5.7".to_string(),
+                },
+                "4.5.6",
+            ),
+            Err(
+                "Downloaded update changed from version 4.5.6 to 4.5.7; review it before installing"
+                    .to_string()
+            )
         );
     }
 
     #[test]
-    fn pending_failure_origin_preserves_manual_recovery_copy() {
-        let failure = PendingUpdateFailure {
+    fn prepared_update_keeps_native_install_approval_metadata() {
+        let prepared = PreparedUpdate::ReadyToInstall {
             version: "4.5.6".to_string(),
-            origin: UpdateFailureOrigin::Manual,
+            requires_system_approval: true,
         };
 
         assert_eq!(
-            serde_json::to_value(failure).unwrap(),
+            serde_json::to_value(prepared).unwrap(),
             serde_json::json!({
+                "status": "ready_to_install",
                 "version": "4.5.6",
-                "origin": "manual"
+                "requires_system_approval": true
             })
+        );
+    }
+
+    #[test]
+    fn restart_requires_a_natively_installed_update() {
+        assert_eq!(
+            validate_update_ready_to_restart(Some(PreparedUpdate::ReadyToRestart {
+                version: "4.5.6".to_string(),
+            })),
+            Ok("4.5.6".to_string())
+        );
+        assert_eq!(
+            validate_update_ready_to_restart(Some(PreparedUpdate::ReadyToInstall {
+                version: "4.5.6".to_string(),
+                requires_system_approval: false,
+            })),
+            Err("Version 4.5.6 is downloaded but has not been installed".to_string())
+        );
+        assert_eq!(
+            validate_update_ready_to_restart(None),
+            Err("No installed update is waiting for Maple to restart".to_string())
         );
     }
 }

--- a/frontend/src/components/GlobalNotification.test.tsx
+++ b/frontend/src/components/GlobalNotification.test.tsx
@@ -1,0 +1,101 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+
+import { GlobalNotification, type Notification } from "./GlobalNotification";
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
+const originalSetTimeout = globalThis.setTimeout;
+const originalClearTimeout = globalThis.clearTimeout;
+
+function installFakeTimers() {
+  let nextTimerId = 1;
+  const timers = new Map<number, () => void>();
+
+  globalThis.setTimeout = ((handler: TimerHandler) => {
+    const timerId = nextTimerId++;
+    if (typeof handler === "function") timers.set(timerId, handler as () => void);
+    return timerId;
+  }) as unknown as typeof setTimeout;
+  globalThis.clearTimeout = ((timerId: number) => {
+    timers.delete(timerId);
+  }) as unknown as typeof clearTimeout;
+
+  return {
+    runAll() {
+      for (const [timerId, handler] of [...timers]) {
+        timers.delete(timerId);
+        handler();
+      }
+    }
+  };
+}
+
+function installReadyNotification(): Notification {
+  return {
+    id: "install-ready",
+    type: "update",
+    title: "Update Ready",
+    message: "Version 9.8.7 is ready.",
+    duration: 0,
+    actions: [
+      {
+        label: "Install Now",
+        onClick: () => {}
+      }
+    ]
+  };
+}
+
+describe("GlobalNotification", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+    globalThis.setTimeout = originalSetTimeout;
+    globalThis.clearTimeout = originalClearTimeout;
+  });
+
+  for (const replacement of [
+    { id: "installed", type: "update" as const, title: "Update Installed" },
+    { id: "failed", type: "error" as const, title: "Update Not Installed" }
+  ]) {
+    test(`does not dismiss a fast ${replacement.type} result from an older install action`, () => {
+      const timers = installFakeTimers();
+      const onDismiss = mock(() => {});
+
+      act(() => {
+        renderer = create(
+          <GlobalNotification notification={installReadyNotification()} onDismiss={onDismiss} />
+        );
+      });
+
+      const installButton = renderer!.root
+        .findAllByType("button")
+        .find((button) => textContent(button) === "Install Now");
+      act(() => installButton!.props.onClick());
+
+      act(() => {
+        renderer!.update(
+          <GlobalNotification
+            notification={{
+              ...replacement,
+              message: "Native updater result.",
+              duration: 0
+            }}
+            onDismiss={onDismiss}
+          />
+        );
+      });
+      act(() => timers.runAll());
+
+      expect(textContent(renderer!.root)).toContain(replacement.title);
+      expect(onDismiss).not.toHaveBeenCalled();
+    });
+  }
+});

--- a/frontend/src/components/GlobalNotification.tsx
+++ b/frontend/src/components/GlobalNotification.tsx
@@ -20,23 +20,38 @@ export interface Notification {
 
 interface GlobalNotificationProps {
   notification: Notification | null;
-  onDismiss: () => void;
+  onDismiss: (notificationId: string) => void;
 }
 
 export function GlobalNotification({ notification, onDismiss }: GlobalNotificationProps) {
   const [isVisible, setIsVisible] = useState(false);
   const [isLeaving, setIsLeaving] = useState(false);
   const dismissTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const notificationIdRef = useRef<string | null>(notification?.id ?? null);
+  notificationIdRef.current = notification?.id ?? null;
 
   const handleDismiss = useCallback(() => {
+    const dismissedNotificationId = notificationIdRef.current;
+    if (!dismissedNotificationId) return;
+
     setIsLeaving(true);
     dismissTimeoutRef.current = setTimeout(() => {
+      // An action can synchronously trigger a replacement notification. Never
+      // let the old toast's exit animation clear or hide that newer result.
+      if (notificationIdRef.current !== dismissedNotificationId) return;
+
       setIsVisible(false);
-      onDismiss();
+      onDismiss(dismissedNotificationId);
+      dismissTimeoutRef.current = null;
     }, 200); // Match animation duration
   }, [onDismiss]);
 
   useEffect(() => {
+    if (dismissTimeoutRef.current) {
+      clearTimeout(dismissTimeoutRef.current);
+      dismissTimeoutRef.current = null;
+    }
+
     if (notification) {
       // Trigger enter animation
       setIsVisible(true);

--- a/frontend/src/components/UpdateEventListener.test.tsx
+++ b/frontend/src/components/UpdateEventListener.test.tsx
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import { NotificationProvider } from "@/contexts/NotificationContext";
+import type { PreparedUpdate, UpdateService } from "@/services/updateService";
+import { UpdateEventListener } from "./UpdateEventListener";
+
+type PreparedHandler = (prepared: PreparedUpdate) => void;
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
+function service(overrides: Partial<UpdateService> = {}): UpdateService {
+  return {
+    loadPreferences: mock(async () => ({ automatic_updates: true })),
+    savePreferences: mock(async () => {}),
+    checkForUpdates: mock(async () => ({ status: "up_to_date" as const })),
+    getPreparedUpdate: mock(async () => null),
+    installPreparedUpdate: mock(async (version: string) => ({
+      status: "ready_to_restart" as const,
+      version
+    })),
+    restartForUpdate: mock(async () => {}),
+    subscribePreparedUpdates: mock(async () => () => {}),
+    ...overrides
+  };
+}
+
+const listenEvent = (async () => () => {}) as typeof import("@tauri-apps/api/event").listen;
+
+describe("UpdateEventListener", () => {
+  let renderer: ReactTestRenderer | null = null;
+  let consoleError: ReturnType<typeof spyOn> | null = null;
+
+  beforeEach(() => {
+    consoleError = spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+    consoleError?.mockRestore();
+    consoleError = null;
+  });
+
+  async function mountListener(updates: UpdateService, eventListener = listenEvent) {
+    await act(async () => {
+      renderer = create(
+        <NotificationProvider>
+          <UpdateEventListener service={updates} isDesktop listenEvent={eventListener} />
+        </NotificationProvider>
+      );
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+  }
+
+  test("does not regress a live restart-ready event with a stale install-error query", async () => {
+    let preparedHandler: PreparedHandler | null = null;
+    let preparedReads = 0;
+    let resolveReconciliation: ((prepared: PreparedUpdate | null) => void) | null = null;
+    const reconciliation = new Promise<PreparedUpdate | null>((resolve) => {
+      resolveReconciliation = resolve;
+    });
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        preparedHandler = handler;
+        return () => {};
+      }),
+      getPreparedUpdate: mock(async () => {
+        preparedReads += 1;
+        return preparedReads === 1 ? null : reconciliation;
+      }),
+      installPreparedUpdate: mock(async () => {
+        throw new Error("concurrent install advanced");
+      })
+    });
+
+    await mountListener(updates);
+    act(() => {
+      preparedHandler?.({
+        status: "ready_to_install",
+        version: "9.8.7",
+        requires_system_approval: false
+      });
+    });
+    const installButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button) === "Install Now");
+
+    await act(async () => {
+      installButton?.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    act(() => {
+      preparedHandler?.({ status: "ready_to_restart", version: "9.8.7" });
+    });
+    await act(async () => {
+      resolveReconciliation?.({
+        status: "ready_to_install",
+        version: "9.8.7",
+        requires_system_approval: false
+      });
+      await reconciliation;
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Update Installed");
+    expect(textContent(renderer!.root)).not.toContain("Update Not Installed");
+  });
+
+  test("shows visible recovery when an update restart fails", async () => {
+    let preparedHandler: PreparedHandler | null = null;
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        preparedHandler = handler;
+        return () => {};
+      }),
+      restartForUpdate: mock(async () => {
+        throw new Error("agent drain failed");
+      })
+    });
+
+    await mountListener(updates);
+    act(() => {
+      preparedHandler?.({ status: "ready_to_restart", version: "9.8.7" });
+    });
+    const restartButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button) === "Restart Now");
+
+    await act(async () => {
+      restartButton?.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Couldn't Restart Maple");
+    expect(textContent(renderer!.root)).toContain("Quit and reopen Maple");
+  });
+
+  test("rehydrates prepared state when an auxiliary event listener fails", async () => {
+    const updates = service({
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_restart" as const,
+        version: "9.8.7"
+      }))
+    });
+    const failingListener = (async () => {
+      throw new Error("event API unavailable");
+    }) as typeof listenEvent;
+
+    await mountListener(updates, failingListener);
+
+    expect(updates.getPreparedUpdate).toHaveBeenCalledTimes(1);
+    expect(textContent(renderer!.root)).toContain("Update Installed");
+  });
+
+  test("applies a newer native snapshot after an older live event", async () => {
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        handler({
+          status: "ready_to_install",
+          version: "9.8.7",
+          requires_system_approval: false
+        });
+        return () => {};
+      }),
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_restart" as const,
+        version: "9.8.7"
+      }))
+    });
+
+    await mountListener(updates);
+
+    expect(textContent(renderer!.root)).toContain("Update Installed");
+    expect(textContent(renderer!.root)).not.toContain("Install Now");
+  });
+});

--- a/frontend/src/components/UpdateEventListener.tsx
+++ b/frontend/src/components/UpdateEventListener.tsx
@@ -1,56 +1,113 @@
 import { useEffect } from "react";
 import { listen } from "@tauri-apps/api/event";
-import { invoke } from "@tauri-apps/api/core";
 import { useNotification } from "@/contexts/NotificationContext";
+import { updateService, type PreparedUpdate, type UpdateService } from "@/services/updateService";
 import { openExternalUrl } from "@/utils/openUrl";
 import { isTauriDesktop } from "@/utils/platform";
 
-interface UpdateReadyPayload {
-  version: string;
-}
-
 interface UpdateFailedPayload {
   version: string;
-  // True when the user approved the install and it did not complete (for
-  // example a cancelled password prompt). The download is kept for a retry.
-  retryable?: boolean;
 }
 
-interface UpdateAvailablePayload {
-  version: string;
+interface UpdateEventListenerProps {
+  service?: UpdateService;
+  isDesktop?: boolean;
+  listenEvent?: typeof listen;
 }
 
-interface ManualInstallFailedPayload {
-  version: string;
-}
-
-interface PendingUpdateFailure {
-  version: string;
-  origin: "automatic" | "manual";
-}
-
-export function UpdateEventListener() {
+export function UpdateEventListener({
+  service = updateService,
+  isDesktop = isTauriDesktop(),
+  listenEvent = listen
+}: UpdateEventListenerProps = {}) {
   const { showNotification } = useNotification();
 
   useEffect(() => {
-    if (!isTauriDesktop()) {
+    if (!isDesktop) {
       return;
     }
 
     let disposed = false;
-    let unlistenUpdateReady: (() => void) | null = null;
+    let preparedUpdateGeneration = 0;
+    let unlistenPreparedUpdate: (() => void) | null = null;
     let unlistenUpdateFailed: (() => void) | null = null;
-    let unlistenUpdateAvailable: (() => void) | null = null;
     let unlistenManualCheckUpToDate: (() => void) | null = null;
     let unlistenManualCheckFailed: (() => void) | null = null;
-    let unlistenManualInstallFailed: (() => void) | null = null;
 
-    const installPendingUpdate = async () => {
+    const installPendingUpdate = async (version: string) => {
       try {
-        await invoke("install_pending_update");
+        const prepared = await service.installPreparedUpdate(version);
+        if (!disposed) {
+          if (prepared.status === "ready_to_restart") {
+            showPreparedUpdate(prepared);
+          } else {
+            // A coalesced caller can observe the first install's retryable
+            // failure as the still-prepared native update.
+            showUpdateInstallFailed(prepared.version);
+          }
+        }
       } catch (error) {
-        // The backend emits update-failed for install errors.
         console.error("Failed to install pending update:", error);
+        if (disposed) return;
+
+        const reconciliationGeneration = preparedUpdateGeneration;
+        try {
+          const currentPrepared = await service.getPreparedUpdate();
+          if (disposed || preparedUpdateGeneration !== reconciliationGeneration) return;
+
+          if (currentPrepared?.status === "ready_to_install") {
+            showUpdateInstallFailed(currentPrepared.version);
+          } else if (currentPrepared?.status === "ready_to_restart") {
+            showUpdateReady(currentPrepared.version);
+          } else {
+            showNotification({
+              type: "error",
+              title: "Update Action Unavailable",
+              message: "Open Settings and check for updates again.",
+              duration: 8000
+            });
+          }
+        } catch (preparedError) {
+          console.error("Failed to reconcile updater state:", preparedError);
+          if (!disposed && preparedUpdateGeneration === reconciliationGeneration) {
+            showNotification({
+              type: "error",
+              title: "Couldn't Confirm the Update",
+              message: "Open Settings and check for updates again.",
+              duration: 8000
+            });
+          }
+        }
+      }
+    };
+
+    const restartForInstalledUpdate = async (version: string) => {
+      try {
+        await service.restartForUpdate();
+      } catch (error) {
+        console.error("Failed to restart for update:", error);
+        showNotification({
+          type: "error",
+          title: "Couldn't Restart Maple",
+          message: `Version ${version} is installed. Quit and reopen Maple to finish updating, or try again.`,
+          duration: 0,
+          actions: [
+            {
+              label: "Later",
+              variant: "secondary",
+              onClick: () => {
+                // Just dismiss - the notification will close automatically
+              }
+            },
+            {
+              label: "Try Again",
+              variant: "primary",
+              onClick: () => {
+                void restartForInstalledUpdate(version);
+              }
+            }
+          ]
+        });
       }
     };
 
@@ -79,70 +136,20 @@ export function UpdateEventListener() {
             label: "Try Again",
             variant: "primary",
             onClick: () => {
-              void installPendingUpdate();
+              void installPendingUpdate(version);
             }
           }
         ]
       });
     };
 
-    const showUpdateFailed = (version: string) => {
-      showNotification({
-        type: "error",
-        title: "Update Failed",
-        message: `Maple couldn't install version ${version} automatically. Download the latest installer to update manually.`,
-        duration: 0,
-        actions: [
-          {
-            label: "Later",
-            variant: "secondary",
-            onClick: () => {
-              // Just dismiss - the notification will close automatically
-            }
-          },
-          {
-            label: "Download Manually",
-            variant: "primary",
-            onClick: () => {
-              void openExternalUrl("https://trymaple.ai/downloads");
-            }
-          }
-        ]
-      });
-    };
-
-    const showManualUpdateFailed = (version: string) => {
-      showNotification({
-        type: "error",
-        title: "Update Not Installed",
-        message: `Maple couldn't install version ${version}. Check again, or download the latest installer.`,
-        duration: 0,
-        actions: [
-          {
-            label: "Later",
-            variant: "secondary",
-            onClick: () => {
-              // Just dismiss - the notification will close automatically
-            }
-          },
-          {
-            label: "Download Manually",
-            variant: "primary",
-            onClick: () => {
-              void openExternalUrl("https://trymaple.ai/downloads");
-            }
-          }
-        ]
-      });
-    };
-
-    // Linux deb/rpm installs open a system password prompt, so the backend
-    // downloads the update and waits for the user to approve the install.
-    const showUpdateAvailable = (version: string) => {
+    const showUpdateAvailable = (version: string, requiresSystemApproval: boolean) => {
       showNotification({
         type: "update",
-        title: "Update Available",
-        message: `Maple downloaded version ${version}. Your system will ask for your password to install it.`,
+        title: "Update Ready",
+        message: requiresSystemApproval
+          ? `Maple downloaded and verified version ${version}. Your system will ask for approval to install it.`
+          : `Maple downloaded and verified version ${version}. Install it when you're ready.`,
         duration: 0,
         actions: [
           {
@@ -156,78 +163,76 @@ export function UpdateEventListener() {
             label: "Install Now",
             variant: "primary",
             onClick: () => {
-              void installPendingUpdate();
+              void installPendingUpdate(version);
             }
           }
         ]
       });
     };
 
+    const showUpdateReady = (version: string) => {
+      showNotification({
+        type: "update",
+        title: "Update Installed",
+        message: `Version ${version} has been installed. Restart Maple to finish updating.`,
+        duration: 0,
+        actions: [
+          {
+            label: "Later",
+            variant: "secondary",
+            onClick: () => {
+              // Just dismiss - the notification will close automatically
+            }
+          },
+          {
+            label: "Restart Now",
+            variant: "primary",
+            onClick: () => {
+              void restartForInstalledUpdate(version);
+            }
+          }
+        ]
+      });
+    };
+
+    const showPreparedUpdate = (prepared: PreparedUpdate) => {
+      preparedUpdateGeneration += 1;
+      if (prepared.status === "ready_to_install") {
+        showUpdateAvailable(prepared.version, prepared.requires_system_approval);
+      } else {
+        showUpdateReady(prepared.version);
+      }
+    };
+
     const setupListeners = async () => {
       try {
-        const unlistenReady = await listen<UpdateReadyPayload>("update-ready", (event) => {
-          const { version } = event.payload;
-          showNotification({
-            type: "update",
-            title: "Update Installed",
-            message: `Version ${version} has been installed. Restart Maple to finish updating.`,
-            duration: 0,
-            actions: [
-              {
-                label: "Later",
-                variant: "secondary",
-                onClick: () => {
-                  // Just dismiss - the notification will close automatically
-                }
-              },
-              {
-                label: "Restart Now",
-                variant: "primary",
-                onClick: async () => {
-                  try {
-                    await invoke("restart_for_update");
-                  } catch (error) {
-                    console.error("Failed to restart for update:", error);
-                  }
-                }
-              }
-            ]
-          });
-        });
+        const unlistenPrepared = await service.subscribePreparedUpdates(showPreparedUpdate);
         if (disposed) {
-          unlistenReady();
+          unlistenPrepared();
           return;
         }
-        unlistenUpdateReady = unlistenReady;
+        unlistenPreparedUpdate = unlistenPrepared;
+      } catch (error) {
+        console.error("Failed to subscribe to prepared updates:", error);
+      }
+      if (disposed) return;
 
-        const unlistenFailed = await listen<UpdateFailedPayload>("update-failed", (event) => {
-          const { version, retryable } = event.payload;
-          if (retryable) {
-            showUpdateInstallFailed(version);
-          } else {
-            showUpdateFailed(version);
-          }
+      try {
+        const unlistenFailed = await listenEvent<UpdateFailedPayload>("update-failed", (event) => {
+          showUpdateInstallFailed(event.payload.version);
         });
         if (disposed) {
           unlistenFailed();
           return;
         }
         unlistenUpdateFailed = unlistenFailed;
+      } catch (error) {
+        console.error("Failed to subscribe to update install failures:", error);
+      }
+      if (disposed) return;
 
-        const unlistenAvailable = await listen<UpdateAvailablePayload>(
-          "update-available",
-          (event) => {
-            const { version } = event.payload;
-            showUpdateAvailable(version);
-          }
-        );
-        if (disposed) {
-          unlistenAvailable();
-          return;
-        }
-        unlistenUpdateAvailable = unlistenAvailable;
-
-        const unlistenUpToDate = await listen("manual-update-check-up-to-date", () => {
+      try {
+        const unlistenUpToDate = await listenEvent("manual-update-check-up-to-date", () => {
           showNotification({
             type: "success",
             title: "Maple Is Up to Date",
@@ -240,8 +245,13 @@ export function UpdateEventListener() {
           return;
         }
         unlistenManualCheckUpToDate = unlistenUpToDate;
+      } catch (error) {
+        console.error("Failed to subscribe to manual update success:", error);
+      }
+      if (disposed) return;
 
-        const unlistenCheckFailed = await listen("manual-update-check-failed", () => {
+      try {
+        const unlistenCheckFailed = await listenEvent("manual-update-check-failed", () => {
           showNotification({
             type: "error",
             title: "Couldn't Check for Updates",
@@ -254,38 +264,19 @@ export function UpdateEventListener() {
           return;
         }
         unlistenManualCheckFailed = unlistenCheckFailed;
+      } catch (error) {
+        console.error("Failed to subscribe to manual update failures:", error);
+      }
+      if (disposed) return;
 
-        const unlistenInstallFailed = await listen<ManualInstallFailedPayload>(
-          "manual-update-install-failed",
-          (event) => {
-            const { version } = event.payload;
-            showManualUpdateFailed(version);
-          }
-        );
-        if (disposed) {
-          unlistenInstallFailed();
-          return;
-        }
-        unlistenManualInstallFailed = unlistenInstallFailed;
-
-        const pendingFailure = await invoke<PendingUpdateFailure | null>(
-          "get_pending_update_failure"
-        );
-        if (!disposed && pendingFailure) {
-          if (pendingFailure.origin === "manual") {
-            showManualUpdateFailed(pendingFailure.version);
-          } else {
-            showUpdateFailed(pendingFailure.version);
-          }
-          return;
-        }
-
-        const pendingInstall = await invoke<string | null>("get_pending_update_install");
-        if (!disposed && pendingInstall) {
-          showUpdateAvailable(pendingInstall);
+      try {
+        const queryGeneration = preparedUpdateGeneration;
+        const prepared = await service.getPreparedUpdate();
+        if (!disposed && prepared && preparedUpdateGeneration === queryGeneration) {
+          showPreparedUpdate(prepared);
         }
       } catch (error) {
-        console.error("Failed to setup update event listeners:", error);
+        console.error("Failed to rehydrate prepared update state:", error);
       }
     };
 
@@ -293,14 +284,12 @@ export function UpdateEventListener() {
 
     return () => {
       disposed = true;
-      if (unlistenUpdateReady) unlistenUpdateReady();
+      if (unlistenPreparedUpdate) unlistenPreparedUpdate();
       if (unlistenUpdateFailed) unlistenUpdateFailed();
-      if (unlistenUpdateAvailable) unlistenUpdateAvailable();
       if (unlistenManualCheckUpToDate) unlistenManualCheckUpToDate();
       if (unlistenManualCheckFailed) unlistenManualCheckFailed();
-      if (unlistenManualInstallFailed) unlistenManualInstallFailed();
     };
-  }, [showNotification]);
+  }, [isDesktop, listenEvent, service, showNotification]);
 
   return null;
 }

--- a/frontend/src/components/settings/UpdateSettings.test.tsx
+++ b/frontend/src/components/settings/UpdateSettings.test.tsx
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
 import { Switch } from "@/components/ui/switch";
-import type { UpdateService } from "@/services/updateService";
+import type { PreparedUpdate, UpdateService } from "@/services/updateService";
 import { UpdateSettings } from "./UpdateSettings";
 
 function textContent(node: ReactTestInstance): string {
@@ -15,6 +15,13 @@ function service(overrides: Partial<UpdateService> = {}): UpdateService {
     loadPreferences: mock(async () => ({ automatic_updates: false })),
     savePreferences: mock(async () => {}),
     checkForUpdates: mock(async () => ({ status: "up_to_date" as const })),
+    getPreparedUpdate: mock(async () => null),
+    installPreparedUpdate: mock(async (expectedVersion: string) => ({
+      status: "ready_to_restart" as const,
+      version: expectedVersion
+    })),
+    restartForUpdate: mock(async () => {}),
+    subscribePreparedUpdates: mock(async () => () => {}),
     ...overrides
   };
 }
@@ -138,7 +145,7 @@ describe("UpdateSettings", () => {
     consoleError.mockRestore();
   });
 
-  test("reports the result of a user-requested check", async () => {
+  test("turns a user-requested ready result into a persistent restart action", async () => {
     const updates = service({
       checkForUpdates: mock(async () => ({
         status: "ready_to_restart" as const,
@@ -160,17 +167,142 @@ describe("UpdateSettings", () => {
     });
 
     expect(updates.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(textContent(renderer!.root)).toContain(
+      "Version 9.8.7 is installed. Restart Maple to apply it."
+    );
     expect(
-      renderer!.root.findAll((node) => node.props.role === "status").map(textContent)
-    ).toContain("Version 9.8.7 is installed. Restart Maple to finish updating.");
+      renderer!.root
+        .findAllByType("button")
+        .some((button) => textContent(button).includes("Restart Maple"))
+    ).toBe(true);
   });
 
-  test("announces a manual install failure as an error", async () => {
+  test("restores an install-ready action after its toast was dismissed", async () => {
     const updates = service({
-      checkForUpdates: mock(async () => ({
-        status: "install_failed" as const,
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_install" as const,
+        version: "9.8.7",
+        requires_system_approval: true
+      }))
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain(
+      "Version 9.8.7 is downloaded and signature-verified. Your system will ask for approval"
+    );
+    expect(
+      renderer!.root
+        .findAllByType("button")
+        .some((button) => textContent(button).includes("Install now"))
+    ).toBe(true);
+  });
+
+  test("updates a mounted Settings page when a background download becomes ready", async () => {
+    let receivePreparedUpdate: ((update: PreparedUpdate) => void) | null = null;
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        receivePreparedUpdate = handler;
+        return () => {};
+      })
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+    act(() => {
+      receivePreparedUpdate?.({
+        status: "ready_to_install",
+        version: "9.8.7",
+        requires_system_approval: false
+      });
+    });
+
+    expect(textContent(renderer!.root)).toContain("Version 9.8.7 is downloaded");
+    expect(textContent(renderer!.root)).not.toContain("Your system will ask for approval");
+  });
+
+  test("does not show a stale rehydration error after a live update arrives", async () => {
+    let receivePreparedUpdate: ((update: PreparedUpdate) => void) | null = null;
+    let rejectPreparedQuery: ((error: Error) => void) | null = null;
+    const preparedQuery = new Promise<PreparedUpdate | null>((_resolve, reject) => {
+      rejectPreparedQuery = reject;
+    });
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        receivePreparedUpdate = handler;
+        return () => {};
+      }),
+      getPreparedUpdate: mock(async () => preparedQuery)
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+    act(() => {
+      receivePreparedUpdate?.({
+        status: "ready_to_install",
+        version: "9.8.7",
+        requires_system_approval: false
+      });
+    });
+    await act(async () => {
+      rejectPreparedQuery?.(new Error("stale IPC failure"));
+      try {
+        await preparedQuery;
+      } catch {
+        // Expected test fixture rejection.
+      }
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Update ready to install");
+    expect(textContent(renderer!.root)).not.toContain(
+      "couldn't confirm whether an update is ready"
+    );
+    consoleError.mockRestore();
+  });
+
+  test("applies a newer native snapshot after an older live update", async () => {
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        handler({
+          status: "ready_to_install",
+          version: "9.8.7",
+          requires_system_approval: false
+        });
+        return () => {};
+      }),
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_restart" as const,
         version: "9.8.7"
       }))
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Restart to finish updating");
+    expect(textContent(renderer!.root)).not.toContain("Install now");
+  });
+
+  test("clears an obsolete up-to-date result when a live update becomes ready", async () => {
+    let receivePreparedUpdate: ((update: PreparedUpdate) => void) | null = null;
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        receivePreparedUpdate = handler;
+        return () => {};
+      })
     });
 
     await act(async () => {
@@ -180,14 +312,252 @@ describe("UpdateSettings", () => {
     const checkButton = renderer!.root
       .findAllByType("button")
       .find((button) => textContent(button).includes("Check for updates"));
+    await act(async () => {
+      checkButton?.props.onClick();
+      await Promise.resolve();
+    });
+    expect(textContent(renderer!.root)).toContain("Maple is up to date.");
+
+    act(() => {
+      receivePreparedUpdate?.({
+        status: "ready_to_install",
+        version: "9.8.7",
+        requires_system_approval: false
+      });
+    });
+
+    expect(textContent(renderer!.root)).toContain("Update ready to install");
+    expect(textContent(renderer!.root)).not.toContain("Maple is up to date.");
+  });
+
+  test("clears an obsolete check error when a live update becomes ready", async () => {
+    let receivePreparedUpdate: ((update: PreparedUpdate) => void) | null = null;
+    const updates = service({
+      checkForUpdates: mock(async () => {
+        throw new Error("temporary network error");
+      }),
+      subscribePreparedUpdates: mock(async (handler) => {
+        receivePreparedUpdate = handler;
+        return () => {};
+      })
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
 
     await act(async () => {
-      checkButton!.props.onClick();
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+    });
+    const checkButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Check for updates"));
+    await act(async () => {
+      checkButton?.props.onClick();
+      await Promise.resolve();
+    });
+    expect(textContent(renderer!.root)).toContain("couldn't complete the update check");
+
+    act(() => {
+      receivePreparedUpdate?.({ status: "ready_to_restart", version: "9.8.7" });
+    });
+
+    expect(textContent(renderer!.root)).toContain("Restart to finish updating");
+    expect(textContent(renderer!.root)).not.toContain("couldn't complete the update check");
+    consoleError.mockRestore();
+  });
+
+  test("installs the exact prepared version and transitions to restart-ready", async () => {
+    const updates = service({
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_install" as const,
+        version: "9.8.7",
+        requires_system_approval: false
+      }))
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const installButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Install now"));
+
+    await act(async () => {
+      installButton!.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(updates.installPreparedUpdate).toHaveBeenCalledWith("9.8.7");
+    expect(textContent(renderer!.root)).toContain("Restart to finish updating");
+  });
+
+  test("keeps a verified update available when explicit installation fails", async () => {
+    const updates = service({
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_install" as const,
+        version: "9.8.7",
+        requires_system_approval: false
+      })),
+      installPreparedUpdate: mock(async () => {
+        throw new Error("installer cancelled");
+      })
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const installButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Install now"));
+
+    await act(async () => {
+      installButton!.props.onClick();
       await Promise.resolve();
     });
 
     expect(textContent(renderer!.root.find((node) => node.props.role === "alert"))).toContain(
-      "Maple couldn't install version 9.8.7"
+      "verified download is still ready"
     );
+    expect(textContent(renderer!.root)).toContain("Install now");
+    consoleError.mockRestore();
+  });
+
+  test("reports a coalesced install that remains ready for retry", async () => {
+    const updates = service({
+      getPreparedUpdate: mock(async () => ({
+        status: "ready_to_install" as const,
+        version: "9.8.7",
+        requires_system_approval: false
+      })),
+      installPreparedUpdate: mock(async () => ({
+        status: "ready_to_install" as const,
+        version: "9.8.7",
+        requires_system_approval: false
+      }))
+    });
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const installButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Install now"));
+
+    await act(async () => {
+      installButton?.props.onClick();
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root.find((node) => node.props.role === "alert"))).toContain(
+      "verified download is still ready"
+    );
+    expect(textContent(renderer!.root)).toContain("Install now");
+  });
+
+  test("reconciles a concurrent install that already advanced to restart-ready", async () => {
+    let preparedReads = 0;
+    const updates = service({
+      getPreparedUpdate: mock(async (): Promise<PreparedUpdate> => {
+        preparedReads += 1;
+        if (preparedReads === 1) {
+          return {
+            status: "ready_to_install",
+            version: "9.8.7",
+            requires_system_approval: false
+          };
+        }
+        return { status: "ready_to_restart", version: "9.8.7" };
+      }),
+      installPreparedUpdate: mock(async () => {
+        throw new Error("already installed by another surface");
+      })
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const installButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Install now"));
+
+    await act(async () => {
+      installButton!.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Restart to finish updating");
+    expect(renderer!.root.findAll((node) => node.props.role === "alert")).toHaveLength(0);
+    consoleError.mockRestore();
+  });
+
+  test("does not regress a live restart-ready event with a stale install-error query", async () => {
+    let receivePreparedUpdate: ((update: PreparedUpdate) => void) | null = null;
+    let preparedReads = 0;
+    let resolveReconciliation: ((prepared: PreparedUpdate | null) => void) | null = null;
+    const reconciliation = new Promise<PreparedUpdate | null>((resolve) => {
+      resolveReconciliation = resolve;
+    });
+    const updates = service({
+      subscribePreparedUpdates: mock(async (handler) => {
+        receivePreparedUpdate = handler;
+        return () => {};
+      }),
+      getPreparedUpdate: mock(async () => {
+        preparedReads += 1;
+        if (preparedReads === 1) {
+          return {
+            status: "ready_to_install" as const,
+            version: "9.8.7",
+            requires_system_approval: false
+          };
+        }
+        return reconciliation;
+      }),
+      installPreparedUpdate: mock(async () => {
+        throw new Error("concurrent install advanced");
+      })
+    });
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(<UpdateSettings service={updates} />);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    const installButton = renderer!.root
+      .findAllByType("button")
+      .find((button) => textContent(button).includes("Install now"));
+
+    await act(async () => {
+      installButton!.props.onClick();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    act(() => {
+      receivePreparedUpdate?.({ status: "ready_to_restart", version: "9.8.7" });
+    });
+    await act(async () => {
+      resolveReconciliation?.({
+        status: "ready_to_install",
+        version: "9.8.7",
+        requires_system_approval: false
+      });
+      await reconciliation;
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Restart to finish updating");
+    expect(renderer!.root.findAll((node) => node.props.role === "alert")).toHaveLength(0);
+    consoleError.mockRestore();
   });
 });

--- a/frontend/src/components/settings/UpdateSettings.tsx
+++ b/frontend/src/components/settings/UpdateSettings.tsx
@@ -5,6 +5,7 @@ import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
 import {
   updateService,
+  type PreparedUpdate,
   type UpdateCheckResult,
   type UpdaterPreferences,
   type UpdateService
@@ -20,8 +21,6 @@ function updateCheckMessage(result: UpdateCheckResult): string {
       return `Version ${result.version} is installed. Restart Maple to finish updating.`;
     case "ready_to_install":
       return `Version ${result.version} is downloaded and ready to install.`;
-    case "install_failed":
-      return `Maple couldn't install version ${result.version}. Try checking again or use the latest installer.`;
     case "automatic_updates_disabled":
       return "Automatic updates are off. You can still check for updates manually.";
   }
@@ -40,6 +39,10 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
   const [loadError, setLoadError] = useState<string | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
   const [loadAttempt, setLoadAttempt] = useState(0);
+  const [preparedUpdate, setPreparedUpdate] = useState<PreparedUpdate | null>(null);
+  const [preparedUpdateError, setPreparedUpdateError] = useState<string | null>(null);
+  const [updateOperation, setUpdateOperation] = useState<"installing" | "restarting" | null>(null);
+  const preparedUpdateGenerationRef = useRef(0);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -71,6 +74,56 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
       mountedRef.current = false;
     };
   }, [service, loadAttempt]);
+
+  useEffect(() => {
+    let disposed = false;
+    let unsubscribe: (() => void) | null = null;
+
+    const receivePreparedUpdate = (prepared: PreparedUpdate) => {
+      if (!disposed) {
+        preparedUpdateGenerationRef.current += 1;
+        setPreparedUpdate(prepared);
+        setPreparedUpdateError(null);
+        setCheckStatus(null);
+        setCheckError(null);
+      }
+    };
+
+    const loadPreparedUpdate = async () => {
+      try {
+        const subscribed = await service.subscribePreparedUpdates(receivePreparedUpdate);
+        if (disposed) {
+          subscribed();
+        } else {
+          unsubscribe = subscribed;
+        }
+      } catch (subscriptionError) {
+        console.error("Failed to subscribe to prepared updater state:", subscriptionError);
+      }
+
+      const queryGeneration = preparedUpdateGenerationRef.current;
+      try {
+        const prepared = await service.getPreparedUpdate();
+        if (!disposed && preparedUpdateGenerationRef.current === queryGeneration) {
+          setPreparedUpdate(prepared);
+        }
+      } catch (preparedError) {
+        console.error("Failed to load prepared updater state:", preparedError);
+        if (!disposed && preparedUpdateGenerationRef.current === queryGeneration) {
+          setPreparedUpdateError(
+            "Maple couldn't confirm whether an update is ready. Check again to refresh its state."
+          );
+        }
+      }
+    };
+
+    void loadPreparedUpdate();
+
+    return () => {
+      disposed = true;
+      unsubscribe?.();
+    };
+  }, [service]);
 
   const setAutomaticUpdates = async (automaticUpdates: boolean) => {
     if (isSaving) return;
@@ -115,12 +168,13 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
     setIsChecking(true);
     setCheckError(null);
     setCheckStatus(null);
+    setPreparedUpdateError(null);
 
     try {
       const result = await service.checkForUpdates();
       if (mountedRef.current) {
-        if (result.status === "install_failed") {
-          setCheckError(updateCheckMessage(result));
+        if (result.status === "ready_to_install" || result.status === "ready_to_restart") {
+          setPreparedUpdate(result);
         } else {
           setCheckStatus(updateCheckMessage(result));
         }
@@ -137,6 +191,86 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
     }
   };
 
+  const installPreparedUpdate = async () => {
+    if (updateOperation || preparedUpdate?.status !== "ready_to_install") return;
+
+    const expectedVersion = preparedUpdate.version;
+    setUpdateOperation("installing");
+    setPreparedUpdateError(null);
+
+    try {
+      const prepared = await service.installPreparedUpdate(expectedVersion);
+      if (mountedRef.current) {
+        setPreparedUpdate(prepared);
+        if (prepared.status === "ready_to_install") {
+          setPreparedUpdateError(
+            `Maple couldn't install version ${expectedVersion}. The verified download is still ready; try again.`
+          );
+        }
+      }
+    } catch (installError) {
+      console.error("Failed to install prepared update:", installError);
+      const reconciliationGeneration = preparedUpdateGenerationRef.current;
+      try {
+        const currentPrepared = await service.getPreparedUpdate();
+        if (
+          mountedRef.current &&
+          preparedUpdateGenerationRef.current === reconciliationGeneration
+        ) {
+          setPreparedUpdate(currentPrepared);
+          if (currentPrepared?.status === "ready_to_restart") {
+            // Another visible surface may have completed this same install
+            // while this command waited on the native single-flight lock.
+            setPreparedUpdateError(null);
+          } else if (
+            currentPrepared?.status === "ready_to_install" &&
+            currentPrepared.version === expectedVersion
+          ) {
+            setPreparedUpdateError(
+              `Maple couldn't install version ${expectedVersion}. The verified download is still ready; try again.`
+            );
+          } else {
+            setPreparedUpdateError(
+              "Maple couldn't confirm the downloaded update after installation failed. Check again to refresh its state."
+            );
+          }
+        }
+      } catch (preparedError) {
+        console.error("Failed to reconcile prepared updater state:", preparedError);
+        if (
+          mountedRef.current &&
+          preparedUpdateGenerationRef.current === reconciliationGeneration
+        ) {
+          setPreparedUpdateError(
+            "Maple couldn't confirm the downloaded update after installation failed. Check again to refresh its state."
+          );
+        }
+      }
+    } finally {
+      if (mountedRef.current) setUpdateOperation(null);
+    }
+  };
+
+  const restartForUpdate = async () => {
+    if (updateOperation || preparedUpdate?.status !== "ready_to_restart") return;
+
+    setUpdateOperation("restarting");
+    setPreparedUpdateError(null);
+
+    try {
+      await service.restartForUpdate();
+    } catch (restartError) {
+      console.error("Failed to restart for update:", restartError);
+      if (mountedRef.current) {
+        setPreparedUpdateError(
+          "Maple couldn't restart automatically. Quit and reopen Maple to finish updating."
+        );
+      }
+    } finally {
+      if (mountedRef.current) setUpdateOperation(null);
+    }
+  };
+
   return (
     <SettingsSection
       title="Updates"
@@ -150,9 +284,9 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
               id="automatic-updates-description"
               className="mt-1 text-xs leading-relaxed text-muted-foreground"
             >
-              With this on, Maple checks shortly after launch and every hour. On macOS, Windows, and
-              AppImage, available updates download and install automatically. Linux deb/rpm packages
-              keep their current install prompt.
+              With this on, Maple checks shortly after launch and every hour, then downloads
+              available updates. You choose when to install them. Linux deb/rpm packages keep their
+              system install prompt.
             </p>
           </div>
           <Switch
@@ -167,15 +301,15 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
 
         <div className="flex flex-col gap-3 border-t border-border/70 pt-4 sm:flex-row sm:items-center sm:justify-between">
           <p className="text-xs leading-relaxed text-muted-foreground">
-            A manual check can download and install an available update immediately on macOS,
-            Windows, and AppImage, even when automatic updates are off. Linux deb/rpm packages keep
-            their install prompt.
+            A manual check downloads an available update even when automatic updates are off. Maple
+            waits for you to install it; Linux deb/rpm packages ask for system approval at that
+            point.
           </p>
           <Button
             type="button"
             variant="outline"
             onClick={() => void checkForUpdates()}
-            disabled={isChecking}
+            disabled={isChecking || updateOperation !== null}
             aria-busy={isChecking}
           >
             <RefreshCw
@@ -188,6 +322,59 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
             {isChecking ? "Checking..." : "Check for updates"}
           </Button>
         </div>
+
+        {preparedUpdate && (
+          <div
+            className="flex flex-col gap-3 rounded-lg border border-border bg-muted/30 p-4 sm:flex-row sm:items-center sm:justify-between"
+            role="status"
+            aria-live="polite"
+          >
+            <div>
+              <p className="text-sm font-medium">
+                {preparedUpdate.status === "ready_to_install"
+                  ? "Update ready to install"
+                  : "Restart to finish updating"}
+              </p>
+              <p
+                id="prepared-update-description"
+                className="mt-1 text-xs leading-relaxed text-muted-foreground"
+              >
+                {preparedUpdate.status === "ready_to_install" ? (
+                  <>
+                    Version {preparedUpdate.version} is downloaded and signature-verified.
+                    {preparedUpdate.requires_system_approval &&
+                      " Your system will ask for approval to install it."}
+                  </>
+                ) : (
+                  <>Version {preparedUpdate.version} is installed. Restart Maple to apply it.</>
+                )}
+              </p>
+            </div>
+            {preparedUpdate.status === "ready_to_install" ? (
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void installPreparedUpdate()}
+                disabled={updateOperation !== null}
+                aria-busy={updateOperation === "installing"}
+                aria-describedby="prepared-update-description"
+              >
+                {updateOperation === "installing" ? "Installing..." : "Install now"}
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                size="sm"
+                onClick={() => void restartForUpdate()}
+                disabled={updateOperation !== null}
+                aria-busy={updateOperation === "restarting"}
+                aria-describedby="prepared-update-description"
+              >
+                {updateOperation === "restarting" ? "Restarting..." : "Restart Maple"}
+              </Button>
+            )}
+          </div>
+        )}
 
         {isLoading && (
           <p className="text-xs text-muted-foreground" role="status">
@@ -239,6 +426,11 @@ export function UpdateSettings({ service = updateService }: { service?: UpdateSe
         {checkError && (
           <p className="text-xs leading-relaxed text-destructive" role="alert">
             {checkError}
+          </p>
+        )}
+        {preparedUpdateError && (
+          <p className="text-xs leading-relaxed text-destructive" role="alert">
+            {preparedUpdateError}
           </p>
         )}
       </div>

--- a/frontend/src/contexts/NotificationContext.tsx
+++ b/frontend/src/contexts/NotificationContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, useMemo } from "react";
+import React, { createContext, useContext, useState, useCallback, useMemo, useRef } from "react";
 import { GlobalNotification, type Notification } from "@/components/GlobalNotification";
 
 interface NotificationContextType {
@@ -10,9 +10,10 @@ const NotificationContext = createContext<NotificationContextType | undefined>(u
 
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
   const [notification, setNotification] = useState<Notification | null>(null);
+  const nextNotificationId = useRef(0);
 
   const showNotification = useCallback((notif: Omit<Notification, "id">) => {
-    const id = Date.now().toString();
+    const id = `${Date.now()}-${++nextNotificationId.current}`;
     setNotification({
       ...notif,
       id,
@@ -24,6 +25,10 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     setNotification(null);
   }, []);
 
+  const dismissNotification = useCallback((notificationId: string) => {
+    setNotification((current) => (current?.id === notificationId ? null : current));
+  }, []);
+
   const contextValue = useMemo(
     () => ({ showNotification, clearNotification }),
     [clearNotification, showNotification]
@@ -32,7 +37,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   return (
     <NotificationContext.Provider value={contextValue}>
       {children}
-      <GlobalNotification notification={notification} onDismiss={clearNotification} />
+      <GlobalNotification notification={notification} onDismiss={dismissNotification} />
     </NotificationContext.Provider>
   );
 }

--- a/frontend/src/services/updateService.test.ts
+++ b/frontend/src/services/updateService.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, mock, test } from "bun:test";
-import { createUpdateService, type UpdaterPreferences } from "./updateService";
+import { createUpdateService, type PreparedUpdate, type UpdaterPreferences } from "./updateService";
 
 describe("updateService", () => {
   test("uses the native app-scoped updater preference commands", async () => {
@@ -28,5 +28,65 @@ describe("updateService", () => {
 
     await expect(service.checkForUpdates()).resolves.toEqual({ status: "up_to_date" });
     expect(invoke).toHaveBeenCalledWith("check_for_updates_manually");
+  });
+
+  test("uses native prepared-update state and exact-version install commands", async () => {
+    const prepared: PreparedUpdate = {
+      status: "ready_to_install",
+      version: "4.5.6",
+      requires_system_approval: false
+    };
+    const ready: PreparedUpdate = { status: "ready_to_restart", version: "4.5.6" };
+    const invoke = mock(async (command: string, args?: Record<string, unknown>) => {
+      if (command === "get_prepared_update") return prepared;
+      if (command === "install_pending_update") {
+        expect(args).toEqual({ expectedVersion: "4.5.6" });
+        return ready;
+      }
+      if (command === "restart_for_update") return undefined;
+      throw new Error(`Unexpected command: ${command}`);
+    });
+    const service = createUpdateService(invoke);
+
+    await expect(service.getPreparedUpdate()).resolves.toEqual(prepared);
+    await expect(service.installPreparedUpdate("4.5.6")).resolves.toEqual(ready);
+    await expect(service.restartForUpdate()).resolves.toBeUndefined();
+  });
+
+  test("subscribes to both native prepared-update transitions and cleans them up", async () => {
+    const handlers = new Map<string, (event: { payload: never }) => void>();
+    const unlistenAvailable = mock(() => {});
+    const unlistenReady = mock(() => {});
+    const listen = mock(async (event: string, handler: (event: { payload: never }) => void) => {
+      handlers.set(event, handler);
+      return event === "update-available" ? unlistenAvailable : unlistenReady;
+    });
+    const service = createUpdateService(
+      mock(async () => undefined),
+      listen as Parameters<typeof createUpdateService>[1]
+    );
+    const received: PreparedUpdate[] = [];
+
+    const unsubscribe = await service.subscribePreparedUpdates((update) => received.push(update));
+    handlers.get("update-available")?.({
+      payload: {
+        version: "4.5.6",
+        requires_system_approval: true
+      } as never
+    });
+    handlers.get("update-ready")?.({ payload: { version: "4.5.6" } as never });
+
+    expect(received).toEqual([
+      {
+        status: "ready_to_install",
+        version: "4.5.6",
+        requires_system_approval: true
+      },
+      { status: "ready_to_restart", version: "4.5.6" }
+    ]);
+
+    unsubscribe();
+    expect(unlistenAvailable).toHaveBeenCalledTimes(1);
+    expect(unlistenReady).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/src/services/updateService.ts
+++ b/frontend/src/services/updateService.ts
@@ -1,4 +1,5 @@
 import { invoke as tauriInvoke } from "@tauri-apps/api/core";
+import { listen as tauriListen } from "@tauri-apps/api/event";
 
 export interface UpdaterPreferences {
   automatic_updates: boolean;
@@ -8,24 +9,74 @@ export type UpdateCheckResult =
   | { status: "automatic_updates_disabled" }
   | { status: "up_to_date" }
   | { status: "ready_to_restart"; version: string }
-  | { status: "ready_to_install"; version: string }
-  | { status: "install_failed"; version: string };
+  | {
+      status: "ready_to_install";
+      version: string;
+      requires_system_approval: boolean;
+    };
+
+export type PreparedUpdate =
+  | {
+      status: "ready_to_install";
+      version: string;
+      requires_system_approval: boolean;
+    }
+  | { status: "ready_to_restart"; version: string };
 
 type Invoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+type Unlisten = () => void;
+type Listen = <T>(event: string, handler: (event: { payload: T }) => void) => Promise<Unlisten>;
 
 export interface UpdateService {
   loadPreferences(): Promise<UpdaterPreferences>;
   savePreferences(preferences: UpdaterPreferences): Promise<void>;
   checkForUpdates(): Promise<UpdateCheckResult>;
+  getPreparedUpdate(): Promise<PreparedUpdate | null>;
+  installPreparedUpdate(expectedVersion: string): Promise<PreparedUpdate>;
+  restartForUpdate(): Promise<void>;
+  subscribePreparedUpdates(handler: (update: PreparedUpdate) => void): Promise<Unlisten>;
 }
 
-export function createUpdateService(invoke: Invoke = tauriInvoke): UpdateService {
+export function createUpdateService(
+  invoke: Invoke = tauriInvoke,
+  listen: Listen = tauriListen as Listen
+): UpdateService {
   return {
     loadPreferences: async () => (await invoke("load_updater_preferences")) as UpdaterPreferences,
     savePreferences: async (preferences) => {
       await invoke("save_updater_preferences", { preferences });
     },
-    checkForUpdates: async () => (await invoke("check_for_updates_manually")) as UpdateCheckResult
+    checkForUpdates: async () => (await invoke("check_for_updates_manually")) as UpdateCheckResult,
+    getPreparedUpdate: async () => (await invoke("get_prepared_update")) as PreparedUpdate | null,
+    installPreparedUpdate: async (expectedVersion) =>
+      (await invoke("install_pending_update", {
+        expectedVersion
+      })) as PreparedUpdate,
+    restartForUpdate: async () => {
+      await invoke("restart_for_update");
+    },
+    subscribePreparedUpdates: async (handler) => {
+      const unlistenAvailable = await listen<{
+        version: string;
+        requires_system_approval: boolean;
+      }>("update-available", ({ payload }) => {
+        handler({ ...payload, status: "ready_to_install" });
+      });
+
+      try {
+        const unlistenReady = await listen<{ version: string }>("update-ready", ({ payload }) => {
+          handler({ ...payload, status: "ready_to_restart" });
+        });
+
+        return () => {
+          unlistenAvailable();
+          unlistenReady();
+        };
+      } catch (error) {
+        unlistenAvailable();
+        throw error;
+      }
+    }
   };
 }
 


### PR DESCRIPTION
Depends on #822.

This changes desktop updates from download-and-install to download, signature verification, and native staging. A verified update stays available for the current Maple process until the user explicitly installs it from the notification or persistent Settings card; dismissing the notification does not lose the action, and manual checks resurface the prepared update without downloading it again. Installation is native-authorized by exact version, single-flight, and fenced against exit/restart. Windows drains Agent and ACP before handing off to the installer.

Validation:
- 739 frontend tests and 2,340 assertions across 86 files
- 387 Rust library tests plus 3 binary tests; 2 intentional ignores
- Prettier, ESLint, TypeScript, cargo fmt, clippy with deny-warnings, and diff checks
- Independent correctness, security/lifecycle, platform, and UX reviews with no remaining findings
- Disposable macOS 0.0.0 bundle downloaded and verified the signed 3.3.6 artifact, remained unchanged before explicit installation, recovered after Later through Check for Updates without a second download, then installed only after Install Now; the resulting bundle passed strict Developer ID signature verification

Boundaries kept explicit: prepared bytes are in memory and survive only the current process; signed-out Windows/Linux still have no persistent recovery surface because Settings is auth-gated and those platforms intentionally have no native menu. A signed Windows runtime and real AppImage/deb/rpm package runtime remain required platform follow-ups.