### PR TITLE
chore: bump version to 3.3.9

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maple",
   "private": true,
-  "version": "3.3.8",
+  "version": "3.3.9",
   "type": "module",
   "packageManager": "bun@1.3.5",
   "trustedDependencies": [],

--- a/frontend/src-tauri/Cargo.lock
+++ b/frontend/src-tauri/Cargo.lock
@@ -4704,7 +4704,7 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "maple"
-version = "3.3.8"
+version = "3.3.9"
 dependencies = [
  "agent-client-protocol",
  "anyhow",

--- a/frontend/src-tauri/Cargo.toml
+++ b/frontend/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maple"
-version = "3.3.8"
+version = "3.3.9"
 description = "Maple AI"
 authors = ["tony@trymaple.ai"]
 license = "MIT"

--- a/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
+++ b/frontend/src-tauri/gen/apple/maple_iOS/Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.8</string>
+	<string>3.3.9</string>
 	<key>CFBundleVersion</key>
-	<string>3.3.8</string>
+	<string>3.3.9</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
 	<key>UILaunchStoryboardName</key>

--- a/frontend/src-tauri/gen/apple/project.yml
+++ b/frontend/src-tauri/gen/apple/project.yml
@@ -53,8 +53,8 @@ targets:
           - UIInterfaceOrientationPortraitUpsideDown
           - UIInterfaceOrientationLandscapeLeft
           - UIInterfaceOrientationLandscapeRight
-        CFBundleShortVersionString: 3.3.8
-        CFBundleVersion: 3.3.8
+        CFBundleShortVersionString: 3.3.9
+        CFBundleVersion: 3.3.9
     entitlements:
       path: maple_iOS/maple_iOS.entitlements
     scheme:

--- a/frontend/src-tauri/tauri.conf.json
+++ b/frontend/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Maple",
-  "version": "3.3.8",
+  "version": "3.3.9",
   "identifier": "cloud.opensecret.maple",
   "build": {
     "frontendDist": "../dist",
@@ -98,7 +98,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 2000028019
+      "versionCode": 2000028020
     },
     "windows": {
       "certificateThumbprint": null,


### PR DESCRIPTION
## Summary
- bump Maple to 3.3.9 for the next patch release
- increment the Android version code to 2000028020
- keep all desktop, iOS, Android, Rust, and package version sources aligned

## Validation
- `nix develop --no-update-lock-file .#ci -c just bump-patch` (version updates applied; the fresh worktree then needed the repository macOS ONNX wrapper for the lockfile check)
- `nix develop --no-update-lock-file .#ci -c sh -lc 'cd frontend/src-tauri && ./scripts/run-with-desktop-onnxruntime.sh cargo check'`\n- `nix develop --no-update-lock-file .#ci -c just get-version`\n- `cargo metadata --locked --format-version 1`\n- `git diff --check`\n- full pre-commit gate: Prettier, frontend build, 765 frontend tests, and Rust tests\n- targeted retry: `agent::macos_login_path::tests::same_group_stdout_holder_is_killed_on_output_timeout` (passed after one timing-related full-suite failure)