### PR TITLE
Add get_model_catalog to Rust SDK

### DIFF
--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -2193,6 +2193,12 @@ impl OpenSecretClient {
             .await
     }
 
+    /// Fetches the full model catalog with context windows and capabilities.
+    pub async fn get_model_catalog(&self) -> Result<ModelCatalogResponse> {
+        self.encrypted_openai_call("/v1/models/catalog", "GET", None::<()>)
+            .await
+    }
+
     /// Creates embeddings for the given input text(s)
     ///
     /// # Example

--- a/sdk/rust/src/types.rs
+++ b/sdk/rust/src/types.rs
@@ -694,6 +694,67 @@ pub struct Model {
     pub owned_by: Option<String>,
 }
 
+/// A catalog entry: model identity plus context and capability metadata.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogModel {
+    pub id: String,
+    #[serde(default = "default_model_object")]
+    pub object: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owned_by: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_window: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub max_context_tokens: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<CatalogCapabilities>,
+}
+
+/// Capability flags a catalog entry advertises.
+///
+/// Mirrors the server and TypeScript SDK `ModelCapabilities` contract.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CatalogCapabilities {
+    #[serde(default)]
+    pub chat: bool,
+    #[serde(default)]
+    pub vision: bool,
+    #[serde(default)]
+    pub reasoning: bool,
+    #[serde(default)]
+    pub tool_use: bool,
+}
+
+/// A catalog alias resolving to a concrete model id.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CatalogAlias {
+    pub id: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target_model: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub capabilities: Option<CatalogCapabilities>,
+}
+
+/// Default alias assignments from the catalog.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct CatalogDefaults {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub quick: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub powerful: Option<String>,
+}
+
+/// The full model catalog from `/v1/models/catalog`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct ModelCatalogResponse {
+    pub object: String,
+    pub data: Vec<CatalogModel>,
+    #[serde(default)]
+    pub aliases: Vec<CatalogAlias>,
+    #[serde(default)]
+    pub defaults: CatalogDefaults,
+}
+
 fn default_model_object() -> String {
     "model".to_string()
 }

--- a/sdk/rust/tests/ai_integration.rs
+++ b/sdk/rust/tests/ai_integration.rs
@@ -122,6 +122,59 @@ async fn test_get_models() {
 }
 
 #[tokio::test]
+async fn test_get_model_catalog() {
+    let client = setup_authenticated_client()
+        .await
+        .expect("Failed to setup client");
+
+    let catalog = client
+        .get_model_catalog()
+        .await
+        .expect("Failed to get model catalog");
+
+    // Verify response structure
+    assert_eq!(catalog.object, "list");
+    assert!(
+        !catalog.data.is_empty(),
+        "Catalog should have at least one model"
+    );
+
+    for model in &catalog.data {
+        assert!(!model.id.is_empty(), "Catalog model ID should not be empty");
+        // Context fields are optional but must be positive when present.
+        if let Some(context_window) = model.context_window {
+            assert!(context_window > 0, "context_window should be positive");
+        }
+        if let Some(max_context_tokens) = model.max_context_tokens {
+            assert!(
+                max_context_tokens > 0,
+                "max_context_tokens should be positive"
+            );
+        }
+    }
+
+    for alias in &catalog.aliases {
+        assert!(!alias.id.is_empty(), "Alias ID should not be empty");
+    }
+
+    // The server always assigns default aliases.
+    assert!(
+        catalog.defaults.quick.is_some(),
+        "Catalog defaults should include a quick model"
+    );
+    assert!(
+        catalog.defaults.powerful.is_some(),
+        "Catalog defaults should include a powerful model"
+    );
+
+    println!(
+        "Found {} catalog models and {} aliases",
+        catalog.data.len(),
+        catalog.aliases.len()
+    );
+}
+
+#[tokio::test]
 #[ignore = "Server currently only supports streaming completions"]
 async fn test_chat_completion_non_streaming() {
     // The server's /v1/chat/completions endpoint only returns SSE streams


### PR DESCRIPTION
## Summary
- Expose `GET /v1/models/catalog` through `OpenSecretClient` as `get_model_catalog()`, returning the new `ModelCatalogResponse` (`data` with `context_window`/`max_context_tokens`/`capabilities`, `aliases` with `target_model`, `defaults`).
- The TypeScript SDK already fetches this endpoint (`fetchModelCatalog`); the Rust SDK only allowed it through the inference proxy allow-list, so native consumers had no way to size context usage against the selected model.
- Adds `test_get_model_catalog` mirroring `test_get_models`.

## Test plan
- [x] `cargo test --lib` (82 passed)
- [x] Live probe against `enclave.trymaple.ai`: catalog returns 7 models with context windows, 2 aliases (`auto:quick` -> `deepseek-v4-flash`, `auto:powerful` -> `kimi-k2-6`), and defaults.
- [ ] CI integration test run