### PR TITLE
security: enforce unsoundness advisories

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -1,7 +1,11 @@
 [advisories]
 # Vulnerability and unsoundness advisories are blocking. Unmaintained-package
 # notices are tracked separately because they often require API migrations.
+unsound = "all"
 unmaintained = "none"
+ignore = [
+    { id = "RUSTSEC-2024-0429", reason = "Tauri's Linux GTK3 stack requires glib 0.18; its GTK4 migration is still open, and Maple's locked graph does not call the affected VariantStrIter API" },
+]
 
 [bans]
 # Emergency supply-chain containment for the August 2026 crates.io campaign.


### PR DESCRIPTION
## Summary

- make cargo-deny block RustSec unsoundness advisories
- narrowly ignore RUSTSEC-2024-0429 because Tauri’s current Linux GTK3 stack requires glib 0.18
- document that Maple and its locked transitive sources do not call the affected VariantStrIter API

Tauri’s GTK4 migration remains open: https://github.com/tauri-apps/tauri/issues/12562

## Validation

- cargo deny --manifest-path frontend/src-tauri/Cargo.toml --all-features --locked check --config deny.toml advisories bans
- Maple pre-commit hook: formatting, production frontend build, and 739 frontend tests