### PR TITLE
Default chat model to Quick for all plans

### DIFF
--- a/frontend/src/state/LocalStateContext.test.tsx
+++ b/frontend/src/state/LocalStateContext.test.tsx
@@ -9,7 +9,7 @@ import type {
   SelectedProjectState,
   SidebarSearchState
 } from "./LocalStateContextDef";
-import { DEFAULT_MODEL_ID, LocalStateProvider, PAID_DEFAULT_MODEL_ID } from "./LocalStateContext";
+import { DEFAULT_MODEL_ID, LocalStateProvider, POWERFUL_MODEL_ALIAS } from "./LocalStateContext";
 import {
   useBillingState,
   useModelState,
@@ -163,7 +163,7 @@ describe("LocalStateProvider", () => {
     });
 
     let before = { ...counts };
-    act(() => snapshots.model?.setModel(PAID_DEFAULT_MODEL_ID));
+    act(() => snapshots.model?.setModel(POWERFUL_MODEL_ALIAS));
     expectRenderDelta(counts, before, { model: 1 });
 
     before = { ...counts };
@@ -186,7 +186,7 @@ describe("LocalStateProvider", () => {
     expectRenderDelta(counts, before, {});
   });
 
-  test("keeps the intentional paid-plan model default scoped to billing and model consumers", () => {
+  test("keeps Quick as the default model when a paid plan is loaded", () => {
     const storage = new CountingMemoryStorage();
     const snapshots: DomainSnapshots = {};
     const counts = createCounts();
@@ -199,11 +199,54 @@ describe("LocalStateProvider", () => {
       );
     });
 
+    expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
+
     const before = { ...counts };
     act(() => snapshots.billing?.setBillingStatus(proBillingStatus()));
 
-    expectRenderDelta(counts, before, { model: 1, billing: 1 });
-    expect(snapshots.model?.model).toBe(PAID_DEFAULT_MODEL_ID);
+    expectRenderDelta(counts, before, { billing: 1 });
+    expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
+    expect(storage.getItem("selectedModel")).toBeNull();
+  });
+
+  test("keeps a stickied model when a paid plan is loaded", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+    storage.setItem("selectedModel", POWERFUL_MODEL_ALIAS);
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    expect(snapshots.model?.model).toBe(POWERFUL_MODEL_ALIAS);
+
+    act(() => snapshots.billing?.setBillingStatus(proBillingStatus()));
+
+    expect(snapshots.model?.model).toBe(POWERFUL_MODEL_ALIAS);
+    expect(storage.getItem("selectedModel")).toBe(POWERFUL_MODEL_ALIAS);
+  });
+
+  test("ignores leftover paid-default cache when no model is stickied", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+    storage.setItem("paidDefaultsApplied", new Date().toISOString());
+    storage.setItem("cachedBillingStatus", JSON.stringify(proBillingStatus()));
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
   });
 
   test("preserves an in-memory model choice when storage is unavailable", () => {

--- a/frontend/src/state/LocalStateContext.test.tsx
+++ b/frontend/src/state/LocalStateContext.test.tsx
@@ -9,7 +9,12 @@ import type {
   SelectedProjectState,
   SidebarSearchState
 } from "./LocalStateContextDef";
-import { DEFAULT_MODEL_ID, LocalStateProvider, POWERFUL_MODEL_ALIAS } from "./LocalStateContext";
+import {
+  DEFAULT_MODEL_ID,
+  LocalStateProvider,
+  POWERFUL_MODEL_ALIAS,
+  SELECTED_MODEL_RESET_AT_KEY
+} from "./LocalStateContext";
 import {
   useBillingState,
   useModelState,
@@ -139,6 +144,15 @@ function proBillingStatus(): BillingStatus {
   };
 }
 
+function stampSelectedModelReset(storage: CountingMemoryStorage, at = "2026-01-01T00:00:00.000Z") {
+  storage.setItem(SELECTED_MODEL_RESET_AT_KEY, at);
+}
+
+function expectIsoTimestamp(value: string | null) {
+  expect(value).toBeTruthy();
+  expect(Number.isNaN(Date.parse(value ?? ""))).toBe(false);
+}
+
 describe("LocalStateProvider", () => {
   let renderer: ReactTestRenderer | null = null;
 
@@ -207,12 +221,61 @@ describe("LocalStateProvider", () => {
     expectRenderDelta(counts, before, { billing: 1 });
     expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
     expect(storage.getItem("selectedModel")).toBeNull();
+    expectIsoTimestamp(storage.getItem(SELECTED_MODEL_RESET_AT_KEY));
+  });
+
+  test("clears a stored model once, then preserves later sticky choices", () => {
+    const storage = new CountingMemoryStorage();
+    const snapshots: DomainSnapshots = {};
+    const counts = createCounts();
+    storage.setItem("selectedModel", POWERFUL_MODEL_ALIAS);
+    storage.setItem(
+      "selectedModelMetadata",
+      JSON.stringify({
+        id: POWERFUL_MODEL_ALIAS,
+        object: "model",
+        created: 1,
+        owned_by: "opensecret"
+      })
+    );
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
+    expect(storage.getItem("selectedModel")).toBeNull();
+    expect(storage.getItem("selectedModelMetadata")).toBeNull();
+    const resetAt = storage.getItem(SELECTED_MODEL_RESET_AT_KEY);
+    expectIsoTimestamp(resetAt);
+
+    act(() => renderer?.unmount());
+    renderer = null;
+
+    storage.setItem("selectedModel", POWERFUL_MODEL_ALIAS);
+
+    act(() => {
+      renderer = create(
+        <LocalStateProvider storage={storage}>
+          <DomainProbes snapshots={snapshots} counts={counts} />
+        </LocalStateProvider>
+      );
+    });
+
+    expect(snapshots.model?.model).toBe(POWERFUL_MODEL_ALIAS);
+    expect(storage.getItem("selectedModel")).toBe(POWERFUL_MODEL_ALIAS);
+    expect(storage.getItem(SELECTED_MODEL_RESET_AT_KEY)).toBe(resetAt);
   });
 
   test("keeps a stickied model when a paid plan is loaded", () => {
     const storage = new CountingMemoryStorage();
     const snapshots: DomainSnapshots = {};
     const counts = createCounts();
+    stampSelectedModelReset(storage);
     storage.setItem("selectedModel", POWERFUL_MODEL_ALIAS);
 
     act(() => {
@@ -247,6 +310,7 @@ describe("LocalStateProvider", () => {
     });
 
     expect(snapshots.model?.model).toBe(DEFAULT_MODEL_ID);
+    expectIsoTimestamp(storage.getItem(SELECTED_MODEL_RESET_AT_KEY));
   });
 
   test("preserves an in-memory model choice when storage is unavailable", () => {
@@ -289,6 +353,7 @@ describe("LocalStateProvider", () => {
 
     act(() => snapshots.model?.setModel(DEFAULT_MODEL_ID));
     expect(storage.getItem("selectedModel")).toBeNull();
+    expectIsoTimestamp(storage.getItem(SELECTED_MODEL_RESET_AT_KEY));
 
     act(() => {
       snapshots.model?.setModel("user-selected-model", {
@@ -309,6 +374,7 @@ describe("LocalStateProvider", () => {
     const storage = new CountingMemoryStorage();
     const snapshots: DomainSnapshots = {};
     const counts = createCounts();
+    stampSelectedModelReset(storage);
     storage.setItem("selectedModel", "cached-model");
     storage.setItem(
       "selectedModelMetadata",

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -17,7 +17,6 @@ import { aliasModelName, migrateStickyModelName } from "@/utils/utils";
 export const QUICK_MODEL_ALIAS = "auto:quick";
 export const POWERFUL_MODEL_ALIAS = "auto:powerful";
 export const DEFAULT_MODEL_ID = QUICK_MODEL_ALIAS;
-export const PAID_DEFAULT_MODEL_ID = POWERFUL_MODEL_ALIAS;
 const SELECTED_MODEL_METADATA_KEY = "selectedModelMetadata";
 type LocalStateStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
@@ -51,17 +50,6 @@ const DEFAULT_MODEL_ALIASES: OpenSecretModelAlias[] = [
     capabilities: { chat: true, vision: true, reasoning: true, tool_use: true }
   }
 ];
-
-// Check if a plan name corresponds to a pro/max/team plan
-function isProMaxOrTeamPlan(planName: string): boolean {
-  return planName.includes("pro") || planName.includes("max") || planName.includes("team");
-}
-
-// Check if paid defaults have already been applied for this user.
-// The value is an ISO date string indicating when defaults were last applied.
-function hasPaidDefaultsBeenApplied(storage: LocalStateStorage | null): boolean {
-  return storage?.getItem("paidDefaultsApplied") != null;
-}
 
 // One-time migration: clear stale webSearchEnabled values that were auto-persisted
 // by the old useEffect (not explicit user choices). After this migration, only values
@@ -98,7 +86,7 @@ export function getInitialWebSearchEnabled(
   return true;
 }
 
-// Helper to get default model based on cached billing status
+// Helper to get the initial model from an explicit sticky choice or the shared default.
 function getInitialModel(storage: LocalStateStorage | null): string {
   // Check for dev override first
   if (import.meta.env.VITE_DEV_MODEL_OVERRIDE) {
@@ -106,7 +94,6 @@ function getInitialModel(storage: LocalStateStorage | null): string {
   }
 
   try {
-    // Priority 1: Check local storage for user's explicit model choice
     const selectedModel = storage?.getItem("selectedModel");
     if (selectedModel) {
       if (getCachedSelectedModelMetadata(selectedModel, storage)) {
@@ -115,30 +102,10 @@ function getInitialModel(storage: LocalStateStorage | null): string {
 
       return migrateStickyModelName(selectedModel);
     }
-
-    // Priority 2: Check if paid defaults were already applied
-    // (user is returning paid user who got the one-time flip but then
-    // cleared selectedModel somehow — unlikely but safe fallback)
-    if (hasPaidDefaultsBeenApplied(storage)) {
-      return PAID_DEFAULT_MODEL_ID;
-    }
-
-    // Priority 3: Check cached billing status for pro/max/team users
-    const cachedBillingStr = storage?.getItem("cachedBillingStatus");
-    if (cachedBillingStr) {
-      const cachedBilling = JSON.parse(cachedBillingStr) as BillingStatus;
-      const planName = cachedBilling.product_name?.toLowerCase() || "";
-
-      // Pro, Max, or Team users get the powerful reasoning model
-      if (isProMaxOrTeamPlan(planName)) {
-        return PAID_DEFAULT_MODEL_ID;
-      }
-    }
   } catch (error) {
     console.error("Failed to load initial model:", error);
   }
 
-  // Priority 4: Default to free model
   return DEFAULT_MODEL_ID;
 }
 
@@ -234,105 +201,9 @@ export const LocalStateProvider = ({
   const [selectedProjectId, setSelectedProjectIdState] = useState<string | null>(null);
   const currentModelRef = useRef(modelState.model);
 
-  // Internal model setter — updates state and localStorage but does NOT mark as
-  // a user's explicit choice. Used by billing/system logic.
-  const setModelInternal = useCallback(
-    (modelId: string, persist = false) => {
-      const aliasedModel = aliasModelName(modelId);
-      currentModelRef.current = aliasedModel;
-      setModelState((prev) => {
-        if (prev.model === aliasedModel) return prev;
-        return { ...prev, model: aliasedModel };
-      });
-      if (persist) {
-        try {
-          storage?.setItem("selectedModel", aliasedModel);
-          cacheSelectedModelMetadata(aliasedModel, storage);
-        } catch (error) {
-          console.error("Failed to save model to localStorage:", error);
-        }
-      }
-    },
-    [storage]
-  );
-
-  const setBillingStatus = useCallback(
-    (status: BillingStatus) => {
-      setBillingStatusState(status);
-
-      const planName = status.product_name?.toLowerCase() || "";
-      const isPaidPlan =
-        planName.includes("pro") || planName.includes("max") || planName.includes("team");
-
-      const isProMaxOrTeam = isProMaxOrTeamPlan(planName);
-
-      // Check if billing plan changed from cached version
-      let billingChanged = false;
-      try {
-        const cachedBillingStr = storage?.getItem("cachedBillingStatus");
-        if (cachedBillingStr) {
-          const cachedBilling = JSON.parse(cachedBillingStr) as BillingStatus;
-          const cachedPlan = cachedBilling.product_name?.toLowerCase() || "";
-          billingChanged = cachedPlan !== planName;
-        }
-      } catch (error) {
-        console.error("Failed to check cached billing:", error);
-      }
-
-      // Cache billing status to localStorage only for paid users
-      try {
-        if (isPaidPlan) {
-          storage?.setItem("cachedBillingStatus", JSON.stringify(status));
-        } else {
-          // Clear cache for free users
-          storage?.removeItem("cachedBillingStatus");
-        }
-      } catch (error) {
-        console.error("Failed to cache billing status:", error);
-      }
-
-      // One-time paid defaults: when a user is on pro/max/team and we haven't
-      // applied paid defaults yet, flip model to "Powerful" and web search ON.
-      // This handles both new signups and free-to-paid upgrades.
-      try {
-        if (storage && isProMaxOrTeam && !hasPaidDefaultsBeenApplied(storage)) {
-          // Apply paid defaults — set model to Powerful reasoning model
-          setModelInternal(PAID_DEFAULT_MODEL_ID, true);
-
-          // Mark when we applied paid defaults (ISO date) so we never override again.
-          // Future defaults can check this date to decide whether to re-apply newer defaults.
-          storage?.setItem("paidDefaultsApplied", new Date().toISOString());
-
-          return;
-        }
-      } catch (error) {
-        console.error("Failed to apply paid defaults:", error);
-      }
-
-      // For users who already had defaults applied: handle plan changes
-      try {
-        if (billingChanged) {
-          if (isProMaxOrTeam) {
-            // Plan changed but still pro-tier — only update model if user
-            // hasn't manually chosen one (selectedModel not in localStorage)
-            const selectedModel = storage?.getItem("selectedModel");
-            if (!selectedModel) {
-              setModelInternal(PAID_DEFAULT_MODEL_ID, true);
-            }
-          } else {
-            // User downgraded to free — switch back to free model
-            // and clear paid defaults so they get re-applied if they upgrade again
-            setModelInternal(DEFAULT_MODEL_ID);
-            storage?.removeItem("paidDefaultsApplied");
-            storage?.removeItem("selectedModel");
-          }
-        }
-      } catch (error) {
-        console.error("Failed to update model based on billing status:", error);
-      }
-    },
-    [setModelInternal, storage]
-  );
+  const setBillingStatus = useCallback((status: BillingStatus) => {
+    setBillingStatusState(status);
+  }, []);
 
   const setSearchQuery = useCallback((query: string) => setSearchQueryState(query), []);
 

--- a/frontend/src/state/LocalStateContext.tsx
+++ b/frontend/src/state/LocalStateContext.tsx
@@ -17,6 +17,7 @@ import { aliasModelName, migrateStickyModelName } from "@/utils/utils";
 export const QUICK_MODEL_ALIAS = "auto:quick";
 export const POWERFUL_MODEL_ALIAS = "auto:powerful";
 export const DEFAULT_MODEL_ID = QUICK_MODEL_ALIAS;
+export const SELECTED_MODEL_RESET_AT_KEY = "selectedModelResetAt";
 const SELECTED_MODEL_METADATA_KEY = "selectedModelMetadata";
 type LocalStateStorage = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
@@ -86,8 +87,27 @@ export function getInitialWebSearchEnabled(
   return true;
 }
 
+// One-time reset: clear any previously stickied model so Quick becomes the
+// shared default. Presence of the timestamp is the boolean gate; the ISO
+// value is only diagnostic. A later reset should use a new key.
+function resetSelectedModelOnce(storage: LocalStateStorage | null): void {
+  if (!storage) return;
+
+  try {
+    if (storage.getItem(SELECTED_MODEL_RESET_AT_KEY) != null) return;
+
+    storage.removeItem("selectedModel");
+    storage.removeItem(SELECTED_MODEL_METADATA_KEY);
+    storage.setItem(SELECTED_MODEL_RESET_AT_KEY, new Date().toISOString());
+  } catch {
+    // Ignore storage errors
+  }
+}
+
 // Helper to get the initial model from an explicit sticky choice or the shared default.
 function getInitialModel(storage: LocalStateStorage | null): string {
+  resetSelectedModelOnce(storage);
+
   // Check for dev override first
   if (import.meta.env.VITE_DEV_MODEL_OVERRIDE) {
     return aliasModelName(import.meta.env.VITE_DEV_MODEL_OVERRIDE);


### PR DESCRIPTION
## Summary

Quick is now the default chat model for every plan. Paid users no longer get flipped to Powerful on first billing load.

A stickied `selectedModel` in localStorage is still respected, including after a paid plan loads. Selecting a model in the UI still writes that sticky value; a no-op Quick selection on a fresh session still does not.

This removes the paid-plan-only default path (`paidDefaultsApplied`, cached billing status, and the internal model setter used to apply Powerful). Billing status updates no longer change the selected model.

Existing sessions that already have `selectedModel` set (including Powerful written by the old one-time paid default) keep that choice.

## Test plan

- [x] `bun --no-env-file test src/state/LocalStateContext.test.tsx`
- [x] `bun run format:check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun --no-env-file test` (767 pass)
- [ ] Manual: signed-out/fresh Pro session with empty `selectedModel` should show Quick
- [ ] Manual: stickied Powerful in localStorage should stay Powerful after reload