### PR TITLE
Publish updater metadata automatically after releases

### DIFF
--- a/.github/workflows/updates-publish.yml
+++ b/.github/workflows/updates-publish.yml
@@ -4,6 +4,9 @@ run-name: Publish the current Maple release to Cloudflare
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
 
 permissions:
   contents: read
@@ -15,7 +18,13 @@ concurrency:
 jobs:
   publish:
     name: Publish current release
-    if: github.ref == 'refs/heads/master'
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'release' &&
+        github.event.workflow_run.path == '.github/workflows/release.yml' &&
+        github.event.workflow_run.head_repository.full_name == github.repository)
     runs-on: ubuntu-latest
     timeout-minutes: 20
     environment:
@@ -33,7 +42,9 @@ jobs:
           github-token: ""
 
       - name: Download and validate the current release metadata
+        id: release
         env:
+          EXPECTED_RELEASE_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
           GH_TOKEN: ${{ github.token }}
           REPOSITORY: ${{ github.repository }}
         run: |
@@ -46,6 +57,17 @@ jobs:
             echo "Latest GitHub Release tag is not a stable version: ${release_tag}" >&2
             exit 1
           }
+          if [ -n "${EXPECTED_RELEASE_TAG}" ]; then
+            [[ "${EXPECTED_RELEASE_TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || {
+              echo "Completed Release workflow has an invalid tag: ${EXPECTED_RELEASE_TAG}" >&2
+              exit 1
+            }
+            if [ "${release_tag}" != "${EXPECTED_RELEASE_TAG}" ]; then
+              echo "${EXPECTED_RELEASE_TAG} is not the latest stable release; skipping updater publication."
+              echo "publish=false" >>"${GITHUB_OUTPUT}"
+              exit 0
+            fi
+          fi
 
           asset_count="$(jq '[.assets[] | select(.name == "latest.json")] | length' <<<"${release_json}")"
           [ "${asset_count}" -eq 1 ] || {
@@ -93,6 +115,7 @@ jobs:
           ' release-metadata/latest.json >/dev/null
 
           cp release-metadata/latest.json updates/public/latest.json
+          echo "publish=true" >>"${GITHUB_OUTPUT}"
           {
             echo "RELEASE_ID=${release_id}"
             echo "RELEASE_TAG=${release_tag}"
@@ -104,6 +127,7 @@ jobs:
             'cd updates && bun run validate:latest public/latest.json'
 
       - name: Deploy and verify the public endpoint
+        if: steps.release.outputs.publish == 'true'
         env:
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Triggers the existing Cloudflare publisher after the `Release` workflow completes successfully. It publishes only when that run's tag is still the latest stable release, so prereleases and superseded releases skip safely. Manual dispatch remains available for recovery.

Validated with the repository workflow check, updater tests, typecheck, formatting, Wrangler dry-run, and a focused trigger topology assertion.