### PR TITLE
Restore simple best-effort Zapstore publishing

### DIFF
--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -15,7 +15,8 @@ commit, external effect, and authority provided by the user.
   frontend, and Rust workflows. The iOS master workflow uploads its verified
   IPA to TestFlight automatically.
 - Creating a GitHub Release starts the cross-platform release workflow. A
-  successful release workflow triggers Zapstore publication.
+  successful release workflow starts a separate best-effort Zapstore attempt.
+  Zapstore never gates or changes the outcome of the Maple release.
 - GitHub Release creation does not itself submit the release IPA or AAB to
   Apple App Store review or Google Play.
 
@@ -140,22 +141,7 @@ Do not classify version/proof mismatches, deterministic builds, signing
 failures, missing credentials, or integrity checks as transient. Do not delete
 or recreate a published release without separate explicit direction.
 
-## Verify downstream publication
-
-Zapstore starts only after the `Release` workflow succeeds. Select the newest
-non-skipped run for the exact commit and watch it:
-
-```bash
-gh run list --repo OpenSecretCloud/Maple --workflow 'Publish to Zapstore' \
-  --commit "$head_sha" --limit 10 \
-  --json databaseId,status,conclusion,headSha,createdAt,url
-
-gh run watch ZAPSTORE_RUN_ID \
-  --repo OpenSecretCloud/Maple --exit-status --compact
-```
-
-Treat pinned Go/zsp verification failures as integrity failures unless logs
-prove a transient transport problem.
+## Verify the release and optionally inspect Zapstore
 
 Verify the published release and its assets:
 
@@ -164,8 +150,22 @@ gh release view "$tag" --repo OpenSecretCloud/Maple \
   --json tagName,name,isDraft,isPrerelease,publishedAt,targetCommitish,url,assets
 ```
 
-Do not call the release complete while a required workflow is queued or
-running.
+Zapstore starts only after `Release` succeeds and is strictly best effort. Its
+queued, running, skipped, or failed state must not delay release completion,
+trigger a release retry, or be reported as a Maple release failure. Inspect it
+only when Zapstore status is specifically useful:
+
+```bash
+gh run list --repo OpenSecretCloud/Maple --workflow 'Publish to Zapstore' \
+  --commit "$head_sha" --limit 10 \
+  --json databaseId,status,conclusion,headSha,createdAt,url
+```
+
+Do not retry or repair Zapstore as part of the Maple release flow. A separate
+explicit request may authorize investigating or retrying Zapstore itself.
+
+Do not call the release complete while a required release workflow is queued
+or running. Zapstore is not a required release workflow.
 
 ## Store and API handoff
 
@@ -196,7 +196,8 @@ in the release handoff or issue that owns them, not in this evergreen skill.
 ## Report
 
 Report the version, tag, exact commit, release URL, main workflow URL and
-attempt count, Zapstore workflow URL, artifact verification result, any retry
-and supporting evidence, authorized store/API actions, and every boundary that
-remains unverified. Separate repository release completion from store
-distribution and live application availability.
+attempt count, artifact verification result, any required-workflow retry and
+supporting evidence, authorized store/API actions, and every boundary that
+remains unverified. If Zapstore was inspected, report its status separately as
+non-gating. Separate repository release completion from store distribution and
+live application availability.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,6 +456,8 @@ jobs:
           cat android-release-artifacts.sha256
 
       - name: Attest Android release artifacts
+        # Keep release uploads running if GitHub token policy rejects artifact attestation.
+        continue-on-error: true
         uses: actions/attest@281a49d4cbb0a72c9575a50d18f6deb515a11deb # was v4
         with:
           subject-checksums: android-release-artifacts.sha256

--- a/.github/workflows/zapstore-publish.yml
+++ b/.github/workflows/zapstore-publish.yml
@@ -9,241 +9,33 @@ permissions:
   contents: read
 
 jobs:
-  classify:
-    name: Classify completed Maple release
+  publish:
     if: >-
       github.event.workflow_run.conclusion == 'success' &&
       github.event.workflow_run.event == 'release' &&
       github.event.workflow_run.head_repository.full_name == github.repository
-    permissions:
-      actions: read
-      contents: read
     runs-on: ubuntu-latest
-    outputs:
-      publish: ${{ steps.classify.outputs.publish }}
-      release_id: ${{ steps.classify.outputs.release_id }}
-      release_sha: ${{ steps.classify.outputs.release_sha }}
-      release_tag: ${{ steps.classify.outputs.release_tag }}
-    steps:
-      - name: Validate completed release workflow
-        id: classify
-        env:
-          EXPECTED_REPOSITORY: ${{ github.repository }}
-          EXPECTED_RUN_ID: ${{ github.event.workflow_run.id }}
-          EXPECTED_SHA: ${{ github.event.workflow_run.head_sha }}
-          EXPECTED_TAG: ${{ github.event.workflow_run.head_branch }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          if [[ ! "${EXPECTED_RUN_ID}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "Unexpected workflow run ID: ${EXPECTED_RUN_ID}" >&2
-            exit 1
-          fi
-          if [[ ! "${EXPECTED_TAG}" =~ ^v(0|[1-9][0-9]*)[.](0|[1-9][0-9]*)[.](0|[1-9][0-9]*)$ ]]; then
-            echo "Refusing to classify unexpected release tag: ${EXPECTED_TAG}" >&2
-            exit 1
-          fi
-          if [[ ! "${EXPECTED_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Refusing to classify unexpected release SHA: ${EXPECTED_SHA}" >&2
-            exit 1
-          fi
-
-          repository_json="$(gh api "repos/${EXPECTED_REPOSITORY}")"
-          jq -e --arg repository "${EXPECTED_REPOSITORY}" '
-            type == "object" and
-            .full_name == $repository and
-            .default_branch == "master"
-          ' <<<"${repository_json}" >/dev/null
-
-          run_json="$(gh api "repos/${EXPECTED_REPOSITORY}/actions/runs/${EXPECTED_RUN_ID}")"
-          jq -e \
-            --arg repository "${EXPECTED_REPOSITORY}" \
-            --arg tag "${EXPECTED_TAG}" \
-            --arg sha "${EXPECTED_SHA}" \
-            --argjson run_id "${EXPECTED_RUN_ID}" '
-              type == "object" and
-              .id == $run_id and
-              .path == ".github/workflows/release.yml" and
-              .event == "release" and
-              .status == "completed" and
-              .conclusion == "success" and
-              .head_branch == $tag and
-              .head_sha == $sha and
-              .repository.full_name == $repository and
-              .head_repository.full_name == $repository
-            ' <<<"${run_json}" >/dev/null
-
-          run_attempt="$(jq -er '.run_attempt | select(type == "number" and . >= 1)' <<<"${run_json}")"
-          jobs_json="$(gh api "repos/${EXPECTED_REPOSITORY}/actions/runs/${EXPECTED_RUN_ID}/jobs?filter=latest&per_page=100")"
-          jq -e '
-            type == "object" and
-            (.total_count | type == "number") and
-            (.total_count <= 100) and
-            (.jobs | type == "array") and
-            (.jobs | length) == .total_count
-          ' <<<"${jobs_json}" >/dev/null
-
-          classifier_count="$(
-            jq -r --argjson run_id "${EXPECTED_RUN_ID}" --argjson run_attempt "${run_attempt}" --arg sha "${EXPECTED_SHA}" '
-              [
-                .jobs[]
-                | select(
-                    .name == "Classify Maple app release" and
-                    .run_id == $run_id and
-                    (.run_attempt | type == "number") and
-                    .run_attempt >= 1 and
-                    .run_attempt <= $run_attempt and
-                    .head_sha == $sha and
-                    .status == "completed" and
-                    .conclusion == "success"
-                  )
-              ]
-              | length
-            ' <<<"${jobs_json}"
-          )"
-          named_classifier_count="$(
-            jq -r '[.jobs[] | select(.name == "Classify Maple app release")] | length' <<<"${jobs_json}"
-          )"
-          # `gh run rerun --failed` can retain a successful classifier from an
-          # earlier attempt. filter=latest returns that job's latest execution,
-          # so its attempt may be older than the completed run's attempt.
-          if [ "${classifier_count}" -ne 1 ] || [ "${named_classifier_count}" -ne 1 ]; then
-            echo "Expected exactly one successful 'Classify Maple app release' job in the completed run." >&2
-            echo "matching=${classifier_count} named=${named_classifier_count}" >&2
-            exit 1
-          fi
-
-          release_json="$(gh api "repos/${EXPECTED_REPOSITORY}/releases/tags/${EXPECTED_TAG}")"
-          jq -e --arg tag "${EXPECTED_TAG}" '
-            type == "object" and
-            (.id | type == "number" and . > 0) and
-            .tag_name == $tag and
-            (.draft | type == "boolean") and
-            .draft == false and
-            (.prerelease | type == "boolean")
-          ' <<<"${release_json}" >/dev/null
-          release_id="$(jq -er '.id' <<<"${release_json}")"
-          prerelease="$(jq -er '.prerelease' <<<"${release_json}")"
-
-          tag_sha="$(gh api "repos/${EXPECTED_REPOSITORY}/commits/${EXPECTED_TAG}" --jq '.sha')"
-          if [ "${tag_sha}" != "${EXPECTED_SHA}" ]; then
-            echo "Release tag no longer resolves to the completed workflow SHA." >&2
-            echo "tag=${EXPECTED_TAG} expected=${EXPECTED_SHA} actual=${tag_sha}" >&2
-            exit 1
-          fi
-
-          compare_json="$(gh api "repos/${EXPECTED_REPOSITORY}/compare/${EXPECTED_SHA}...master")"
-          jq -e --arg sha "${EXPECTED_SHA}" '
-            type == "object" and
-            (.status == "ahead" or .status == "identical") and
-            .base_commit.sha == $sha and
-            .merge_base_commit.sha == $sha
-          ' <<<"${compare_json}" >/dev/null
-
-          publish=false
-          if [ "${prerelease}" = "false" ]; then
-            latest_json="$(gh api "repos/${EXPECTED_REPOSITORY}/releases/latest")"
-            jq -e '
-              type == "object" and
-              (.id | type == "number" and . > 0) and
-              (.tag_name | type == "string") and
-              .draft == false and
-              .prerelease == false
-            ' <<<"${latest_json}" >/dev/null
-
-            latest_id="$(jq -er '.id' <<<"${latest_json}")"
-            latest_tag="$(jq -er '.tag_name' <<<"${latest_json}")"
-            if [ "${latest_id}" = "${release_id}" ] && [ "${latest_tag}" = "${EXPECTED_TAG}" ]; then
-              publish=true
-            else
-              echo "Release ${EXPECTED_TAG} is no longer the latest stable release; skipping Zapstore publish."
-            fi
-          else
-            echo "Release ${EXPECTED_TAG} is a prerelease; skipping Zapstore publish."
-          fi
-
-          {
-            echo "publish=${publish}"
-            echo "release_id=${release_id}"
-            echo "release_sha=${EXPECTED_SHA}"
-            echo "release_tag=${EXPECTED_TAG}"
-          } >>"${GITHUB_OUTPUT}"
-
-  publish:
-    name: Publish current stable release to Zapstore
-    needs: classify
-    if: needs.classify.outputs.publish == 'true'
-    permissions:
-      attestations: read
-      contents: read
-    runs-on: ubuntu-latest
-    concurrency:
-      group: zapstore-production
-      cancel-in-progress: false
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # was v4
         with:
-          fetch-depth: 0
           persist-credentials: false
-          ref: ${{ needs.classify.outputs.release_sha }}
           sparse-checkout: |
             zapstore.yaml
-            frontend/package.json
-            frontend/src-tauri/Cargo.toml
-            frontend/src-tauri/tauri.conf.json
             frontend/src-tauri/icons/icon.png
-            scripts/ci/_common.sh
-            scripts/ci/classify-app-release.sh
-            scripts/ci/validate-release-version.sh
-
-      - name: Verify checked-out release identity
-        env:
-          RELEASE_SHA: ${{ needs.classify.outputs.release_sha }}
-          RELEASE_TAG: ${{ needs.classify.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-
-          if [ "$(git rev-parse HEAD)" != "${RELEASE_SHA}" ]; then
-            echo "Checked-out commit does not match the classified release SHA." >&2
-            exit 1
-          fi
-
-          ./scripts/ci/classify-app-release.sh \
-            --repo-root "${GITHUB_WORKSPACE}" \
-            --tag "${RELEASE_TAG}" \
-            --sha "${RELEASE_SHA}" \
-            --draft false \
-            --prerelease false \
-            --ref "refs/tags/${RELEASE_TAG}" \
-            --protected-ref refs/remotes/origin/master
 
       - name: Download APK from release
         env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_TAG: ${{ needs.classify.outputs.release_tag }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ github.event.workflow_run.head_branch }}
         run: |
-          set -euo pipefail
-          echo "Downloading APK from release ${RELEASE_TAG}"
-          gh release download "${RELEASE_TAG}" \
-            --repo "${GITHUB_REPOSITORY}" \
+          if [[ ! "$RELEASE_TAG" =~ ^v?[0-9]+[.][0-9]+[.][0-9]+(-[0-9A-Za-z.-]+)?([+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Refusing to publish from unexpected release tag: $RELEASE_TAG" >&2
+            exit 1
+          fi
+          echo "Downloading APK from release $RELEASE_TAG"
+          gh release download "$RELEASE_TAG" \
             --pattern "app-universal-release.apk" \
             --dir .
-
-      - name: Verify APK release provenance
-        env:
-          GH_TOKEN: ${{ github.token }}
-          RELEASE_SHA: ${{ needs.classify.outputs.release_sha }}
-          RELEASE_TAG: ${{ needs.classify.outputs.release_tag }}
-        run: |
-          set -euo pipefail
-          gh attestation verify app-universal-release.apk \
-            --repo "${GITHUB_REPOSITORY}" \
-            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release.yml" \
-            --signer-digest "${RELEASE_SHA}" \
-            --source-digest "${RELEASE_SHA}" \
-            --source-ref "refs/tags/${RELEASE_TAG}" \
-            --deny-self-hosted-runners
 
       - name: Setup Go
         uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # was v5
@@ -304,109 +96,21 @@ jobs:
           fi
 
           go install "${ZSP_MODULE}@${ZSP_VERSION}"
-          echo "$(go env GOPATH)/bin" >> "${GITHUB_PATH}"
-
-      - name: Confirm release is still current
-        id: current
-        env:
-          EXPECTED_RELEASE_ID: ${{ needs.classify.outputs.release_id }}
-          EXPECTED_SHA: ${{ needs.classify.outputs.release_sha }}
-          EXPECTED_TAG: ${{ needs.classify.outputs.release_tag }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-
-          not_current() {
-            echo "current=false" >>"${GITHUB_OUTPUT}"
-            echo "$1; skipping Zapstore publish."
-            exit 0
-          }
-
-          fail() {
-            echo "$1" >&2
-            exit 1
-          }
-
-          repository_json="$(gh api "repos/${GITHUB_REPOSITORY}")" || \
-            fail "Could not re-read repository state."
-          jq -e --arg repository "${GITHUB_REPOSITORY}" '
-            type == "object" and
-            .full_name == $repository and
-            .default_branch == "master"
-          ' <<<"${repository_json}" >/dev/null || \
-            fail "Repository response is malformed or the protected default branch is no longer master."
-
-          release_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/tags/${EXPECTED_TAG}")" || \
-            fail "Could not re-read release ${EXPECTED_TAG}."
-          jq -e \
-            --argjson id "${EXPECTED_RELEASE_ID}" \
-            --arg tag "${EXPECTED_TAG}" '
-              type == "object" and
-              (.id | type == "number" and . > 0) and
-              .id == $id and
-              .tag_name == $tag and
-              (.draft | type == "boolean") and
-              .draft == false and
-              (.prerelease | type == "boolean")
-            ' <<<"${release_json}" >/dev/null || \
-            fail "Release ${EXPECTED_TAG} is malformed or its protected identity changed."
-
-          tag_json="$(gh api "repos/${GITHUB_REPOSITORY}/commits/${EXPECTED_TAG}")" || \
-            fail "Could not re-resolve release tag ${EXPECTED_TAG}."
-          jq -e --arg sha "${EXPECTED_SHA}" '
-            type == "object" and
-            (.sha | type == "string") and
-            .sha == $sha
-          ' <<<"${tag_json}" >/dev/null || \
-            fail "Release tag ${EXPECTED_TAG} moved or returned a malformed response."
-
-          compare_json="$(gh api "repos/${GITHUB_REPOSITORY}/compare/${EXPECTED_SHA}...master")" || \
-            fail "Could not re-check protected-master ancestry."
-          jq -e --arg sha "${EXPECTED_SHA}" '
-            type == "object" and
-            (.status == "ahead" or .status == "identical") and
-            .base_commit.sha == $sha and
-            .merge_base_commit.sha == $sha
-          ' <<<"${compare_json}" >/dev/null || \
-            fail "Release ${EXPECTED_TAG} is no longer on protected master or ancestry response is malformed."
-
-          if [ "$(jq -er '.prerelease' <<<"${release_json}")" = "true" ]; then
-            not_current "Release ${EXPECTED_TAG} is now a prerelease"
-          fi
-
-          latest_json="$(gh api "repos/${GITHUB_REPOSITORY}/releases/latest")" || \
-            fail "Could not re-read the latest stable release."
-          jq -e '
-            type == "object" and
-            (.id | type == "number" and . > 0) and
-            (.tag_name | type == "string") and
-            .draft == false and
-            .prerelease == false
-          ' <<<"${latest_json}" >/dev/null || \
-            fail "Latest stable release response is malformed."
-
-          latest_id="$(jq -er '.id' <<<"${latest_json}")"
-          latest_tag="$(jq -er '.tag_name' <<<"${latest_json}")"
-          if [ "${latest_id}" != "${EXPECTED_RELEASE_ID}" ] || [ "${latest_tag}" != "${EXPECTED_TAG}" ]; then
-            not_current "Release ${EXPECTED_TAG} is no longer latest"
-          fi
-
-          echo "current=true" >>"${GITHUB_OUTPUT}"
+          echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Publish to Zapstore
-        if: steps.current.outputs.current == 'true'
         env:
-          COMMIT_SHA: ${{ needs.classify.outputs.release_sha }}
-          GOTOOLCHAIN: local
           SIGN_WITH: ${{ secrets.ZAPSTORE_SIGN_WITH }}
+          COMMIT_SHA: ${{ github.event.workflow_run.head_sha }}
+          GOTOOLCHAIN: local
         run: |
           if [ -z "${SIGN_WITH}" ]; then
             echo "Missing required secret: ZAPSTORE_SIGN_WITH" >&2
             exit 1
           fi
 
-          if [[ ! "${COMMIT_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "Refusing to publish with unexpected commit SHA: ${COMMIT_SHA}" >&2
+          if [[ ! "$COMMIT_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Refusing to publish with unexpected commit SHA: $COMMIT_SHA" >&2
             exit 1
           fi
 
@@ -414,21 +118,21 @@ jobs:
           output="$(
             zsp publish \
               --quiet \
-              --commit "${COMMIT_SHA}" \
+              --commit "$COMMIT_SHA" \
               zapstore.yaml 2>&1
           )"
           status=$?
           set -e
 
-          if [ -n "${output}" ]; then
-            printf '%s\n' "${output}"
+          if [ -n "$output" ]; then
+            printf '%s\n' "$output"
           fi
 
-          if [ "${status}" -ne 0 ]; then
-            exit "${status}"
+          if [ "$status" -ne 0 ]; then
+            exit "$status"
           fi
 
-          if [[ "${output}" == *"flag provided but not defined"* || "${output}" == *"Usage of publish:"* ]]; then
+          if [[ "$output" == *"flag provided but not defined"* || "$output" == *"Usage of publish:"* ]]; then
             echo "zsp returned success but printed CLI usage, treating this as a failure." >&2
             exit 1
           fi

--- a/scripts/ci/test-release-gates.sh
+++ b/scripts/ci/test-release-gates.sh
@@ -160,11 +160,9 @@ expect_failure "rejects an unknown argument" \
   bash "${classifier}" --unknown value
 
 release_json="${temp_root}/release.json"
-zapstore_json="${temp_root}/zapstore.json"
 yq -o=json '.' "${repo_root}/.github/workflows/release.yml" > "${release_json}"
-yq -o=json '.' "${repo_root}/.github/workflows/zapstore-publish.yml" > "${zapstore_json}"
 
-python3 - "${release_json}" "${zapstore_json}" <<'PY'
+python3 - "${release_json}" <<'PY'
 import json
 import re
 import sys
@@ -223,8 +221,8 @@ android_attestation_steps = [
 ]
 check(len(android_attestation_steps) == 1, "Android release artifacts must be attested exactly once")
 check(
-    android_attestation_steps[0].get("continue-on-error") is not True,
-    "Android attestation must succeed before the Release can wake Zapstore",
+    android_attestation_steps[0].get("continue-on-error") is True,
+    "Android attestation must remain best effort",
 )
 
 classifier_checkouts = [
@@ -249,103 +247,7 @@ for job_id, job in release_jobs.items():
             check(checkout.get("ref") == release_ref, f"Release checkout in {job_id} must pin classifier SHA")
             check(checkout.get("persist-credentials") is False, f"Release checkout in {job_id} must not persist credentials")
 
-with open(sys.argv[2], encoding="utf-8") as handle:
-    zapstore = json.load(handle)
-
-zapstore_jobs = zapstore["jobs"]
-check("classify" in zapstore_jobs, "Zapstore workflow must have classify job")
-check("publish" in zapstore_jobs, "Zapstore workflow must have publish job")
-zapstore_classifier = zapstore_jobs["classify"]
-check(not secret_names(zapstore_classifier), "Zapstore classifier must not receive secrets")
-check(
-    zapstore_classifier.get("permissions", {}) == {"actions": "read", "contents": "read"},
-    "Zapstore classifier must have only actions: read and contents: read permissions",
-)
-check(
-    not any(
-        str(step.get("uses", "")).startswith("actions/checkout@")
-        for step in zapstore_classifier.get("steps", [])
-    ),
-    "Zapstore classifier must not checkout or execute repository content",
-)
-zapstore_classifier_run = "\n".join(
-    str(step.get("run", "")) for step in zapstore_classifier.get("steps", [])
-)
-check(
-    ".run_attempt == $run_attempt" not in zapstore_classifier_run,
-    "Zapstore classifier must allow a successful classifier retained by --failed reruns",
-)
-publish = zapstore_jobs["publish"]
-check("classify" in needs(publish), "Zapstore publish must directly need classify")
-check(
-    publish.get("permissions", {}) == {"attestations": "read", "contents": "read"},
-    "Zapstore publish must have only attestations: read and contents: read permissions",
-)
-publish_metadata = {key: value for key, value in publish.items() if key != "steps"}
-check(
-    not (secret_names(publish_metadata) - {"GITHUB_TOKEN"}),
-    "Zapstore custom secret must not be exposed at job scope",
-)
-concurrency = publish.get("concurrency", {})
-check(concurrency.get("group") == "zapstore-production", "Zapstore publish concurrency group must be hard-coded")
-check(concurrency.get("cancel-in-progress") is False, "Zapstore publish must not cancel an in-progress publication")
-
-steps = publish.get("steps", [])
-checkout_steps = [step for step in steps if str(step.get("uses", "")).startswith("actions/checkout@")]
-check(len(checkout_steps) == 1, "Zapstore publish must have exactly one checkout")
-checkout = checkout_steps[0].get("with", {})
-check(
-    checkout.get("ref") == "${{ needs.classify.outputs.release_sha }}",
-    "Zapstore checkout must pin the classified upstream SHA",
-)
-check(checkout.get("persist-credentials") is False, "Zapstore checkout must not persist credentials")
-
-attestation_steps = [step for step in steps if step.get("name") == "Verify APK release provenance"]
-check(len(attestation_steps) == 1, "Zapstore must verify APK release provenance exactly once")
-attestation_index = steps.index(attestation_steps[0])
-attestation_run = str(attestation_steps[0].get("run", ""))
-for required_fragment in (
-    "gh attestation verify app-universal-release.apk",
-    "--signer-workflow",
-    "--signer-digest",
-    "--source-digest",
-    "--source-ref",
-    "--deny-self-hosted-runners",
-):
-    check(required_fragment in attestation_run, f"Zapstore APK verification must use {required_fragment}")
-
-publish_indexes = [index for index, step in enumerate(steps) if step.get("name") == "Publish to Zapstore"]
-check(len(publish_indexes) == 1, "Zapstore workflow must have one final Publish to Zapstore step")
-publish_index = publish_indexes[0]
-check(attestation_index < publish_index, "APK provenance verification must precede Zapstore publish")
-publish_step = steps[publish_index]
-check(publish_index == len(steps) - 1, "Publish to Zapstore must be the final step")
-check(publish_index > 0, "Publish to Zapstore must follow a current-release recheck")
-recheck = steps[publish_index - 1]
-recheck_name = str(recheck.get("name", "")).lower()
-check(
-    "release" in recheck_name and any(word in recheck_name for word in ("recheck", "current", "confirm")),
-    "Current-release recheck must immediately precede publish",
-)
-check("releases/latest" in str(recheck.get("run", "")), "Current-release recheck must query releases/latest")
-recheck_id = recheck.get("id")
-check(isinstance(recheck_id, str) and recheck_id, "Current-release recheck must expose a step output")
-expected_publish_condition = f"steps.{recheck_id}.outputs.current == 'true'"
-check(
-    publish_step.get("if") == expected_publish_condition,
-    "Zapstore publish must be conditional on the immediately preceding current-release recheck: "
-    f"expected {expected_publish_condition!r}, got {publish_step.get('if')!r}",
-)
-zsp_indexes = [index for index, step in enumerate(steps) if "zsp publish" in str(step.get("run", ""))]
-check(zsp_indexes == [publish_index], "zsp publish must run only in the final secret-bearing step")
-
-for index, step in enumerate(steps):
-    custom_secrets = secret_names(step) - {"GITHUB_TOKEN"}
-    if index == publish_index:
-        check(custom_secrets == {"ZAPSTORE_SIGN_WITH"}, "Final publish must receive only ZAPSTORE_SIGN_WITH")
-    else:
-        check(not custom_secrets, f"Custom secret exposed before final publish step {index}")
 PY
-pass "workflow release-gate topology is fail closed"
+pass "workflow release-gate topology is fail closed without gating on Zapstore"
 
 printf '1..%d\n' "${passed}"


### PR DESCRIPTION
## Summary

- restore the Zapstore workflow exactly to the v3.3.7 version that last published successfully
- remove the Zapstore-specific classifier and release-gate coupling introduced in #832
- restore Android artifact attestation to best effort and document Zapstore as non-gating
- leave updater metadata and `latest.json` publishing unchanged

## Regression

v3.3.8 was the first release after #832 rewrote the Zapstore workflow from 138 to 434 lines. Its new classifier failed before publication began even though the Release workflow succeeded and the same live state now satisfies its assertions. This PR reverts that out-of-scope architectural change instead of adding more logic around the brittle classifier.

## Validation

- confirmed `.github/workflows/zapstore-publish.yml` exactly matches v3.3.7
- `nix develop --no-update-lock-file .#ci -c ./scripts/ci/test-release-gates.sh` (23 passed)
- `nix flake check --no-update-lock-file --print-build-logs`
- repository pre-commit hook (production frontend build; 764 tests passed)