### PR TITLE
Fail closed on Maple app release identity and prerelease follow-ons

### DIFF
--- a/.github/workflows/release-gates-tests.yml
+++ b/.github/workflows/release-gates-tests.yml
@@ -1,0 +1,49 @@
+name: Release gates tests
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-gates-tests.yml"
+      - ".github/workflows/zapstore-publish.yml"
+      - "scripts/ci/classify-app-release.sh"
+      - "scripts/ci/test-release-gates.sh"
+      - "scripts/ci/validate-release-version.sh"
+      - "frontend/package.json"
+      - "frontend/src-tauri/Cargo.toml"
+      - "frontend/src-tauri/tauri.conf.json"
+      - "flake.nix"
+      - "flake.lock"
+  push:
+    branches: [master]
+    paths:
+      - ".github/workflows/release.yml"
+      - ".github/workflows/release-gates-tests.yml"
+      - ".github/workflows/zapstore-publish.yml"
+      - "scripts/ci/classify-app-release.sh"
+      - "scripts/ci/test-release-gates.sh"
+      - "scripts/ci/validate-release-version.sh"
+      - "frontend/package.json"
+      - "frontend/src-tauri/Cargo.toml"
+      - "frontend/src-tauri/tauri.conf.json"
+      - "flake.nix"
+      - "flake.lock"
+
+permissions:
+  contents: read
+
+jobs:
+  release-gates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
+        with:
+          persist-credentials: false
+
+      - name: Install Nix
+        uses: DeterminateSystems/nix-installer-action@ef8a148080ab6020fd15196c2084a2eea5ff2d25 # was v22
+        with:
+          github-token: ""
+
+      - name: Test release gates
+        run: nix build --no-link --print-build-logs .#checks.x86_64-linux.release-gates

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,33 +8,122 @@ permissions:
   contents: read
 
 jobs:
-  create-release:
+  classify-app-release:
+    name: Classify Maple app release
     runs-on: ubuntu-latest
     permissions:
       contents: read
     outputs:
-      version: ${{ steps.get_version.outputs.version }}
+      tag: ${{ steps.classify.outputs.tag }}
+      release_sha: ${{ steps.classify.outputs.release_sha }}
+      version: ${{ steps.classify.outputs.version }}
+      prerelease: ${{ steps.classify.outputs.prerelease }}
+      stable: ${{ steps.classify.outputs.stable }}
 
     steps:
+      - name: Validate release event against GitHub state
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY: ${{ github.repository }}
+          REPOSITORY_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_ACTION: ${{ github.event.action }}
+          RELEASE_ID: ${{ github.event.release.id }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_REF: ${{ github.ref }}
+          RELEASE_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "Release classification failed: $*" >&2
+            exit 1
+          }
+
+          [ "${REPOSITORY_DEFAULT_BRANCH}" = "master" ] || fail "default branch must be master"
+          [ "${RELEASE_ACTION}" = "created" ] || fail "event action must be created"
+          [[ "${RELEASE_ID}" =~ ^[0-9]+$ ]] || fail "release id must be numeric"
+          [[ "${RELEASE_TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || \
+            fail "tag must be an exact vX.Y.Z Maple app tag"
+          [ "${RELEASE_DRAFT}" = "false" ] || fail "draft releases are not publishable"
+          case "${RELEASE_PRERELEASE}" in
+            true|false) ;;
+            *) fail "prerelease must be a boolean" ;;
+          esac
+          [ "${RELEASE_REF}" = "refs/tags/${RELEASE_TAG}" ] || fail "release ref does not match tag"
+          [[ "${RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "release SHA is invalid"
+          [[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "workflow SHA is invalid"
+          [ "${WORKFLOW_SHA}" = "${RELEASE_SHA}" ] || fail "workflow and release SHAs differ"
+
+          live_default_branch="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${REPOSITORY}" \
+            --jq '.default_branch')"
+          [ "${live_default_branch}" = "master" ] || fail "live default branch must be master"
+
+          release_json="$(mktemp)"
+          trap 'rm -f "${release_json}"' EXIT
+          gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${REPOSITORY}/releases/${RELEASE_ID}" > "${release_json}"
+          jq -e \
+            --argjson id "${RELEASE_ID}" \
+            --arg tag "${RELEASE_TAG}" \
+            --argjson prerelease "${RELEASE_PRERELEASE}" \
+            '(.id == $id)
+              and (.tag_name == $tag)
+              and (.draft == false)
+              and (.prerelease == $prerelease)' \
+            "${release_json}" > /dev/null || fail "live release no longer matches the event"
+
+          live_tag_sha="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${REPOSITORY}/commits/${RELEASE_TAG}" \
+            --jq '.sha')"
+          [ "${live_tag_sha}" = "${RELEASE_SHA}" ] || fail "live tag no longer resolves to the event SHA"
+
+          compare_status="$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "repos/${REPOSITORY}/compare/${RELEASE_SHA}...master" \
+            --jq '.status')"
+          case "${compare_status}" in
+            ahead|identical) ;;
+            *) fail "release SHA is not reachable from protected master" ;;
+          esac
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
           persist-credentials: false
 
-      - name: Validate release tag
-        id: get_version
+      - name: Classify app release
+        id: classify
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_SHA: ${{ github.sha }}
+          RELEASE_DRAFT: ${{ github.event.release.draft }}
+          RELEASE_PRERELEASE: ${{ github.event.release.prerelease }}
+          RELEASE_REF: ${{ github.ref }}
         run: |
-          if [ -z "${RELEASE_TAG}" ] || [ "${RELEASE_TAG}" != "${GITHUB_REF#refs/tags/}" ]; then
-            echo "Release tag does not match GITHUB_REF" >&2
-            exit 1
-          fi
-
-          version="$(./scripts/ci/validate-release-version.sh "${RELEASE_TAG}")"
-          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          ./scripts/ci/classify-app-release.sh \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --tag "${RELEASE_TAG}" \
+            --sha "${RELEASE_SHA}" \
+            --draft "${RELEASE_DRAFT}" \
+            --prerelease "${RELEASE_PRERELEASE}" \
+            --ref "${RELEASE_REF}" \
+            --protected-ref refs/remotes/origin/master \
+            >> "${GITHUB_OUTPUT}"
 
   build-tauri:
-    needs: create-release
+    needs: classify-app-release
     permissions:
       contents: write
       id-token: write
@@ -55,6 +144,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
@@ -139,7 +229,7 @@ jobs:
       - name: Upload desktop release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           set -euo pipefail
           files=()
@@ -166,7 +256,7 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${files[@]}" --clobber
 
   build-windows:
-    needs: create-release
+    needs: classify-app-release
     runs-on: windows-2025
     environment: windows-signing
     env:
@@ -181,6 +271,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Setup Bun
@@ -282,7 +373,7 @@ jobs:
       - name: Upload Windows release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         shell: bash
         run: |
           set -euo pipefail
@@ -301,7 +392,7 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${files[@]}" --clobber
 
   build-android:
-    needs: create-release
+    needs: classify-app-release
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: write
@@ -311,6 +402,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -364,8 +456,6 @@ jobs:
           cat android-release-artifacts.sha256
 
       - name: Attest Android release artifacts
-        # Keep release uploads running if GitHub token policy rejects artifact attestation.
-        continue-on-error: true
         uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # was v4
         with:
           subject-checksums: android-release-artifacts.sha256
@@ -373,7 +463,7 @@ jobs:
       - name: Upload Android release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           set -euo pipefail
           files=()
@@ -393,7 +483,7 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${files[@]}" --clobber
 
   build-ios:
-    needs: create-release
+    needs: classify-app-release
     runs-on: macos-26-xlarge
     permissions:
       contents: write
@@ -403,6 +493,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
@@ -484,7 +575,7 @@ jobs:
       - name: Upload iOS release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           set -euo pipefail
           files=()
@@ -505,7 +596,7 @@ jobs:
           gh release upload "${RELEASE_TAG}" "${files[@]}" --clobber
 
   build-web:
-    needs: create-release
+    needs: classify-app-release
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: write
@@ -515,6 +606,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -547,7 +639,7 @@ jobs:
       - name: Upload web release artifact
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           set -euo pipefail
           gh release upload "${RELEASE_TAG}" \
@@ -556,13 +648,16 @@ jobs:
             --clobber
 
   verify-android-release-artifacts:
-    needs: build-android
+    needs:
+      - classify-app-release
+      - build-android
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -573,7 +668,7 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
@@ -584,13 +679,16 @@ jobs:
         run: nix develop --no-update-lock-file .#android -c ./scripts/ci/verify-release-artifacts.sh artifacts android
 
   verify-linux-desktop-release-artifacts:
-    needs: build-tauri
+    needs:
+      - classify-app-release
+      - build-tauri
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -601,7 +699,7 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
@@ -610,13 +708,16 @@ jobs:
         run: nix develop --no-update-lock-file .#desktop-linux -c ./scripts/ci/verify-release-artifacts.sh artifacts linux
 
   verify-macos-desktop-release-artifacts:
-    needs: build-tauri
+    needs:
+      - classify-app-release
+      - build-tauri
     runs-on: macos-26-xlarge
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
@@ -646,7 +747,7 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
@@ -655,13 +756,16 @@ jobs:
         run: nix develop --no-update-lock-file .#ci -c ./scripts/ci/verify-release-artifacts.sh artifacts macos
 
   verify-windows-desktop-release-artifacts:
-    needs: build-windows
+    needs:
+      - classify-app-release
+      - build-windows
     runs-on: ubuntu-latest-8-cores
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -672,7 +776,7 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
@@ -682,6 +786,7 @@ jobs:
 
   verify-desktop-release-artifacts:
     needs:
+      - classify-app-release
       - verify-linux-desktop-release-artifacts
       - verify-macos-desktop-release-artifacts
       - verify-windows-desktop-release-artifacts
@@ -691,7 +796,9 @@ jobs:
         run: echo "Desktop release artifact verification completed for Linux, macOS, and Windows."
 
   update-latest-json:
-    needs: verify-desktop-release-artifacts
+    needs:
+      - classify-app-release
+      - verify-desktop-release-artifacts
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -701,6 +808,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -711,14 +819,14 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
 
       - name: Generate latest.json
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
           MAPLE_LATEST_JSON_PUB_DATE: ${{ github.event.release.published_at || github.event.release.created_at }}
         run: nix develop --no-update-lock-file .#ci -c ./scripts/ci/latest-json.sh artifacts latest.json
 
@@ -739,7 +847,7 @@ jobs:
       - name: Upload latest.json and provenance
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           gh release upload "${RELEASE_TAG}" \
             latest.json \
@@ -748,6 +856,7 @@ jobs:
 
   verify-release-artifacts:
     needs:
+      - classify-app-release
       - verify-desktop-release-artifacts
       - build-ios
       - build-web
@@ -759,6 +868,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       # Xcode 26.5 is temporarily exposed as a beta app on macos-26 runners: https://github.com/actions/runner-images/issues/14108
@@ -788,7 +898,7 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
@@ -799,7 +909,9 @@ jobs:
           MAPLE_ENFORCE_IOS_SIGNED_REPRODUCIBILITY: "1"
 
   publish-release-verification-guide:
-    needs: verify-release-artifacts
+    needs:
+      - classify-app-release
+      - verify-release-artifacts
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -809,6 +921,7 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          ref: ${{ needs.classify-app-release.outputs.release_sha }}
           persist-credentials: false
 
       - name: Install Nix
@@ -819,7 +932,7 @@ jobs:
       - name: Download release artifacts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           mkdir -p artifacts
           gh release download "${RELEASE_TAG}" -D artifacts
@@ -829,7 +942,7 @@ jobs:
 
       - name: Generate release verification guide
         env:
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           nix develop --no-update-lock-file .#ci -c ./scripts/ci/release-verification-guide.sh \
             artifacts \
@@ -851,7 +964,7 @@ jobs:
       - name: Upload release verification guide
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.release.tag_name }}
+          RELEASE_TAG: ${{ needs.classify-app-release.outputs.tag }}
         run: |
           gh release upload "${RELEASE_TAG}" \
             MAPLE_RELEASE_VERIFICATION.md \

--- a/.github/workflows/zapstore-publish.yml
+++ b/.github/workflows/zapstore-publish.yml
@@ -9,33 +9,241 @@ permissions:
   contents: read
 
 jobs:
-  publish:
+  classify:
+    name: Classify completed Maple release
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'release' &&
       github.event.workflow_run.head_repository.full_name == github.repository
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-latest
+    outputs:
+      publish: ${{ steps.classify.outputs.publish }}
+      release_id: ${{ steps.classify.outputs.release_id }}
+      release_sha: ${{ steps.classify.outputs.release_sha }}
+      release_tag: ${{ steps.classify.outputs.release_tag }}
+    steps:
+      - name: Validate completed release workflow
+        id: classify
+        env:
+          EXPECTED_REPOSITORY: ${{ github.repository }}
+          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
+          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
+          EXPECTED_TAG: ${{ github.event.workflow_run.head_branch }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${EXPECTED_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Unexpected workflow run ID: ${EXPECTED_RUN_ID}" >&2
+            exit 1
+          fi
+          if [[ ! "${EXPECTED_TAG}" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+            echo "Refusing to classify unexpected release tag: ${EXPECTED_TAG}" >&2
+            exit 1
+          fi
+          if [[ ! "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Refusing to classify unexpected release SHA: ${EXPECTED_SHA}" >&2
+            exit 1
+          fi
+
+          repository_json="$(gh api "repos/${EXPECTED_REPOSITORY}")"
+          jq -e --arg repository "${EXPECTED_REPOSITORY}" '
+            type == "object" and
+            .full_name == $repository and
+            .default_branch == "master"
+          ' <<<"${repository_json}" >/dev/null
+
+          run_json="$(gh api "repos/${EXPECTED_REPOSITORY}/actions/runs/${EXPECTED_RUN_ID}")"
+          jq -e \
+            --arg repository "${EXPECTED_REPOSITORY}" \
+            --arg tag "${EXPECTED_TAG}" \
+            --arg sha "${EXPECTED_SHA}" \
+            --argjson run_id "${EXPECTED_RUN_ID}" '
+              type == "object" and
+              .id == $run_id and
+              .path == ".github/workflows/release.yml" and
+              .event == "release" and
+              .status == "completed" and
+              .conclusion == "success" and
+              .head_branch == $tag and
+              .head_sha == $sha and
+              .repository.full_name == $repository and
+              .head_repository.full_name == $repository
+            ' <<<"${run_json}" >/dev/null
+
+          run_attempt="$(jq -er '.run_attempt | select(type == "number" and . >= 1)' <<<"${run_json}")"
+          jobs_json="$(gh api "repos/${EXPECTED_REPOSITORY}/actions/runs/${EXPECTED_RUN_ID}/jobs?filter=latest&per_page=100")"
+          jq -e '
+            type == "object" and
+            (.total_count | type == "number") and
+            (.total_count <= 100) and
+            (.jobs | type == "array") and
+            (.jobs | length) == .total_count
+          ' <<<"${jobs_json}" >/dev/null
+
+          classifier_count="$(
+            jq -r --argjson run_id "${EXPECTED_RUN_ID}" --argjson run_attempt "${run_attempt}" --arg sha "${EXPECTED_SHA}" '
+              [
+                .jobs[]
+                | select(
+                    .name == "Classify Maple app release" and
+                    .run_id == $run_id and
+                    (.run_attempt | type == "number") and
+                    .run_attempt >= 1 and
+                    .run_attempt <= $run_attempt and
+                    .head_sha == $sha and
+                    .status == "completed" and
+                    .conclusion == "success"
+                  )
+              ]
+              | length
+            ' <<<"${jobs_json}"
+          )"
+          named_classifier_count="$(
+            jq -r '[.jobs[] | select(.name == "Classify Maple app release")] | length' <<<"${jobs_json}"
+          )"
+          # `gh run rerun --failed` can retain a successful classifier from an
+          # earlier attempt. filter=latest returns that job's latest execution,
+          # so its attempt may be older than the completed run's attempt.
+          if [ "${classifier_count}" -ne 1 ] || [ "${named_classifier_count}" -ne 1 ]; then
+            echo "Expected exactly one successful 'Classify Maple app release' job in the completed run." >&2
+            echo "matching=${classifier_count} named=${named_classifier_count}" >&2
+            exit 1
+          fi
+
+          release_json="$(gh api "repos/${EXPECTED_REPOSITORY}/releases/tags/${EXPECTED_TAG}")"
+          jq -e --arg tag "${EXPECTED_TAG}" '
+            type == "object" and
+            (.id | type == "number" and . > 0) and
+            .tag_name == $tag and
+            (.draft | type == "boolean") and
+            .draft == false and
+            (.prerelease | type == "boolean")
+          ' <<<"${release_json}" >/dev/null
+          release_id="$(jq -er '.id' <<<"${release_json}")"
+          prerelease="$(jq -er '.prerelease' <<<"${release_json}")"
+
+          tag_sha="$(gh api "repos/${EXPECTED_REPOSITORY}/commits/${EXPECTED_TAG}" --jq '.sha')"
+          if [ "${tag_sha}" != "${EXPECTED_SHA}" ]; then
+            echo "Release tag no longer resolves to the completed workflow SHA." >&2
+            echo "tag=${EXPECTED_TAG} expected=${EXPECTED_SHA} actual=${tag_sha}" >&2
+            exit 1
+          fi
+
+          compare_json="$(gh api "repos/${EXPECTED_REPOSITORY}/compare/${EXPECTED_SHA}...master")"
+          jq -e --arg sha "${EXPECTED_SHA}" '
+            type == "object" and
+            (.status == "ahead" or .status == "identical") and
+            .base_commit.sha == $sha and
+            .merge_base_commit.sha == $sha
+          ' <<<"${compare_json}" >/dev/null
+
+          publish=false
+          if [ "${prerelease}" = "false" ]; then
+            latest_json="$(gh api "repos/${EXPECTED_REPOSITORY}/releases/latest")"
+            jq -e '
+              type == "object" and
+              (.id | type == "number" and . > 0) and
+              (.tag_name | type == "string") and
+              .draft == false and
+              .prerelease == false
+            ' <<<"${latest_json}" >/dev/null
+
+            latest_id="$(jq -er '.id' <<<"${latest_json}")"
+            latest_tag="$(jq -er '.tag_name' <<<"${latest_json}")"
+            if [ "${latest_id}" = "${release_id}" ] && [ "${latest_tag}" = "${EXPECTED_TAG}" ]; then
+              publish=true
+            else
+              echo "Release ${EXPECTED_TAG} is no longer the latest stable release; skipping Zapstore publish."
+            fi
+          else
+            echo "Release ${EXPECTED_TAG} is a prerelease; skipping Zapstore publish."
+          fi
+
+          {
+            echo "publish=${publish}"
+            echo "release_id=${release_id}"
+            echo "release_sha=${EXPECTED_SHA}"
+            echo "release_tag=${EXPECTED_TAG}"
+          } >>"${GITHUB_OUTPUT}"
+
+  publish:
+    name: Publish current stable release to Zapstore
+    needs: classify
+    if: needs.classify.outputs.publish == 'true'
+    permissions:
+      attestations: read
+      contents: read
+    runs-on: ubuntu-latest
+    concurrency:
+      group: zapstore-production
+      cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
+          fetch-depth: 0
           persist-credentials: false
+          ref: ${{ needs.classify.outputs.release_sha }}
           sparse-checkout: |
             zapstore.yaml
+            frontend/package.json
+            frontend/src-tauri/Cargo.toml
+            frontend/src-tauri/tauri.conf.json
             frontend/src-tauri/icons/icon.png
+            scripts/ci/_common.sh
+            scripts/ci/classify-app-release.sh
+            scripts/ci/validate-release-version.sh
+
+      - name: Verify checked-out release identity
+        env:
+          RELEASE_SHA: ${{ needs.classify.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.classify.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+
+          if [ "$(git rev-parse HEAD)" != "${RELEASE_SHA}" ]; then
+            echo "Checked-out commit does not match the classified release SHA." >&2
+            exit 1
+          fi
+
+          ./scripts/ci/classify-app-release.sh \
+            --repo-root "${GITHUB_WORKSPACE}" \
+            --tag "${RELEASE_TAG}" \
+            --sha "${RELEASE_SHA}" \
+            --draft false \
+            --prerelease false \
+            --ref "refs/tags/${RELEASE_TAG}" \
+            --protected-ref refs/remotes/origin/master
 
       - name: Download APK from release
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.classify.outputs.release_tag }}
         run: |
-          if [[ ! "$RELEASE_TAG" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
-            echo "Refusing to publish from unexpected release tag: $RELEASE_TAG" >&2
-            exit 1
-          fi
-          echo "Downloading APK from release $RELEASE_TAG"
-          gh release download "$RELEASE_TAG" \
+          set -euo pipefail
+          echo "Downloading APK from release ${RELEASE_TAG}"
+          gh release download "${RELEASE_TAG}" \
+            --repo "${GITHUB_REPOSITORY}" \
             --pattern "app-universal-release.apk" \
             --dir .
+
+      - name: Verify APK release provenance
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ needs.classify.outputs.release_sha }}
+          RELEASE_TAG: ${{ needs.classify.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh attestation verify app-universal-release.apk \
+            --repo "${GITHUB_REPOSITORY}" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release.yml" \
+            --signer-digest "${RELEASE_SHA}" \
+            --source-digest "${RELEASE_SHA}" \
+            --source-ref "refs/tags/${RELEASE_TAG}" \
+            --deny-self-hosted-runners
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # was v5
@@ -96,21 +304,109 @@ jobs:
           fi
 
           go install "${ZSP_MODULE}@${ZSP_VERSION}"
-          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
+
+      - name: Confirm release is still current
+        id: current
+        env:
+          EXPECTED_RELEASE_ID: ${{ needs.classify.outputs.release_id }}
+          EXPECTED_SHA: ${{ needs.classify.outputs.release_sha }}
+          EXPECTED_TAG: ${{ needs.classify.outputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          not_current() {
+            echo "current=false" >>"${GITHUB_OUTPUT}"
+            echo "$1; skipping Zapstore publish."
+            exit 0
+          }
+
+          fail() {
+            echo "$1" >&2
+            exit 1
+          }
+
+          repository_json="$(gh api "repos/${GITHUB_REPOSITORY}")" || \
+            fail "Could not re-read repository state."
+          jq -e --arg repository "${GITHUB_REPOSITORY}" '
+            type == "object" and
+            .full_name == $repository and
+            .default_branch == "master"
+          ' <<<"${repository_json}" >/dev/null || \
+            fail "Repository response is malformed or the protected default branch is no longer master."
+
+          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${EXPECTED_TAG}")" || \
+            fail "Could not re-read release ${EXPECTED_TAG}."
+          jq -e \
+            --argjson id "${EXPECTED_RELEASE_ID}" \
+            --arg tag "${EXPECTED_TAG}" '
+              type == "object" and
+              (.id | type == "number" and . > 0) and
+              .id == $id and
+              .tag_name == $tag and
+              (.draft | type == "boolean") and
+              .draft == false and
+              (.prerelease | type == "boolean")
+            ' <<<"${release_json}" >/dev/null || \
+            fail "Release ${EXPECTED_TAG} is malformed or its protected identity changed."
+
+          tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${EXPECTED_TAG}")" || \
+            fail "Could not re-resolve release tag ${EXPECTED_TAG}."
+          jq -e --arg sha "${EXPECTED_SHA}" '
+            type == "object" and
+            (.sha | type == "string") and
+            .sha == $sha
+          ' <<<"${tag_json}" >/dev/null || \
+            fail "Release tag ${EXPECTED_TAG} moved or returned a malformed response."
+
+          compare_json="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${EXPECTED_SHA}...master")" || \
+            fail "Could not re-check protected-master ancestry."
+          jq -e --arg sha "${EXPECTED_SHA}" '
+            type == "object" and
+            (.status == "ahead" or .status == "identical") and
+            .base_commit.sha == $sha and
+            .merge_base_commit.sha == $sha
+          ' <<<"${compare_json}" >/dev/null || \
+            fail "Release ${EXPECTED_TAG} is no longer on protected master or ancestry response is malformed."
+
+          if [ "$(jq -er '.prerelease' <<<"${release_json}")" = "true" ]; then
+            not_current "Release ${EXPECTED_TAG} is now a prerelease"
+          fi
+
+          latest_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")" || \
+            fail "Could not re-read the latest stable release."
+          jq -e '
+            type == "object" and
+            (.id | type == "number" and . > 0) and
+            (.tag_name | type == "string") and
+            .draft == false and
+            .prerelease == false
+          ' <<<"${latest_json}" >/dev/null || \
+            fail "Latest stable release response is malformed."
+
+          latest_id="$(jq -er '.id' <<<"${latest_json}")"
+          latest_tag="$(jq -er '.tag_name' <<<"${latest_json}")"
+          if [ "${latest_id}" != "${EXPECTED_RELEASE_ID}" ] || [ "${latest_tag}" != "${EXPECTED_TAG}" ]; then
+            not_current "Release ${EXPECTED_TAG} is no longer latest"
+          fi
+
+          echo "current=true" >>"${GITHUB_OUTPUT}"
 
       - name: Publish to Zapstore
+        if: steps.current.outputs.current == 'true'
         env:
-          SIGN_WITH: ${{ secrets.ZAPSTORE_SIGN_WITH }}
-          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          COMMIT_SHA: ${{ needs.classify.outputs.release_sha }}
           GOTOOLCHAIN: local
+          SIGN_WITH: ${{ secrets.ZAPSTORE_SIGN_WITH }}
         run: |
           if [ -z "${SIGN_WITH}" ]; then
             echo "Missing required secret: ZAPSTORE_SIGN_WITH" >&2
             exit 1
           fi
 
-          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Refusing to publish with unexpected commit SHA: $COMMIT_SHA" >&2
+          if [[ ! "${COMMIT_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Refusing to publish with unexpected commit SHA: ${COMMIT_SHA}" >&2
             exit 1
           fi
 
@@ -118,21 +414,21 @@ jobs:
           output="$(
             zsp publish \
               --quiet \
-              --commit "$COMMIT_SHA" \
+              --commit "${COMMIT_SHA}" \
               zapstore.yaml 2>&1
           )"
           status=$?
           set -e
 
-          if [ -n "$output" ]; then
-            printf '%s\n' "$output"
+          if [ -n "${output}" ]; then
+            printf '%s\n' "${output}"
           fi
 
-          if [ "$status" -ne 0 ]; then
-            exit "$status"
+          if [ "${status}" -ne 0 ]; then
+            exit "${status}"
           fi
 
-          if [[ "$output" == *"flag provided but not defined"* || "$output" == *"Usage of publish:"* ]]; then
+          if [[ "${output}" == *"flag provided but not defined"* || "${output}" == *"Usage of publish:"* ]]; then
             echo "zsp returned success but printed CLI usage, treating this as a failure." >&2
             exit 1
           fi

--- a/flake.nix
+++ b/flake.nix
@@ -190,6 +190,7 @@
           python3
           sccache
           unzip
+          yq-go
           zip
           actionlint
           rustToolchain
@@ -681,6 +682,7 @@
               mobile-pr-build.yml \
               mobile-build.yml \
               release.yml \
+              release-gates-tests.yml \
               rust-tests.yml \
               tauri-pr-change-detection.yml \
               updates-tests.yml \
@@ -695,6 +697,22 @@
           } ''
             cd "$src"
             bash ./scripts/ci/validate-release-version.sh >/dev/null
+            touch "$out"
+          '';
+
+          release-gates = pkgs.runCommand "maple-release-gates-check" {
+            nativeBuildInputs = with pkgs; [
+              bash
+              coreutils
+              git
+              jq
+              python3
+              yq-go
+            ];
+            src = ./.;
+          } ''
+            cd "$src"
+            bash ./scripts/ci/test-release-gates.sh
             touch "$out"
           '';
         };

--- a/scripts/ci/classify-app-release.sh
+++ b/scripts/ci/classify-app-release.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+fail() {
+  echo "$*" >&2
+  exit 1
+}
+
+require_value() {
+  local option="$1"
+  local value="${2:-}"
+
+  if [ -z "${value}" ] || [[ "${value}" == --* ]]; then
+    fail "${option} requires a value."
+  fi
+}
+
+repo_root=""
+tag=""
+release_sha=""
+draft=""
+prerelease=""
+release_ref=""
+protected_ref=""
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --repo-root)
+      require_value "$1" "${2:-}"
+      [ -z "${repo_root}" ] || fail "--repo-root may only be specified once."
+      repo_root="$2"
+      shift 2
+      ;;
+    --tag)
+      require_value "$1" "${2:-}"
+      [ -z "${tag}" ] || fail "--tag may only be specified once."
+      tag="$2"
+      shift 2
+      ;;
+    --sha)
+      require_value "$1" "${2:-}"
+      [ -z "${release_sha}" ] || fail "--sha may only be specified once."
+      release_sha="$2"
+      shift 2
+      ;;
+    --draft)
+      require_value "$1" "${2:-}"
+      [ -z "${draft}" ] || fail "--draft may only be specified once."
+      draft="$2"
+      shift 2
+      ;;
+    --prerelease)
+      require_value "$1" "${2:-}"
+      [ -z "${prerelease}" ] || fail "--prerelease may only be specified once."
+      prerelease="$2"
+      shift 2
+      ;;
+    --ref)
+      require_value "$1" "${2:-}"
+      [ -z "${release_ref}" ] || fail "--ref may only be specified once."
+      release_ref="$2"
+      shift 2
+      ;;
+    --protected-ref)
+      require_value "$1" "${2:-}"
+      [ -z "${protected_ref}" ] || fail "--protected-ref may only be specified once."
+      protected_ref="$2"
+      shift 2
+      ;;
+    *)
+      fail "Unknown argument: $1"
+      ;;
+  esac
+done
+
+[ -n "${repo_root}" ] || fail "--repo-root is required."
+[ -n "${tag}" ] || fail "--tag is required."
+[ -n "${release_sha}" ] || fail "--sha is required."
+[ -n "${draft}" ] || fail "--draft is required."
+[ -n "${prerelease}" ] || fail "--prerelease is required."
+[ -n "${release_ref}" ] || fail "--ref is required."
+[ -n "${protected_ref}" ] || fail "--protected-ref is required."
+
+if ! repo_root="$(cd "${repo_root}" && pwd -P)"; then
+  fail "--repo-root is not an accessible directory."
+fi
+
+if [[ ! "${tag}" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
+  fail "Refusing unexpected app release tag: ${tag}"
+fi
+
+if [[ ! "${release_sha}" =~ ^[0-9a-f]{40}$ ]]; then
+  fail "Release SHA must be exactly 40 lowercase hexadecimal characters."
+fi
+
+if [ "${draft}" != "false" ]; then
+  fail "Release must not be a draft."
+fi
+
+case "${prerelease}" in
+  true | false)
+    ;;
+  *)
+    fail "Prerelease must be either true or false."
+    ;;
+esac
+
+if [ "${release_ref}" != "refs/tags/${tag}" ]; then
+  fail "Release ref does not match the release tag."
+fi
+
+if [[ ! "${protected_ref}" =~ ^refs/(heads|remotes)/[0-9A-Za-z._/-]+$ ]] || \
+  ! git check-ref-format "${protected_ref}" >/dev/null 2>&1; then
+  fail "Protected ref has an unexpected format."
+fi
+
+if ! git -C "${repo_root}" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+  fail "Repository root is not a Git worktree: ${repo_root}"
+fi
+
+if ! head_sha="$(git -C "${repo_root}" rev-parse --verify 'HEAD^{commit}' 2>/dev/null)"; then
+  fail "Unable to resolve the checked-out HEAD commit."
+fi
+if [ "${head_sha}" != "${release_sha}" ]; then
+  fail "Checked-out HEAD does not match the release SHA."
+fi
+
+if ! tag_sha="$(git -C "${repo_root}" rev-parse --verify "refs/tags/${tag}^{commit}" 2>/dev/null)"; then
+  fail "Unable to resolve release tag ${tag}."
+fi
+if [ "${tag_sha}" != "${release_sha}" ]; then
+  fail "Release tag ${tag} does not resolve to the release SHA."
+fi
+
+if ! git -C "${repo_root}" rev-parse --verify "${protected_ref}^{commit}" >/dev/null 2>&1; then
+  fail "Unable to resolve protected ref ${protected_ref}."
+fi
+if ! git -C "${repo_root}" merge-base --is-ancestor "${release_sha}" "${protected_ref}"; then
+  fail "Release SHA is not reachable from protected ref ${protected_ref}."
+fi
+
+version="$(
+  MAPLE_RELEASE_REPO_ROOT="${repo_root}" \
+    bash "${script_dir}/validate-release-version.sh" "${tag}"
+)"
+
+stable=true
+if [ "${prerelease}" = "true" ]; then
+  stable=false
+fi
+
+printf 'tag=%s\n' "${tag}"
+printf 'release_sha=%s\n' "${release_sha}"
+printf 'version=%s\n' "${version}"
+printf 'prerelease=%s\n' "${prerelease}"
+printf 'stable=%s\n' "${stable}"

--- a/scripts/ci/test-release-gates.sh
+++ b/scripts/ci/test-release-gates.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd -P)"
+classifier="${script_dir}/classify-app-release.sh"
+temp_root="$(mktemp -d)"
+trap 'rm -rf "${temp_root}"' EXIT HUP INT TERM
+
+passed=0
+
+pass() {
+  passed=$((passed + 1))
+  printf 'ok %d - %s\n' "${passed}" "$1"
+}
+
+fail() {
+  echo "not ok - $*" >&2
+  exit 1
+}
+
+expect_failure() {
+  local label="$1"
+  shift
+
+  if output="$("$@" 2>&1)"; then
+    echo "Unexpected success output:" >&2
+    printf '%s\n' "${output}" >&2
+    fail "${label}"
+  fi
+  pass "${label}"
+}
+
+make_fixture() {
+  local directory="$1"
+  local app_version="$2"
+  local release_tag="$3"
+  local cargo_version="${4:-${app_version}}"
+
+  mkdir -p "${directory}/frontend/src-tauri"
+  printf '{"version":"%s"}\n' "${app_version}" > "${directory}/frontend/package.json"
+  printf '{"version":"%s"}\n' "${app_version}" > "${directory}/frontend/src-tauri/tauri.conf.json"
+  printf '[package]\nname = "maple-fixture"\nversion = "%s"\n\n[dependencies]\n' "${cargo_version}" \
+    > "${directory}/frontend/src-tauri/Cargo.toml"
+  git -C "${directory}" init -q -b master
+  git -C "${directory}" config user.name "Maple release gate tests"
+  git -C "${directory}" config user.email "release-gates@example.invalid"
+  git -C "${directory}" add \
+    frontend/package.json \
+    frontend/src-tauri/Cargo.toml \
+    frontend/src-tauri/tauri.conf.json
+  git -C "${directory}" commit -q -m "fixture"
+  git -C "${directory}" tag -a "${release_tag}" -m "${release_tag}"
+}
+
+run_classifier() {
+  local fixture="$1"
+  local tag="$2"
+  local sha="$3"
+  local draft="$4"
+  local prerelease="$5"
+  local ref="$6"
+  local protected_ref="$7"
+
+  bash "${classifier}" \
+    --repo-root "${fixture}" \
+    --tag "${tag}" \
+    --sha "${sha}" \
+    --draft "${draft}" \
+    --prerelease "${prerelease}" \
+    --ref "${ref}" \
+    --protected-ref "${protected_ref}"
+}
+
+fixture="${temp_root}/valid"
+make_fixture "${fixture}" "1.2.3" "v1.2.3"
+sha="$(git -C "${fixture}" rev-parse HEAD)"
+
+expected_stable="$(cat <<EOF
+tag=v1.2.3
+release_sha=${sha}
+version=1.2.3
+prerelease=false
+stable=true
+EOF
+)"
+actual="$(run_classifier "${fixture}" "v1.2.3" "${sha}" false false refs/tags/v1.2.3 refs/heads/master)"
+[ "${actual}" = "${expected_stable}" ] || fail "stable release output did not match"
+pass "accepts a stable app release"
+
+expected_prerelease="$(cat <<EOF
+tag=v1.2.3
+release_sha=${sha}
+version=1.2.3
+prerelease=true
+stable=false
+EOF
+)"
+actual="$(run_classifier "${fixture}" "v1.2.3" "${sha}" false true refs/tags/v1.2.3 refs/heads/master)"
+[ "${actual}" = "${expected_prerelease}" ] || fail "GitHub prerelease output did not match"
+pass "accepts an exact app tag marked as a GitHub prerelease"
+
+for malformed_tag in 1.2.3 v1.2 v1.2.3-beta.1 v1.2.3+build v01.2.3 V1.2.3; do
+  expect_failure "rejects malformed tag ${malformed_tag}" \
+    run_classifier "${fixture}" "${malformed_tag}" "${sha}" false false "refs/tags/${malformed_tag}" refs/heads/master
+done
+
+uppercase_sha="$(printf '%s' "${sha}" | tr '[:lower:]' '[:upper:]')"
+if [ "${uppercase_sha}" = "${sha}" ]; then
+  uppercase_sha="A${sha:1}"
+fi
+expect_failure "rejects an uppercase SHA" \
+  run_classifier "${fixture}" v1.2.3 "${uppercase_sha}" false false refs/tags/v1.2.3 refs/heads/master
+expect_failure "rejects a short SHA" \
+  run_classifier "${fixture}" v1.2.3 "${sha:0:12}" false false refs/tags/v1.2.3 refs/heads/master
+expect_failure "rejects draft=true" \
+  run_classifier "${fixture}" v1.2.3 "${sha}" true false refs/tags/v1.2.3 refs/heads/master
+expect_failure "rejects a malformed draft boolean" \
+  run_classifier "${fixture}" v1.2.3 "${sha}" no false refs/tags/v1.2.3 refs/heads/master
+expect_failure "rejects a malformed prerelease boolean" \
+  run_classifier "${fixture}" v1.2.3 "${sha}" false no refs/tags/v1.2.3 refs/heads/master
+expect_failure "rejects a release ref that does not match the tag" \
+  run_classifier "${fixture}" v1.2.3 "${sha}" false false refs/tags/v9.9.9 refs/heads/master
+expect_failure "rejects a malformed protected ref" \
+  run_classifier "${fixture}" v1.2.3 "${sha}" false false refs/tags/v1.2.3 'master^{commit}'
+
+printf 'new head\n' > "${fixture}/README.md"
+git -C "${fixture}" add README.md
+git -C "${fixture}" commit -q -m "move head"
+new_head_sha="$(git -C "${fixture}" rev-parse HEAD)"
+expect_failure "rejects a tag that does not peel to the release SHA" \
+  run_classifier "${fixture}" v1.2.3 "${new_head_sha}" false false refs/tags/v1.2.3 refs/heads/master
+expect_failure "rejects a checked-out HEAD that does not match the release SHA" \
+  run_classifier "${fixture}" v1.2.3 "${sha}" false false refs/tags/v1.2.3 refs/heads/master
+
+non_ancestor_fixture="${temp_root}/non-ancestor"
+make_fixture "${non_ancestor_fixture}" "1.2.3" "v1.2.3"
+tree="$(git -C "${non_ancestor_fixture}" rev-parse 'HEAD^{tree}')"
+side_sha="$(printf 'unrelated release\n' | git -C "${non_ancestor_fixture}" commit-tree "${tree}")"
+git -C "${non_ancestor_fixture}" update-ref refs/tags/v1.2.3 "${side_sha}"
+git -C "${non_ancestor_fixture}" checkout -q --detach "${side_sha}"
+expect_failure "rejects a release SHA outside the protected branch" \
+  run_classifier "${non_ancestor_fixture}" v1.2.3 "${side_sha}" false false refs/tags/v1.2.3 refs/heads/master
+
+version_fixture="${temp_root}/version-mismatch"
+make_fixture "${version_fixture}" "9.9.9" "v1.2.3"
+version_sha="$(git -C "${version_fixture}" rev-parse HEAD)"
+expect_failure "rejects an app manifest version mismatch" \
+  run_classifier "${version_fixture}" v1.2.3 "${version_sha}" false false refs/tags/v1.2.3 refs/heads/master
+
+cargo_fixture="${temp_root}/cargo-version-mismatch"
+make_fixture "${cargo_fixture}" "1.2.3" "v1.2.3" "9.9.9"
+cargo_sha="$(git -C "${cargo_fixture}" rev-parse HEAD)"
+expect_failure "rejects a Cargo package version mismatch" \
+  run_classifier "${cargo_fixture}" v1.2.3 "${cargo_sha}" false false refs/tags/v1.2.3 refs/heads/master
+
+expect_failure "rejects a missing required argument" \
+  bash "${classifier}" --repo-root "${fixture}"
+expect_failure "rejects an unknown argument" \
+  bash "${classifier}" --unknown value
+
+release_json="${temp_root}/release.json"
+zapstore_json="${temp_root}/zapstore.json"
+yq -o=json '.' "${repo_root}/.github/workflows/release.yml" > "${release_json}"
+yq -o=json '.' "${repo_root}/.github/workflows/zapstore-publish.yml" > "${zapstore_json}"
+
+python3 - "${release_json}" "${zapstore_json}" <<'PY'
+import json
+import re
+import sys
+
+
+def check(condition, message):
+    if not condition:
+        raise AssertionError(message)
+
+
+def needs(job):
+    value = job.get("needs", [])
+    return [value] if isinstance(value, str) else value
+
+
+def secret_names(value):
+    found = set()
+    if isinstance(value, dict):
+        for child in value.values():
+            found.update(secret_names(child))
+    elif isinstance(value, list):
+        for child in value:
+            found.update(secret_names(child))
+    elif isinstance(value, str):
+        dot_pattern = r"secrets\.([A-Za-z0-9_]+)"
+        bracket_pattern = r"secrets\[['\"]([A-Za-z0-9_]+)['\"]\]"
+        found.update(re.findall(dot_pattern, value))
+        found.update(re.findall(bracket_pattern, value))
+        remaining = re.sub(dot_pattern, "", value)
+        remaining = re.sub(bracket_pattern, "", remaining)
+        if re.search(r"\bsecrets\b", remaining):
+            found.add("*")
+    return found
+
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    release = json.load(handle)
+
+release_jobs = release["jobs"]
+classifier_id = "classify-app-release"
+check(classifier_id in release_jobs, "Release workflow must have classify-app-release job")
+classifier = release_jobs[classifier_id]
+classifier_permissions = classifier.get("permissions", {})
+check(
+    classifier_permissions == {"contents": "read"},
+    "Release classifier must have only contents: read permission",
+)
+check(not secret_names(classifier), "Release classifier must not receive secrets")
+for output in ("tag", "release_sha", "version", "prerelease", "stable"):
+    check(output in classifier.get("outputs", {}), f"Release classifier must emit {output}")
+
+android_attestation_steps = [
+    step
+    for step in release_jobs.get("build-android", {}).get("steps", [])
+    if step.get("name") == "Attest Android release artifacts"
+]
+check(len(android_attestation_steps) == 1, "Android release artifacts must be attested exactly once")
+check(
+    android_attestation_steps[0].get("continue-on-error") is not True,
+    "Android attestation must succeed before the Release can wake Zapstore",
+)
+
+classifier_checkouts = [
+    step
+    for step in classifier.get("steps", [])
+    if str(step.get("uses", "")).startswith("actions/checkout@")
+]
+check(len(classifier_checkouts) == 1, "Release classifier must have exactly one checkout")
+classifier_checkout = classifier_checkouts[0].get("with", {})
+check(classifier_checkout.get("ref") == "${{ github.sha }}", "Release classifier must checkout github.sha")
+check(classifier_checkout.get("fetch-depth") in (0, "0"), "Release classifier must fetch complete history")
+check(classifier_checkout.get("persist-credentials") is False, "Release classifier must not persist credentials")
+
+release_ref = "${{ needs.classify-app-release.outputs.release_sha }}"
+for job_id, job in release_jobs.items():
+    if job_id == classifier_id:
+        continue
+    check(classifier_id in needs(job), f"Release job {job_id} must directly need {classifier_id}")
+    for step in job.get("steps", []):
+        if str(step.get("uses", "")).startswith("actions/checkout@"):
+            checkout = step.get("with", {})
+            check(checkout.get("ref") == release_ref, f"Release checkout in {job_id} must pin classifier SHA")
+            check(checkout.get("persist-credentials") is False, f"Release checkout in {job_id} must not persist credentials")
+
+with open(sys.argv[2], encoding="utf-8") as handle:
+    zapstore = json.load(handle)
+
+zapstore_jobs = zapstore["jobs"]
+check("classify" in zapstore_jobs, "Zapstore workflow must have classify job")
+check("publish" in zapstore_jobs, "Zapstore workflow must have publish job")
+zapstore_classifier = zapstore_jobs["classify"]
+check(not secret_names(zapstore_classifier), "Zapstore classifier must not receive secrets")
+check(
+    zapstore_classifier.get("permissions", {}) == {"actions": "read", "contents": "read"},
+    "Zapstore classifier must have only actions: read and contents: read permissions",
+)
+check(
+    not any(
+        str(step.get("uses", "")).startswith("actions/checkout@")
+        for step in zapstore_classifier.get("steps", [])
+    ),
+    "Zapstore classifier must not checkout or execute repository content",
+)
+zapstore_classifier_run = "\n".join(
+    str(step.get("run", "")) for step in zapstore_classifier.get("steps", [])
+)
+check(
+    ".run_attempt == $run_attempt" not in zapstore_classifier_run,
+    "Zapstore classifier must allow a successful classifier retained by --failed reruns",
+)
+publish = zapstore_jobs["publish"]
+check("classify" in needs(publish), "Zapstore publish must directly need classify")
+check(
+    publish.get("permissions", {}) == {"attestations": "read", "contents": "read"},
+    "Zapstore publish must have only attestations: read and contents: read permissions",
+)
+publish_metadata = {key: value for key, value in publish.items() if key != "steps"}
+check(
+    not (secret_names(publish_metadata) - {"GITHUB_TOKEN"}),
+    "Zapstore custom secret must not be exposed at job scope",
+)
+concurrency = publish.get("concurrency", {})
+check(concurrency.get("group") == "zapstore-production", "Zapstore publish concurrency group must be hard-coded")
+check(concurrency.get("cancel-in-progress") is False, "Zapstore publish must not cancel an in-progress publication")
+
+steps = publish.get("steps", [])
+checkout_steps = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout@")]
+check(len(checkout_steps) == 1, "Zapstore publish must have exactly one checkout")
+checkout = checkout_steps[0].get("with", {})
+check(
+    checkout.get("ref") == "${{ needs.classify.outputs.release_sha }}",
+    "Zapstore checkout must pin the classified upstream SHA",
+)
+check(checkout.get("persist-credentials") is False, "Zapstore checkout must not persist credentials")
+
+attestation_steps = [step for step in steps if step.get("name") == "Verify APK release provenance"]
+check(len(attestation_steps) == 1, "Zapstore must verify APK release provenance exactly once")
+attestation_index = steps.index(attestation_steps[0])
+attestation_run = str(attestation_steps[0].get("run", ""))
+for required_fragment in (
+    "gh attestation verify app-universal-release.apk",
+    "--signer-workflow",
+    "--signer-digest",
+    "--source-digest",
+    "--source-ref",
+    "--deny-self-hosted-runners",
+):
+    check(required_fragment in attestation_run, f"Zapstore APK verification must use {required_fragment}")
+
+publish_indexes = [index for index, step in enumerate(steps) if step.get("name") == "Publish to Zapstore"]
+check(len(publish_indexes) == 1, "Zapstore workflow must have one final Publish to Zapstore step")
+publish_index = publish_indexes[0]
+check(attestation_index < publish_index, "APK provenance verification must precede Zapstore publish")
+publish_step = steps[publish_index]
+check(publish_index == len(steps) - 1, "Publish to Zapstore must be the final step")
+check(publish_index > 0, "Publish to Zapstore must follow a current-release recheck")
+recheck = steps[publish_index - 1]
+recheck_name = str(recheck.get("name", "")).lower()
+check(
+    "release" in recheck_name and any(word in recheck_name for word in ("recheck", "current", "confirm")),
+    "Current-release recheck must immediately precede publish",
+)
+check("releases/latest" in str(recheck.get("run", "")), "Current-release recheck must query releases/latest")
+recheck_id = recheck.get("id")
+check(isinstance(recheck_id, str) and recheck_id, "Current-release recheck must expose a step output")
+expected_publish_condition = f"steps.{recheck_id}.outputs.current == 'true'"
+check(
+    publish_step.get("if") == expected_publish_condition,
+    "Zapstore publish must be conditional on the immediately preceding current-release recheck: "
+    f"expected {expected_publish_condition!r}, got {publish_step.get('if')!r}",
+)
+zsp_indexes = [index for index, step in enumerate(steps) if "zsp publish" in str(step.get("run", ""))]
+check(zsp_indexes == [publish_index], "zsp publish must run only in the final secret-bearing step")
+
+for index, step in enumerate(steps):
+    custom_secrets = secret_names(step) - {"GITHUB_TOKEN"}
+    if index == publish_index:
+        check(custom_secrets == {"ZAPSTORE_SIGN_WITH"}, "Final publish must receive only ZAPSTORE_SIGN_WITH")
+    else:
+        check(not custom_secrets, f"Custom secret exposed before final publish step {index}")
+PY
+pass "workflow release-gate topology is fail closed"
+
+printf '1..%d\n' "${passed}"

--- a/scripts/ci/validate-release-version.sh
+++ b/scripts/ci/validate-release-version.sh
@@ -1,11 +1,39 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/_common.sh"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [ -n "${MAPLE_RELEASE_REPO_ROOT:-}" ]; then
+  if ! repo_root="$(cd "${MAPLE_RELEASE_REPO_ROOT}" && pwd -P)"; then
+    echo "MAPLE_RELEASE_REPO_ROOT is not an accessible directory: ${MAPLE_RELEASE_REPO_ROOT}" >&2
+    exit 1
+  fi
+else
+  repo_root="$(cd "${script_dir}/../.." && pwd -P)"
+fi
+
+frontend_dir="${repo_root}/frontend"
+tauri_dir="${frontend_dir}/src-tauri"
 
 release_tag="${1:-${RELEASE_TAG:-${GITHUB_REF_NAME:-}}}"
-package_version="$(jq -er '.version' "${FRONTEND_DIR}/package.json")"
-tauri_version="$(jq -er '.version' "${TAURI_DIR}/tauri.conf.json")"
+package_version="$(jq -er '.version' "${frontend_dir}/package.json")"
+tauri_version="$(jq -er '.version' "${tauri_dir}/tauri.conf.json")"
+cargo_version="$(awk '
+  /^\[package\]$/ { in_package = 1; next }
+  /^\[/ && in_package { exit }
+  in_package && /^version[[:space:]]*=/ {
+    value = $0
+    sub(/^[^=]*=[[:space:]]*"/, "", value)
+    sub(/"[[:space:]]*$/, "", value)
+    print value
+    exit
+  }
+' "${tauri_dir}/Cargo.toml")"
+
+if [ -z "${cargo_version}" ]; then
+  echo "Could not read the Cargo package version." >&2
+  exit 1
+fi
 
 if [ "${package_version}" != "${tauri_version}" ]; then
   echo "frontend/package.json version does not match frontend/src-tauri/tauri.conf.json." >&2
@@ -14,12 +42,19 @@ if [ "${package_version}" != "${tauri_version}" ]; then
   exit 1
 fi
 
+if [ "${package_version}" != "${cargo_version}" ]; then
+  echo "frontend/package.json version does not match frontend/src-tauri/Cargo.toml." >&2
+  echo "package=${package_version}" >&2
+  echo "cargo=${cargo_version}" >&2
+  exit 1
+fi
+
 if [ -z "${release_tag}" ]; then
   printf '%s\n' "${tauri_version}"
   exit 0
 fi
 
-if [[ ! "${release_tag}" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+if [[ ! "${release_tag}" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
   echo "Refusing to build unexpected release tag: ${release_tag}" >&2
   exit 1
 fi


### PR DESCRIPTION
## Summary

- classify only exact `vX.Y.Z` Maple app Releases whose live tag and workflow SHA resolve to a commit reachable from `master`
- make every Release job depend directly on that classifier and checkout its accepted SHA
- let GitHub prereleases build, while Zapstore publishes only the current stable release under one concurrency lock
- bind the Zapstore APK to an attestation from the exact Release workflow, tag, and commit before exposing its signing secret
- add a reusable local classifier plus 23 credential-free behavior and workflow-topology checks

## Validation

- `nix flake check --no-update-lock-file --print-build-logs`
- focused release-gate tests: 23/23
- `actionlint` on all changed workflows
- `shellcheck -x` on the release-gate scripts
- Maple frontend check/build plus 764 tests
- live v3.3.7 API and APK-attestation compatibility check
- three independent security/release/test reviews found no code blocker

No Release or deployment was triggered.

## Required production boundary

The currently active `master` ruleset prevents deletion and non-fast-forward updates, but it does not require reviewed changes, and no `v*` tag ruleset exists. Before the next production Release, restrict `v*` creation/update/deletion and establish reviewed ownership of the privileged workflows. GitHub loads a release workflow from the tagged commit, so historical tags also remain under trusted Release-management authority.