### PR TITLE
ci: revert Windows Cargo source cache

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -252,19 +252,6 @@ jobs:
         with:
           toolchain: 1.94.1
 
-      - name: Cache Cargo sources
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/src
-            ~/.cargo/git/db
-            ~/.cargo/git/checkouts
-          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-sources-v1-
-
       - name: Install sccache
         shell: bash
         run: |

--- a/.github/workflows/desktop-pr-build.yml
+++ b/.github/workflows/desktop-pr-build.yml
@@ -149,19 +149,6 @@ jobs:
         with:
           toolchain: 1.94.1
 
-      - name: Restore Cargo sources
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/src
-            ~/.cargo/git/db
-            ~/.cargo/git/checkouts
-          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-sources-v1-
-
       - name: Install sccache
         shell: bash
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -284,19 +284,6 @@ jobs:
         with:
           toolchain: 1.94.1
 
-      - name: Restore Cargo sources
-        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # was v4
-        with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/registry/src
-            ~/.cargo/git/db
-            ~/.cargo/git/checkouts
-          key: ${{ runner.os }}-cargo-sources-v1-${{ hashFiles('frontend/src-tauri/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-sources-v1-
-
       - name: Install sccache
         shell: bash
         run: |


### PR DESCRIPTION
## Summary

- remove the Cargo registry/git source cache added in #857 from Windows master, PR, and release jobs
- keep the existing sccache configuration unchanged
- restore all three workflows exactly to their pre-#857 contents

## Why

The warm cache restored about 2.96 GB in 2m10s-2m37s to avoid roughly 2m59s of cold source fetching. That demonstrated only about 19-47 seconds of attributable end-to-end savings, while total Windows job time remained dominated by hosted-runner variance. The cache is not earning its size and workflow complexity.

## Validation

- `git diff --check`
- exact comparison against pre-#857 workflow versions
- `nix flake check --no-update-lock-file --print-build-logs` (actionlint, change detection, 25 release-gate tests, release metadata, toolchain)
- repository pre-commit hook (format, frontend build, 765 Bun tests)