### PR TITLE
Use Maple updates Worker for desktop updates

### DIFF
--- a/frontend/src-tauri/src/lib.rs
+++ b/frontend/src-tauri/src/lib.rs
@@ -954,7 +954,11 @@ async fn check_for_updates(
     log::info!("Checking for updates...");
 
     // Get the updater
-    let updater = match app_handle.updater() {
+    let updater = match app_handle
+        .updater_builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+    {
         Ok(u) => u,
         Err(e) => {
             log::error!("Failed to get updater: {e}");

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
   "plugins": {
     "updater": {
       "endpoints": [
+        "https://updates.trymaple.ai/latest.json",
         "https://github.com/OpenSecretCloud/Maple/releases/latest/download/latest.json"
       ],
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDRCRjU0OEJCM0M2OTNEQjAKUldTd1BXazh1MGoxUyt3TXdHREU1WUdzL1VNYlludXhORHpQSUc1cGxSSW1kdEYrOXNPNzRjdUUK"


### PR DESCRIPTION
## Summary

- query `https://updates.trymaple.ai/latest.json` before the existing GitHub metadata endpoint
- retain GitHub as a fallback
- bound each updater metadata request to 30 seconds

## Local validation

- built an isolated macOS `Maple.app` configured as version 3.3.6
- observed the packaged app connect to `updates.trymaple.ai` first, detect version 3.3.7, download the 125,666,456-byte release artifact, and verify its updater signature
- confirmed the native UI displayed **Update Ready** for version 3.3.7; did not install it
- `nix develop --no-update-lock-file .#ci -c just rust-lint`
- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/rust.sh` (401 passed, 2 ignored)
- repository pre-commit hook