### PR TITLE
feat: surface native app downloads in web About settings

### DIFF
--- a/frontend/src/components/settings/AboutSettings.test.tsx
+++ b/frontend/src/components/settings/AboutSettings.test.tsx
@@ -5,7 +5,7 @@ mock.module("@tanstack/react-router", () => ({
   Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>
 }));
 
-const { AboutSettings } = await import("./AboutSettings");
+const { AboutSettings, resolveAboutSettingsGating } = await import("./AboutSettings");
 
 function textContent(node: ReactTestInstance): string {
   return node.children
@@ -13,12 +13,51 @@ function textContent(node: ReactTestInstance): string {
     .join("");
 }
 
+describe("resolveAboutSettingsGating", () => {
+  test("shows downloads only in the web view", () => {
+    expect(
+      resolveAboutSettingsGating({
+        isTauriDesktop: () => false,
+        isWeb: () => true
+      })
+    ).toEqual({ supportsDesktopUpdates: false, showAppDownloads: true });
+  });
+
+  test("shows desktop updates only on Tauri desktop", () => {
+    expect(
+      resolveAboutSettingsGating({
+        isTauriDesktop: () => true,
+        isWeb: () => false
+      })
+    ).toEqual({ supportsDesktopUpdates: true, showAppDownloads: false });
+  });
+
+  test("hides both sections on Tauri mobile", () => {
+    expect(
+      resolveAboutSettingsGating({
+        isTauriDesktop: () => false,
+        isWeb: () => false
+      })
+    ).toEqual({ supportsDesktopUpdates: false, showAppDownloads: false });
+  });
+});
+
 describe("AboutSettings", () => {
   let renderer: ReactTestRenderer | null = null;
 
   afterEach(() => {
     if (renderer) act(() => renderer?.unmount());
     renderer = null;
+  });
+
+  test("uses the live platform defaults in this web test environment", async () => {
+    await act(async () => {
+      renderer = create(<AboutSettings />);
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Get the Maple app");
+    expect(textContent(renderer!.root)).not.toContain("Automatic updates");
   });
 
   test("shows app downloads in the web view and hides desktop update settings", async () => {

--- a/frontend/src/components/settings/AboutSettings.test.tsx
+++ b/frontend/src/components/settings/AboutSettings.test.tsx
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+
+mock.module("@tanstack/react-router", () => ({
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => <a href={to}>{children}</a>
+}));
+
+const { AboutSettings } = await import("./AboutSettings");
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
+describe("AboutSettings", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+  });
+
+  test("shows app downloads in the web view and hides desktop update settings", async () => {
+    await act(async () => {
+      renderer = create(<AboutSettings supportsDesktopUpdates={false} showAppDownloads />);
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("Get the Maple app");
+    expect(textContent(renderer!.root)).not.toContain("Automatic updates");
+  });
+
+  test("hides both native-only sections on Tauri mobile", () => {
+    act(() => {
+      renderer = create(<AboutSettings supportsDesktopUpdates={false} showAppDownloads={false} />);
+    });
+
+    expect(textContent(renderer!.root)).not.toContain("Automatic updates");
+    expect(textContent(renderer!.root)).not.toContain("Get the Maple app");
+  });
+});

--- a/frontend/src/components/settings/AboutSettings.tsx
+++ b/frontend/src/components/settings/AboutSettings.tsx
@@ -3,8 +3,9 @@ import { ExternalLink, FileText, Info, Mail, Shield } from "lucide-react";
 import packageJson from "../../../package.json";
 import { Button } from "@/components/ui/button";
 import { openExternalUrl } from "@/utils/openUrl";
-import { isTauriDesktop } from "@/utils/platform";
+import { isTauriDesktop, isWeb } from "@/utils/platform";
 import { SettingsPage, SettingsSection } from "./SettingsPage";
+import { DownloadSettings } from "./DownloadSettings";
 import { UpdateSettings } from "./UpdateSettings";
 
 type ExternalRowProps = {
@@ -27,9 +28,13 @@ function ExternalRow({ label, url, icon: Icon }: ExternalRowProps) {
   );
 }
 
-export function AboutSettings() {
-  const supportsDesktopUpdates = isTauriDesktop();
-
+export function AboutSettings({
+  supportsDesktopUpdates = isTauriDesktop(),
+  showAppDownloads = isWeb()
+}: {
+  supportsDesktopUpdates?: boolean;
+  showAppDownloads?: boolean;
+} = {}) {
   return (
     <SettingsPage title="About" description="Maple information, updates, policies, and support.">
       <SettingsSection title="Maple Research">
@@ -50,6 +55,7 @@ export function AboutSettings() {
       </SettingsSection>
 
       {supportsDesktopUpdates && <UpdateSettings />}
+      {showAppDownloads && <DownloadSettings />}
 
       <SettingsSection title="Policies and support">
         <div className="space-y-2">

--- a/frontend/src/components/settings/AboutSettings.tsx
+++ b/frontend/src/components/settings/AboutSettings.tsx
@@ -28,13 +28,28 @@ function ExternalRow({ label, url, icon: Icon }: ExternalRowProps) {
   );
 }
 
+export function resolveAboutSettingsGating(
+  checks: { isTauriDesktop: () => boolean; isWeb: () => boolean } = {
+    isTauriDesktop,
+    isWeb
+  }
+) {
+  return {
+    supportsDesktopUpdates: checks.isTauriDesktop(),
+    showAppDownloads: checks.isWeb()
+  };
+}
+
 export function AboutSettings({
-  supportsDesktopUpdates = isTauriDesktop(),
-  showAppDownloads = isWeb()
+  supportsDesktopUpdates,
+  showAppDownloads
 }: {
   supportsDesktopUpdates?: boolean;
   showAppDownloads?: boolean;
 } = {}) {
+  const gating = resolveAboutSettingsGating();
+  const showUpdates = supportsDesktopUpdates ?? gating.supportsDesktopUpdates;
+  const showDownloads = showAppDownloads ?? gating.showAppDownloads;
   return (
     <SettingsPage title="About" description="Maple information, updates, policies, and support.">
       <SettingsSection title="Maple Research">
@@ -54,8 +69,8 @@ export function AboutSettings({
         </div>
       </SettingsSection>
 
-      {supportsDesktopUpdates && <UpdateSettings />}
-      {showAppDownloads && <DownloadSettings />}
+      {showUpdates && <UpdateSettings />}
+      {showDownloads && <DownloadSettings />}
 
       <SettingsSection title="Policies and support">
         <div className="space-y-2">

--- a/frontend/src/components/settings/DownloadSettings.test.tsx
+++ b/frontend/src/components/settings/DownloadSettings.test.tsx
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
 import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
-import type { DownloadInfo } from "@/utils/githubRelease";
+import { GITHUB_RELEASES_LATEST_URL, type DownloadInfo } from "@/utils/githubRelease";
 import { DownloadSettings } from "./DownloadSettings";
 
 function textContent(node: ReactTestInstance): string {
@@ -104,9 +104,18 @@ describe("DownloadSettings", () => {
         { href: "https://example.test/Maple.rpm", label: ".rpm" }
       ])
     );
+
+    await act(async () => {
+      linuxRadio?.props.onKeyDown({
+        key: "ArrowDown",
+        preventDefault() {}
+      });
+    });
+    const iosRadio = radioButtons(renderer!).find((button) => textContent(button).includes("iOS"));
+    expect(iosRadio?.props["aria-checked"]).toBe(true);
   });
 
-  test("keeps packaged fallback links when the GitHub lookup fails", async () => {
+  test("keeps latest-release fallback links when the GitHub lookup fails", async () => {
     const loadDownloadInfo = mock(async () => null);
     const consoleError = spyOn(console, "error").mockImplementation(() => {});
 
@@ -123,8 +132,7 @@ describe("DownloadSettings", () => {
     const downloadLink = renderer!.root
       .findAllByType("a")
       .find((link) => textContent(link).includes("Download for macOS"));
-    expect(downloadLink?.props.href).toContain("Maple_");
-    expect(downloadLink?.props.href).toContain("_universal.dmg");
+    expect(downloadLink?.props.href).toBe(GITHUB_RELEASES_LATEST_URL);
     expect(textContent(renderer!.root)).toContain("Choose the platform you want to install.");
     consoleError.mockRestore();
   });

--- a/frontend/src/components/settings/DownloadSettings.test.tsx
+++ b/frontend/src/components/settings/DownloadSettings.test.tsx
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, mock, spyOn, test } from "bun:test";
+import { act, create, type ReactTestInstance, type ReactTestRenderer } from "react-test-renderer";
+import type { DownloadInfo } from "@/utils/githubRelease";
+import { DownloadSettings } from "./DownloadSettings";
+
+function textContent(node: ReactTestInstance): string {
+  return node.children
+    .map((child) => (typeof child === "string" ? child : textContent(child)))
+    .join("");
+}
+
+const latestInfo: DownloadInfo = {
+  version: "9.9.9",
+  tagName: "v9.9.9",
+  downloadUrls: {
+    macOS: "https://example.test/Maple.dmg",
+    windowsExe: "https://example.test/Maple.exe",
+    linuxAppImage: "https://example.test/Maple.AppImage",
+    linuxDeb: "https://example.test/Maple.deb",
+    linuxRpm: "https://example.test/Maple.rpm",
+    androidApk: "https://example.test/Maple.apk"
+  },
+  releaseUrl: "https://example.test/releases/v9.9.9"
+};
+
+function radioButtons(renderer: ReactTestRenderer): ReactTestInstance[] {
+  return renderer.root.findAll((node) => node.props.role === "radio");
+}
+
+describe("DownloadSettings", () => {
+  let renderer: ReactTestRenderer | null = null;
+
+  afterEach(() => {
+    if (renderer) act(() => renderer?.unmount());
+    renderer = null;
+  });
+
+  test("suggests macOS for a Mac browser and uses the latest dmg URL", async () => {
+    const loadDownloadInfo = mock(async () => latestInfo);
+
+    await act(async () => {
+      renderer = create(
+        <DownloadSettings
+          environment={{
+            userAgent:
+              "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+            platform: "MacIntel",
+            maxTouchPoints: 0
+          }}
+          loadDownloadInfo={loadDownloadInfo}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    expect(textContent(renderer!.root)).toContain("This browser looks like macOS");
+    const macosRadio = radioButtons(renderer!).find((button) =>
+      textContent(button).includes("macOS")
+    );
+    expect(macosRadio?.props["aria-checked"]).toBe(true);
+    expect(textContent(macosRadio!)).toContain("Suggested");
+
+    const downloadLink = renderer!.root
+      .findAllByType("a")
+      .find((link) => textContent(link).includes("Download for macOS"));
+    expect(downloadLink?.props.href).toBe("https://example.test/Maple.dmg");
+    expect(textContent(renderer!.root)).toContain("9.9.9");
+  });
+
+  test("lets the user switch to another platform", async () => {
+    const loadDownloadInfo = mock(async () => latestInfo);
+
+    await act(async () => {
+      renderer = create(
+        <DownloadSettings
+          environment={{
+            userAgent:
+              "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+          }}
+          loadDownloadInfo={loadDownloadInfo}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    const linuxRadio = radioButtons(renderer!).find((button) =>
+      textContent(button).includes("Linux")
+    );
+    await act(async () => {
+      linuxRadio?.props.onClick();
+    });
+
+    expect(linuxRadio?.props["aria-checked"]).toBe(true);
+    expect(linuxRadio?.props.tabIndex).toBe(0);
+    expect(
+      renderer!.root.findAllByType("a").map((link) => ({
+        href: link.props.href,
+        label: textContent(link)
+      }))
+    ).toEqual(
+      expect.arrayContaining([
+        { href: "https://example.test/Maple.AppImage", label: "Download AppImage" },
+        { href: "https://example.test/Maple.deb", label: ".deb" },
+        { href: "https://example.test/Maple.rpm", label: ".rpm" }
+      ])
+    );
+  });
+
+  test("keeps packaged fallback links when the GitHub lookup fails", async () => {
+    const loadDownloadInfo = mock(async () => null);
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+
+    await act(async () => {
+      renderer = create(
+        <DownloadSettings
+          environment={{ userAgent: "UnknownClient/1.0" }}
+          loadDownloadInfo={loadDownloadInfo}
+        />
+      );
+      await Promise.resolve();
+    });
+
+    const downloadLink = renderer!.root
+      .findAllByType("a")
+      .find((link) => textContent(link).includes("Download for macOS"));
+    expect(downloadLink?.props.href).toContain("Maple_");
+    expect(downloadLink?.props.href).toContain("_universal.dmg");
+    expect(textContent(renderer!.root)).toContain("Choose the platform you want to install.");
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/components/settings/DownloadSettings.tsx
+++ b/frontend/src/components/settings/DownloadSettings.tsx
@@ -1,0 +1,173 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import packageJson from "../../../package.json";
+import { buttonVariants } from "@/components/ui/button";
+import {
+  APP_DOWNLOAD_TARGETS,
+  appDownloadActions,
+  appDownloadCopy,
+  appDownloadTargetLabel,
+  detectAppDownloadTarget,
+  readAppDownloadEnvironment,
+  type AppDownloadEnvironment,
+  type AppDownloadTarget
+} from "@/utils/appDownloads";
+import {
+  buildFallbackDownloadInfo,
+  getLatestDownloadInfo,
+  type DownloadInfo
+} from "@/utils/githubRelease";
+import { cn } from "@/utils/utils";
+import { SettingsSection } from "./SettingsPage";
+
+const DEFAULT_TARGET: AppDownloadTarget = "macos";
+
+export type DownloadSettingsProps = {
+  environment?: AppDownloadEnvironment;
+  loadDownloadInfo?: (signal?: AbortSignal) => Promise<DownloadInfo | null>;
+};
+
+export function DownloadSettings({
+  environment,
+  loadDownloadInfo = getLatestDownloadInfo
+}: DownloadSettingsProps) {
+  const resolvedEnvironment = environment ?? readAppDownloadEnvironment();
+  const detectedTarget = detectAppDownloadTarget(resolvedEnvironment);
+  const fallbackInfo = useMemo(() => buildFallbackDownloadInfo(packageJson.version), []);
+  const [selectedTarget, setSelectedTarget] = useState<AppDownloadTarget>(
+    detectedTarget ?? DEFAULT_TARGET
+  );
+  const [downloadInfo, setDownloadInfo] = useState<DownloadInfo>(fallbackInfo);
+  const [isLoading, setIsLoading] = useState(true);
+  const targetButtonRefs = useRef<Partial<Record<AppDownloadTarget, HTMLButtonElement | null>>>({});
+
+  const selectTarget = (target: AppDownloadTarget) => {
+    setSelectedTarget(target);
+    targetButtonRefs.current[target]?.focus();
+  };
+
+  useEffect(() => {
+    let cancelled = false;
+    const controller = new AbortController();
+
+    const load = async () => {
+      try {
+        const latest = await loadDownloadInfo(controller.signal);
+        if (!cancelled && latest) {
+          setDownloadInfo(latest);
+        }
+      } catch (error) {
+        if (!cancelled) {
+          console.error("Failed to load latest Maple download info:", error);
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [loadDownloadInfo]);
+
+  const copy = appDownloadCopy(selectedTarget);
+  const actions = appDownloadActions(selectedTarget, downloadInfo.downloadUrls);
+
+  return (
+    <SettingsSection
+      title="Get the Maple app"
+      description="Install Maple on your computer or phone. Native apps include document upload; the desktop app also has Agent Mode and automatic updates."
+    >
+      <div className="space-y-5">
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          {detectedTarget
+            ? `This browser looks like ${appDownloadTargetLabel(detectedTarget)}. Choose another platform if you want a different installer.`
+            : "Choose the platform you want to install."}
+        </p>
+
+        <div role="radiogroup" aria-label="Download platform" className="flex flex-wrap gap-2">
+          {APP_DOWNLOAD_TARGETS.map((target) => {
+            const selected = target === selectedTarget;
+            return (
+              <button
+                key={target}
+                type="button"
+                role="radio"
+                aria-checked={selected}
+                tabIndex={selected ? 0 : -1}
+                ref={(node) => {
+                  targetButtonRefs.current[target] = node;
+                }}
+                onClick={() => selectTarget(target)}
+                onKeyDown={(event) => {
+                  if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+                    return;
+                  }
+                  event.preventDefault();
+                  const index = APP_DOWNLOAD_TARGETS.indexOf(target);
+                  const delta = event.key === "ArrowRight" ? 1 : -1;
+                  const nextIndex =
+                    (index + delta + APP_DOWNLOAD_TARGETS.length) % APP_DOWNLOAD_TARGETS.length;
+                  selectTarget(APP_DOWNLOAD_TARGETS[nextIndex] ?? DEFAULT_TARGET);
+                }}
+                className={cn(
+                  "rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors",
+                  selected
+                    ? "border-[hsl(var(--maple-primary))] bg-[hsl(var(--maple-primary-container))]/70 text-foreground"
+                    : "border-border/70 text-muted-foreground hover:border-[hsl(var(--maple-primary))]/60 hover:bg-muted/50"
+                )}
+              >
+                {appDownloadTargetLabel(target)}
+                {target === detectedTarget ? (
+                  <span className="ml-2 text-[10px] font-semibold uppercase tracking-wide text-[hsl(var(--maple-primary))]">
+                    Suggested
+                  </span>
+                ) : null}
+              </button>
+            );
+          })}
+        </div>
+
+        <div className="flex flex-col gap-3 border-t border-border/70 pt-4 sm:flex-row sm:items-center sm:justify-between">
+          <div>
+            <p className="text-sm font-medium">{copy.title}</p>
+            <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{copy.description}</p>
+          </div>
+          <div className="flex flex-wrap gap-2 sm:justify-end">
+            {actions.map((action) => (
+              <a
+                key={`${selectedTarget}-${action.label}`}
+                className={buttonVariants({
+                  variant: action.variant === "primary" ? "primary" : "outline",
+                  size: "sm"
+                })}
+                href={action.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {action.label}
+              </a>
+            ))}
+          </div>
+        </div>
+
+        <p className="text-xs leading-relaxed text-muted-foreground">
+          Current version: <span className="font-mono text-foreground">{downloadInfo.version}</span>
+          {isLoading ? " (loading...)" : null} •{" "}
+          <a
+            href={downloadInfo.releaseUrl}
+            className="text-[hsl(var(--maple-primary))] underline-offset-4 hover:underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Release notes
+          </a>
+        </p>
+      </div>
+    </SettingsSection>
+  );
+}

--- a/frontend/src/components/settings/DownloadSettings.tsx
+++ b/frontend/src/components/settings/DownloadSettings.tsx
@@ -21,6 +21,27 @@ import { SettingsSection } from "./SettingsPage";
 
 const DEFAULT_TARGET: AppDownloadTarget = "macos";
 
+function nextDownloadTarget(current: AppDownloadTarget, key: string): AppDownloadTarget | null {
+  const index = APP_DOWNLOAD_TARGETS.indexOf(current);
+  if (key === "Home") {
+    return APP_DOWNLOAD_TARGETS[0] ?? DEFAULT_TARGET;
+  }
+  if (key === "End") {
+    return APP_DOWNLOAD_TARGETS[APP_DOWNLOAD_TARGETS.length - 1] ?? DEFAULT_TARGET;
+  }
+  if (key === "ArrowRight" || key === "ArrowDown") {
+    return APP_DOWNLOAD_TARGETS[(index + 1) % APP_DOWNLOAD_TARGETS.length] ?? DEFAULT_TARGET;
+  }
+  if (key === "ArrowLeft" || key === "ArrowUp") {
+    return (
+      APP_DOWNLOAD_TARGETS[
+        (index - 1 + APP_DOWNLOAD_TARGETS.length) % APP_DOWNLOAD_TARGETS.length
+      ] ?? DEFAULT_TARGET
+    );
+  }
+  return null;
+}
+
 export type DownloadSettingsProps = {
   environment?: AppDownloadEnvironment;
   loadDownloadInfo?: (signal?: AbortSignal) => Promise<DownloadInfo | null>;
@@ -104,15 +125,12 @@ export function DownloadSettings({
                 }}
                 onClick={() => selectTarget(target)}
                 onKeyDown={(event) => {
-                  if (event.key !== "ArrowRight" && event.key !== "ArrowLeft") {
+                  const next = nextDownloadTarget(target, event.key);
+                  if (!next) {
                     return;
                   }
                   event.preventDefault();
-                  const index = APP_DOWNLOAD_TARGETS.indexOf(target);
-                  const delta = event.key === "ArrowRight" ? 1 : -1;
-                  const nextIndex =
-                    (index + delta + APP_DOWNLOAD_TARGETS.length) % APP_DOWNLOAD_TARGETS.length;
-                  selectTarget(APP_DOWNLOAD_TARGETS[nextIndex] ?? DEFAULT_TARGET);
+                  selectTarget(next);
                 }}
                 className={cn(
                   "rounded-lg border px-3 py-1.5 text-sm font-medium transition-colors",

--- a/frontend/src/utils/appDownloads.test.ts
+++ b/frontend/src/utils/appDownloads.test.ts
@@ -83,6 +83,12 @@ describe("appDownloadActions", () => {
     ]);
   });
 
+  test("offers the Windows installer as the primary action", () => {
+    expect(appDownloadActions("windows", urls)).toEqual([
+      { label: "Download for Windows", href: urls.windowsExe, variant: "primary" }
+    ]);
+  });
+
   test("offers Linux package choices", () => {
     expect(appDownloadActions("linux", urls).map((action) => action.label)).toEqual([
       "Download AppImage",

--- a/frontend/src/utils/appDownloads.test.ts
+++ b/frontend/src/utils/appDownloads.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from "bun:test";
+import {
+  appDownloadActions,
+  APP_STORE_URL,
+  detectAppDownloadTarget,
+  GOOGLE_PLAY_URL,
+  TESTFLIGHT_URL
+} from "./appDownloads";
+import { buildFallbackDownloadInfo } from "./githubRelease";
+
+describe("detectAppDownloadTarget", () => {
+  test("detects iPhone Safari as iOS", () => {
+    expect(
+      detectAppDownloadTarget({
+        userAgent:
+          "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
+      })
+    ).toBe("ios");
+  });
+
+  test("detects iPadOS desktop UA as iOS when the device has a touch screen", () => {
+    expect(
+      detectAppDownloadTarget({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        platform: "MacIntel",
+        maxTouchPoints: 5
+      })
+    ).toBe("ios");
+  });
+
+  test("detects macOS Safari as macOS", () => {
+    expect(
+      detectAppDownloadTarget({
+        userAgent:
+          "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        platform: "MacIntel",
+        maxTouchPoints: 0
+      })
+    ).toBe("macos");
+  });
+
+  test("detects Windows Chrome as Windows", () => {
+    expect(
+      detectAppDownloadTarget({
+        userAgent:
+          "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        platform: "Win32"
+      })
+    ).toBe("windows");
+  });
+
+  test("detects Android Chrome as Android rather than Linux", () => {
+    expect(
+      detectAppDownloadTarget({
+        userAgent:
+          "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"
+      })
+    ).toBe("android");
+  });
+
+  test("detects Ubuntu Chrome as Linux", () => {
+    expect(
+      detectAppDownloadTarget({
+        userAgent:
+          "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        platform: "Linux x86_64"
+      })
+    ).toBe("linux");
+  });
+
+  test("returns null for an unrecognized user agent", () => {
+    expect(detectAppDownloadTarget({ userAgent: "UnknownClient/1.0" })).toBeNull();
+  });
+});
+
+describe("appDownloadActions", () => {
+  const urls = buildFallbackDownloadInfo("3.3.8").downloadUrls;
+
+  test("offers the macOS dmg as the primary action", () => {
+    expect(appDownloadActions("macos", urls)).toEqual([
+      { label: "Download for macOS", href: urls.macOS, variant: "primary" }
+    ]);
+  });
+
+  test("offers Linux package choices", () => {
+    expect(appDownloadActions("linux", urls).map((action) => action.label)).toEqual([
+      "Download AppImage",
+      ".deb",
+      ".rpm"
+    ]);
+  });
+
+  test("uses store URLs for mobile platforms", () => {
+    expect(appDownloadActions("ios", urls).map((action) => action.href)).toEqual([
+      APP_STORE_URL,
+      TESTFLIGHT_URL
+    ]);
+    expect(appDownloadActions("android", urls)[0]?.href).toBe(GOOGLE_PLAY_URL);
+    expect(appDownloadActions("android", urls)[1]?.href).toBe(urls.androidApk);
+  });
+});

--- a/frontend/src/utils/appDownloads.ts
+++ b/frontend/src/utils/appDownloads.ts
@@ -1,0 +1,143 @@
+import type { DownloadUrls } from "./githubRelease";
+
+export type AppDownloadTarget = "macos" | "windows" | "linux" | "ios" | "android";
+
+export type AppDownloadEnvironment = {
+  userAgent: string;
+  platform?: string;
+  maxTouchPoints?: number;
+};
+
+export type AppDownloadActionVariant = "primary" | "outline";
+
+export type AppDownloadAction = {
+  label: string;
+  href: string;
+  variant: AppDownloadActionVariant;
+};
+
+export const APP_STORE_URL = "https://apps.apple.com/us/app/id6743764835";
+export const TESTFLIGHT_URL = "https://testflight.apple.com/join/zjgtyAeD";
+export const GOOGLE_PLAY_URL =
+  "https://play.google.com/store/apps/details?id=cloud.opensecret.maple";
+export const GOOGLE_PLAY_BETA_URL = "https://play.google.com/apps/testing/cloud.opensecret.maple";
+
+export const APP_DOWNLOAD_TARGETS: readonly AppDownloadTarget[] = [
+  "macos",
+  "windows",
+  "linux",
+  "ios",
+  "android"
+];
+
+const TARGET_LABELS: Record<AppDownloadTarget, string> = {
+  macos: "macOS",
+  windows: "Windows",
+  linux: "Linux",
+  ios: "iOS",
+  android: "Android"
+};
+
+const TARGET_COPY: Record<AppDownloadTarget, { title: string; description: string }> = {
+  macos: {
+    title: "macOS",
+    description: "Universal installer for Apple Silicon and Intel Macs running macOS 11.0 or later."
+  },
+  windows: {
+    title: "Windows",
+    description: "Installer for Windows PCs."
+  },
+  linux: {
+    title: "Linux",
+    description:
+      "Ubuntu 24.04+ is the officially supported target. Other distributions are not officially supported."
+  },
+  ios: {
+    title: "iOS",
+    description: "Native app for iPhone and iPad."
+  },
+  android: {
+    title: "Android",
+    description: "Native app for phones and tablets, or a direct APK from GitHub releases."
+  }
+};
+
+export function appDownloadTargetLabel(target: AppDownloadTarget): string {
+  return TARGET_LABELS[target];
+}
+
+export function appDownloadCopy(target: AppDownloadTarget): {
+  title: string;
+  description: string;
+} {
+  return TARGET_COPY[target];
+}
+
+export function detectAppDownloadTarget(
+  environment: AppDownloadEnvironment
+): AppDownloadTarget | null {
+  const userAgent = environment.userAgent;
+  const platform = environment.platform ?? "";
+  const maxTouchPoints = environment.maxTouchPoints ?? 0;
+
+  if (/iPhone|iPod/i.test(userAgent) || /iPad/i.test(userAgent)) {
+    return "ios";
+  }
+  if ((/Macintosh|Mac OS X/i.test(userAgent) || /Mac/i.test(platform)) && maxTouchPoints > 1) {
+    return "ios";
+  }
+  if (/Android/i.test(userAgent)) {
+    return "android";
+  }
+  if (/Windows/i.test(userAgent) || /Win32|Win64|Windows/i.test(platform)) {
+    return "windows";
+  }
+  if (/Macintosh|Mac OS X|MacIntel/i.test(userAgent) || /Mac/i.test(platform)) {
+    return "macos";
+  }
+  if (/CrOS/i.test(userAgent) || /Linux/i.test(userAgent) || /Linux/i.test(platform)) {
+    return "linux";
+  }
+  return null;
+}
+
+export function readAppDownloadEnvironment(): AppDownloadEnvironment {
+  if (typeof navigator === "undefined") {
+    return { userAgent: "" };
+  }
+
+  return {
+    userAgent: navigator.userAgent,
+    platform: navigator.platform,
+    maxTouchPoints: navigator.maxTouchPoints
+  };
+}
+
+export function appDownloadActions(
+  target: AppDownloadTarget,
+  downloadUrls: DownloadUrls
+): AppDownloadAction[] {
+  switch (target) {
+    case "macos":
+      return [{ label: "Download for macOS", href: downloadUrls.macOS, variant: "primary" }];
+    case "windows":
+      return [{ label: "Download for Windows", href: downloadUrls.windowsExe, variant: "primary" }];
+    case "linux":
+      return [
+        { label: "Download AppImage", href: downloadUrls.linuxAppImage, variant: "primary" },
+        { label: ".deb", href: downloadUrls.linuxDeb, variant: "outline" },
+        { label: ".rpm", href: downloadUrls.linuxRpm, variant: "outline" }
+      ];
+    case "ios":
+      return [
+        { label: "App Store", href: APP_STORE_URL, variant: "primary" },
+        { label: "TestFlight", href: TESTFLIGHT_URL, variant: "outline" }
+      ];
+    case "android":
+      return [
+        { label: "Google Play", href: GOOGLE_PLAY_URL, variant: "primary" },
+        { label: "Download APK", href: downloadUrls.androidApk, variant: "outline" },
+        { label: "Play Beta", href: GOOGLE_PLAY_BETA_URL, variant: "outline" }
+      ];
+  }
+}

--- a/frontend/src/utils/githubRelease.test.ts
+++ b/frontend/src/utils/githubRelease.test.ts
@@ -36,7 +36,6 @@ describe("buildFallbackDownloadInfo", () => {
 describe("resolveDownloadUrlsFromRelease", () => {
   test("prefers matched GitHub assets, including the rpmbuild Linux name", () => {
     const urls = resolveDownloadUrlsFromRelease({
-      tag_name: "v3.3.7",
       assets: [
         {
           name: "Maple_3.3.7_universal.dmg",
@@ -81,7 +80,6 @@ describe("resolveDownloadUrlsFromRelease", () => {
 
   test("falls back to the latest release page when an asset is missing", () => {
     const urls = resolveDownloadUrlsFromRelease({
-      tag_name: "v3.3.8",
       assets: [
         {
           name: "Maple_3.3.8_universal.dmg",

--- a/frontend/src/utils/githubRelease.test.ts
+++ b/frontend/src/utils/githubRelease.test.ts
@@ -4,6 +4,7 @@ import {
   fetchLatestRelease,
   getLatestDownloadInfo,
   GITHUB_RELEASES_API_URL,
+  GITHUB_RELEASES_LATEST_URL,
   resolveDownloadUrlsFromRelease
 } from "./githubRelease";
 
@@ -15,25 +16,19 @@ afterEach(() => {
 });
 
 describe("buildFallbackDownloadInfo", () => {
-  test("builds GitHub tag URLs from the packaged version", () => {
+  test("points GitHub-hosted installers at the latest release page instead of versioned filenames", () => {
     expect(buildFallbackDownloadInfo("3.3.8")).toEqual({
       version: "3.3.8",
       tagName: "v3.3.8",
       downloadUrls: {
-        macOS:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_universal.dmg",
-        windowsExe:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_x64-setup.exe",
-        linuxAppImage:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_amd64.AppImage",
-        linuxDeb:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_amd64.deb",
-        linuxRpm:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_x86_64.rpm",
-        androidApk:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/app-universal-release.apk"
+        macOS: GITHUB_RELEASES_LATEST_URL,
+        windowsExe: GITHUB_RELEASES_LATEST_URL,
+        linuxAppImage: GITHUB_RELEASES_LATEST_URL,
+        linuxDeb: GITHUB_RELEASES_LATEST_URL,
+        linuxRpm: GITHUB_RELEASES_LATEST_URL,
+        androidApk: GITHUB_RELEASES_LATEST_URL
       },
-      releaseUrl: "https://github.com/OpenSecretCloud/Maple/releases/latest"
+      releaseUrl: GITHUB_RELEASES_LATEST_URL
     });
   });
 });
@@ -84,7 +79,7 @@ describe("resolveDownloadUrlsFromRelease", () => {
     });
   });
 
-  test("keeps constructed URLs when an asset is missing", () => {
+  test("falls back to the latest release page when an asset is missing", () => {
     const urls = resolveDownloadUrlsFromRelease({
       tag_name: "v3.3.8",
       assets: [
@@ -96,9 +91,7 @@ describe("resolveDownloadUrlsFromRelease", () => {
     });
 
     expect(urls.macOS).toBe("https://example.test/Maple.dmg");
-    expect(urls.windowsExe).toBe(
-      "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_x64-setup.exe"
-    );
+    expect(urls.windowsExe).toBe(GITHUB_RELEASES_LATEST_URL);
   });
 });
 
@@ -133,14 +126,10 @@ describe("getLatestDownloadInfo", () => {
       downloadUrls: {
         macOS: "https://example.test/Maple_9.9.9_universal.dmg",
         windowsExe: "https://example.test/Maple_9.9.9_x64-setup.exe",
-        linuxAppImage:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/Maple_9.9.9_amd64.AppImage",
-        linuxDeb:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/Maple_9.9.9_amd64.deb",
-        linuxRpm:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/Maple_9.9.9_x86_64.rpm",
-        androidApk:
-          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/app-universal-release.apk"
+        linuxAppImage: GITHUB_RELEASES_LATEST_URL,
+        linuxDeb: GITHUB_RELEASES_LATEST_URL,
+        linuxRpm: GITHUB_RELEASES_LATEST_URL,
+        androidApk: GITHUB_RELEASES_LATEST_URL
       },
       releaseUrl: "https://github.com/OpenSecretCloud/Maple/releases/tag/v9.9.9"
     });

--- a/frontend/src/utils/githubRelease.test.ts
+++ b/frontend/src/utils/githubRelease.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, spyOn, test } from "bun:test";
+import {
+  buildFallbackDownloadInfo,
+  fetchLatestRelease,
+  getLatestDownloadInfo,
+  GITHUB_RELEASES_API_URL,
+  resolveDownloadUrlsFromRelease
+} from "./githubRelease";
+
+let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
+
+afterEach(() => {
+  fetchSpy?.mockRestore();
+  fetchSpy = null;
+});
+
+describe("buildFallbackDownloadInfo", () => {
+  test("builds GitHub tag URLs from the packaged version", () => {
+    expect(buildFallbackDownloadInfo("3.3.8")).toEqual({
+      version: "3.3.8",
+      tagName: "v3.3.8",
+      downloadUrls: {
+        macOS:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_universal.dmg",
+        windowsExe:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_x64-setup.exe",
+        linuxAppImage:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_amd64.AppImage",
+        linuxDeb:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_amd64.deb",
+        linuxRpm:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_x86_64.rpm",
+        androidApk:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/app-universal-release.apk"
+      },
+      releaseUrl: "https://github.com/OpenSecretCloud/Maple/releases/latest"
+    });
+  });
+});
+
+describe("resolveDownloadUrlsFromRelease", () => {
+  test("prefers matched GitHub assets, including the rpmbuild Linux name", () => {
+    const urls = resolveDownloadUrlsFromRelease({
+      tag_name: "v3.3.7",
+      assets: [
+        {
+          name: "Maple_3.3.7_universal.dmg",
+          browser_download_url: "https://example.test/Maple.dmg"
+        },
+        {
+          name: "Maple_3.3.7_x64-setup.exe",
+          browser_download_url: "https://example.test/Maple.exe"
+        },
+        {
+          name: "Maple_3.3.7_amd64.AppImage",
+          browser_download_url: "https://example.test/Maple.AppImage"
+        },
+        {
+          name: "Maple_3.3.7_amd64.deb",
+          browser_download_url: "https://example.test/Maple.deb"
+        },
+        {
+          name: "Maple-3.3.7-1.x86_64.rpm",
+          browser_download_url: "https://example.test/Maple.rpm"
+        },
+        {
+          name: "Maple-3.3.7-1.x86_64.rpm.sig",
+          browser_download_url: "https://example.test/Maple.rpm.sig"
+        },
+        {
+          name: "app-universal-release.apk",
+          browser_download_url: "https://example.test/Maple.apk"
+        }
+      ]
+    });
+
+    expect(urls).toEqual({
+      macOS: "https://example.test/Maple.dmg",
+      windowsExe: "https://example.test/Maple.exe",
+      linuxAppImage: "https://example.test/Maple.AppImage",
+      linuxDeb: "https://example.test/Maple.deb",
+      linuxRpm: "https://example.test/Maple.rpm",
+      androidApk: "https://example.test/Maple.apk"
+    });
+  });
+
+  test("keeps constructed URLs when an asset is missing", () => {
+    const urls = resolveDownloadUrlsFromRelease({
+      tag_name: "v3.3.8",
+      assets: [
+        {
+          name: "Maple_3.3.8_universal.dmg",
+          browser_download_url: "https://example.test/Maple.dmg"
+        }
+      ]
+    });
+
+    expect(urls.macOS).toBe("https://example.test/Maple.dmg");
+    expect(urls.windowsExe).toBe(
+      "https://github.com/OpenSecretCloud/Maple/releases/download/v3.3.8/Maple_3.3.8_x64-setup.exe"
+    );
+  });
+});
+
+describe("getLatestDownloadInfo", () => {
+  test("returns matched download URLs from the GitHub latest release", async () => {
+    fetchSpy = spyOn(globalThis, "fetch").mockImplementation((async (input) => {
+      expect(String(input)).toBe(GITHUB_RELEASES_API_URL);
+      return new Response(
+        JSON.stringify({
+          tag_name: "v9.9.9",
+          name: "v9.9.9",
+          published_at: "2026-08-23T00:00:00Z",
+          html_url: "https://github.com/OpenSecretCloud/Maple/releases/tag/v9.9.9",
+          assets: [
+            {
+              name: "Maple_9.9.9_universal.dmg",
+              browser_download_url: "https://example.test/Maple_9.9.9_universal.dmg"
+            },
+            {
+              name: "Maple_9.9.9_x64-setup.exe",
+              browser_download_url: "https://example.test/Maple_9.9.9_x64-setup.exe"
+            }
+          ]
+        }),
+        { status: 200, headers: { "Content-Type": "application/json" } }
+      );
+    }) as typeof fetch);
+
+    await expect(getLatestDownloadInfo()).resolves.toEqual({
+      version: "9.9.9",
+      tagName: "v9.9.9",
+      downloadUrls: {
+        macOS: "https://example.test/Maple_9.9.9_universal.dmg",
+        windowsExe: "https://example.test/Maple_9.9.9_x64-setup.exe",
+        linuxAppImage:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/Maple_9.9.9_amd64.AppImage",
+        linuxDeb:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/Maple_9.9.9_amd64.deb",
+        linuxRpm:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/Maple_9.9.9_x86_64.rpm",
+        androidApk:
+          "https://github.com/OpenSecretCloud/Maple/releases/download/v9.9.9/app-universal-release.apk"
+      },
+      releaseUrl: "https://github.com/OpenSecretCloud/Maple/releases/tag/v9.9.9"
+    });
+  });
+
+  test("returns null without logging when the request is aborted", async () => {
+    const consoleError = spyOn(console, "error").mockImplementation(() => {});
+    const controller = new AbortController();
+    controller.abort();
+    await expect(fetchLatestRelease(controller.signal)).resolves.toBeNull();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+});

--- a/frontend/src/utils/githubRelease.ts
+++ b/frontend/src/utils/githubRelease.ts
@@ -38,7 +38,7 @@ interface GitHubRelease {
   assets?: GitHubReleaseAsset[];
 }
 
-export const DOWNLOAD_ASSET_MATCHERS: Record<DownloadAssetKey, (name: string) => boolean> = {
+const DOWNLOAD_ASSET_MATCHERS: Record<DownloadAssetKey, (name: string) => boolean> = {
   macOS: (name) => name.endsWith("_universal.dmg"),
   windowsExe: (name) => name.endsWith("_x64-setup.exe"),
   linuxAppImage: (name) => name.endsWith("_amd64.AppImage"),
@@ -61,15 +61,14 @@ function tagFromVersion(version: string): string {
   return version.startsWith("v") ? version : `v${version}`;
 }
 
-function constructedDownloadUrls(tagName: string, version: string): DownloadUrls {
-  const baseDownloadUrl = `https://github.com/OpenSecretCloud/Maple/releases/download/${tagName}`;
+function latestReleaseDownloadUrls(): DownloadUrls {
   return {
-    macOS: `${baseDownloadUrl}/Maple_${version}_universal.dmg`,
-    windowsExe: `${baseDownloadUrl}/Maple_${version}_x64-setup.exe`,
-    linuxAppImage: `${baseDownloadUrl}/Maple_${version}_amd64.AppImage`,
-    linuxDeb: `${baseDownloadUrl}/Maple_${version}_amd64.deb`,
-    linuxRpm: `${baseDownloadUrl}/Maple_${version}_x86_64.rpm`,
-    androidApk: `${baseDownloadUrl}/app-universal-release.apk`
+    macOS: GITHUB_RELEASES_LATEST_URL,
+    windowsExe: GITHUB_RELEASES_LATEST_URL,
+    linuxAppImage: GITHUB_RELEASES_LATEST_URL,
+    linuxDeb: GITHUB_RELEASES_LATEST_URL,
+    linuxRpm: GITHUB_RELEASES_LATEST_URL,
+    androidApk: GITHUB_RELEASES_LATEST_URL
   };
 }
 
@@ -79,7 +78,7 @@ export function buildFallbackDownloadInfo(version: string): DownloadInfo {
   return {
     version: normalizedVersion,
     tagName,
-    downloadUrls: constructedDownloadUrls(tagName, normalizedVersion),
+    downloadUrls: latestReleaseDownloadUrls(),
     releaseUrl: GITHUB_RELEASES_LATEST_URL
   };
 }
@@ -101,8 +100,7 @@ function isGitHubRelease(value: unknown): value is GitHubRelease {
 export function resolveDownloadUrlsFromRelease(
   release: Pick<GitHubRelease, "tag_name" | "assets">
 ): DownloadUrls {
-  const version = versionFromTag(release.tag_name);
-  const resolved = constructedDownloadUrls(release.tag_name, version);
+  const resolved = latestReleaseDownloadUrls();
   const assets = Array.isArray(release.assets) ? release.assets : [];
 
   for (const key of DOWNLOAD_ASSET_KEYS) {

--- a/frontend/src/utils/githubRelease.ts
+++ b/frontend/src/utils/githubRelease.ts
@@ -1,49 +1,151 @@
 /**
- * Utility for fetching the latest GitHub release information
+ * Utility for fetching the latest GitHub release information and matching
+ * installable assets the same way the Maple marketing site does.
  */
+
+export const GITHUB_RELEASES_API_URL =
+  "https://api.github.com/repos/OpenSecretCloud/Maple/releases/latest";
+export const GITHUB_RELEASES_LATEST_URL =
+  "https://github.com/OpenSecretCloud/Maple/releases/latest";
+
+export type DownloadAssetKey =
+  | "macOS"
+  | "windowsExe"
+  | "linuxAppImage"
+  | "linuxDeb"
+  | "linuxRpm"
+  | "androidApk";
+
+export type DownloadUrls = Record<DownloadAssetKey, string>;
+
+export interface DownloadInfo {
+  version: string;
+  tagName: string;
+  downloadUrls: DownloadUrls;
+  releaseUrl: string;
+}
+
+interface GitHubReleaseAsset {
+  name: string;
+  browser_download_url: string;
+}
 
 interface GitHubRelease {
   tag_name: string;
   name: string;
   published_at: string;
   html_url: string;
+  assets?: GitHubReleaseAsset[];
 }
 
-interface DownloadInfo {
-  version: string;
-  tagName: string;
-  downloadUrls: {
-    macOS: string;
-    linuxAppImage: string;
-    linuxDeb: string;
-    linuxRpm: string;
-    androidApk: string;
+export const DOWNLOAD_ASSET_MATCHERS: Record<DownloadAssetKey, (name: string) => boolean> = {
+  macOS: (name) => name.endsWith("_universal.dmg"),
+  windowsExe: (name) => name.endsWith("_x64-setup.exe"),
+  linuxAppImage: (name) => name.endsWith("_amd64.AppImage"),
+  linuxDeb: (name) => name.endsWith("_amd64.deb"),
+  linuxRpm: (name) => name.endsWith("_x86_64.rpm") || name.endsWith(".x86_64.rpm"),
+  androidApk: (name) => name === "app-universal-release.apk"
+};
+
+const DOWNLOAD_ASSET_KEYS = Object.keys(DOWNLOAD_ASSET_MATCHERS) as DownloadAssetKey[];
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === "AbortError";
+}
+
+function versionFromTag(tagName: string): string {
+  return tagName.startsWith("v") ? tagName.slice(1) : tagName;
+}
+
+function tagFromVersion(version: string): string {
+  return version.startsWith("v") ? version : `v${version}`;
+}
+
+function constructedDownloadUrls(tagName: string, version: string): DownloadUrls {
+  const baseDownloadUrl = `https://github.com/OpenSecretCloud/Maple/releases/download/${tagName}`;
+  return {
+    macOS: `${baseDownloadUrl}/Maple_${version}_universal.dmg`,
+    windowsExe: `${baseDownloadUrl}/Maple_${version}_x64-setup.exe`,
+    linuxAppImage: `${baseDownloadUrl}/Maple_${version}_amd64.AppImage`,
+    linuxDeb: `${baseDownloadUrl}/Maple_${version}_amd64.deb`,
+    linuxRpm: `${baseDownloadUrl}/Maple_${version}_x86_64.rpm`,
+    androidApk: `${baseDownloadUrl}/app-universal-release.apk`
   };
-  releaseUrl: string;
+}
+
+export function buildFallbackDownloadInfo(version: string): DownloadInfo {
+  const tagName = tagFromVersion(version);
+  const normalizedVersion = versionFromTag(tagName);
+  return {
+    version: normalizedVersion,
+    tagName,
+    downloadUrls: constructedDownloadUrls(tagName, normalizedVersion),
+    releaseUrl: GITHUB_RELEASES_LATEST_URL
+  };
+}
+
+function isGitHubRelease(value: unknown): value is GitHubRelease {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const release = value as GitHubRelease;
+  return (
+    typeof release.tag_name === "string" &&
+    typeof release.name === "string" &&
+    typeof release.published_at === "string" &&
+    typeof release.html_url === "string"
+  );
+}
+
+export function resolveDownloadUrlsFromRelease(
+  release: Pick<GitHubRelease, "tag_name" | "assets">
+): DownloadUrls {
+  const version = versionFromTag(release.tag_name);
+  const resolved = constructedDownloadUrls(release.tag_name, version);
+  const assets = Array.isArray(release.assets) ? release.assets : [];
+
+  for (const key of DOWNLOAD_ASSET_KEYS) {
+    const matcher = DOWNLOAD_ASSET_MATCHERS[key];
+    const asset = assets.find(
+      (candidate) =>
+        typeof candidate?.name === "string" &&
+        typeof candidate.browser_download_url === "string" &&
+        matcher(candidate.name)
+    );
+    if (asset?.browser_download_url) {
+      resolved[key] = asset.browser_download_url;
+    }
+  }
+
+  return resolved;
 }
 
 /**
  * Fetches the latest release from GitHub
  */
-export async function fetchLatestRelease(): Promise<GitHubRelease | null> {
+export async function fetchLatestRelease(signal?: AbortSignal): Promise<GitHubRelease | null> {
   try {
-    const response = await fetch(
-      "https://api.github.com/repos/OpenSecretCloud/Maple/releases/latest"
-    );
+    const response = await fetch(GITHUB_RELEASES_API_URL, {
+      headers: { Accept: "application/vnd.github+json" },
+      signal
+    });
 
     if (!response.ok) {
       console.error("Failed to fetch latest release:", response.status);
       return null;
     }
 
-    const data = await response.json();
-    if (!data?.tag_name || !data?.name || !data?.published_at || !data?.html_url) {
+    const data: unknown = await response.json();
+    if (!isGitHubRelease(data)) {
       console.error("Invalid release data format from GitHub API");
       return null;
     }
-    const release: GitHubRelease = data;
-    return release;
+    return data;
   } catch (error) {
+    if (isAbortError(error)) {
+      return null;
+    }
     console.error("Error fetching latest release:", error);
     return null;
   }
@@ -52,28 +154,19 @@ export async function fetchLatestRelease(): Promise<GitHubRelease | null> {
 /**
  * Gets download information for the latest release
  */
-export async function getLatestDownloadInfo(): Promise<DownloadInfo | null> {
-  const release = await fetchLatestRelease();
+export async function getLatestDownloadInfo(signal?: AbortSignal): Promise<DownloadInfo | null> {
+  const release = await fetchLatestRelease(signal);
 
   if (!release) {
     return null;
   }
 
-  // Extract version number from tag (remove 'v' prefix if present)
-  const version = release.tag_name.startsWith("v") ? release.tag_name.slice(1) : release.tag_name;
-
-  const baseDownloadUrl = `https://github.com/OpenSecretCloud/Maple/releases/download/${release.tag_name}`;
+  const version = versionFromTag(release.tag_name);
 
   return {
     version,
     tagName: release.tag_name,
-    downloadUrls: {
-      macOS: `${baseDownloadUrl}/Maple_${version}_universal.dmg`,
-      linuxAppImage: `${baseDownloadUrl}/Maple_${version}_amd64.AppImage`,
-      linuxDeb: `${baseDownloadUrl}/Maple_${version}_amd64.deb`,
-      linuxRpm: `${baseDownloadUrl}/Maple_${version}_x86_64.rpm`,
-      androidApk: `${baseDownloadUrl}/app-universal-release.apk`
-    },
+    downloadUrls: resolveDownloadUrlsFromRelease(release),
     releaseUrl: release.html_url
   };
 }

--- a/frontend/src/utils/githubRelease.ts
+++ b/frontend/src/utils/githubRelease.ts
@@ -98,7 +98,7 @@ function isGitHubRelease(value: unknown): value is GitHubRelease {
 }
 
 export function resolveDownloadUrlsFromRelease(
-  release: Pick<GitHubRelease, "tag_name" | "assets">
+  release: Pick<GitHubRelease, "assets">
 ): DownloadUrls {
   const resolved = latestReleaseDownloadUrls();
   const assets = Array.isArray(release.assets) ? release.assets : [];


### PR DESCRIPTION
## Summary

Web testers looking for a desktop download link expected to find it in Settings. This adds a **Get the Maple app** section on **Settings → About** for the web view only, in the same place desktop already shows automatic-update controls.

- Suggests the current browser OS (including mobile web) and still lets the user pick macOS, Windows, Linux, iOS, or Android
- Desktop packages come from the latest GitHub release assets, using the same matchers as the marketing site (`_universal.dmg`, `_x64-setup.exe`, AppImage/deb/rpm, APK)
- Mobile actions use the App Store, TestFlight, Google Play, Play Beta, and direct APK links
- Falls back to packaged-version GitHub URLs if the releases API is unavailable
- Native desktop keeps update settings; native mobile is unchanged

Banner placement from #779 is still TBD. This is the Settings/About first cut.

## Test plan

- [x] `bun --no-env-file test` for the new About/download/GitHub helpers
- [x] Frontend format, lint, typecheck, and the pre-commit frontend suite
- [ ] Cloudflare preview: signed-in web **Settings → About** shows the download section
- [ ] Detected platform is suggested, and switching platforms updates the installer/store links
- [ ] Desktop app still shows automatic updates instead of this section
- [ ] Native mobile does not show the new section

Related to #779.