### PR TITLE
ci: canary sccache 0.16 on Windows PR builds

### DIFF
--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -154,8 +154,8 @@ jobs:
       - name: Install sccache
         shell: bash
         run: |
-          SCCACHE_VERSION=0.8.2
-          SCCACHE_SHA256="de5e9f66bb8a6bbdf0e28cb8a086a8d12699af796bf70bcd9dc40d80715bf9b8"
+          SCCACHE_VERSION=0.16.0
+          SCCACHE_SHA256="c82319cc392b693e9fc72e6567cce47e218308f00fbf1df942e39b62e30f98da"
           SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-pc-windows-msvc.tar.gz"
           SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
           # Run download/verify/extract inside a subshell cd'd to RUNNER_TEMP so
@@ -176,16 +176,17 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~\AppData\Local\Mozilla\sccache
-          key: ${{ runner.os }}-sccache-windows-${{ hashFiles('**/Cargo.lock') }}
+          # Isolate this canary from caches created by older sccache and Rust versions.
+          key: ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-sccache-windows-
-            ${{ runner.os }}-sccache-
+            ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-
 
       - name: Build Tauri App (Windows, unsigned)
         shell: bash
         run: ./scripts/ci/desktop-windows-pr.sh
 
       - name: Show sccache stats
+        if: always()
         run: sccache --show-stats
 
       - name: Upload Windows PR Build


### PR DESCRIPTION
## Summary

- upgrade only the Windows PR lane from sccache 0.8.2 to checksum-pinned 0.16.0
- isolate the canary from the unusable legacy cache with an sccache/Rust-versioned namespace
- preserve all reproducibility flags and artifact verification
- show sccache statistics even when the build fails

This intentionally leaves master, release, Bun caching, Cargo source caching, and reproducibility scripts unchanged. If the PR lane proves the configuration, master/release parity will be a later separate change.

## Version choice

sccache 0.16.0 supports `--remap-path-prefix`, which 0.8.2 rejects. The current 0.17.0 release is deliberately avoided because mozilla/sccache#2787 documents a Windows Rust argfile regression and its fix in #2789 is still unmerged.

## Local validation

- official GitHub asset digest, checksum sidecar, streamed SHA-256, and archive layout agree
- `nix flake check --no-update-lock-file --print-build-logs`
- repository pre-commit hook: frontend format, production build, and 765 tests
- `git diff --check`

## Windows canary acceptance

The first run is intentionally cold: require sccache 0.16.0, nonzero executed requests/misses, no `--remap-path-prefix` rejection, successful cache save, and green artifact proofs. Then rerun the same commit and require real cache hits, lower compile time, and the same green reproducibility checks before considering merge.