### PR TITLE
chore: update spin to 0.9.9

### DIFF
--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -7889,9 +7889,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 dependencies = [
  "lock_api",
 ]


### PR DESCRIPTION
## Summary

- update the transitive spin lockfile entry from yanked 0.9.8 to non-yanked 0.9.9
- leave the dependency path otherwise unchanged: Goose -> SQLx SQLite -> flume -> spin

## Validation

- cargo deny --manifest-path frontend/src-tauri/Cargo.toml --all-features --locked check --config deny.toml advisories bans
- Maple Rust CI: 391 passed, 2 expected ignored
- repository pre-commit hook: frontend production build, frontend tests, and Rust tests