### PR TITLE
Document in-tree SDK and proxy workflows

### DIFF
--- a/.agents/skills/change-maple-agent-mode/SKILL.md
+++ b/.agents/skills/change-maple-agent-mode/SKILL.md
@@ -39,10 +39,10 @@ Use these seams:
 - `frontend/src-tauri/src/agent.rs`: transport-neutral Agent domain state, account handles, Goose/session orchestration, persistence, run ownership, timelines, MCP and skills attachment, and permission routing. Do not import Tauri or ACP protocol types into this core.
 - `frontend/src-tauri/src/agent/provider.rs`: Goose-provider request construction, encrypted inference transport, streaming, bounded error handling, retry policy, and cancellation.
 - `frontend/src-tauri/src/maple_api.rs`: account-scoped native OpenSecret SDK sessions, backend identity validation, atomic credential replacement, and refresh reconciliation.
-- `sdk/rust/`: source for the OpenSecret Rust SDK. Maple's native application
-  still consumes the published crate pinned in
-  `frontend/src-tauri/Cargo.toml`; do not claim an in-tree SDK edit reached
-  Agent Mode until that dependency boundary is deliberately wired or updated.
+- `sdk/rust/`: source for the OpenSecret Rust SDK consumed by Maple's desktop
+  application through the path dependency in `frontend/src-tauri/Cargo.toml`.
+  Rust SDK runtime changes therefore reach Agent Mode desktop builds; verify
+  the local dependency graph rather than treating the in-tree source as inert.
 - `frontend/src-tauri/src/agent/developer_tools.rs`: Maple's privileged read, write, edit, image, shell, and backend web-tool implementations. Add privileged tools here rather than exposing an unmediated Goose tool path.
 - `frontend/src-tauri/src/agent/{shell_permission,web_permission,tool_context,web_tools}.rs`: automatic policy, secret-bearing execution context, public-URL admission, provenance, and output bounds.
 - `frontend/src-tauri/src/agent/system_prompt.rs`: the narrowly rebranded copy of the pinned Goose system prompt.

--- a/.agents/skills/develop-maple-proxy/SKILL.md
+++ b/.agents/skills/develop-maple-proxy/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: develop-maple-proxy
+description: Develop and review the maple-proxy Rust crate, binary, container, and OpenAI-compatible HTTP behavior under Maple's proxy directory. Use for proxy APIs, configuration, authentication, CORS, attested OpenSecret transport, tests, container builds, package versions, or an explicitly authorized crates.io or GHCR publishing handoff; use develop-maple for the Tauri lifecycle wrapper alone.
+---
+
+# Develop Maple Proxy
+
+Work from the `OpenSecretCloud/Maple` repository root; the component source is
+under `proxy/`. Read the repository-root `AGENTS.md`, `proxy/README.md`,
+affected source and tests, and the root
+`.github/workflows/proxy-*.yml` files relevant to the change.
+
+The source is part of Maple but keeps distinct public package and runtime
+boundaries:
+
+- `proxy/` builds the `maple-proxy` crate and binary.
+- `proxy/Cargo.toml` consumes the in-tree OpenSecret Rust SDK at `../sdk/rust`
+  with a registry version retained for Cargo publishing.
+- desktop Maple consumes `../../proxy` and `../../sdk/rust` from
+  `frontend/src-tauri/Cargo.toml`; iOS and Android do not compile the proxy.
+- `frontend/src-tauri/src/proxy.rs` owns Maple's account-scoped listener,
+  configuration, key storage, and lifecycle around the library. Do not move
+  that application behavior into the reusable crate incidentally.
+
+Do not commit, push, open a PR, publish, tag, release, or change live
+infrastructure unless the user authorizes that action.
+
+## Keep validation and routing aligned
+
+Run the credential-free proxy checks through its pinned shell:
+
+```sh
+nix develop --no-update-lock-file ./proxy -c bash -lc '
+  cd proxy
+  cargo fmt --all -- --check
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+  cargo test --locked --all-features
+  RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features
+  cargo machete
+'
+```
+
+For Rust SDK or dependency-wiring changes, also prove the application resolves
+one local SDK and one local proxy:
+
+```sh
+nix develop --no-update-lock-file .#ci -c \
+  ./scripts/ci/verify-local-rust-deps.sh
+```
+
+Root workflows own proxy Rust, daily supply-chain, non-publishing container,
+and native-release rehearsal checks. `proxy/src/**`, `proxy/Cargo.toml`, and
+unknown proxy build inputs are desktop application inputs; tests, examples,
+docs, the standalone lockfile, and container-only files do not by themselves
+route expensive Maple app builds. `sdk/rust` runtime changes affect both proxy
+checks and desktop Maple. When a new input changes either graph, update
+`scripts/ci/change_detection.py`, its table-driven tests, and workflow paths in
+the same change.
+
+## Exercise the right runtime
+
+Run the standalone proxy on a checkout-specific loopback port with an explicit
+backend and PCR0 environment. Keep API keys in ignored local configuration or
+the invoking process; never print or commit them. Exercise `/health`,
+`/v1/models`, streaming and non-streaming chat, embeddings, invalid
+authentication, timeout, and cancellation only as relevant to the change.
+
+Container builds require the Maple repository root as context because the
+Dockerfile copies both `proxy/` and `sdk/rust`:
+
+```sh
+docker build -f proxy/Dockerfile -t maple-proxy:dev .
+```
+
+Use the configured container runtime from `proxy/justfile` when Docker is not
+the intended local engine. A successful image build is not proof that GHCR was
+published or that the service works against a live enclave.
+
+For authentication, CORS, bind exposure, saved-key behavior, backend URL or
+PCR0 selection, request forwarding, logging, or timeout changes, load
+`$review-maple-security`. Preserve the core loopback and CORS-off defaults;
+treat container CORS-on configuration as a separate exposed mode. A configured
+default API key is for private/originless clients; browser-facing CORS mode must
+require each request's bearer key rather than spending the saved default. Never
+assume protections in the Tauri wrapper also exist in the standalone router.
+Never log any portion of an API key. Treat raw OpenAI request and response
+bodies as untrusted and potentially sensitive.
+
+## Preserve publishing boundaries
+
+Maple's current GitHub Release workflow builds, checksums, attests, uploads,
+and re-verifies four native proxy archives. The first post-integration release
+is still the live publication canary. Never create a proxy GitHub tag or
+Release; a proxy-only binary fix ships through a normal Maple patch release.
+
+Crates.io publishing remains separately versioned and manual. On an authorized
+publish, inspect the exact package first:
+
+```sh
+cargo package --locked --manifest-path proxy/Cargo.toml
+```
+
+If the proxy references a new `opensecret` version, publish that SDK crate
+first. Do not publish either crate from Maple's application Release workflow.
+The current root proxy container workflow builds without pushing; adding or
+running a GHCR publisher is a separate production action requiring explicit
+repository, version, image namespace, tag, and credential authority.
+
+## Report
+
+State the proxy behavior and public contract changed, SDK/application boundary,
+exact checks and runtime evidence, container or package inspection performed,
+version/publisher state left unchanged or deliberately updated, and every
+platform, live backend, registry, or release boundary not exercised.

--- a/.agents/skills/develop-maple/SKILL.md
+++ b/.agents/skills/develop-maple/SKILL.md
@@ -15,6 +15,8 @@ Work from the `OpenSecretCloud/Maple` repository root. Treat `justfile`, `fronte
 - Use `$develop-opensecret-sdk` for changes to the TypeScript/React or Rust SDK
   source under `sdk/`, including its backend integration revision or package
   boundaries.
+- Use `$develop-maple-proxy` for changes to the proxy crate, standalone binary,
+  container, or public OpenAI-compatible behavior under `proxy/`.
 - Use `$release-maple` for version bumps, tags, publishing, release CI, or distribution. Never use `just release` during ordinary development.
 
 Keep the current task scoped when one of these skills is unnecessary. Do not claim specialized validation that was not run.

--- a/.agents/skills/develop-opensecret-sdk/SKILL.md
+++ b/.agents/skills/develop-opensecret-sdk/SKILL.md
@@ -16,9 +16,9 @@ package boundaries remain independently versioned and publishable:
 - `rust/` builds the `opensecret` crate for native consumers.
 - `frontend/package.json` is authoritative for whether Maple's browser client
   consumes a published TypeScript version or the in-tree `file:../sdk` package.
-- Maple's native client continues to consume the published Rust crate pinned in
-  `frontend/src-tauri/Cargo.toml` until the proxy and Rust consumers switch
-  together.
+- desktop Maple and `proxy/` consume the in-tree Rust crate through versioned
+  path dependencies. iOS and Android do not compile those desktop-only
+  consumers.
 
 Do not commit, push, open a PR, publish, or alter Maple's application dependency
 wiring unless the user authorizes that action.
@@ -80,8 +80,10 @@ bun run pack
 cargo package --locked --manifest-path rust/Cargo.toml
 ```
 
-These commands validate package contents; they do not publish them or prove a
-Maple application consumes the result.
+These commands validate package contents; they do not publish them. For Rust
+SDK changes, also run the root `scripts/ci/verify-local-rust-deps.sh` check and
+the applicable desktop/proxy validation before claiming Maple consumes the
+result.
 
 ## Publishing boundary
 

--- a/.agents/skills/release-maple/SKILL.md
+++ b/.agents/skills/release-maple/SKILL.md
@@ -21,6 +21,9 @@ commit, external effect, and authority provided by the user.
 - The same Maple GitHub Release receives four native `maple-proxy` archives and
   their checksum manifest. Never create a separate proxy Release or proxy tag;
   `/releases/latest` must continue to identify the Maple application release.
+- Maple GitHub Releases do not publish `opensecret` or `maple-proxy` to
+  crates.io and do not push a GHCR image. Those are separately versioned,
+  separately authorized production mutations.
 - GitHub Release creation does not itself submit the release IPA or AAB to
   Apple App Store review or Google Play.
 
@@ -81,6 +84,20 @@ The script requires a clean current `master`, exact manifest version parity, a
 newer version and unused tag, and successful required workflows for the exact
 commit. Stop on any failure; correct it through the normal reviewed process.
 Never overwrite or move a release tag.
+
+Record the proxy version and whether proxy or Rust SDK runtime inputs changed
+since `previous_tag`:
+
+```bash
+proxy_version="$(sed -n 's/^version = "\([^"]*\)"/\1/p' proxy/Cargo.toml | head -n 1)"
+git diff --name-only "$previous_tag".."$head_sha" -- proxy sdk/rust
+printf 'proxy_version=%s\n' "$proxy_version"
+```
+
+If runtime inputs changed without a proxy version change, stop and make the
+version decision explicit before publishing. A normal Maple Release always
+builds the checked-in proxy version, but that does not implicitly authorize a
+crates.io or GHCR publish.
 
 Preview GitHub's generated notes:
 
@@ -182,6 +199,13 @@ nix develop --no-update-lock-file .#ci -c \
   ./scripts/ci/verify-release-artifacts.sh artifacts proxy
 ```
 
+Confirm the release contains all four stable proxy archives and
+`maple-proxy-release-final.sha256`, and that their attestations and the
+published-asset verification job succeeded. Report the embedded proxy version
+separately from the Maple application version. Do not report crates.io or GHCR
+as updated unless their independent publisher was explicitly authorized and
+verified.
+
 Zapstore starts only after `Release` succeeds and is strictly best effort. Its
 queued, running, skipped, or failed state must not delay release completion,
 trigger a release retry, or be reported as a Maple release failure. Inspect it
@@ -228,9 +252,10 @@ in the release handoff or issue that owns them, not in this evergreen skill.
 
 ## Report
 
-Report the version, tag, exact commit, release URL, main workflow URL and
-attempt count, artifact verification result, any required-workflow retry and
-supporting evidence, authorized store/API actions, and every boundary that
-remains unverified. If Zapstore was inspected, report its status separately as
+Report the Maple version, proxy version, tag, exact commit, release URL, main
+workflow URL and attempt count, application and four-proxy-archive verification
+results, any required-workflow retry and supporting evidence, authorized
+store/API actions, and every boundary that remains unverified. State crates.io
+and GHCR status separately. If Zapstore was inspected, report its status as
 non-gating. Separate repository release completion from store distribution and
 live application availability.

--- a/.agents/skills/review-maple-security/SKILL.md
+++ b/.agents/skills/review-maple-security/SKILL.md
@@ -219,7 +219,13 @@ assuming intentional execution authority violates the design.
 
 ## Review the Local OpenAI Proxy
 
-Inspect `frontend/src-tauri/src/proxy.rs`, `frontend/src/services/proxyService.ts`, the settings UI, all startup/logout callers, and tests as one boundary.
+Inspect `proxy/src/{config,lib,main,proxy}.rs`,
+`proxy/{Cargo.toml,.env.example,Dockerfile,docker-compose.yml,justfile}`,
+`frontend/src-tauri/src/proxy.rs`, `frontend/src/services/proxyService.ts`, the
+settings UI, all startup/logout callers, and tests as one boundary. Keep the
+reusable HTTP proxy's request and authentication rules distinct from Maple's
+account-scoped Tauri lifecycle. The standalone crate, binary, and container do
+not inherit protections implemented only by the Tauri wrapper.
 
 Require these defaults unless an explicit product decision changes them:
 
@@ -229,6 +235,20 @@ Require these defaults unless an explicit product decision changes them:
 - keep browser reachability separate from Maple's saved credential.
 
 When CORS is disabled, verify browser-controlled `Origin` and `Sec-Fetch-Site` requests are rejected before a saved key can be spent. Omitting CORS response headers alone is insufficient. When CORS is enabled for browser compatibility, require every inference request to provide its own bearer key and remove saved-key fallback.
+
+Build a core-versus-Tauri regression matrix for CORS on/off, saved-key
+present/absent, browser `Origin`/`Sec-Fetch-Site` headers, and per-request
+bearer keys. Test the standalone router directly as well as the exact app;
+passing wrapper tests does not establish the core policy.
+
+Review the exact exposed routes and methods, request-size and concurrency
+bounds, forwarded and stripped headers, response-cache bounds, setup and
+stream-idle timeouts, cancellation, exactly one streaming terminator, upstream
+status/body leakage, backend and PCR trust selection, bind/TLS policy, and
+logs. Never log any portion of an API key, authorization header, encrypted or
+decrypted request body, response body, or credential-bearing URL. `/health`
+proves liveness only; exercise `/v1/models`, non-streaming chat, streaming chat,
+and embeddings when their shared forwarding path changes.
 
 Review host, port, CORS mode, saved credential, auto-start, owner account, and backend URL as one security object. Validate bind hosts and endpoints natively. Allow plaintext HTTP only for explicit loopback development; reject embedded URL credentials and unexpected path, query, or fragment components unless the API contract requires them.
 
@@ -269,12 +289,10 @@ Preserve the OpenSecret SDK's encrypted and attested transport. Do not replace `
 
 Review development and production enclave URLs and PCR/attestation allowlists together. Reject an endpoint that is not HTTPS unless it is an explicit loopback development address. Reject URL credentials and unexpected paths, queries, or fragments at the native authority boundary. Treat source-configured PCR values as policy, not proof that a live enclave currently matches; perform live attestation before making deployment claims.
 
-The SDK source is in this repository. Read `frontend/package.json` to determine
-whether the browser client resolves a published version or `file:../sdk`;
-continue treating the Rust crate pin in `frontend/src-tauri/Cargo.toml` as a
-published dependency until the coordinated proxy/Rust switch. Review source
-changes and resolved application dependencies as distinct boundaries; do not
-assume an in-tree fix protects a client that does not consume it. Do not assume
+The SDK source is in this repository. The browser uses `file:../sdk`, while
+desktop Maple and `proxy/` use versioned path dependencies on `sdk/rust`.
+Review source changes and resolved application dependencies as distinct
+boundaries, and verify the local Cargo graph before claiming coverage. Do not assume
 the browser and native SDKs have identical features, request schemas, refresh
 behavior, attestation behavior, or error handling. For an OpenSecret API
 contract change, validate both clients. Keep decrypted upstream errors and

--- a/.agents/skills/validate-maple/SKILL.md
+++ b/.agents/skills/validate-maple/SKILL.md
@@ -39,15 +39,21 @@ Use for pure React, TypeScript, CSS, state, and browser behavior with no native 
 - Smoke the changed state in a real browser. Cover loading, empty, success, error, and disabled states when relevant.
 - Test keyboard operation, focus, accessible labels, light/dark themes, and narrow/wide layouts when the change can affect them.
 
-SDK-only changes under `sdk/` are an independent monorepo component rather
-than Maple frontend changes. Load `$develop-opensecret-sdk`, run the applicable
-TypeScript or Rust SDK checks, and add the pinned local OpenSecret integration
-when the public protocol or backend compatibility changes. Read
-`frontend/package.json` to determine whether TypeScript SDK changes are Maple
-frontend inputs; the dependency may be a published version or `file:../sdk`.
-Rust SDK-only changes remain outside Maple application coverage until the
-published crate pin or coordinated proxy/Rust wiring changes. Do not run
-unrelated Maple packaging solely because an independent SDK boundary changed.
+SDK work under `sdk/` has its own component checks. Load
+`$develop-opensecret-sdk`, run the applicable TypeScript or Rust SDK checks,
+and add the pinned local OpenSecret integration when the public protocol or
+backend compatibility changes. Maple's frontend consumes `file:../sdk`;
+desktop Maple and `proxy/` consume `sdk/rust` through local path dependencies.
+Rust SDK runtime changes therefore require proxy checks and desktop Maple
+coverage, while SDK tests/docs/examples and standalone lockfile changes remain
+independent. Do not run unrelated mobile packaging for desktop-only Rust SDK
+or proxy inputs.
+
+Proxy work under `proxy/` likewise has component and application boundaries.
+Load `$develop-maple-proxy`. Proxy or Rust SDK runtime inputs route to desktop
+Maple, not iOS or Android; proxy tests, examples, docs, its standalone
+`Cargo.lock`, and container-only inputs remain independently scoped unless the
+dependency graph or public runtime contract changes.
 
 ### Tier 2: API, account, persistence, and streaming integration
 
@@ -146,6 +152,38 @@ nix develop --no-update-lock-file .#ci -c ./scripts/ci/rust.sh
 ```
 
 The lint recipe runs `cargo fmt --check` and Clippy with warnings denied. The CI script provisions Linux ONNX Runtime when needed and runs `cargo test --all-targets --locked`. Neither command launches Maple.
+
+### Proxy checks and local dependency graph
+
+Run the proxy's CI-equivalent component checks through its pinned shell:
+
+```bash
+nix develop --no-update-lock-file ./proxy -c bash -lc '
+  cd proxy
+  cargo fmt --all -- --check
+  cargo clippy --locked --all-targets --all-features -- -D warnings
+  cargo test --locked --all-features
+  RUSTDOCFLAGS="-D warnings" cargo doc --locked --no-deps --all-features
+  cargo machete
+'
+```
+
+For proxy dependency-wiring or Rust SDK runtime changes, also prove the root
+application resolves the intended in-tree crates:
+
+```bash
+nix develop --no-update-lock-file .#ci -c \
+  ./scripts/ci/verify-local-rust-deps.sh
+```
+
+The container build uses the Maple root as context because it copies
+`proxy/` and `sdk/rust/`:
+
+```bash
+docker build -f proxy/Dockerfile -t maple-proxy:validation .
+```
+
+A component check or image build is not runtime evidence.
 
 ### Repository configuration checks
 
@@ -301,6 +339,17 @@ Choose only scenarios relevant to the change, but cross every changed boundary.
 - Before local-proxy smoke, choose and verify an unused checkout-specific
   loopback port. After start, verify that the recorded Maple PID owns the
   listener; do not assume the default port is available.
+- Keep two proxy smoke targets separate. For the standalone binary, launch the
+  exact checkout on loopback with explicit backend/PCR configuration, no saved
+  key in browser-facing CORS mode, and record the binary and listener PID. For
+  the Tauri Local OpenAI Proxy, start it through the exact packaged or
+  development app UI and verify its account, lifecycle, saved-key, CORS, and
+  logout behavior through that app. One target does not prove the other.
+- When forwarding behavior changes, exercise authenticated `/v1/models`, one
+  non-streaming chat response, one streaming response with exactly one
+  `[DONE]`, and embeddings against the intended backend. Add invalid/missing
+  authentication, timeout, cancellation, and upstream-error cases as
+  applicable. `/health` alone is only liveness evidence.
 
 ### PDF and OCR
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,7 +50,7 @@ in-tree `sdk/rust` crate. Do not assume the TypeScript and Rust SDKs have
 identical transports, retries, or API coverage. A backend contract change that
 Maple consumes needs compatibility checks for every affected client path.
 
-The standalone proxy source lives under `proxy/`. From the repository root,
+The Maple Proxy source lives under `proxy/`. From the repository root,
 run its Rust commands through
 `nix develop --no-update-lock-file ./proxy -c bash -lc 'cd proxy && ...'`;
 root path-scoped workflows own proxy CI. Proxy and Rust SDK runtime changes are
@@ -260,6 +260,8 @@ requests release work, and report the tag and commit before publishing.
 - `$develop-opensecret-sdk`: TypeScript/React and Rust SDK development under
   `sdk/`, backend compatibility, package-boundary checks, and publishing
   handoff.
+- `$develop-maple-proxy`: proxy crate, binary, OpenAI-compatible HTTP behavior,
+  container builds, application dependency boundary, and publishing handoff.
 - `$validate-maple`: focused tests, CI parity, exact-app smoke, full-stack
   smoke, and evidence reporting.
 - `$change-maple-agent-mode`: Agent Mode, ACP, Goose/provider, permissions,

--- a/proxy/README.md
+++ b/proxy/README.md
@@ -13,15 +13,20 @@ Environment (TEE) processing.
 - **Flexible Authentication** - Environment variables or per-request API keys
 - **Familiar Clients** - Point compatible OpenAI clients at the proxy base URL
 - **Lightweight** - Minimal overhead, maximum performance
-- **CORS Support** - Ready for web applications
+- **Optional CORS** - Browser mode requires per-request keys and deployment review
 
 ## 📦 Installation
 
 ### As a Binary
 
-Every Maple GitHub Release includes native proxy archives for Linux x86_64,
-Linux ARM64, Apple Silicon macOS, and Windows x86_64. The stable download URLs
-use the ordinary Maple release, for example:
+Maple's current release workflow builds native proxy archives for Linux x86_64,
+Linux ARM64, Apple Silicon macOS, and Windows x86_64 and attaches them to the
+ordinary Maple app Release. No post-integration Maple release has been cut yet,
+so the current `releases/latest` entry does not contain these files. Until the
+first such release is published, build from source as shown below.
+
+After that release, verify the assets are present and use the stable download
+URLs, for example:
 
 ```bash
 curl -LO https://github.com/OpenSecretCloud/Maple/releases/latest/download/maple-proxy-linux-x86_64.tar.gz
@@ -30,7 +35,7 @@ sha256sum --check --ignore-missing maple-proxy-release-final.sha256
 ```
 
 There is no separate proxy GitHub Release or proxy release tag. To build from
-source instead:
+source now:
 
 ```bash
 git clone https://github.com/OpenSecretCloud/Maple.git
@@ -60,9 +65,9 @@ export MAPLE_HOST=127.0.0.1                    # Server host (default: 127.0.0.1
 export MAPLE_PORT=8080                         # Server port (default: 8080)
 export MAPLE_BACKEND_URL=http://localhost:3000         # Maple backend URL (prod: https://enclave.trymaple.ai)
 export MAPLE_PCR0_ENVIRONMENT=production       # PCR0 trust roots: production (default) or development
-export MAPLE_API_KEY=your-maple-api-key        # Default API key (optional)
+export MAPLE_API_KEY=your-maple-api-key        # Optional for trusted, non-browser clients only
 export MAPLE_DEBUG=true                        # Enable debug logging
-export MAPLE_ENABLE_CORS=true                  # Enable CORS
+export MAPLE_ENABLE_CORS=false                 # Default; see browser warning below
 export MAPLE_REQUEST_TIMEOUT_SECS=300          # Backend request timeout
 export MAPLE_STREAM_IDLE_TIMEOUT_SECS=300      # Streaming idle timeout between chunks
 ```
@@ -270,17 +275,27 @@ curl -H "Authorization: Bearer different-api-key" ...
 
 ## 🌐 CORS Support
 
-Enable CORS for web applications:
+The standalone proxy does not inherit Maple's Tauri wrapper protections. If a
+browser must call it, do not configure `MAPLE_API_KEY`; require every request
+to carry its own bearer key and review the network exposure separately before
+enabling CORS:
+
 ```bash
+unset MAPLE_API_KEY
 export MAPLE_ENABLE_CORS=true
 cargo run --locked
 ```
 
 ## 🐳 Docker Deployment
 
-### Quick Start with Pre-built Image
+### Legacy Pre-built Image
 
-Pull and run the official image from GitHub Container Registry:
+The currently published GHCR `latest` image is the independently released
+standalone proxy 0.3.2. Maple's in-tree source is 0.3.3, and the root container
+workflow currently builds without pushing. Build from source for the current
+code until an explicitly authorized Maple-owned GHCR publisher is added.
+
+To run the legacy image deliberately:
 
 ```bash
 # Pull the latest image
@@ -306,7 +321,7 @@ just docker-run
 
 ### Production Docker Setup
 
-1. **Option A: Use pre-built image from GHCR**
+1. **Option A: Use the legacy 0.3.2 image from GHCR**
 ```bash
 # In your docker-compose.yml, use:
 image: ghcr.io/opensecretcloud/maple-proxy:latest
@@ -344,10 +359,9 @@ client = OpenAI(
 )
 ```
 
-This ensures:
-- Users' API keys remain private
-- Multiple users can share the same proxy instance
-- No API keys are exposed in container configurations
+This keeps API keys out of the shared container configuration and allows each
+client to supply its own credential. Review proxy logs and browser policy
+before treating a public deployment as safe.
 
 ### Docker Commands
 
@@ -379,7 +393,6 @@ The Docker image:
 - Uses multi-stage builds for minimal size (~130MB)
 - Runs as non-root user for security
 - Includes health checks
-- Optimizes dependency caching with cargo-chef
 - Supports both x86_64 and ARM architectures
 
 ### Environment Variables for Docker
@@ -404,6 +417,13 @@ in the Maple repository. Root, path-scoped workflows run locked Rust checks,
 supply-chain policy, and non-publishing AMD64/ARM64 container builds for proxy
 changes. Production publishing is intentionally handled separately from these
 CI checks.
+
+`proxy/Cargo.lock`, `sdk/rust/Cargo.lock`, and
+`frontend/src-tauri/Cargo.lock` remain separate lockfiles. Runtime dependency
+changes must keep the path graph and all affected locks coherent. Docker builds
+must use the Maple repository root as context so both `proxy/` and `sdk/rust/`
+are available. GitHub Release archives, crates.io, and GHCR are three separate
+publication paths; completing one does not update the others.
 
 **Local Development (Justfile)**
 ```bash

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -1,7 +1,7 @@
 # OpenSecret SDKs
 
-This repository contains the TypeScript/React and Rust clients used by Maple
-and OpenSecret's internal applications. Both clients establish attested,
+This directory contains the TypeScript/React and Rust clients used by Maple and
+OpenSecret's internal applications. Both clients establish attested,
 end-to-end encrypted sessions with an OpenSecret backend and expose the API
 surface needed by those applications.
 
@@ -19,6 +19,12 @@ and tests.
 - `docs/PLATFORM.md` — internal developer/platform API notes.
 - repository-root `.github/workflows/sdk-*.yml` — path-scoped TypeScript, Rust,
   and supply-chain validation for this directory.
+
+Maple's frontend consumes this TypeScript package through `file:../sdk`.
+Desktop Maple and `proxy/` consume `sdk/rust` through versioned path
+dependencies; iOS and Android exclude those desktop-only Rust consumers.
+Published npm and crates.io packages remain independent compatibility surfaces
+for external users.
 
 ## Security model
 
@@ -116,7 +122,7 @@ opensecret = "3"
 The primary entry point is `OpenSecretClient`. See `rust/README.md` for native
 client examples and transport details.
 
-Run the Rust validation from the repository root:
+Run the Rust validation from the `sdk/` directory:
 
 ```sh
 nix develop --no-update-lock-file -c bash -lc '

--- a/sdk/rust/README.md
+++ b/sdk/rust/README.md
@@ -1,5 +1,9 @@
 # OpenSecret Rust SDK
 
+This source lives under Maple's `sdk/rust/` directory. Desktop Maple and
+Maple's in-tree `proxy/` consume it through versioned path dependencies, while
+crates.io publishing remains an independent compatibility surface.
+
 Rust SDK for OpenSecret - secure AI API interactions with nitro attestation.
 
 ## Features
@@ -225,7 +229,8 @@ match client.login(email, password, client_id).await {
 
 ## Testing
 
-The SDK reads configuration from `.env.local` in the parent directory (OpenSecret-SDK root), matching the TypeScript SDK setup.
+The SDK reads configuration from `.env.local` in the parent Maple `sdk/`
+directory, matching the TypeScript SDK setup.
 
 Required environment variables in `.env.local`:
 ```bash


### PR DESCRIPTION
## Summary

- add a focused Maple Proxy development skill and route validation, security review, and release guidance through the in-tree component
- correct stale SDK dependency guidance now that desktop Maple and proxy consume the local Rust SDK
- document the current proxy artifact, crates.io, and legacy GHCR boundaries without changing runtime behavior

## Scope

This is guidance and documentation only. The imported standalone core still needs a separate focused runtime follow-up for saved-key plus CORS enforcement and key-fragment logging; this PR makes that boundary explicit but does not claim to fix it.

## Validation

- all seven changed or new skills pass quick validation
- Maple pre-commit gate passed: frontend formatting, production build, and 765 Bun tests
- `git diff --check`