### PR TITLE
ci: share Windows sccache across build lanes

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -246,8 +246,8 @@ jobs:
       - name: Install sccache
         shell: bash
         run: |
-          SCCACHE_VERSION=0.8.2
-          SCCACHE_SHA256="de5e9f66bb8a6bbdf0e28cb8a086a8d12699af796bf70bcd9dc40d80715bf9b8"
+          SCCACHE_VERSION=0.16.0
+          SCCACHE_SHA256="c82319cc392b693e9fc72e6567cce47e218308f00fbf1df942e39b62e30f98da"
           SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-pc-windows-msvc.tar.gz"
           SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
           # Run download/verify/extract inside a subshell cd'd to RUNNER_TEMP so
@@ -268,10 +268,9 @@ jobs:
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~\AppData\Local\Mozilla\sccache
-          key: ${{ runner.os }}-sccache-windows-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-sccache-windows-
-            ${{ runner.os }}-sccache-
+            ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-
 
       - name: Build Windows app executable
         shell: bash

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -173,10 +173,9 @@ jobs:
           "$SCCACHE_BIN_DIR/sccache.exe" --version
 
       - name: Cache sccache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~\AppData\Local\Mozilla\sccache
-          # Isolate this canary from caches created by older sccache and Rust versions.
           key: ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
             ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -287,8 +287,8 @@ jobs:
       - name: Install sccache
         shell: bash
         run: |
-          SCCACHE_VERSION=0.8.2
-          SCCACHE_SHA256="de5e9f66bb8a6bbdf0e28cb8a086a8d12699af796bf70bcd9dc40d80715bf9b8"
+          SCCACHE_VERSION=0.16.0
+          SCCACHE_SHA256="c82319cc392b693e9fc72e6567cce47e218308f00fbf1df942e39b62e30f98da"
           SCCACHE_ARCHIVE="sccache-v${SCCACHE_VERSION}-x86_64-pc-windows-msvc.tar.gz"
           SCCACHE_URL="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}/${SCCACHE_ARCHIVE}"
           (
@@ -302,12 +302,12 @@ jobs:
           "$SCCACHE_BIN_DIR/sccache.exe" --version
 
       - name: Cache sccache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
         with:
           path: ~\AppData\Local\Mozilla\sccache
-          key: ${{ runner.os }}-sccache-windows-release-${{ hashFiles('**/Cargo.lock') }}
+          key: ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-sccache-windows-release-
+            ${{ runner.os }}-sccache-windows-v0.16.0-rust-1.94.1-
 
       - name: Build Windows app executable
         shell: bash


### PR DESCRIPTION
## Summary

- roll the already-canary-tested sccache 0.16.0 binary and verified checksum into Windows master and release builds
- use one versioned Rust 1.94.1 cache namespace across master, PR, and release
- keep protected master as the sole cache writer; make PR and release restore-only
- remove the earlier Cargo Git cache experiment entirely

## Demonstrated impact

The exact reviewed head passed in [Desktop run 32920378504](https://github.com/OpenSecretCloud/Maple/actions/runs/32920378504):

- Windows job: 31m30s, down from the comparable 44m15s cold run by 12m45s (28.8%)
- Windows build step: 28m48s, down from 40m20s by 11m32s
- Cargo release compile: 21m36s, down from 33m48s by 12m12s
- sccache: exact 810,885,520-byte hit; 804 hits, 88 misses, 90.13% hit rate, and zero cache errors
- cache restore: 1m35s, fully included in the wall-clock result
- Windows artifact reproducibility verifier: passed
- complete PR gate: 20 successes and 2 expected skips, with no failures

This is about 13 minutes faster than the original 44m54s Windows baseline.

## Cache topology

Current master and release use sccache 0.8.2, which rejects the reproducible-build remap flag and executes zero cacheable requests. This change gives master the proven v0.16 configuration and leaves it on the normal read/write cache action. PR and release use the pinned restore-only subaction with the identical path and key.

The warm proof above used the existing cache scoped to refs/pull/845/merge. After merge, the first successful master build must cold-populate the same key under refs/heads/master; later PR and release jobs can then restore that trusted default-branch cache.

## Reproducibility boundary

All Rust toolchain pins, remap flags, locked dependency resolution, signing steps, artifact manifests, and verifier jobs are unchanged. Existing Windows traces do not establish raw cross-run byte identity because the uncached MSVC link changes PE timestamp and PDB GUID metadata. Independent comparison found only those 24 metadata bytes differed between the canary executables; after normalization, the 134.8 MB executables were identical.

No release is performed here. No Cargo source, Cargo target, credential, executable, registry, or checkout cache is added.

## Validation

- git diff --check
- nix flake check --no-update-lock-file --print-build-logs
- repository pre-commit hook: Prettier, frontend production build, and 765 tests
- independent cache-scope, trace, and reproducibility review

## Post-merge gate

The first master run is an expected cold seed, not a performance result. It must remain fully green and publish the exact cache under refs/heads/master. The next warm master run and first later PR must restore that default-branch entry and retain the material wall-clock improvement. The next normal release will verify release consumption; no release is created for this test.