### PR TITLE
Centralize Maple GitHub repository metadata

### DIFF
--- a/frontend/src/utils/githubRelease.test.ts
+++ b/frontend/src/utils/githubRelease.test.ts
@@ -3,10 +3,25 @@ import {
   buildFallbackDownloadInfo,
   fetchLatestRelease,
   getLatestDownloadInfo,
+  GITHUB_REPOSITORY,
+  GITHUB_REPOSITORY_URL,
   GITHUB_RELEASES_API_URL,
   GITHUB_RELEASES_LATEST_URL,
   resolveDownloadUrlsFromRelease
 } from "./githubRelease";
+
+describe("repository metadata", () => {
+  test("builds the current Maple GitHub URLs from the shared repository identity", () => {
+    expect(GITHUB_REPOSITORY).toBe("OpenSecretCloud/Maple");
+    expect(GITHUB_REPOSITORY_URL).toBe("https://github.com/OpenSecretCloud/Maple");
+    expect(GITHUB_RELEASES_API_URL).toBe(
+      "https://api.github.com/repos/OpenSecretCloud/Maple/releases/latest"
+    );
+    expect(GITHUB_RELEASES_LATEST_URL).toBe(
+      "https://github.com/OpenSecretCloud/Maple/releases/latest"
+    );
+  });
+});
 
 let fetchSpy: ReturnType<typeof spyOn<typeof globalThis, "fetch">> | null = null;
 

--- a/frontend/src/utils/githubRelease.ts
+++ b/frontend/src/utils/githubRelease.ts
@@ -3,10 +3,13 @@
  * installable assets the same way the Maple marketing site does.
  */
 
-export const GITHUB_RELEASES_API_URL =
-  "https://api.github.com/repos/OpenSecretCloud/Maple/releases/latest";
-export const GITHUB_RELEASES_LATEST_URL =
-  "https://github.com/OpenSecretCloud/Maple/releases/latest";
+import repositoryMetadata from "../../../repo.meta.json";
+
+export const GITHUB_REPOSITORY = `${repositoryMetadata.github.owner}/${repositoryMetadata.github.repository}`;
+export const GITHUB_REPOSITORY_URL = `https://github.com/${GITHUB_REPOSITORY}`;
+
+export const GITHUB_RELEASES_API_URL = `https://api.github.com/repos/${GITHUB_REPOSITORY}/releases/latest`;
+export const GITHUB_RELEASES_LATEST_URL = `${GITHUB_REPOSITORY_URL}/releases/latest`;
 
 export type DownloadAssetKey =
   | "macOS"

--- a/repo.meta.json
+++ b/repo.meta.json
@@ -1,0 +1,6 @@
+{
+  "github": {
+    "owner": "OpenSecretCloud",
+    "repository": "Maple"
+  }
+}

--- a/scripts/ci/latest-json.sh
+++ b/scripts/ci/latest-json.sh
@@ -22,6 +22,11 @@ fi
 configure_reproducible_build_metadata
 pub_date="${MAPLE_LATEST_JSON_PUB_DATE:-$(source_date_rfc3339)}"
 
+repository_metadata="${REPO_ROOT}/repo.meta.json"
+github_owner="$(jq -er '.github.owner | select(type == "string" and length > 0)' "${repository_metadata}")"
+github_repository="$(jq -er '.github.repository | select(type == "string" and length > 0)' "${repository_metadata}")"
+github_repository_url="https://github.com/${github_owner}/${github_repository}"
+
 find_one_artifact() {
   local pattern="$1"
   local file
@@ -68,16 +73,16 @@ linux_appimage_sig_content="$(cat "${linux_appimage_sig}")"
 linux_deb_sig_content="$(cat "${linux_deb_sig}")"
 linux_rpm_sig_content="$(cat "${linux_rpm_sig}")"
 windows_sig_content="$(cat "${windows_sig}")"
-macos_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${macos_bundle}")"
-linux_appimage_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_appimage_bundle}")"
-linux_deb_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_deb_bundle}")"
-linux_rpm_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${linux_rpm_bundle}")"
-windows_url="https://github.com/OpenSecretCloud/Maple/releases/download/${release_tag}/$(basename "${windows_bundle}")"
+macos_url="${github_repository_url}/releases/download/${release_tag}/$(basename "${macos_bundle}")"
+linux_appimage_url="${github_repository_url}/releases/download/${release_tag}/$(basename "${linux_appimage_bundle}")"
+linux_deb_url="${github_repository_url}/releases/download/${release_tag}/$(basename "${linux_deb_bundle}")"
+linux_rpm_url="${github_repository_url}/releases/download/${release_tag}/$(basename "${linux_rpm_bundle}")"
+windows_url="${github_repository_url}/releases/download/${release_tag}/$(basename "${windows_bundle}")"
 
 tmp="$(mktemp)"
 jq -S -n \
   --arg version "${release_tag#v}" \
-  --arg notes "See the release notes at https://github.com/OpenSecretCloud/Maple/releases/tag/${release_tag}" \
+  --arg notes "See the release notes at ${github_repository_url}/releases/tag/${release_tag}" \
   --arg pub_date "${pub_date}" \
   --arg macos_sig "${macos_sig_content}" \
   --arg linux_appimage_sig "${linux_appimage_sig_content}" \

--- a/updates/src/worker.test.ts
+++ b/updates/src/worker.test.ts
@@ -1,9 +1,14 @@
 import { describe, expect, test } from "bun:test";
 
-import { handleRequest, isLatestRelease, type Env } from "./worker";
+import {
+  GITHUB_REPOSITORY,
+  handleRequest,
+  isLatestRelease,
+  type Env,
+} from "./worker";
 
 function releaseUrl(version: string, name: string): string {
-  return `https://github.com/OpenSecretCloud/Maple/releases/download/v${version}/${name}`;
+  return `https://github.com/${GITHUB_REPOSITORY}/releases/download/v${version}/${name}`;
 }
 
 function validRelease(version = "3.3.8") {
@@ -55,6 +60,10 @@ function envReturning(response: Response, requests: Request[] = []): Env {
 }
 
 describe("latest.json validation", () => {
+  test("uses the shared Maple GitHub repository identity", () => {
+    expect(GITHUB_REPOSITORY).toBe("OpenSecretCloud/Maple");
+  });
+
   test("accepts the Maple release schema", () => {
     expect(isLatestRelease(validRelease())).toBe(true);
   });

--- a/updates/src/worker.ts
+++ b/updates/src/worker.ts
@@ -1,5 +1,8 @@
+import repositoryMetadata from "../../repo.meta.json";
+
 const LATEST_JSON_PATH = "/latest.json";
 const MAX_LATEST_JSON_BYTES = 64 * 1024;
+export const GITHUB_REPOSITORY = `${repositoryMetadata.github.owner}/${repositoryMetadata.github.repository}`;
 const STABLE_VERSION = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
 const GENERATED_PUB_DATE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
 const REQUIRED_PLATFORMS = [
@@ -76,8 +79,8 @@ function isExpectedArtifactUrl(value: string, version: string): boolean {
   const segments = url.pathname.split("/").filter(Boolean);
   return (
     segments.length === 6 &&
-    segments[0] === "OpenSecretCloud" &&
-    segments[1] === "Maple" &&
+    segments[0] === repositoryMetadata.github.owner &&
+    segments[1] === repositoryMetadata.github.repository &&
     segments[2] === "releases" &&
     segments[3] === "download" &&
     segments[4] === `v${version}` &&


### PR DESCRIPTION
## Summary

- add one root source of truth for the Maple GitHub owner and repository
- derive frontend release/download links and generated latest.json URLs from it
- make the updates Worker validate artifact URLs against the same metadata
- preserve all current OpenSecretCloud/Maple URLs and leave the compiled updater fallback unchanged

## Validation

- focused GitHub release URL tests (6 passed)
- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/frontend.sh` (765 passed)
- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/updates.sh` (10 passed; Wrangler dry-run passed)
- `MAPLE_WEB_ENVIRONMENT=pr nix develop --no-update-lock-file .#ci -c ./scripts/ci/web.sh`
- `nix flake check --no-update-lock-file --print-build-logs`
- repository pre-commit hook