### PR TITLE
docs: add monorepo SDK agent guidance

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -39,12 +39,16 @@ Use these seams:
 - `frontend/src-tauri/src/agent.rs`: transport-neutral Agent domain state, account handles, Goose/session orchestration, persistence, run ownership, timelines, MCP and skills attachment, and permission routing. Do not import Tauri or ACP protocol types into this core.
 - `frontend/src-tauri/src/agent/provider.rs`: Goose-provider request construction, encrypted inference transport, streaming, bounded error handling, retry policy, and cancellation.
 - `frontend/src-tauri/src/maple_api.rs`: account-scoped native OpenSecret SDK sessions, backend identity validation, atomic credential replacement, and refresh reconciliation.
+- `sdk/rust/`: source for the OpenSecret Rust SDK. Maple's native application
+  still consumes the published crate pinned in
+  `frontend/src-tauri/Cargo.toml`; do not claim an in-tree SDK edit reached
+  Agent Mode until that dependency boundary is deliberately wired or updated.
 - `frontend/src-tauri/src/agent/developer_tools.rs`: Maple's privileged read, write, edit, image, shell, and backend web-tool implementations. Add privileged tools here rather than exposing an unmediated Goose tool path.
 - `frontend/src-tauri/src/agent/{shell_permission,web_permission,tool_context,web_tools}.rs`: automatic policy, secret-bearing execution context, public-URL admission, provenance, and output bounds.
 - `frontend/src-tauri/src/agent/system_prompt.rs`: the narrowly rebranded copy of the pinned Goose system prompt.
 - `frontend/src-tauri/src/agent_acp.rs`: ACP framing, Unix socket ownership, connection/session leases, caller-owned permissions, and adapter-specific environment allowlists.
 
-Put behavior in OpenSecret instead when it must be authoritative against a modified client, shared by multiple clients, durable across devices, or part of the public API, authentication, confidential-compute, model, provider, search, or extraction contract. Coordinate the open-source backend and SDK rather than emulating missing enforcement in Maple.
+Put behavior in OpenSecret instead when it must be authoritative against a modified client, shared by multiple clients, durable across devices, or part of the public API, authentication, confidential-compute, model, provider, search, or extraction contract. Coordinate the open-source backend and the in-tree SDK under `sdk/` rather than emulating missing enforcement in Maple.
 
 ## Preserve Trust and Lifecycle Invariants
 

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -12,6 +12,9 @@ Work from the `OpenSecretCloud/Maple` repository root. Treat `justfile`, `fronte
 - Use `$validate-maple` for full validation, packaged-app smoke tests, cross-platform builds, or release-artifact verification.
 - Use `$review-maple-security` for security audits or changes involving authentication, authorization, attestation, OAuth/deep links, credentials, storage, CSP, local proxy exposure, filesystem/shell access, or trust boundaries.
 - Use `$change-maple-agent-mode` for Goose, Agent Mode runtime/UI, tool permissions, MCP, ACP, subagents, or agent persistence.
+- Use `$develop-opensecret-sdk` for changes to the TypeScript/React or Rust SDK
+  source under `sdk/`, including its backend integration revision or package
+  boundaries.
 - Use `$release-maple` for version bumps, tags, publishing, release CI, or distribution. Never use `just release` during ordinary development.
 
 Keep the current task scoped when one of these skills is unnecessary. Do not claim specialized validation that was not run.
@@ -63,13 +66,17 @@ Keep in OpenSecret:
 - Model/provider policy, confidential-compute enforcement, and public API semantics.
 - Validation that must remain authoritative when a client is modified or bypassed.
 
-Do not emulate missing server enforcement in Maple. If the work changes an API contract, coordinate the open-source backend and SDK changes, preserve compatible failure behavior where practical, and test Maple against the exact backend revision. Configure external billing and flags services through their public API URLs; do not depend on their source trees.
+Do not emulate missing server enforcement in Maple. If the work changes an API
+contract, coordinate the open-source backend with the SDK source under `sdk/`,
+preserve compatible failure behavior where practical, and test Maple against
+the exact backend revision. Configure external billing and flags services
+through their public API URLs; do not depend on their source trees.
 
 ## Follow the Existing Architecture
 
 - Put React, routes, contexts, and browser-facing services under `frontend/src/`.
 - Put privileged/native behavior under `frontend/src-tauri/src/` and expose the narrowest typed Tauri command or event needed by the UI.
-- Use `@opensecret/react` and the existing OpenSecret client paths for authentication, encryption, and API calls. Do not duplicate protocol or cryptographic logic in components.
+- Use `@opensecret/react` and the existing OpenSecret client paths for authentication, encryption, and API calls. Read `frontend/package.json` to determine whether the application consumes a published version or the in-tree `file:../sdk` package; do not infer that boundary from prose. Do not duplicate protocol or cryptographic logic in components.
 - Follow nearby state ownership, cancellation, error, and cleanup patterns. Preserve account isolation and handle logout, navigation, retries, and stale async completion explicitly.
 - Treat all network, file, deep-link, shell, tool, and Tauri-command inputs as untrusted. Validate again at the enforcing boundary.
 - Keep feature flags as rollout/UI controls, never authorization controls.

--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: develop-opensecret-sdk
+description: Develop and review the OpenSecret TypeScript/React and Rust SDKs under Maple's sdk directory. Use for SDK API, authentication, attestation, encrypted transport, tests, the pinned OpenSecret integration revision, package contents, versions, or an explicitly authorized npm or crates.io publishing handoff; use develop-maple for application-only work.
+---
+
+# Develop the OpenSecret SDK
+
+Work from `OpenSecretCloud/Maple/sdk`. Read the repository-root `AGENTS.md`,
+`sdk/README.md`, the affected implementation and tests, and the root
+`.github/workflows/sdk-*.yml` files relevant to the change.
+
+The SDK source is part of the Maple repository, but its TypeScript and Rust
+package boundaries remain independently versioned and publishable:
+
+- `src/` builds `@opensecret/react` for browser and React consumers.
+- `rust/` builds the `opensecret` crate for native consumers.
+- `frontend/package.json` is authoritative for whether Maple's browser client
+  consumes a published TypeScript version or the in-tree `file:../sdk` package.
+- Maple's native client continues to consume the published Rust crate pinned in
+  `frontend/src-tauri/Cargo.toml` until the proxy and Rust consumers switch
+  together.
+
+Do not commit, push, open a PR, publish, or alter Maple's application dependency
+wiring unless the user authorizes that action.
+
+## Keep protocol ownership clear
+
+OpenSecret owns authentication and authorization truth, public HTTP semantics,
+provider policy, persistence, and usage accounting. The SDKs own client-side
+attestation, encrypted sessions, typed contracts, authentication state, and
+safe transport adaptation. Maple owns application presentation and local
+device behavior.
+
+For a public contract change, inspect the exact OpenSecret backend revision and
+both SDK implementations when they expose the affected behavior. Preserve
+old-client/new-server and new-client/old-server compatibility where clients can
+update independently. Do not weaken HTTPS, PCR validation, attestation, key
+exchange, randomness, retry safety, or sanitized errors to accommodate a
+caller.
+
+## Develop and validate
+
+Use the SDK's pinned Nix shell. For TypeScript/React work:
+
+```sh
+nix develop --no-update-lock-file -c bun install --frozen-lockfile --ignore-scripts
+nix develop --no-update-lock-file -c bun run format:check
+nix develop --no-update-lock-file -c bun run build
+nix develop --no-update-lock-file -c bun test --timeout 30000
+```
+
+For Rust work:
+
+```sh
+nix develop --no-update-lock-file -c bash -lc '
+  cd rust
+  cargo fmt --all -- --check
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+  cargo test --locked --all-features
+  cargo doc --locked --no-deps --all-features
+'
+```
+
+Run focused tests while iterating, then match the root path-scoped workflows:
+`sdk-typescript.yml`, `sdk-rust.yml`, and `sdk-supply-chain.yml` as applicable.
+When the change reaches backend behavior, authentication, or the encrypted wire
+contract, also match `sdk-integration.yml`. It checks out the full commit SHA in
+`opensecret-integration-revision`, starts disposable PostgreSQL and OpenSecret,
+and tests both SDK implementations without a hosted development server.
+
+Advance `opensecret-integration-revision` only to an inspected OpenSecret commit
+whose compatibility the change intends to establish. Provider-spending tests
+remain opt-in through `RUN_LIVE_AI=1` and require explicit credential, egress,
+and cost authorization.
+
+Before handoff, inspect package boundaries as applicable:
+
+```sh
+bun run pack
+cargo package --locked --manifest-path rust/Cargo.toml
+```
+
+These commands validate package contents; they do not publish them or prove a
+Maple application consumes the result.
+
+## Publishing boundary
+
+SDK publishing is separate from the Maple application release workflow.
+`just publish-npm` and `just publish-cargo` are external production mutations;
+run either only with explicit authority for the exact package, version, registry,
+and source commit. Verify versions, clean state, tests, and the built package
+before publishing, then report the immutable registry result. Do not create a
+Maple GitHub Release merely to publish an SDK.
+
+## Report
+
+State which SDK changed, the backend/API compatibility boundary, exact commands
+and results, package inspection performed, the Maple dependency pins left
+unchanged or deliberately updated, and every client, platform, live provider,
+or publishing boundary not exercised.

--- a/.agents/skills/review-maple-security/SKILL.md
+++ b/.agents/skills/review-maple-security/SKILL.md
@@ -261,13 +261,25 @@ Inspect the browser and native OpenSecret clients independently:
 - `frontend/src/services/mapleApiAuthService.ts`
 - `frontend/src-tauri/src/maple_api.rs`
 - `frontend/src-tauri/src/agent/provider.rs`
+- `sdk/src/` and `sdk/rust/` when the SDK implementation or public protocol is
+  in scope
 - the pinned JavaScript and Rust OpenSecret SDK versions and lockfiles
 
 Preserve the OpenSecret SDK's encrypted and attested transport. Do not replace `aiCustomFetch` or the native SDK client with raw browser/native fetch merely to make a request work. Avoid layering automatic client retries over Maple operations that may have server-side effects; keep retry ownership explicit.
 
 Review development and production enclave URLs and PCR/attestation allowlists together. Reject an endpoint that is not HTTPS unless it is an explicit loopback development address. Reject URL credentials and unexpected paths, queries, or fragments at the native authority boundary. Treat source-configured PCR values as policy, not proof that a live enclave currently matches; perform live attestation before making deployment claims.
 
-Do not assume the browser and native SDK pins have identical features, request schemas, refresh behavior, attestation behavior, or error handling. For an OpenSecret API contract change, validate both clients. Keep decrypted upstream errors and response bodies out of logs and user-facing native errors; expose bounded categories unless safe detail is deliberately part of the public contract.
+The SDK source is in this repository. Read `frontend/package.json` to determine
+whether the browser client resolves a published version or `file:../sdk`;
+continue treating the Rust crate pin in `frontend/src-tauri/Cargo.toml` as a
+published dependency until the coordinated proxy/Rust switch. Review source
+changes and resolved application dependencies as distinct boundaries; do not
+assume an in-tree fix protects a client that does not consume it. Do not assume
+the browser and native SDKs have identical features, request schemas, refresh
+behavior, attestation behavior, or error handling. For an OpenSecret API
+contract change, validate both clients. Keep decrypted upstream errors and
+response bodies out of logs and user-facing native errors; expose bounded
+categories unless safe detail is deliberately part of the public contract.
 
 When backend confirmation is needed, inspect the current open-source OpenSecret repository and follow its `AGENTS.md` and relevant skills. Do not infer its authorization, transport, or deployment behavior solely from Maple's caller.
 

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -39,6 +39,16 @@ Use for pure React, TypeScript, CSS, state, and browser behavior with no native 
 - Smoke the changed state in a real browser. Cover loading, empty, success, error, and disabled states when relevant.
 - Test keyboard operation, focus, accessible labels, light/dark themes, and narrow/wide layouts when the change can affect them.
 
+SDK-only changes under `sdk/` are an independent monorepo component rather
+than Maple frontend changes. Load `$develop-opensecret-sdk`, run the applicable
+TypeScript or Rust SDK checks, and add the pinned local OpenSecret integration
+when the public protocol or backend compatibility changes. Read
+`frontend/package.json` to determine whether TypeScript SDK changes are Maple
+frontend inputs; the dependency may be a published version or `file:../sdk`.
+Rust SDK-only changes remain outside Maple application coverage until the
+published crate pin or coordinated proxy/Rust wiring changes. Do not run
+unrelated Maple packaging solely because an independent SDK boundary changed.
+
 ### Tier 2: API, account, persistence, and streaming integration
 
 Use when behavior depends on an OpenSecret server, authentication, account state, conversation persistence, billing API endpoint, feature-flag API endpoint, or streamed responses.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,10 +44,13 @@ OpenSecret is its required backend. Keep these runtime paths distinct:
 - Local proxy: a separate user-facing OpenAI-compatible relay. Research chat
   and Agent Mode do not internally route through it.
 
-The browser client and native Agent Mode use independently pinned OpenSecret
-SDKs. Do not assume their versions, transports, retries, or API coverage are
-identical. A backend contract change that Maple consumes needs compatibility
-checks for every affected client path.
+The OpenSecret SDK source lives under `sdk/`. Treat `frontend/package.json` as
+the authority for whether the browser client consumes a published version or
+the in-tree `file:../sdk` package. Native Agent Mode continues to consume the
+published Rust crate pinned in `frontend/src-tauri/Cargo.toml` until the proxy
+and Rust consumers switch together. Do not assume the TypeScript and Rust SDKs
+have identical transports, retries, or API coverage. A backend contract change
+that Maple consumes needs compatibility checks for every affected client path.
 
 ## Code ownership and placement
 
@@ -249,6 +252,9 @@ requests release work, and report the tag and commit before publishing.
 
 - `$develop-maple`: setup, placement, implementation loop, and common web,
   desktop, mobile, and backend-integration work.
+- `$develop-opensecret-sdk`: TypeScript/React and Rust SDK development under
+  `sdk/`, backend compatibility, package-boundary checks, and publishing
+  handoff.
 - `$validate-maple`: focused tests, CI parity, exact-app smoke, full-stack
   smoke, and evidence reporting.
 - `$change-maple-agent-mode`: Agent Mode, ACP, Goose/provider, permissions,


### PR DESCRIPTION
## Summary

- clarify that SDK source lives under `sdk/` while `frontend/package.json` determines whether Maple consumes a published TypeScript version or `file:../sdk`
- record that native Maple remains on the published Rust crate until the coordinated proxy/Rust switch
- add a focused `develop-opensecret-sdk` skill for TypeScript, Rust, local backend integration, package inspection, and publishing boundaries
- update Maple development, validation, security-review, and Agent Mode guidance for the new source location
- leave the Maple release skill unchanged because SDK publishing remains a separate explicitly authorized workflow

The wording is intentionally valid both before and after PR #850 and does not stack on that branch.

## Validation

- all five changed or new skills passed `quick_validate.py`
- Maple pre-commit hook passed: Prettier, frontend production build, and 765 Bun tests
- `git diff --check`