### PR TITLE
Attach updater domain through Cloudflare API

### DIFF
--- a/.github/workflows/updates-publish.yml
+++ b/.github/workflows/updates-publish.yml
@@ -136,6 +136,18 @@ jobs:
               --tag 'release-${RELEASE_TAG#v}' \
               --message 'Publish ${RELEASE_TAG} from GitHub Release ${RELEASE_ID}'"
 
+          domain_response="$(curl --fail-with-body --silent --show-error \
+            --request PUT \
+            --header "Authorization: Bearer ${CLOUDFLARE_API_TOKEN}" \
+            --header 'Content-Type: application/json' \
+            --data '{"hostname":"updates.trymaple.ai","service":"maple-updates","zone_name":"trymaple.ai"}' \
+            "https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/workers/domains")"
+          jq -e '
+            .success == true
+            and .result.hostname == "updates.trymaple.ai"
+            and .result.service == "maple-updates"
+          ' <<<"${domain_response}" >/dev/null
+
           served_metadata="$(mktemp "${RUNNER_TEMP}/maple-updates-live.XXXXXX")"
           endpoint="https://updates.trymaple.ai/latest.json"
           for attempt in $(seq 1 60); do

--- a/updates/wrangler.jsonc
+++ b/updates/wrangler.jsonc
@@ -5,12 +5,6 @@
   "compatibility_date": "2026-08-24",
   "workers_dev": false,
   "preview_urls": false,
-  "routes": [
-    {
-      "pattern": "updates.trymaple.ai",
-      "custom_domain": true,
-    },
-  ],
   "assets": {
     "directory": "./public",
     "binding": "ASSETS",


### PR DESCRIPTION
Wrangler uploaded the Worker and latest.json successfully, then failed while listing zone routes because the deployment token intentionally lacks zone-route permissions.

This uses Cloudflare's Custom Domain API directly after deployment. That endpoint accepts the existing Workers Scripts Edit permission, so no token change is required. Focused Worker checks and workflow validation pass.