### PR TITLE
Fix user-message copy action on mobile

### DIFF
--- a/frontend/src/components/chat/ChatTurn.test.tsx
+++ b/frontend/src/components/chat/ChatTurn.test.tsx
@@ -17,7 +17,7 @@ describe("shared chat typography scope", () => {
     expect(markup).not.toContain("data-stacked-user");
   });
 
-  test("tightens consecutive user turns without reserving a copy row", () => {
+  test("keeps actions below on mobile and beside compact consecutive turns on desktop", () => {
     const markup = renderToStaticMarkup(
       <ChatUserTurn stackedTop stackedBottom actions={<button type="button">Copy</button>}>
         <p>Follow-up</p>
@@ -27,7 +27,8 @@ describe("shared chat typography scope", () => {
     expect(markup).toContain("data-stacked-user");
     expect(markup).toContain("pt-1 -mt-1");
     expect(markup).toContain("pb-0");
-    expect(markup).toContain("right-full");
+    expect(markup).toContain("justify-end pr-1 pt-1");
+    expect(markup).toContain("md:absolute md:bottom-0 md:right-full");
     expect(markup).toContain("Copy");
   });
 

--- a/frontend/src/components/chat/ChatTurn.tsx
+++ b/frontend/src/components/chat/ChatTurn.tsx
@@ -54,7 +54,7 @@ export function ChatUserTurn({
           </div>
         </div>
         {actions ? (
-          <div className="absolute bottom-0 right-full mr-0.5 flex justify-end opacity-100 transition-opacity md:opacity-0 md:group-hover/user:opacity-100 md:group-focus-within/user:opacity-100 landscape-short:opacity-100">
+          <div className="flex justify-end pr-1 pt-1 opacity-100 transition-opacity md:absolute md:bottom-0 md:right-full md:mr-0.5 md:pr-0 md:pt-0 md:opacity-0 md:group-hover/user:opacity-100 md:group-focus-within/user:opacity-100 landscape-short:opacity-100">
             {actions}
           </div>
         ) : null}


### PR DESCRIPTION
## Summary

- keep user-message actions below and right-aligned on mobile layouts
- preserve the compact side-mounted hover treatment at the `md` breakpoint and wider
- update the shared ChatTurn regression test for both responsive layouts

## Validation

- `bun --no-env-file test` (739 passed)
- `bun run format:check`
- `bun run lint` (0 errors; 13 existing warnings)
- `bun run typecheck`
- `bun run build`
- `git diff --check`