### PR TITLE
ci: cache Windows Cargo sources

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -252,6 +252,19 @@ jobs:
         with:
           toolchain: 1.94.1
 
+      - name: Cache Cargo sources
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/src
+            ~/.cargo/git/db
+            ~/.cargo/git/checkouts
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-v1-
+
       - name: Install sccache
         shell: bash
         run: |

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -149,6 +149,19 @@ jobs:
         with:
           toolchain: 1.94.1
 
+      - name: Restore Cargo sources
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/src
+            ~/.cargo/git/db
+            ~/.cargo/git/checkouts
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-v1-
+
       - name: Install sccache
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,6 +284,19 @@ jobs:
         with:
           toolchain: 1.94.1
 
+      - name: Restore Cargo sources
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
+        with:
+          path: |
+            ~/.cargo/registry/index
+            ~/.cargo/registry/cache
+            ~/.cargo/registry/src
+            ~/.cargo/git/db
+            ~/.cargo/git/checkouts
+          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-sources-v1-
+
       - name: Install sccache
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- cache the Windows Cargo registry index, crate archives, extracted sources, and Git dependency checkouts
- let only master save the cache; PR and release Windows jobs are restore-only
- scope the cache to the desktop Cargo.lock, with a compatible fallback for lockfile updates

## Safety boundary
- does not cache target outputs, Cargo configuration, credentials, or installed binaries
- does not change sccache, compiler flags, build scripts, signing, bundling, attestations, or reproducibility verification
- Cargo remains locked and continues verifying registry checksums and pinned Git revisions

The PR build is expected to miss this new cache because only master publishes it. After merge, the first master run populates the cache; a later master run with the same desktop lockfile is the warm measurement.

## Validation
- nix flake check --no-update-lock-file --print-build-logs
- 11 change-detection tests passed
- 25 release-gate tests passed
- parsed all three Windows jobs to confirm master uses actions/cache while PR and release use actions/cache/restore with identical paths and keys
- repository pre-commit hook passed, including frontend/SDK builds and 765 Bun tests
- git diff --check

Windows cache restore/save behavior still requires GitHub Actions runtime evidence; it cannot be executed from the macOS development VM.
