### PR TITLE
Promote Pages production after stable releases

### DIFF
--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -15,8 +15,9 @@ commit, external effect, and authority provided by the user.
   frontend, and Rust workflows. The iOS master workflow uploads its verified
   IPA to TestFlight automatically.
 - Creating a GitHub Release starts the cross-platform release workflow. A
-  successful release workflow starts a separate best-effort Zapstore attempt.
-  Zapstore never gates or changes the outcome of the Maple release.
+  successful release workflow starts separate updater-metadata, Pages
+  production-branch, and best-effort Zapstore workflows. These sibling
+  workflows never gate or change the outcome of the core Maple release.
 - GitHub Release creation does not itself submit the release IPA or AAB to
   Apple App Store review or Google Play.
 
@@ -125,6 +126,28 @@ updater `latest.json`, aggregate verification, and verification-guide step.
 Packaging success alone is not runtime smoke; inspect the workflow's actual
 verification and attestation results.
 
+After `Release` succeeds, inspect the two required publication handoffs. Do
+not rerun the core Release to repair either sibling:
+
+```bash
+gh run list --repo OpenSecretCloud/Maple --workflow 'Publish updater metadata' \
+  --commit "$head_sha" --limit 10 \
+  --json databaseId,status,conclusion,headSha,createdAt,url
+
+gh run list --repo OpenSecretCloud/Maple --workflow 'Promote Pages production' \
+  --commit "$head_sha" --limit 10 \
+  --json databaseId,status,conclusion,headSha,createdAt,url
+```
+
+The updater workflow must publish the verified `latest.json` before reporting
+the desktop updater control plane current. The Pages workflow advances the
+machine-owned `pages-production` ref to the exact stable release SHA; its
+success proves the ref mutation, not Cloudflare's external build or live-site
+result. Verify the corresponding Cloudflare Pages check/deployment separately
+before reporting Maple web production current. A failure in either sibling is
+reported and repaired in that workflow without changing the completed release
+artifacts.
+
 On failure, read the failed logs before acting:
 
 ```bash
@@ -164,8 +187,9 @@ gh run list --repo OpenSecretCloud/Maple --workflow 'Publish to Zapstore' \
 Do not retry or repair Zapstore as part of the Maple release flow. A separate
 explicit request may authorize investigating or retrying Zapstore itself.
 
-Do not call the release complete while a required release workflow is queued
-or running. Zapstore is not a required release workflow.
+Do not call the core repository release complete while its required `Release`
+workflow is queued or running. Report updater publication and Pages production
+as separate downstream states. Zapstore is not a required release workflow.
 
 ## Store and API handoff
 

--- a/.github/workflows/pages-production.yml
+++ b/.github/workflows/pages-production.yml
@@ -1,0 +1,142 @@
+name: Promote Pages production
+
+run-name: Promote the current Maple release to Pages production
+
+on:
+  workflow_run:
+    workflows: ["Release"]
+    types: [completed]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-production
+  cancel-in-progress: false
+
+jobs:
+  promote:
+    name: Advance pages-production
+    if: >-
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master') ||
+      (github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'release' &&
+        github.event.workflow_run.path == '.github/workflows/release.yml' &&
+        github.event.workflow_run.head_repository.full_name == github.repository)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Advance the production branch to the verified release SHA
+        env:
+          EXPECTED_RELEASE_SHA: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || '' }}
+          EXPECTED_RELEASE_TAG: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
+          GH_TOKEN: ${{ github.token }}
+          PAGES_PRODUCTION_BRANCH: pages-production
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          fail() {
+            echo "Pages production promotion failed: $*" >&2
+            exit 1
+          }
+
+          api() {
+            gh api \
+              -H "Accept: application/vnd.github+json" \
+              -H "X-GitHub-Api-Version: 2022-11-28" \
+              "$@"
+          }
+
+          [ "${PAGES_PRODUCTION_BRANCH}" = "pages-production" ] || \
+            fail "unexpected production branch"
+
+          default_branch="$(api "repos/${REPOSITORY}" --jq '.default_branch')"
+          [ "${default_branch}" = "master" ] || fail "default branch must be master"
+
+          latest_release="$(api "repos/${REPOSITORY}/releases/latest")"
+          release_id="$(jq -er 'select(.draft == false and .prerelease == false) | .id' \
+            <<<"${latest_release}")"
+          release_tag="$(jq -er '.tag_name' <<<"${latest_release}")"
+          [[ "${release_id}" =~ ^[0-9]+$ ]] || fail "release id must be numeric"
+          [[ "${release_tag}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || \
+            fail "latest stable release must use an exact vX.Y.Z tag"
+
+          if [ -n "${EXPECTED_RELEASE_TAG}" ]; then
+            [[ "${EXPECTED_RELEASE_TAG}" =~ ^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || \
+              fail "completed Release workflow has an invalid tag"
+            if [ "${release_tag}" != "${EXPECTED_RELEASE_TAG}" ]; then
+              echo "${EXPECTED_RELEASE_TAG} is no longer the latest stable release; leaving ${PAGES_PRODUCTION_BRANCH} unchanged."
+              exit 0
+            fi
+          fi
+
+          release_sha="$(api "repos/${REPOSITORY}/commits/${release_tag}" --jq '.sha')"
+          [[ "${release_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "release SHA is invalid"
+          if [ -n "${EXPECTED_RELEASE_SHA}" ]; then
+            [[ "${EXPECTED_RELEASE_SHA}" =~ ^[0-9a-f]{40}$ ]] || \
+              fail "completed Release workflow has an invalid SHA"
+            [ "${release_sha}" = "${EXPECTED_RELEASE_SHA}" ] || \
+              fail "release tag no longer resolves to the completed workflow SHA"
+          fi
+
+          master_status="$(api \
+            "repos/${REPOSITORY}/compare/${release_sha}...master" \
+            --jq '.status')"
+          case "${master_status}" in
+            ahead|identical) ;;
+            *) fail "release SHA is not reachable from protected master" ;;
+          esac
+
+          production_ref="repos/${REPOSITORY}/git/ref/heads/${PAGES_PRODUCTION_BRANCH}"
+          current_sha="$(api "${production_ref}" --jq '.object.sha')"
+          [[ "${current_sha}" =~ ^[0-9a-f]{40}$ ]] || \
+            fail "current production branch SHA is invalid"
+
+          if [ "${current_sha}" = "${release_sha}" ]; then
+            echo "${PAGES_PRODUCTION_BRANCH} already points to ${release_tag} (${release_sha})."
+            exit 0
+          fi
+
+          promotion_status="$(api \
+            "repos/${REPOSITORY}/compare/${current_sha}...${release_sha}" \
+            --jq '.status')"
+          [ "${promotion_status}" = "ahead" ] || \
+            fail "refusing a non-forward production change from ${current_sha} to ${release_sha}"
+
+          current_release_id="$(api \
+            "repos/${REPOSITORY}/releases/latest" \
+            --jq 'select(.draft == false and .prerelease == false) | .id')"
+          if [ "${current_release_id}" != "${release_id}" ]; then
+            echo "The latest stable release changed during this run; leaving ${PAGES_PRODUCTION_BRANCH} unchanged."
+            exit 0
+          fi
+
+          checked_sha="$(api "${production_ref}" --jq '.object.sha')"
+          [ "${checked_sha}" = "${current_sha}" ] || \
+            fail "production branch changed during this run"
+
+          updated_sha="$(api \
+            --method PATCH \
+            "repos/${REPOSITORY}/git/refs/heads/${PAGES_PRODUCTION_BRANCH}" \
+            -f sha="${release_sha}" \
+            -F force=true \
+            --jq '.object.sha')"
+          [ "${updated_sha}" = "${release_sha}" ] || \
+            fail "GitHub did not update the production branch to the release SHA"
+
+          live_sha="$(api "${production_ref}" --jq '.object.sha')"
+          [ "${live_sha}" = "${release_sha}" ] || \
+            fail "production branch verification returned an unexpected SHA"
+
+          echo "Advanced ${PAGES_PRODUCTION_BRANCH} to ${release_tag} (${release_sha})."
+          {
+            echo "### Pages production"
+            echo
+            echo "Advanced \`${PAGES_PRODUCTION_BRANCH}\` to \`${release_tag}\` (\`${release_sha}\`)."
+            echo "Cloudflare Pages now owns the external build and production deployment result."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/release-gates-tests.yml
+++ b/.github/workflows/release-gates-tests.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - ".github/workflows/release.yml"
       - ".github/workflows/release-gates-tests.yml"
+      - ".github/workflows/pages-production.yml"
       - ".github/workflows/zapstore-publish.yml"
       - "scripts/ci/classify-app-release.sh"
       - "scripts/ci/test-release-gates.sh"
@@ -19,6 +20,7 @@ on:
     paths:
       - ".github/workflows/release.yml"
       - ".github/workflows/release-gates-tests.yml"
+      - ".github/workflows/pages-production.yml"
       - ".github/workflows/zapstore-publish.yml"
       - "scripts/ci/classify-app-release.sh"
       - "scripts/ci/test-release-gates.sh"

--- a/flake.nix
+++ b/flake.nix
@@ -681,6 +681,7 @@
               frontend-tests.yml \
               mobile-pr-build.yml \
               mobile-build.yml \
+              pages-production.yml \
               release.yml \
               release-gates-tests.yml \
               rust-tests.yml \

--- a/scripts/ci/test-release-gates.sh
+++ b/scripts/ci/test-release-gates.sh
@@ -160,9 +160,11 @@ expect_failure "rejects an unknown argument" \
   bash "${classifier}" --unknown value
 
 release_json="${temp_root}/release.json"
+pages_production_json="${temp_root}/pages-production.json"
 yq -o=json '.' "${repo_root}/.github/workflows/release.yml" > "${release_json}"
+yq -o=json '.' "${repo_root}/.github/workflows/pages-production.yml" > "${pages_production_json}"
 
-python3 - "${release_json}" <<'PY'
+python3 - "${release_json}" "${pages_production_json}" <<'PY'
 import json
 import re
 import sys
@@ -200,6 +202,9 @@ def secret_names(value):
 
 with open(sys.argv[1], encoding="utf-8") as handle:
     release = json.load(handle)
+
+with open(sys.argv[2], encoding="utf-8") as handle:
+    pages_production = json.load(handle)
 
 release_jobs = release["jobs"]
 classifier_id = "classify-app-release"
@@ -247,7 +252,65 @@ for job_id, job in release_jobs.items():
             check(checkout.get("ref") == release_ref, f"Release checkout in {job_id} must pin classifier SHA")
             check(checkout.get("persist-credentials") is False, f"Release checkout in {job_id} must not persist credentials")
 
+check(
+    pages_production.get("permissions") == {"contents": "read"},
+    "Pages production workflow must default to contents: read",
+)
+pages_on = pages_production.get("on", {})
+check("workflow_dispatch" in pages_on, "Pages production workflow must support manual retry")
+pages_workflow_run = pages_on.get("workflow_run", {})
+check(
+    pages_workflow_run.get("workflows") == ["Release"]
+    and pages_workflow_run.get("types") == ["completed"],
+    "Pages production workflow must follow completed Release workflows",
+)
+check(
+    pages_production.get("concurrency")
+    == {"group": "pages-production", "cancel-in-progress": False},
+    "Pages production workflow must serialize promotions without cancellation",
+)
+
+pages_jobs = pages_production.get("jobs", {})
+check(set(pages_jobs) == {"promote"}, "Pages production workflow must have one promotion job")
+pages_job = pages_jobs["promote"]
+check(
+    pages_job.get("permissions") == {"contents": "write"},
+    "Pages production promotion must have only contents: write permission",
+)
+check(not secret_names(pages_production), "Pages production workflow must not receive secrets")
+check("environment" not in pages_job, "Pages production promotion must not require a secret-bearing environment")
+
+pages_if = str(pages_job.get("if", ""))
+for required_gate in (
+    "workflow_run.conclusion == 'success'",
+    "workflow_run.event == 'release'",
+    "workflow_run.path == '.github/workflows/release.yml'",
+    "workflow_run.head_repository.full_name == github.repository",
+):
+    check(required_gate in pages_if, f"Pages production job is missing gate: {required_gate}")
+
+pages_steps = pages_job.get("steps", [])
+check(len(pages_steps) == 1, "Pages production promotion must have one non-checkout step")
+pages_step = pages_steps[0]
+check("uses" not in pages_step, "Pages production promotion must not run a third-party action")
+pages_env = pages_step.get("env", {})
+check(
+    pages_env.get("PAGES_PRODUCTION_BRANCH") == "pages-production",
+    "Pages production branch must be hardcoded",
+)
+check(pages_env.get("GH_TOKEN") == "${{ github.token }}", "Pages promotion must use github.token")
+
+pages_run = str(pages_step.get("run", ""))
+for required_control in (
+    "repos/${REPOSITORY}/releases/latest",
+    "repos/${REPOSITORY}/compare/${release_sha}...master",
+    "repos/${REPOSITORY}/compare/${current_sha}...${release_sha}",
+    "repos/${REPOSITORY}/git/refs/heads/${PAGES_PRODUCTION_BRANCH}",
+    '-F force=true',
+):
+    check(required_control in pages_run, f"Pages production step is missing control: {required_control}")
+
 PY
-pass "workflow release-gate topology is fail closed without gating on Zapstore"
+pass "workflow release-gate topology is fail closed with isolated downstream publishers"
 
 printf '1..%d\n' "${passed}"


### PR DESCRIPTION
## What this does

- Adds an independent workflow that advances the machine-owned `pages-production` branch to the exact commit of the latest successful stable Maple release.
- Keeps Pages promotion outside the core release dependency chain, so a Pages failure cannot block the release or updater metadata publication.
- Uses only the scoped GitHub token (`contents: write`); no Cloudflare credential is added.
- Rejects stale runs, prereleases, tag/SHA mismatches, rollbacks, divergence, and race changes before updating the ref.
- Updates release-gate tests, actionlint coverage, and the release runbook.

Cloudflare remains unchanged by this PR. After it merges, we can point the existing Pages project production branch from `master` to `pages-production`.

## Validation

- `nix develop --no-update-lock-file .#ci -c bash ./scripts/ci/test-release-gates.sh` — 23/23 passed
- `nix develop --no-update-lock-file .#ci -c actionlint .github/workflows/pages-production.yml .github/workflows/release-gates-tests.yml`
- `nix flake check --no-update-lock-file --print-build-logs`
- Exercised the promotion script against live repository state using v3.3.8; it rejected the intentional rollback case before mutation and left `pages-production` unchanged at `8b175196f9c0fa5959c32ba08404a7026faf5347`.